### PR TITLE
Bug 1150695 - Move isProbablyReaderable function to Readability.js

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1561,6 +1561,39 @@ Readability.prototype = {
   },
 
   /**
+   * Decides whether or not the document is reader-able without parsing the whole thing.
+   *
+   * @return boolean Whether or not we suspect parse() will suceeed at returning an article object.
+   */
+  isProbablyReaderable: function() {
+    var nodes = this._doc.getElementsByTagName("p");
+    if (nodes.length < 5) {
+      return false;
+    }
+
+    var possibleParagraphs = 0;
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      var matchString = node.className + " " + node.id;
+
+      if (this.REGEXPS.unlikelyCandidates.test(matchString) &&
+          !this.REGEXPS.okMaybeItsACandidate.test(matchString)) {
+        continue;
+      }
+
+      if (node.textContent.trim().length < 100) {
+        continue;
+      }
+
+      possibleParagraphs++;
+      if (possibleParagraphs >= 5) {
+        return true;
+      }
+    }
+    return false;
+  },
+
+  /**
    * Runs readability.
    *
    * Workflow:

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -9,6 +9,23 @@ var JSDOMParser = readability.JSDOMParser;
 
 var testPages = require("./bootstrap").getTestPages();
 
+describe("Test isProbablyReaderable", function() {
+  testPages.forEach(function(testPage) {
+    describe(testPage.dir, function() {
+      var doc, isProbablyReaderable;
+
+      before(function() {
+        doc = new JSDOMParser().parse(testPage.source);
+        isProbablyReaderable = new Readability(null, doc).isProbablyReaderable();
+      });
+
+      it("should probably be readerable", function() {
+        expect(isProbablyReaderable).eql(true);
+      });
+    });
+  });
+});
+
 describe("Test page", function() {
   testPages.forEach(function(testPage) {
     describe(testPage.dir, function() {


### PR DESCRIPTION
f? @n1k0 

This should address https://github.com/mozilla/readability/issues/85

I added a simple test for this, but we fail to detect that some of our test pages are "probably readerable", so we'll either need to update `isProbablyReaderable` to be more lenient (long term solution) or find a way to hide these test failures (short term solution).