### PR TITLE
Add benchmark for readability and show averages by using custom reporter

### DIFF
--- a/benchmark-reporter.js
+++ b/benchmark-reporter.js
@@ -1,0 +1,41 @@
+var matchaPath = require.resolve('matcha');
+var path = require('path');
+
+var clean = require('matcha/lib/matcha/reporters/clean'));
+
+function average(list) {
+  if (!list.length)
+    return 0;
+
+  var sum = list.reduce(function(previous, current) { return previous + current; });
+  return (sum / list.length).toFixed(0);
+}
+
+
+// Like clean, but also produces an average:
+module.exports = function(runner, utils) {
+  var humanize = utils.humanize;
+  var padBefore = utils.padBefore;
+  var color = utils.color;
+  var results = {};
+  var currentResults = [];
+  runner.on('bench end', function(results) {
+    currentResults.push(results.ops);
+  });
+  runner.on('suite end', function(suite) {
+    var avg = humanize(average(currentResults));
+    console.log(padBefore(avg + ' op/s', 22) + ' » ' + suite.title);
+    console.log();
+    results[suite.title] = avg;
+    currentResults = [];
+  });
+
+  runner.on('end', function() {
+    for (var k in results) {
+      console.log(color(padBefore(k, 30) + ':  ', 'gray') + results[k] + ' op/s');
+    }
+    console.log();
+  });
+
+  clean(runner, utils);
+};

--- a/benchmarks.js
+++ b/benchmarks.js
@@ -26,13 +26,33 @@ if (process.env.READABILITY_PERF_REFERENCE === "1") {
   });
 }
 
-suite("Readability test page perf", function () {
+suite("JSDOMParser test page perf", function () {
   set("iterations", 1);
   set("type", "static");
 
   testPages.forEach(function(testPage) {
-    bench(testPage.dir + " perf", function() {
+    bench(testPage.dir + " document parse perf", function() {
       new JSDOMParser().parse(testPage.source);
+    });
+  });
+});
+
+
+suite("Readability test page perf", function () {
+  set("iterations", 1);
+  set("type", "static");
+
+  var uri = {
+    spec: "http://fakehost/test/page.html",
+    host: "fakehost",
+    prePath: "http://fakehost",
+    scheme: "http",
+    pathBase: "http://fakehost/test"
+  };
+  testPages.forEach(function(testPage) {
+    var doc = new JSDOMParser().parse(testPage.source);
+    bench(testPage.dir + " readability perf", function() {
+      new Readability(uri, doc).parse();
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha test/test-*.js",
     "generate-testcase": "node test/generate-testcase.js",
     "perf": "matcha benchmarks.js",
-    "perf-reference": "READABILITY_PERF_REFERENCE=1 matcha benchmarks.js"
+    "perf-reference": "READABILITY_PERF_REFERENCE=1 matcha --reporter ./benchmark-reporter.js benchmarks.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@n1k0 noticed two issues:

1. We were only testing JSDOMParser instead of testing Readability
2. It was hard to interpret the results because the test time is meant to stay the same (that's what iterations are for) so we still had to inspect the number of operations/second for each file.

I added a custom reporter that fixes (2) and added a second benchmark suite that fixes (1). Does this all make sense?

PS: should we do a separate PR to move this all into a subdir like "benchmarks" or "lib" or whatever? Having this stuff in the toplevel seems ugly...