### PR TITLE
Fix script parsing to ignore closing tags in comments

### DIFF
--- a/test/test-jsdomparser.js
+++ b/test/test-jsdomparser.js
@@ -208,3 +208,42 @@ describe("Test JSDOM functionality", function() {
     }
   });
 });
+
+
+describe("Script parsing", function() {
+  it("should strip ?-based comments within script tags", function() {
+    var html = '<script><?Silly test <img src="test"></script>';
+    var doc = new JSDOMParser().parse(html);
+    expect(doc.firstChild.tagName).eql("SCRIPT");
+    expect(doc.firstChild.textContent).eql("");
+    expect(doc.firstChild.children.length).eql(0);
+    expect(doc.firstChild.childNodes.length).eql(1);
+  });
+
+  it("should strip !-based comments within script tags", function() {
+    var html = '<script><!--Silly test > <script src="foo.js"></script>--></script>';
+    var doc = new JSDOMParser().parse(html);
+    expect(doc.firstChild.tagName).eql("SCRIPT");
+    expect(doc.firstChild.textContent).eql("");
+    expect(doc.firstChild.children.length).eql(0);
+    expect(doc.firstChild.childNodes.length).eql(1);
+  });
+
+  it("should strip any other nodes within script tags", function() {
+    var html = "<script><div>Hello, I'm not really in a </div></script>";
+    var doc = new JSDOMParser().parse(html);
+    expect(doc.firstChild.tagName).eql("SCRIPT");
+    expect(doc.firstChild.textContent).eql("<div>Hello, I'm not really in a </div>");
+    expect(doc.firstChild.children.length).eql(0);
+    expect(doc.firstChild.childNodes.length).eql(1);
+  });
+
+  it("should not be confused by partial closing tags", function() {
+    var html = "<script>var x = '<script>Hi<' + '/script>';</script>";
+    var doc = new JSDOMParser().parse(html);
+    expect(doc.firstChild.tagName).eql("SCRIPT");
+    expect(doc.firstChild.textContent).eql("var x = '<script>Hi<' + '/script>';");
+    expect(doc.firstChild.children.length).eql(0);
+    expect(doc.firstChild.childNodes.length).eql(1);
+  });
+});

--- a/test/test-pages/comment-inside-script-parsing/expected-metadata.json
+++ b/test/test-pages/comment-inside-script-parsing/expected-metadata.json
@@ -1,0 +1,5 @@
+{
+  "title": "Test script parsing",
+  "byline": null,
+  "excerpt": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n        tempor incididunt ut labore et dolore magna aliqua."
+}

--- a/test/test-pages/comment-inside-script-parsing/expected.html
+++ b/test/test-pages/comment-inside-script-parsing/expected.html
@@ -1,0 +1,19 @@
+<div id="readability-page-1" class="page">
+    <div>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua.</p>
+        <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+            ut aliquip ex ea commodo consequat.</p>
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+            dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+            proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div>
+        <p>Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+            quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat.</p>
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+            dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+            proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+</div>

--- a/test/test-pages/comment-inside-script-parsing/source.html
+++ b/test/test-pages/comment-inside-script-parsing/source.html
@@ -1,0 +1,34 @@
+<html>
+  <head><title>Test script parsing</title></head>
+<body>
+  <script>
+    <!--
+    Silly test
+    <script src="foo.js"></script>
+    -->
+  </script>
+  <article>
+    <h1>Lorem</h1>
+    <div>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat.</p>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <h2>Foo</h2>
+    <div>
+      <p>Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat.</p>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur.
+      Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+  </article>
+</body>
+</html>


### PR DESCRIPTION
r? @n1k0 and/or @leibovic

This should fix #77, but I've not tested that, just the reduced testcase in this commit.