### PR TITLE
Added support for getElementsByClassName to JSDOMParser.

### DIFF
--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -313,6 +313,16 @@
     return elems;
   }
 
+  function getElementsByClassName(classname) {
+    var elems = [];
+    var re = new RegExp('(^| )' + classname + '( |$)');
+    var nodes = this.getElementsByTagName("*");
+    for (var i=0, j=nodes.length; i<j; i++)
+      if (re.test(nodes[i].className))
+        elems.push(nodes[i]);
+    return elems;
+  }
+
   var Node = function () {};
 
   Node.prototype = {
@@ -571,6 +581,8 @@
 
     getElementsByTagName: getElementsByTagName,
 
+    getElementsByClassName: getElementsByClassName,
+
     getElementById: function (id) {
       function getElem(node) {
         var length = node.children.length;
@@ -614,6 +626,8 @@
     nodeType: Node.ELEMENT_NODE,
 
     getElementsByTagName: getElementsByTagName,
+
+    getElementsByClassName: getElementsByClassName,
 
     get className() {
       return this.getAttribute("class") || "";

--- a/test/test-jsdomparser.js
+++ b/test/test-jsdomparser.js
@@ -282,3 +282,36 @@ describe("Tag local name case handling", function() {
     expect(doc.firstChild.firstChild.firstChild.localName).eql("clippath");
   });
 });
+
+describe("#getElementsByClassName", function() {
+  var doc;
+
+  beforeEach(function() {
+    var html = '<div>' +
+    '  <div class="foo bar">plop</div>' +
+    '  <div class="bar">plap</div>' +
+    '  <p>baz</p>' +
+    '</div>';
+    doc = new JSDOMParser().parse(html);
+  });
+
+  it("should find elements having provided class name", function() {
+    expect(doc.getElementsByClassName("foo")).to.have.length.of(1);
+  });
+
+  it("shouldn't find unmacthing elements", function() {
+    expect(doc.getElementsByClassName("baz")).to.have.length.of(0);
+  });
+
+  it("should retrieve multiple elements matching a single class name", function() {
+    expect(doc.getElementsByClassName("bar")).to.have.length.of(2);
+  });
+
+  it("should search combined class names", function() {
+    expect(doc.getElementsByClassName("foo bar")).to.have.length.of(1);
+  });
+
+  it("should perform a case-sensitive search", function() {
+    expect(doc.getElementsByClassName("FOO")).to.have.length.of(0);
+  });
+});


### PR DESCRIPTION
While debugging _things_, I've added support for `getElementsByClassName` to JSDOMParser. It's convenient while not too slow, though I still miss a good use case for readability just yet.

Let me isolate and park this work here for now, so if we ever need it, there it is.
