### PR TITLE
Fix readability to work with real dom (fixes #72)

### DIFF
--- a/test/test-jsdomparser.js
+++ b/test/test-jsdomparser.js
@@ -48,8 +48,13 @@ describe("Test JSDOM functionality", function() {
     nodeExpect(baseDoc.body.parentNode, baseDoc.documentElement);
     expect(baseDoc.body.childNodes.length).eql(3);
 
-    var generatedHTML = "<html>" + baseDoc.documentElement.innerHTML + "</html>";
-    expect(generatedHTML).eql(BASETESTCASE);
+    var generatedHTML = baseDoc.getElementsByTagName("p")[0].innerHTML;
+    expect(generatedHTML).eql('Some text and <a class="someclass" href="#">a link</a>');
+    var scriptNode = baseDoc.getElementsByTagName("script")[0];
+    generatedHTML = scriptNode.innerHTML;
+    expect(generatedHTML).eql('With &lt; fancy " characters in it because');
+    expect(scriptNode.textContent).eql('With < fancy " characters in it because');
+
   });
 
   it("should deal with script tags", function() {
@@ -206,5 +211,12 @@ describe("Test JSDOM functionality", function() {
           nodeExpect(replacedNode.nextElementSibling.previousElementSibling, replacedNode);
       }
     }
+  });
+
+  it("should handle encoding HTML correctly", function() {
+    var baseStr = "<p>Hello,&nbsp;everyone &amp; all their friends, &lt;this&gt; is a test.</p>";
+    var doc = new JSDOMParser().parse(baseStr);
+    var p = doc.getElementsByTagName("p")[0];
+    expect("<p>" + p.innerHTML + "</p>").eql(baseStr);
   });
 });

--- a/test/test-pages/001/expected.html
+++ b/test/test-pages/001/expected.html
@@ -18,9 +18,9 @@ help.</strong>
             actually works…</p>
         <blockquote class="twitter-tweet tw-align-center">
             <p>Drinking game for web devs:
-                <br/>(1) Think of a noun
-                <br/>(2) Google "&lt;noun&gt;.js"
-                <br/>(3) If a library with that name exists - drink</p>— Shay Friedman (@ironshay)
+                <br>(1) Think of a noun
+                <br>(2) Google "&lt;noun&gt;.js"
+                <br>(3) If a library with that name exists - drink</p>— Shay Friedman (@ironshay)
             <a
             href="https://twitter.com/ironshay/statuses/370525864523743232">August 22, 2013</a>
         </blockquote>
@@ -120,8 +120,7 @@ describe("Cow", function() {
         </ul>
         <p>Running the tests now gives us something like this:</p>
         <p>
-            <img alt="screenshot" src="http://fakehost/static/code/2013/blanket-coverage.png"
-            />
+            <img alt="screenshot" src="http://fakehost/static/code/2013/blanket-coverage.png">
         </p>
         <p>As you can see, the report at the bottom highlights that we haven't actually
             tested the case where an error is raised in case a target name is missing.

--- a/test/test-pages/002/expected.html
+++ b/test/test-pages/002/expected.html
@@ -85,19 +85,19 @@
 </div>
 <p>The <code>fetch()</code> function’s arguments are the same as those passed
     to the
-    <br/>
+    <br>
 <code>Request()</code> constructor, so you may directly pass arbitrarily
     complex requests to <code>fetch()</code> as discussed below.</p>
 
 <h2>Headers</h2>
 
 <p>Fetch introduces 3 interfaces. These are <code>Headers</code>, <code>Request</code> and
-    <br/>
+    <br>
 <code>Response</code>. They map directly to the underlying HTTP concepts,
     but have
-    <br/>certain visibility filters in place for privacy and security reasons,
+    <br>certain visibility filters in place for privacy and security reasons,
     such as
-    <br/>supporting CORS rules and ensuring cookies aren’t readable by third parties.</p>
+    <br>supporting CORS rules and ensuring cookies aren’t readable by third parties.</p>
 <p>The <a href="https://fetch.spec.whatwg.org/#headers-class">Headers interface</a> is
     a simple multi-map of names to values:</p>
 <div class="wp_syntax">
@@ -117,7 +117,7 @@ reqHeaders.<span>append</span><span>(</span><span>"X-Custom-Header"</span><span>
 </div>
 <p>The same can be achieved by passing an array of arrays or a JS object
     literal
-    <br/>to the constructor:</p>
+    <br>to the constructor:</p>
 <div class="wp_syntax">
     <table>
         <tbody>
@@ -155,25 +155,25 @@ console.<span>log</span><span>(</span>reqHeaders.<span>getAll</span><span>(</spa
     </table>
 </div>
 <p>Some of these operations are only useful in ServiceWorkers, but they provide
-    <br/>a much nicer API to Headers.</p>
+    <br>a much nicer API to Headers.</p>
 <p>Since Headers can be sent in requests, or received in responses, and have
     various limitations about what information can and should be mutable, <code>Headers</code> objects
     have a <strong>guard</strong> property. This is not exposed to the Web, but
     it affects which mutation operations are allowed on the Headers object.
-    <br/>Possible values are:</p>
+    <br>Possible values are:</p>
 <ul>
     <li>“none”: default.</li>
     <li>“request”: guard for a Headers object obtained from a Request (<code>Request.headers</code>).</li>
     <li>“request-no-cors”: guard for a Headers object obtained from a Request
         created
-        <br/>with mode “no-cors”.</li>
+        <br>with mode “no-cors”.</li>
     <li>“response”: naturally, for Headers obtained from Response (<code>Response.headers</code>).</li>
     <li>“immutable”: Mostly used for ServiceWorkers, renders a Headers object
-        <br/>read-only.</li>
+        <br>read-only.</li>
 </ul>
 <p>The details of how each guard affects the behaviors of the Headers object
     are
-    <br/>in the <a href="https://fetch.spec.whatwg.org">specification</a>. For example,
+    <br>in the <a href="https://fetch.spec.whatwg.org">specification</a>. For example,
     you may not append or set a “request” guarded Headers’ “Content-Length”
     header. Similarly, inserting “Set-Cookie” into a Response header is not
     allowed so that ServiceWorkers may not set cookies via synthesized Responses.</p>
@@ -221,9 +221,9 @@ console.<span>log</span><span>(</span>req.<span>url</span><span>)</span><span>;<
     </div>
     <p>You may also pass a Request to the <code>Request()</code> constructor to
         create a copy.
-        <br/>(This is not the same as calling the <code>clone()</code> method, which
+        <br>(This is not the same as calling the <code>clone()</code> method, which
         is covered in
-        <br/>the “Reading bodies” section.).</p>
+        <br>the “Reading bodies” section.).</p>
     <div class="wp_syntax">
         <table>
             <tbody>
@@ -240,7 +240,7 @@ console.<span>log</span><span>(</span>copy.<span>url</span><span>)</span><span>;
     <p>Again, this form is probably only useful in ServiceWorkers.</p>
     <p>The non-URL attributes of the <code>Request</code> can only be set by passing
         initial
-        <br/>values as a second argument to the constructor. This argument is a dictionary.</p>
+        <br>values as a second argument to the constructor. This argument is a dictionary.</p>
     <div
     class="wp_syntax">
         <table>
@@ -266,7 +266,7 @@ console.<span>log</span><span>(</span>copy.<span>url</span><span>)</span><span>;
         <p>The <code>"same-origin"</code> mode is simple, if a request is made to another
             origin with this mode set, the result is simply an error. You could use
             this to ensure that
-            <br/>a request is always being made to your origin.</p>
+            <br>a request is always being made to your origin.</p>
         <div class="wp_syntax">
             <table>
                 <tbody>
@@ -295,7 +295,7 @@ fetch<span>(</span>arbitraryUrl<span>,</span> <span>{</span> mode<span>:</span> 
         <p><code>"cors"</code> mode is what you’ll usually use to make known cross-origin
             requests to access various APIs offered by other vendors. These are expected
             to adhere to
-            <br/>the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS">CORS protocol</a>.
+            <br>the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS">CORS protocol</a>.
             Only a <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">limited set</a> of
             headers is exposed in the Response, but the body is readable. For example,
             you could get a list of Flickr’s <a href="https://www.flickr.com/services/api/flickr.interestingness.getList.html">most interesting</a> photos
@@ -330,7 +330,7 @@ apiCall.<span>then</span><span>(</span><span>function</span><span>(</span>respon
         </div>
         <p>You may not read out the “Date” header since Flickr does not allow it
             via
-            <br/>
+            <br>
 <code>Access-Control-Expose-Headers</code>.</p>
         <div class="wp_syntax">
             <table>
@@ -345,21 +345,21 @@ apiCall.<span>then</span><span>(</span><span>function</span><span>(</span>respon
         </div>
         <p>The <code>credentials</code> enumeration determines if cookies for the other
             domain are
-            <br/>sent to cross-origin requests. This is similar to XHR’s <code>withCredentials</code>
+            <br>sent to cross-origin requests. This is similar to XHR’s <code>withCredentials</code>
 
-            <br/>flag, but tri-valued as <code>"omit"</code> (default), <code>"same-origin"</code> and <code>"include"</code>.</p>
+            <br>flag, but tri-valued as <code>"omit"</code> (default), <code>"same-origin"</code> and <code>"include"</code>.</p>
         <p>The Request object will also give the ability to offer caching hints to
             the user-agent. This is currently undergoing some <a href="https://github.com/slightlyoff/ServiceWorker/issues/585">security review</a>.
             Firefox exposes the attribute, but it has no effect.</p>
         <p>Requests have two read-only attributes that are relevant to ServiceWorkers
-            <br/>intercepting them. There is the string <code>referrer</code>, which is
+            <br>intercepting them. There is the string <code>referrer</code>, which is
             set by the UA to be
-            <br/>the referrer of the Request. This may be an empty string. The other is
-            <br/>
+            <br>the referrer of the Request. This may be an empty string. The other is
+            <br>
 <code>context</code> which is a rather <a href="https://fetch.spec.whatwg.org/#requestcredentials">large enumeration</a> defining
             what sort of resource is being fetched. This could be “image” if the request
             is from an
-            <img/>tag in the controlled document, “worker” if it is an attempt to load a
+            <img>tag in the controlled document, “worker” if it is an attempt to load a
             worker script, and so on. When used with the <code>fetch()</code> function,
             it is “fetch”.</p>
         
@@ -377,11 +377,11 @@ apiCall.<span>then</span><span>(</span><span>function</span><span>(</span>respon
             The <code>url</code> attribute reflects the URL of the corresponding request.</p>
         <p>Response also has a <code>type</code>, which is “basic”, “cors”, “default”,
             “error” or
-            <br/>“opaque”.</p>
+            <br>“opaque”.</p>
         <ul>
             <li><code>"basic"</code>: normal, same origin response, with all headers exposed
                 except
-                <br/>“Set-Cookie” and “Set-Cookie2″.</li>
+                <br>“Set-Cookie” and “Set-Cookie2″.</li>
             <li><code>"cors"</code>: response was received from a valid cross-origin request.
                 <a
                 href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">Certain headers and the body</a>may be accessed.</li>
@@ -389,7 +389,7 @@ apiCall.<span>then</span><span>(</span><span>function</span><span>(</span>respon
                 the error is available. The Response’s status is 0, headers are empty and
                 immutable. This is the type for a Response obtained from <code>Response.error()</code>.</li>
             <li><code>"opaque"</code>: response for “no-cors” request to cross-origin
-                resource. <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">Severely<br/>
+                resource. <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">Severely<br>
   restricted</a>
 
             </li>
@@ -398,7 +398,7 @@ apiCall.<span>then</span><span>(</span><span>function</span><span>(</span>respon
             TypeError.</p>
         <p>There are certain attributes that are useful only in a ServiceWorker scope.
             The
-            <br/>idiomatic way to return a Response to an intercepted request in ServiceWorkers
+            <br>idiomatic way to return a Response to an intercepted request in ServiceWorkers
             is:</p>
         <div class="wp_syntax">
             <table>
@@ -421,7 +421,7 @@ apiCall.<span>then</span><span>(</span><span>function</span><span>(</span>respon
         <p>The static method <code>Response.error()</code> simply returns an error
             response. Similarly, <code>Response.redirect(url, status)</code> returns
             a Response resulting in
-            <br/>a redirect to <code>url</code>.</p>
+            <br>a redirect to <code>url</code>.</p>
         
 <h2>Dealing with bodies</h2>
 
@@ -561,7 +561,7 @@ res.<span>text</span><span>(</span><span>)</span>.<span>catch</span><span>(</spa
                 <a
                 href="https://github.com/slightlyoff/ServiceWorker/issues">ServiceWorker</a>specifications.</p>
             <p>For a better web!</p>
-            <p><em>The author would like to thank Andrea Marchesini, Anne van Kesteren and Ben<br/>
+            <p><em>The author would like to thank Andrea Marchesini, Anne van Kesteren and Ben<br>
 Kelly for helping with the specification and implementation.</em>
 
             </p>

--- a/test/test-pages/base-url/expected.html
+++ b/test/test-pages/base-url/expected.html
@@ -19,19 +19,19 @@
         </p>
         <p>Images</p>
         <p>
-            <img src="http://fakehost/test/foo/bar/baz.png" />
+            <img src="http://fakehost/test/foo/bar/baz.png">
         </p>
         <p>
-            <img src="http://fakehost/test/foo/bar/baz.png" />
+            <img src="http://fakehost/test/foo/bar/baz.png">
         </p>
         <p>
-            <img src="http://fakehost/foo/bar/baz.png" />
+            <img src="http://fakehost/foo/bar/baz.png">
         </p>
         <p>
-            <img src="http://test/foo/bar/baz.png" />
+            <img src="http://test/foo/bar/baz.png">
         </p>
         <p>
-            <img src="https://test/foo/bar/baz.png" />
+            <img src="https://test/foo/bar/baz.png">
         </p>
         <p>Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
             quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo

--- a/test/test-pages/embedded-videos/expected.html
+++ b/test/test-pages/embedded-videos/expected.html
@@ -10,20 +10,21 @@
 
         <p>At root</p>
         <iframe width="560" height="315" src="https://www.youtube.com/embed/LtOGa5M8AuU"
-        frameborder="0"></iframe>
+        frameborder="0" allowfullscreen=""></iframe>
         <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/LtOGa5M8AuU"
-        frameborder="0"></iframe>
-        <iframe src="https://player.vimeo.com/video/32246206?color=ffffff&title=0&byline=0&portrait=0"
-        width="500" height="281" frameborder="0"></iframe>
+        frameborder="0" allowfullscreen=""></iframe>
+        <iframe src="https://player.vimeo.com/video/32246206?color=ffffff&amp;title=0&amp;byline=0&amp;portrait=0"
+        width="500" height="281" frameborder="0" webkitallowfullscreen="" mozallowfullscreen=""
+        allowfullscreen=""></iframe>
         <p>In a paragraph</p>
         <p>
             <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/LtOGa5M8AuU"
-            frameborder="0"></iframe>
+            frameborder="0" allowfullscreen=""></iframe>
         </p>
         <p>In a div</p>
         <p>
             <iframe width="560" height="315" src="https://www.youtube.com/embed/LtOGa5M8AuU"
-            frameborder="0"></iframe>
+            frameborder="0" allowfullscreen=""></iframe>
         </p>
          <h2>Foo</h2>
 

--- a/test/test-pages/herald-sun-1/expected.html
+++ b/test/test-pages/herald-sun-1/expected.html
@@ -4,8 +4,7 @@
             <div class="image">
                 <div class="image-frame">
                     <img data-src="http://api.news.com.au/content/1.0/heraldsun/images/1227261885862?format=jpg&amp;group=iphone&amp;size=medium"
-                    alt="A new Bill would require telecommunications service providers to store so-called ‘metadat"
-                    />
+                    alt="A new Bill would require telecommunications service providers to store so-called ‘metadat">
                 </div>
                 <p class="caption">	<span id="imgCaption" class="caption-text">A new Bill would require telecommunications service providers to store so-called ‘metadata’ for two years.</span>
 

--- a/test/test-pages/medium-1/expected.html
+++ b/test/test-pages/medium-1/expected.html
@@ -1,7 +1,7 @@
 <div id="readability-page-1" class="page">
     <div>
         <h4 name="425a" id="425a" data-align="center" class="graf--h4"><em class="markup--em markup--h4-em">Better Student Journalism</em></h4>
-        <h4 name="08db" id="08db" class="graf--h4 graf--empty"><br/></h4>
+        <h4 name="08db" id="08db" class="graf--h4 graf--empty"><br></h4>
         <p name="d178" id="d178" class="graf--p">We pushed out the first version of the <a href="http://pippinlee.github.io/open-journalism-project/"
             data-href="http://pippinlee.github.io/open-journalism-project/" class="markup--anchor markup--p-anchor"
             rel="nofollow">Open Journalism site</a> in January. Our goal is for the
@@ -36,8 +36,7 @@
                 <div class="aspectRatioPlaceholder is-locked">
                     <img class="graf-image" data-image-id="1*AzYWbe4cZkMMEUbfRjysLQ.png" data-width="1000"
                     data-height="500" data-action="zoom" data-action-value="1*AzYWbe4cZkMMEUbfRjysLQ.png"
-                    src="https://d262ilb51hltx0.cloudfront.net/max/800/1*AzYWbe4cZkMMEUbfRjysLQ.png"
-                    />
+                    src="https://d262ilb51hltx0.cloudfront.net/max/800/1*AzYWbe4cZkMMEUbfRjysLQ.png">
                 </div>
                 <figcaption class="imageCaption">topleftpixel.com</figcaption>
             </figure>
@@ -64,8 +63,7 @@
                 <div class="aspectRatioPlaceholder is-locked">
                     <img class="graf-image" data-image-id="1*d0Hp6KlzyIcGHcL6to1sYQ.png" data-width="868"
                     data-height="451" data-action="zoom" data-action-value="1*d0Hp6KlzyIcGHcL6to1sYQ.png"
-                    src="https://d262ilb51hltx0.cloudfront.net/max/800/1*d0Hp6KlzyIcGHcL6to1sYQ.png"
-                    />
+                    src="https://d262ilb51hltx0.cloudfront.net/max/800/1*d0Hp6KlzyIcGHcL6to1sYQ.png">
                 </div>
             </figure>
             <h3 name="e2f0" id="e2f0" class="graf--h3">We don’t know what we don’t know</h3>
@@ -119,8 +117,7 @@
                 <div class="aspectRatioPlaceholder is-locked">
                     <img class="graf-image" data-image-id="1*_9KYIFrk_PqWFgptsMDeww.png" data-width="1086"
                     data-height="500" data-action="zoom" data-action-value="1*_9KYIFrk_PqWFgptsMDeww.png"
-                    src="https://d262ilb51hltx0.cloudfront.net/max/800/1*_9KYIFrk_PqWFgptsMDeww.png"
-                    />
+                    src="https://d262ilb51hltx0.cloudfront.net/max/800/1*_9KYIFrk_PqWFgptsMDeww.png">
                 </div>
                 <figcaption class="imageCaption">From our 2011 research</figcaption>
             </figure>
@@ -180,8 +177,7 @@
                     <figure name="416f" id="416f" class="graf--figure">
                         <div class="aspectRatioPlaceholder is-locked">
                             <img class="graf-image" data-image-id="1*Vh2MpQjqjPkzYJaaWExoVg.png" data-width="624"
-                            data-height="560" src="https://d262ilb51hltx0.cloudfront.net/max/800/1*Vh2MpQjqjPkzYJaaWExoVg.png"
-                            />
+                            data-height="560" src="https://d262ilb51hltx0.cloudfront.net/max/800/1*Vh2MpQjqjPkzYJaaWExoVg.png">
                         </div>
                         <figcaption class="imageCaption"><strong class="markup--strong markup--figure-strong">We designed many of these slides to help explain to ourselves what we were doing</strong>
 
@@ -196,21 +192,21 @@
                     <ol class="postList">
                         <li name="91b5" id="91b5" class="graf--li"><strong class="markup--strong markup--li-strong">The handoff</strong>
 
-                            <br/>Problems arise because web editors are given roles that absolve the rest
+                            <br>Problems arise because web editors are given roles that absolve the rest
                             of the editors from thinking about the web. All editors should be involved
                             in the process of story development for the web. While it’s a good idea
                             to have one specific editor manage the website, contributors and editors
                             should all play with and learn about the web. Instead of “can you make
                             a computer do XYZ for me?”, we should be saying “can you show me how to
                             make a computer do XYZ?”</li>
-                        <li name="6448" id="6448" class="graf--li"><strong class="markup--strong markup--li-strong">Not just social media<br/></strong>A
+                        <li name="6448" id="6448" class="graf--li"><strong class="markup--strong markup--li-strong">Not just social media<br></strong>A
                             web editor could do much more than simply being in charge of the social
                             media accounts for the student paper. Their responsibility could include
                             teaching all other editors to be listening to what’s happening online.
                             The web editor can take advantage of live information to change how the
                             student newsroom reports news in real time.</li>
                         <li name="ab30" id="ab30"
-                        class="graf--li"><strong class="markup--strong markup--li-strong">Web (interactive) editor<br/></strong>The
+                        class="graf--li"><strong class="markup--strong markup--li-strong">Web (interactive) editor<br></strong>The
                             goal of having a web editor should be for someone to build and tell stories
                             that take full advantage of the web as their medium. Too often the web’s
                             interactivity is not considered when developing the story. The web then
@@ -234,8 +230,7 @@
                         <div class="aspectRatioPlaceholder is-locked">
                             <img class="graf-image" data-image-id="1*2Ln_DmC95Xpz6LzgywkcFQ.png" data-width="1315"
                             data-height="718" data-action="zoom" data-action-value="1*2Ln_DmC95Xpz6LzgywkcFQ.png"
-                            src="https://d262ilb51hltx0.cloudfront.net/max/800/1*2Ln_DmC95Xpz6LzgywkcFQ.png"
-                            />
+                            src="https://d262ilb51hltx0.cloudfront.net/max/800/1*2Ln_DmC95Xpz6LzgywkcFQ.png">
                         </div>
                         <figcaption class="imageCaption">The current Open Journalism site was a few years in the making. This was
                             an original launch page we use in 2012</figcaption>
@@ -244,7 +239,7 @@
                     <ul class="postList">
                         <li name="f7fe" id="f7fe" class="graf--li"><strong class="markup--strong markup--li-strong">New process</strong>
 
-                            <br/>Our rough research has told us newsrooms need to be reorganized. This
+                            <br>Our rough research has told us newsrooms need to be reorganized. This
                             includes every part of the newsroom’s workflow: from where a story and
                             its information comes from, to thinking of every word, pixel, and interaction
                             the reader will have with your stories. If I was a photo editor that wanted
@@ -258,7 +253,7 @@
                             fits your newsroom’s needs.</li>
                         <li name="d757" id="d757" class="graf--li"><strong class="markup--strong markup--li-strong">More (remote) mentorship</strong>
 
-                            <br/>Lack of mentorship is still a big problem. <a href="http://www.google.com/get/journalismfellowship/"
+                            <br>Lack of mentorship is still a big problem. <a href="http://www.google.com/get/journalismfellowship/"
                             data-href="http://www.google.com/get/journalismfellowship/" class="markup--anchor markup--li-anchor"
                             rel="nofollow">Google’s fellowship program</a> is great. The fact that it
                             only caters to United States students isn’t. There are only a handful of
@@ -270,7 +265,7 @@
                         <li name="a9b8"
                         id="a9b8" class="graf--li"><strong class="markup--strong markup--li-strong">Changing a newsroom culture</strong>
 
-                            <br/>Skill diversity needs to change. We encourage every student newsroom we
+                            <br>Skill diversity needs to change. We encourage every student newsroom we
                             talk to, to start building a partnership with their school’s Computer Science
                             department. It will take some work, but you’ll find there are many CS undergrads
                             that love playing with web technologies, and using data to tell stories.
@@ -285,7 +280,7 @@
                     <ul class="postList">
                         <li name="7320" id="7320" class="graf--li"><strong class="markup--strong markup--li-strong">Sharing curiosity for the web</strong>
 
-                            <br/>We don’t know how to best teach students about the web. It’s not efficient
+                            <br>We don’t know how to best teach students about the web. It’s not efficient
                             for us to teach coding classes. We do go into newsrooms and get them running
                             their first code exercises, but if someone wants to learn to program, we
                             can only provide the initial push and curiosity. We will be trying out
@@ -293,13 +288,13 @@
                             of how to teach students about the web.</li>
                         <li name="8b23" id="8b23" class="graf--li"><strong class="markup--strong markup--li-strong">Business</strong>
 
-                            <br/>We don’t know how to convince the business side of student papers that
+                            <br>We don’t know how to convince the business side of student papers that
                             they should invest in the web. At the very least we’re able to explain
                             that having students graduate with their current skill set is painful in
                             the current job market.</li>
                         <li name="191e" id="191e" class="graf--li"><strong class="markup--strong markup--li-strong">The future</strong>
 
-                            <br/>We don’t know what journalism or the web will be like in 10 years, but
+                            <br>We don’t know what journalism or the web will be like in 10 years, but
                             we can start encouraging students to keep an open mind about the skills
                             they’ll need. We’re less interested in preparing students for the current
                             newsroom climate, than we are in teaching students to have the ability
@@ -311,7 +306,7 @@
         <ul class="postList">
             <li name="8bfa" id="8bfa" class="graf--li"><strong class="markup--strong markup--li-strong">A concise guide to building stories for the web</strong>
 
-                <br/>There are too many options to get started. We hope to provide an opinionated
+                <br>There are too many options to get started. We hope to provide an opinionated
                 guide that follows both our experiences, research, and observations from
                 trying to teach our peers.</li>
         </ul>
@@ -329,8 +324,7 @@
             id="7ed3" class="graf--figure">
                 <div class="aspectRatioPlaceholder is-locked">
                     <img class="graf-image" data-image-id="1*bXaR_NBJdoHpRc8lUWSsow.png" data-width="686"
-                    data-height="400" src="https://d262ilb51hltx0.cloudfront.net/max/800/1*bXaR_NBJdoHpRc8lUWSsow.png"
-                    />
+                    data-height="400" src="https://d262ilb51hltx0.cloudfront.net/max/800/1*bXaR_NBJdoHpRc8lUWSsow.png">
                 </div>
                 <figcaption class="imageCaption">2012</figcaption>
             </figure>
@@ -358,8 +352,7 @@
                 <div class="aspectRatioPlaceholder is-locked">
                     <img class="graf-image" data-image-id="1*lulfisQxgSQ209vPHMAifg.png" data-width="950"
                     data-height="534" data-action="zoom" data-action-value="1*lulfisQxgSQ209vPHMAifg.png"
-                    src="https://d262ilb51hltx0.cloudfront.net/max/800/1*lulfisQxgSQ209vPHMAifg.png"
-                    />
+                    src="https://d262ilb51hltx0.cloudfront.net/max/800/1*lulfisQxgSQ209vPHMAifg.png">
                 </div>
             </figure>
             <p name="2c5c" id="2c5c" class="graf--p"><strong class="markup--strong markup--p-strong">Let’s talk. Let’s listen.</strong>

--- a/test/test-pages/medium-2/expected.html
+++ b/test/test-pages/medium-2/expected.html
@@ -4,8 +4,7 @@
             <div class="aspectRatioPlaceholder is-locked">
                 <img class="graf-image" data-image-id="1*eR_J8DurqygbhrwDg-WPnQ.png" data-width="1891"
                 data-height="1280" data-action="zoom" data-action-value="1*eR_J8DurqygbhrwDg-WPnQ.png"
-                src="https://d262ilb51hltx0.cloudfront.net/max/1600/1*eR_J8DurqygbhrwDg-WPnQ.png"
-                />
+                src="https://d262ilb51hltx0.cloudfront.net/max/1600/1*eR_J8DurqygbhrwDg-WPnQ.png">
             </div>
             <figcaption class="imageCaption">Words need defenders.</figcaption>
         </figure>

--- a/test/test-pages/reordering-paragraphs/expected.html
+++ b/test/test-pages/reordering-paragraphs/expected.html
@@ -23,5 +23,5 @@
         of matter is called quark-gluon plasma.[81] The exact conditions needed
         to give rise to this state are unknown and have been the subject of a great
         deal of speculation and experimentation.</p>
-    <br id="br2" />
+    <br id="br2">
 </div>

--- a/test/test-pages/tmz-1/expected.html
+++ b/test/test-pages/tmz-1/expected.html
@@ -12,8 +12,7 @@
 
             </p>
             <p>
-                <img alt="0225-lupita-nyongo-getty-01" src="http://ll-media.tmz.com/2015/02/26/0225-lupita-nyongo-getty-4.jpg"
-                /><strong>Lupita Nyong</strong>'<strong>o</strong>'s now-famous Oscar dress
+                <img alt="0225-lupita-nyongo-getty-01" src="http://ll-media.tmz.com/2015/02/26/0225-lupita-nyongo-getty-4.jpg"><strong>Lupita Nyong</strong>'<strong>o</strong>'s now-famous Oscar dress
                 -- adorned in pearls -- was stolen right out of her hotel room ... TMZ
                 has learned.</p>
             <p>Law enforcement sources tell TMZ ... the dress was taken out of Lupita's
@@ -24,13 +23,11 @@
             <p>We're told there is security footage that cops are looking at that could
                 catch the culprit right in the act.&nbsp;</p>
             <p>
-                <img alt="update_graphic_red_bar" src="http://ll-media.tmz.com/2013/11/20/update-graphic-red-bar.jpg"
-                /><strong>12:00 PM PT</strong> -- Sheriff's deputies were at The London Thursday
+                <img alt="update_graphic_red_bar" src="http://ll-media.tmz.com/2013/11/20/update-graphic-red-bar.jpg"><strong>12:00 PM PT</strong> -- Sheriff's deputies were at The London Thursday
                 morning. &nbsp;We know they were in the manager's office and we're told
                 they have looked at security footage to determine if they can ID the culprit.</p>
             <p>
-                <img alt="0226-SUB-london-hotel-swipe-tmz-02" src="http://ll-media.tmz.com/2015/02/26/0226-sub-london-hotel-swipe-tmz-11.jpg"
-                />
+                <img alt="0226-SUB-london-hotel-swipe-tmz-02" src="http://ll-media.tmz.com/2015/02/26/0226-sub-london-hotel-swipe-tmz-11.jpg">
             </p><a name="continued"></a>
         </div>
     </div>

--- a/test/test-pages/wapo-1/expected.html
+++ b/test/test-pages/wapo-1/expected.html
@@ -114,9 +114,8 @@
             <div class="inline-content inline-graphic-embedded">
                 <img class="unprocessed" data-hi-res-src="https://img.washingtonpost.com/rf/image_1484w/2010-2019/WashingtonPost/2015/03/18/Foreign/Graphics/tunisia600.jpg?uuid=1_yuLs2LEeSHME9HNBbnWQ"
                 data-low-res-src="https://img.washingtonpost.com/rf/image_480w/2010-2019/WashingtonPost/2015/03/18/Foreign/Graphics/tunisia600.jpg?uuid=1_yuLs2LEeSHME9HNBbnWQ"
-                src="https://img.washingtonpost.com/rf/image_480w/2010-2019/WashingtonPost/2015/03/18/Foreign/Graphics/tunisia600.jpg?uuid=1_yuLs2LEeSHME9HNBbnWQ"
-                />
-                <br/>
+                src="https://img.washingtonpost.com/rf/image_480w/2010-2019/WashingtonPost/2015/03/18/Foreign/Graphics/tunisia600.jpg?uuid=1_yuLs2LEeSHME9HNBbnWQ">
+                <br>
             </div>
             <p>Officials are worried about the number of Tunisian militants who may have
                 joined the jihadists in Libya — with the goal of returning home to fight

--- a/test/test-pages/wapo-2/expected.html
+++ b/test/test-pages/wapo-2/expected.html
@@ -96,7 +96,7 @@
         <p>“That could be an issue forced onto the agenda about the same time as
             a potential nuclear deal.”</p>
     </article>
-    <div><a href="http://www.washingtonpost.com/people/steven-mufson"><img class="post-body-headshot-left" src="http://img.washingtonpost.com/wp-apps/imrs.php?src=http://www.washingtonpost.com/blogs/wonkblog/files/2014/07/mufson_steve.jpg&amp;h=180&amp;w=180"/></a>
+    <div><a href="http://www.washingtonpost.com/people/steven-mufson"><img class="post-body-headshot-left" src="http://img.washingtonpost.com/wp-apps/imrs.php?src=http://www.washingtonpost.com/blogs/wonkblog/files/2014/07/mufson_steve.jpg&amp;h=180&amp;w=180"></a>
         <p
         class="post-body-bio has-photo">Steven Mufson covers the White House. Since joining The Post, he has covered
             economics, China, foreign policy and energy.</p>

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -1,6 +1,7 @@
 var path = require("path");
 var fs = require("fs");
 var prettyPrint = require("html").prettyPrint;
+var jsdom = require("jsdom").jsdom;
 var chai = require("chai");
 chai.config.includeStack = true;
 var expect = chai.expect;
@@ -50,7 +51,7 @@ var testPages = fs.readdirSync(testPageRoot).map(function(dir) {
 describe("Test page", function() {
   testPages.forEach(function(testPage) {
     describe(testPage.dir, function() {
-      var doc, result, metadata;
+      var doc, jsdomDoc, result, jsdomResult, metadata;
 
       var expectedMetadata = readJSON(testPage.expectedMetadata);
       var expectedContent = readFile(testPage.expected);
@@ -65,27 +66,36 @@ describe("Test page", function() {
 
       before(function() {
         doc = new JSDOMParser().parse(source);
+        jsdomDoc = jsdom(source);
         result = new Readability(uri, doc).parse();
+        jsdomResult = new Readability(uri, jsdomDoc).parse();
       });
 
       it("should return a result object", function() {
         expect(result).to.include.keys("content", "title", "excerpt", "byline");
+        expect(jsdomResult).to.include.keys("content", "title", "excerpt", "byline");
       });
 
-      it("should extract expected content", function() {
+      it("should extract expected content with JSDOMParser", function() {
         expect(expectedContent).eql(prettyPrint(result.content));
+      });
+      it("should extract expected content with jsdom", function() {
+        expect(expectedContent).eql(prettyPrint(jsdomResult.content));
       });
 
       it("should extract expected title", function() {
         expect(expectedMetadata.title).eql(result.title);
+        expect(expectedMetadata.title).eql(jsdomResult.title);
       });
 
       it("should extract expected byline", function() {
         expect(expectedMetadata.byline).eql(result.byline);
+        expect(expectedMetadata.byline).eql(jsdomResult.byline);
       });
 
       it("should extract expected excerpt", function() {
         expect(expectedMetadata.excerpt).eql(result.excerpt);
+        expect(expectedMetadata.excerpt).eql(jsdomResult.excerpt);
       });
     });
   });


### PR DESCRIPTION
This really needs careful review and probably another iteration or two.

There is 1 failing test, the TMZ one, with jsdom, because it contains a comment.

I don't want to add comment parsing to JSDOMParser.
I don't want to have different testcase output for jsdom.
I don't really want to strip all the comments explicitly because it'll need another DOM walk and is essentially useless.

Thoughts? @leibovic @n1k0 @DavidBruant 