### PR TITLE
Fixes #163 - Avoid including footer tag contents.

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -389,6 +389,7 @@ Readability.prototype = {
     this._clean(articleContent, "object");
     this._clean(articleContent, "embed");
     this._clean(articleContent, "h1");
+    this._clean(articleContent, "footer");
 
     // If there is only one h2, they are probably using it as a header
     // and not a subheader, so remove it since we already have a header.

--- a/test/test-pages/002/expected.html
+++ b/test/test-pages/002/expected.html
@@ -565,14 +565,5 @@ res.<span>text</span><span>(</span><span>)</span>.<span>catch</span><span>(</spa
 Kelly for helping with the specification and implementation.</em>
 
             </p>
-            <footer class="entry-meta">
-                <p>Posted by <a href="https://hacks.mozilla.org/author/nmarathemozilla-com/"
-                    title="Posts by Nikhil Marathe" class="url fn" rel="author">Nikhil Marathe</a>
-on
-                    <time
-                    datetime="2015-03-10T08:05:41-07:00">March 10, 2015</time>at
-                        <time datetime="PDT08:05:41-07:00">08:05</time>
-                </p>
-            </footer>
             </article>
             </div>

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -22,7 +22,7 @@ function runTestsWithItems(label, beforeFn, expectedContent, expectedMetadata) {
     });
 
     it("should extract expected content", function() {
-      expect(expectedContent).eql(prettyPrint(result.content));
+      expect(expectedContent.split("\n")).eql(prettyPrint(result.content).split("\n"));
     });
 
     it("should extract expected title", function() {


### PR DESCRIPTION
This patch removes all `<footer>` tags and their contents. It also dramatically improves readability of large string diffs by turning them to arrays of lines:

![screen shot 2015-04-17 at 17 31 54](https://cloud.githubusercontent.com/assets/41547/7205216/02dafab6-e528-11e4-98ee-78245c57aab0.png)

r=? @gijsk @leibovic 