### PR TITLE
Preserve inline tweets as they're part of article contents.

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -88,7 +88,7 @@ Readability.prototype = {
   // All of the regular expressions in use within readability.
   // Defined up here so we don't instantiate them repeatedly in loops.
   REGEXPS: {
-    unlikelyCandidates: /combx|comment|community|disqus|extra|foot|header|menu|remark|rss|shoutbox|sidebar|sponsor|ad-break|agegate|pagination|pager|popup|tweet|twitter/i,
+    unlikelyCandidates: /combx|comment|community|disqus|extra|foot|header|menu|remark|rss|shoutbox|sidebar|sponsor|ad-break|agegate|pagination|pager|popup/i,
     okMaybeItsACandidate: /and|article|body|column|main|shadow/i,
     positive: /article|body|content|entry|hentry|main|page|pagination|post|text|blog|story/i,
     negative: /hidden|combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|shoutbox|sidebar|sponsor|shopping|tags|tool|widget/i,

--- a/test/test-pages/001/expected.html
+++ b/test/test-pages/001/expected.html
@@ -16,6 +16,14 @@ help.</strong>
             I guess.</p>
         <p>Actually I've only found one which provides an adapter for <a href="http://visionmedia.github.io/mocha/">Mocha</a> and
             actually works…</p>
+        <blockquote class="twitter-tweet tw-align-center">
+            <p>Drinking game for web devs:
+                <br/>(1) Think of a noun
+                <br/>(2) Google "&lt;noun&gt;.js"
+                <br/>(3) If a library with that name exists - drink</p>— Shay Friedman (@ironshay)
+            <a
+            href="https://twitter.com/ironshay/statuses/370525864523743232">August 22, 2013</a>
+        </blockquote>
         <p><strong><a href="http://blanketjs.org/">Blanket.js</a></strong> is an <em>easy to install, easy to configure,
 and easy to use JavaScript code coverage library that works both in-browser and
 with nodejs.</em>


### PR DESCRIPTION
I can see no good reason to filter out inline tweets, as they're most likely to contribute to article meaning.