### PR TITLE
Update README to include license

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@ For outstanding issues, see this bug list: https://bugzilla.mozilla.org/show_bug
 For easy development, you can use the compare-view page to compare an original test page to its reader-ized content. Due to the same-origin policy, this will only work with pages hosted on the same domain as this compare-view page, so you should save testcases locally, and run a local http server to test.
 
 For a simple node http server, see [http-server](https://github.com/nodeapps/http-server).
+
+## License
+
+    Copyright (c) 2010 Arc90 Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.


### PR DESCRIPTION
I took this license block from the Readability.js license header.

This should address this issue #8.