### PR TITLE
Fixed broken benchmark reporter code, moved benchmark code to its own folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Combo time:
 
     $ mocha test/test-*.js -w -g 001
 
+## Benchmarks
+
+Benchmarks for all test pages:
+
+    $ npm run perf
+
+Reference benchmark:
+
+    $ npm run perf-reference
+
 ## License
 
     Copyright (c) 2010 Arc90 Inc

--- a/benchmarks/benchmark-reporter.js
+++ b/benchmarks/benchmark-reporter.js
@@ -1,7 +1,4 @@
-var matchaPath = require.resolve('matcha');
-var path = require('path');
-
-var clean = require('matcha/lib/matcha/reporters/clean'));
+var clean = require('matcha/lib/matcha/reporters/clean');
 
 function average(list) {
   if (!list.length)

--- a/benchmarks/benchmarks.js
+++ b/benchmarks/benchmarks.js
@@ -1,6 +1,6 @@
-var getTestPages = require("./test/bootstrap").getTestPages;
+var getTestPages = require("../test/bootstrap").getTestPages;
 
-var readability = require("./index.js");
+var readability = require("../index.js");
 var Readability = readability.Readability;
 var JSDOMParser = readability.JSDOMParser;
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "mocha test/test-*.js",
     "generate-testcase": "node test/generate-testcase.js",
-    "perf": "matcha benchmarks.js",
-    "perf-reference": "READABILITY_PERF_REFERENCE=1 matcha --reporter ./benchmark-reporter.js benchmarks.js"
+    "perf": "matcha benchmarks/benchmarks.js",
+    "perf-reference": "READABILITY_PERF_REFERENCE=1 matcha --reporter ./benchmarks/benchmark-reporter.js benchmarks/benchmarks.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
r=? @leibovic @gijsk 