### PR TITLE
Fixes #99 - Fixed JSDOMParser tag name case handling.

### DIFF
--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -962,7 +962,7 @@
      */
     match: function (str) {
       var strlen = str.length;
-      if (this.html.substr(this.currentChar, strlen) === str) {
+      if (this.html.substr(this.currentChar, strlen).toLowerCase() === str.toLowerCase()) {
         this.currentChar += strlen;
         return true;
       }
@@ -1058,7 +1058,7 @@
      */
     readNode: function () {
       var c = this.nextChar();
- 
+
       if (c === undefined)
         return null;
 

--- a/test/test-jsdomparser.js
+++ b/test/test-jsdomparser.js
@@ -267,3 +267,16 @@ describe("Script parsing", function() {
     expect(doc.firstChild.childNodes.length).eql(1);
   });
 });
+
+describe("Tag local name case handling", function() {
+  it("should lowercase tag names", function() {
+    var html = "<DIV><svG><clippath/></svG></DIV>";
+    var doc = new JSDOMParser().parse(html);
+    expect(doc.firstChild.tagName).eql("DIV");
+    expect(doc.firstChild.localName).eql("div");
+    expect(doc.firstChild.firstChild.tagName).eql("SVG");
+    expect(doc.firstChild.firstChild.localName).eql("svg");
+    expect(doc.firstChild.firstChild.firstChild.tagName).eql("CLIPPATH");
+    expect(doc.firstChild.firstChild.firstChild.localName).eql("clippath");
+  });
+});

--- a/test/test-pages/svg-parsing/expected-metadata.json
+++ b/test/test-pages/svg-parsing/expected-metadata.json
@@ -1,0 +1,6 @@
+{
+  "title": "SVG parsing",
+  "byline": null,
+  "excerpt": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\ntempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\nquis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\nconsequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\ncillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non\nproident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  "readerable": true
+}

--- a/test/test-pages/svg-parsing/expected.html
+++ b/test/test-pages/svg-parsing/expected.html
@@ -1,0 +1,44 @@
+<div id="readability-page-1" class="page">
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <svg
+    version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 50 50" height="50" width="50">
+        <g>
+            <clippath id="hex-mask-large">
+                <polygon points="15,35 10,35 10,0 10,0 45,0 45,35 45,35 25,35 15,43"></polygon>
+            </clippath>
+            <clippath id="hex-mask-small">
+                <polygon points="5,1 5,16 3,23 10,20 24,20 24,1"></polygon>
+            </clippath>
+        </g>
+        </svg>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+            quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+            cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+            non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+            quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+            cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+            non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+            quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+            cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+            non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>

--- a/test/test-pages/svg-parsing/source.html
+++ b/test/test-pages/svg-parsing/source.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SVG parsing</title>
+</head>
+<body>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<svg version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" height="50" width="50" style="position: absolute;">
+  <g>
+    <clipPath id="hex-mask-large"><polygon points="15,35 10,35 10,0 10,0 45,0 45,35 45,35 25,35 15,43"/></clipPath>
+    <clipPath id="hex-mask-small"><polygon points="5,1 5,16 3,23 10,20 24,20 24,1"/></clipPath>
+  </g>
+</svg>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</body>
+</html>


### PR DESCRIPTION
Okay so this patch fixes #99 from the JSDOMParser side of things, but unfortunately it appears that jsdom related tests are now failing. This is because jsdom serializer forces lowercasing tag names:

```
$ node
> jsdom = require("jsdom").jsdom
> serialize = require("jsdom").serializeDocument
> serialize(jsdom("<html><body><svg><clipPath/></svg></body></html>"))
'<html><head></head><body><svg><clippath></clippath></svg></body></html>'
```

I suspect jsdom shouldn't alter tag name case that way. Dunno what to do, thoughts?