### PR TITLE
Detect search engine results pages and make sure isProbablyReaderable returns false

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1642,6 +1642,13 @@ Readability.prototype = {
    * @return boolean Whether or not we suspect parse() will suceeed at returning an article object.
    */
   isProbablyReaderable: function() {
+    var nodes = this._doc.getElementsByTagName('input');
+    for (var i = 0; i < nodes.length; i++) {
+    if (nodes[i].value != '' && nodes[i].value.length > 3 && this._doc.title.replace(/\W/g, '').indexOf(nodes[i].value.replace(/\W/g, '')) != - 1 && this._doc.URL.replace(/\W/g, '').indexOf(nodes[i].value.replace(/\W/g, '')) != - 1)  
+    {
+      return false;
+    }
+  }
     var nodes = this._doc.getElementsByTagName("p");
     if (nodes.length < 5) {
       return false;


### PR DESCRIPTION
This should detect search engine results pages and make isProbablyReaderable return false.
It's not perfect though, as it will have some false positives (some search results will slip through).
But it seems to do the job quite well. Maybe it's worth taking a look at? Thanks.
https://bugzilla.mozilla.org/show_bug.cgi?id=1151087