### PR TITLE
Fixed test result output was sent at once.

### DIFF
--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -10,32 +10,6 @@ var JSDOMParser = readability.JSDOMParser;
 
 var testPages = require("./bootstrap").getTestPages();
 
-function suite(result, expectedContent, expectedMetadata) {
-  it("should return a result object", function() {
-    expect(result).to.include.keys("content", "title", "excerpt", "byline");
-  });
-
-  it("should extract expected content", function() {
-    expect(expectedContent).eql(prettyPrint(result.content));
-  });
-
-  it("should extract expected title", function() {
-    expect(expectedMetadata.title).eql(result.title);
-  });
-
-  it("should extract expected byline", function() {
-    expect(expectedMetadata.byline).eql(result.byline);
-  });
-
-  it("should extract expected excerpt", function() {
-    expect(expectedMetadata.excerpt).eql(result.excerpt);
-  });
-
-  it("should probably be readerable", function() {
-    expect(expectedMetadata.readerable).eql(result.readerable);
-  });
-}
-
 function removeCommentNodesRecursively(node) {
   [].forEach.call(node.childNodes, function(child) {
     if (child.nodeType === child.COMMENT_NODE) {
@@ -58,27 +32,83 @@ describe("Test page", function() {
       };
 
       describe("jsdom", function() {
-        var doc = jsdom(testPage.source, {
-          features: {
-            FetchExternalResources: false,
-            ProcessExternalResources: false
-          }
+        var result;
+
+        before(function() {
+          var doc = jsdom(testPage.source, {
+            features: {
+              FetchExternalResources: false,
+              ProcessExternalResources: false
+            }
+          });
+          removeCommentNodesRecursively(doc);
+          var readability = new Readability(uri, doc);
+          var readerable = readability.isProbablyReaderable();
+
+          result = readability.parse();
+          result.readerable = readerable;
         });
-        removeCommentNodesRecursively(doc);
-        var readability = new Readability(uri, doc);
-        var readerable = readability.isProbablyReaderable();
-        var result = readability.parse();
-        result.readerable = readerable;
-        suite(result, testPage.expectedContent, testPage.expectedMetadata);
+
+        it("should return a result object", function() {
+          expect(result).to.include.keys("content", "title", "excerpt", "byline");
+        });
+
+        it("should extract expected content", function() {
+          expect(testPage.expectedContent).eql(prettyPrint(result.content));
+        });
+
+        it("should extract expected title", function() {
+          expect(testPage.expectedMetadata.title).eql(result.title);
+        });
+
+        it("should extract expected byline", function() {
+          expect(testPage.expectedMetadata.byline).eql(result.byline);
+        });
+
+        it("should extract expected excerpt", function() {
+          expect(testPage.expectedMetadata.excerpt).eql(result.excerpt);
+        });
+
+        it("should probably be readerable", function() {
+          expect(testPage.expectedMetadata.readerable).eql(result.readerable);
+        });
       });
 
       describe("JSDOMParser", function() {
-        var doc = new JSDOMParser().parse(testPage.source);
-        var readability = new Readability(uri, doc);
-        var readerable = readability.isProbablyReaderable();
-        var result = readability.parse();
-        result.readerable = readerable;
-        suite(result, testPage.expectedContent, testPage.expectedMetadata);
+        var result;
+
+        before(function() {
+          var doc = new JSDOMParser().parse(testPage.source);
+          var readability = new Readability(uri, doc);
+          var readerable = readability.isProbablyReaderable();
+
+          result = readability.parse();
+          result.readerable = readerable;
+        });
+
+        it("should return a result object", function() {
+          expect(result).to.include.keys("content", "title", "excerpt", "byline");
+        });
+
+        it("should extract expected content", function() {
+          expect(testPage.expectedContent).eql(prettyPrint(result.content));
+        });
+
+        it("should extract expected title", function() {
+          expect(testPage.expectedMetadata.title).eql(result.title);
+        });
+
+        it("should extract expected byline", function() {
+          expect(testPage.expectedMetadata.byline).eql(result.byline);
+        });
+
+        it("should extract expected excerpt", function() {
+          expect(testPage.expectedMetadata.excerpt).eql(result.excerpt);
+        });
+
+        it("should probably be readerable", function() {
+          expect(testPage.expectedMetadata.readerable).eql(result.readerable);
+        });
       });
     });
   });


### PR DESCRIPTION
In b1f6c62b2512e3350f46bfd5ddb3761ad689667f we refactored the tests for readability so they share a suite between jsdom and JSDOMParser; though this introduced a strange behavior for the test runner, which is displaying all the test output at once since, instead of realtime as previously.

This patch addresses this issue.

r=? @leibovic @gijsk 