### PR TITLE
Fixes #150 - Keep article intermediary headings.

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1655,7 +1655,7 @@ Readability.prototype = {
     for (var headerIndex = 1; headerIndex < 3; headerIndex += 1) {
       var headers = e.getElementsByTagName('h' + headerIndex);
       for (var i = headers.length - 1; i >= 0; i -= 1) {
-        if (this._getClassWeight(headers[i]) < 0 || this._getLinkDensity(headers[i]) > 0.33)
+        if (this._getClassWeight(headers[i]) < 0)
           headers[i].parentNode.removeChild(headers[i]);
       }
     }

--- a/test/test-pages/lwn-1/expected-metadata.json
+++ b/test/test-pages/lwn-1/expected-metadata.json
@@ -1,0 +1,6 @@
+{
+  "title": "LWN.net Weekly Edition for March 26, 2015 [LWN.net]",
+  "byline": "By Nathan Willis\n                                            March 25, 2015",
+  "excerpt": "The Arduino has been one of the biggest success stories of the open-hardware movement, but that success does not protect it from internal conflict. In recent months, two of the project's founders have come into conflict about the direction of future efforts—and that conflict has turned into a legal dispute about who owns the rights to the Arduino trademark.",
+  "readerable": true
+}

--- a/test/test-pages/lwn-1/expected.html
+++ b/test/test-pages/lwn-1/expected.html
@@ -1,0 +1,576 @@
+<div id="readability-page-1" class="page">
+    <div class="ArticleText">
+        <h2 class="SummaryHL"><a href="http://fakehost/Articles/637755/">A trademark battle in the Arduino community</a></h2>
+        <p>The <a href="https://en.wikipedia.org/wiki/Arduino">Arduino</a> has been one of the biggest success stories of the open-hardware movement, but that success does not protect it from internal conflict. In recent months, two of the project's founders have come into conflict about the direction of future efforts—and that conflict has turned into a legal dispute about who owns the rights to the Arduino trademark. </p>
+        <p>The current fight is a battle between two companies that both bear the Arduino name: Arduino LLC and Arduino SRL. The disagreements that led to present state of affairs go back a bit further. </p>
+        <p>The Arduino project grew out of 2005-era course work taught at the Interaction Design Institute Ivrea (IDII) in Ivrea, Italy (using <a href="https://en.wikipedia.org/wiki/Processing_(programming_language)">Processing</a>, <a href="https://en.wikipedia.org/wiki/Wiring_%28development_platform%29">Wiring</a>, and pre-existing microcontroller hardware). After the IDII program was discontinued, the open-hardware Arduino project as we know it was launched by Massimo Banzi, David Cuartielles, and David Mellis (who had worked together at IDII), with co-founders Tom Igoe and Gianluca Martino joining shortly afterward. The project released open hardware designs (including full schematics and design files) as well as the microcontroller software to run on the boards and the desktop IDE needed to program it. </p>
+        <p>Arduino LLC was incorporated in 2008 by Banzi, Cuartielles, Mellis, Igoe, and Martino. The company is registered in the United States, and it has continued to design the Arduino product line, develop the software, and run the Arduino community site. The hardware devices themselves, however, were manufactured by a separate company, "Smart Projects SRL," that was founded by Martino. "SRL" is essentially the Italian equivalent of "LLC"—Smart Projects was incorporated in Italy. </p>
+        <p>This division of responsibilities—with the main Arduino project handling everything except for board manufacturing—may seem like an odd one, but it is consistent with Arduino's marketing story. From its earliest days, the designs for the hardware have been freely available, and outside companies were allowed to make Arduino-compatible devices. The project has long run a <a href="http://arduino.cc/en/ArduinoCertified/Products#program">certification
+program</a> for third-party manufacturers interested in using the "Arduino" branding, but allows (and arguably even encourages) informal software and firmware compatibility. </p>
+        <p>The Arduino branding was not formally registered as a trademark in the early days, however. Arduino LLC <a href="http://tsdr.uspto.gov/#caseNumber=3931675&amp;caseType=US_REGISTRATION_NO&amp;searchType=statusSearch">filed</a> to register the US trademark in April 2009, and it was granted in 2011. </p>
+        <p>At this point, the exact events begin to be harder to verify, but the original group of founders reportedly had a difference of opinion about how to license out hardware production rights to other companies. Wired Italy <a href="http://www.wired.it/gadget/computer/2015/02/12/arduino-nel-caos-situazione/">reports</a> that Martino and Smart Projects resisted the other four founders' plans to "internationalize" production—although it is not clear if that meant that Smart Projects disapproved of licensing out <em>any</em> official hardware manufacturing to other companies, or had some other concern. Heise Online <a href="http://www.heise.de/make/meldung/Arduino-gegen-Arduino-Gruender-streiten-um-die-Firma-2549653.html">adds</a> that the conflict seemed to be about moving some production to China. </p>
+        <p>What is clear is that Smart Projects filed a <a href="http://ttabvue.uspto.gov/ttabvue/v?pno=92060077&amp;pty=CAN&amp;eno=1">petition</a> with the US Patent and Trademark Office (USPTO) in October 2014 asking the USPTO to cancel Arduino LLC's trademark on "Arduino." Then, in November 2014, Smart Projects changed its company's name to Arduino SRL. Somewhere around that time, Martino sold off his ownership stake in Smart Projects SRL and new owner Federico Musto was named CEO. </p>
+        <p>Unsurprisingly, Arduino LLC did not care for the petition to the USPTO and, in January 2015, the company filed a trademark-infringement <a href="http://dockets.justia.com/docket/massachusetts/madce/1:2015cv10181/167131">lawsuit</a> against Arduino SRL. Confusing matters further, the re-branded Arduino SRL has set up its own web site using the domain name <tt>arduino.org</tt>, which duplicates most of the site features found on the original Arduino site (<tt>arduino.cc</tt>). That includes both a hardware store and software downloads. </p>
+        <p>Musto, the new CEO of the company now called Arduino SRL, has a bit of a history with Arduino as well. His other manufacturing business had <a href="http://www.eetimes.com/document.asp?doc_id=1263246">collaborated</a> with Arduino LLC on the design and production of the Arduino Yún, which has received some <a href="http://hackaday.com/2015/02/24/is-the-arduino-yun-open-hardware/">criticism</a> for including proprietary components. </p>
+        <p>Hackaday has run a two-part series (in <a href="http://hackaday.com/2015/02/25/arduino-v-arduino/">February</a> and <a href="http://hackaday.com/2015/03/12/arduino-v-arduino-part-ii/">March</a>) digging into the ins and outs of the dispute, including the suggestion that Arduino LLC's recent release of version 1.6.0 of the Arduino IDE was a move intended to block Arduino SRL from hijacking IDE development. Commenter Paul Stoffregen (who was the author of the Heise story above) <a href="http://hackaday.com/2015/02/25/arduino-v-arduino/comment-page-1/#comment-2453084">noted</a> that Arduino SRL recently created a fork of the Arduino IDE on GitHub. </p>
+        <p>Most recently, Banzi broke his silence about the dispute in a <a href="http://makezine.com/2015/03/19/massimo-banzi-fighting-for-arduino">story</a> published at MAKEzine. There, Banzi claims that Martino secretly filed a trademark application on "Arduino" in Italy in 2008 and told none of the other Arduino founders. He also details a series of unpleasant negotiations between the companies, including Smart Projects stopping the royalty payments it had long sent to Arduino LLC for manufacturing devices and re-branding its boards with the Arduino.org URL. </p>
+        <p>Users appear to be stuck in the middle. Banzi says that several retail outlets that claim to be selling "official" Arduino boards are actually paying Arduino SRL, not Arduino LLC, but it is quite difficult to determine which retailers are lined up on which side, since there are (typically) several levels of supplier involved. The two Arduino companies' web sites also disagree about the available hardware, with Arduino.org offering the new <a href="http://arduino.org/products/arduino-zero-pro">Arduino Zero</a> model for sale today and Arduino.cc <a href="http://arduino.cc/en/Main/Products">listing it</a> as "Coming soon." </p>
+        <p>Furthermore, as Hackaday's March story explains, the recently-released Arduino.cc IDE now reports that boards manufactured by Arduino SRL are "uncertified." That warning does not prevent users from programming the other company's hardware, but it will no doubt confuse quite a few users who believe they possess genuine Arduino-manufactured devices. </p>
+        <p>The USPTO page for Arduino SRL's petition notes pre-trial disclosure dates have been set for August and October of 2015 (for Arduino SRL and Arduino LLC, respectively), which suggests that this debate is far from over. Of course, it is always disappointing to observe a falling out between project founders, particularly when the project in question has had such an impact on open-source software and open hardware. </p>
+        <p>One could argue that disputes of this sort are proof that even small projects started among friends need to take legal and intellectual-property issues (such as trademarks) seriously from the very beginning—perhaps Arduino and Smart Projects thought that an informal agreement was all that was necessary in the early days, after all. </p>
+        <p>But, perhaps, once a project becomes profitable, there is simply no way to predict what might happen. Arduino LLC would seem to have a strong case for continual and rigorous use of the "Arduino" trademark, which is the salient point in US trademark law. It could still be a while before the courts rule on either side of that question, however. </p>
+        <p><a href="http://fakehost/Articles/637755/#Comments">Comments (5 posted)</a> </p>
+        <h2 class="SummaryHL"><a href="http://fakehost/Articles/637533/">Mapping and data mining with QGIS 2.8</a></h2>
+        <p class="FeatureByline"> By <b>Nathan Willis</b>
+            <br>March 25, 2015 </p>
+        <p><a href="http://qgis.org/">QGIS</a> is a free-software geographic information system (GIS) tool; it provides a unified interface in which users can import, edit, and analyze geographic-oriented information, and it can produce output as varied as printable maps or map-based web services. The project recently made its first update to be designated a long-term release (LTR), and that release is both poised for high-end usage and friendly to newcomers alike. </p>
+        <p>The new release is version 2.8, which was unveiled on March&nbsp;2. An official <a href="http://qgis.org/en/site/forusers/visualchangelog28/index.html">change
+log</a> is available on the QGIS site, while the release itself was announced primarily through blog posts (such as <a href="http://anitagraser.com/2015/03/02/qgis-2-8-ltr-has-landed/">this
+post</a> by Anita Graser of the project's steering committee). Downloads are <a href="http://qgis.org/en/site/forusers/download.html">available</a> for a variety of platforms, including packages for Ubuntu, Debian, Fedora, openSUSE, and several other distributions.</p>
+        <a href="http://fakehost/Articles/637747/"> <img src="http://fakehost/images/2015/03-qgis-map-sm.png" border="0" hspace="5" align="right" width="350" height="264" alt="[QGIS main interface]"> </a>
+        <p>As the name might suggest, QGIS is a Qt application; the latest release will, in fact, build on both Qt4 and Qt5, although the binaries released by the project come only in Qt4 form at present. 2.8 has been labeled a long-term release (LTR)—which, in this case, means that the project has committed to providing backported bug fixes for one full calendar year, and that the 2.8.x series is in permanent feature freeze. The goal, according to the change log, is to provide a stable version suitable for businesses and deployments in other large organizations. The change log itself points out that the development of quite a few new features was underwritten by various GIS companies or university groups, which suggests that taking care of these organizations' needs is reaping dividends for the project. </p>
+        <p>For those new to QGIS (or GIS in general), there is a detailed new-user <a href="http://docs.qgis.org/testing/en/docs/training_manual/">tutorial</a> that provides a thorough walk-through of the data-manipulation, mapping, and analysis functions. Being a new user, I went through the tutorial; although there are a handful of minor differences between QGIS 2.8 and the version used in the text (primarily whether specific features were accessed through a toolbar or right-click menu), on the whole it is well worth the time. </p>
+        <p>QGIS is designed to make short work of importing spatially oriented data sets, mining information from them, and turning the results into a meaningful visualization. Technically speaking, the visualization output is optional: one could simply extract the needed statistics and results and use them to answer some question or, perhaps, publish the massaged data set as a database for others to use. </p>
+        <p>But well-made maps are often the easiest way to illuminate facts about populations, political regions, geography, and many other topics when human comprehension is the goal. QGIS makes importing data from databases, web-mapping services (WMS), and even unwieldy flat-file data dumps a painless experience. It handles converting between a variety of map-referencing systems more or less automatically, and allows the user to focus on finding the useful attributes of the data sets and rendering them on screen. </p>
+        <h4>Here be data</h4>
+        <p>The significant changes in QGIS 2.8 fall into several categories. There are updates to how QGIS handles the mathematical expressions and queries users can use to filter information out of a data set, improvements to the tools used to explore the on-screen map canvas, and enhancements to the "map composer" used to produce visual output. This is on top of plenty of other under-the-hood improvements, naturally.</p>
+        <a href="http://fakehost/Articles/637748/"> <img src="http://fakehost/images/2015/03-qgis-query-sm.png" border="0" hspace="5" align="left" width="300" height="302" alt="[QGIS query builder]"> </a>
+        <p>In the first category are several updates to the filtering tools used to mine a data set. Generally speaking, each independent data set is added to a QGIS project as its own layer, then transformed with filters to focus in on a specific portion of the original data. For instance, the land-usage statistics for a region might be one layer, while roads and buildings for the same region from OpenStreetMap might be two additional layers. Such filters can be created in several ways: there is a "query builder" that lets the user construct and test expressions on a data layer, then save the results, an SQL console for performing similar queries on a database, and spreadsheet-like editing tools for working directly on data tables. </p>
+        <p>All three have been improved in this release. New are support for <tt>if(condition, true, false)</tt> conditional statements, a set of operations for geometry primitives (e.g., to test whether regions overlap or lines intersect), and an "integer divide" operation. Users can also add comments to their queries to annotate their code, and there is a new <a href="http://nathanw.net/2015/01/19/function-editor-for-qgis-expressions/">custom
+function editor</a> for writing Python functions that can be called in mathematical expressions within the query builder. </p>
+        <p>It is also now possible to select only some rows in a table, then perform calculations just on the selection—previously, users would have to extract the rows of interest into a new table first. Similarly, in the SQL editor, the user can highlight a subset of the SQL query and execute it separately, which is no doubt helpful for debugging. </p>
+        <p>There have also been several improvements to the Python and Processing plugins. Users can now drag-and-drop Python scripts onto QGIS and they will be run automatically. Several new analysis algorithms are now available through the Processing interface that were previously Python-only; they include algorithms for generating grids of points or vectors within a region, splitting layers and lines, generating <a href="http://en.wikipedia.org/wiki/Hypsometric_curve">hypsometric
+curves</a>, refactoring data sets, and more. </p>
+        <h4>Maps in, maps out</h4>
+        <a href="http://fakehost/Articles/637749/"> <img src="http://fakehost/images/2015/03-qgis-simplify-sm.png" border="0" hspace="5" align="right" width="300" height="303" alt="[QGIS simplify tool]"> </a>
+        <p>The process of working with on-screen map data picked up some improvements in the new release as well. Perhaps the most fundamental is that each map layer added to the canvas is now handled in its own thread, so fewer hangs in the user interface are experienced when re-rendering a layer (as happens whenever the user changes the look of points or shapes in a layer). Since remote databases can also be layers, this multi-threaded approach is more resilient against connectivity problems, too. The interface also now supports temporary "scratch" layers that can be used to merge, filter, or simply experiment with a data set, but are not saved when the current project is saved. </p>
+        <p>For working on the canvas itself, polygonal regions can now use raster images (tiled, if necessary) as fill colors, the map itself can be rotated arbitrarily, and objects can be "snapped" to align with items on any layer (not just the current layer). For working with raster image layers (e.g., aerial photographs) or simply creating new geometric shapes by hand, there is a new digitizing tool that can offer assistance by locking lines to specific angles, automatically keeping borders parallel, and other niceties. </p>
+        <p>There is a completely overhauled "simplify" tool that is used to reduce the number of extraneous vertices of a vector layer (thus reducing its size). The old simplify tool provided only a relative "tolerance" setting that did not correspond directly to any units. With the new tool, users can set a simplification threshold in terms of the underlying map units, layer-specific units, pixels, and more—and, in addition, the tool reports how much the simplify operation has reduced the size of the data.</p>
+        <a href="http://fakehost/Articles/637751/"> <img src="http://fakehost/images/2015/03-qgis-style-sm.png" border="0" hspace="5" align="left" width="300" height="286" alt="[QGIS style editing]"> </a>
+        <p>There has also been an effort to present a uniform interface to one of the most important features of the map canvas: the ability to change the symbology used for an item based on some data attribute. The simplest example might be to change the line color of a road based on whether its road-type attribute is "highway," "service road," "residential," or so on. But the same feature is used to automatically highlight layer information based on the filtering and querying functionality discussed above. The new release allows many more map attributes to be controlled by these "data definition" settings, and provides a hard-to-miss button next to each attribute, through which a custom data definition can be set. </p>
+        <p>QGIS's composer module is the tool used to take project data and generate a map that can be used outside of the application (in print, as a static image, or as a layer for <a href="http://mapserver.org/">MapServer</a> or some other software tool, for example). Consequently, it is not a simple select-and-click-export tool; composing the output can involve a lot of choices about which data to make visible, how (and where) to label it, and how to make it generally accessible. </p>
+        <p>The updated composer in 2.8 now has a full-screen mode and sports several new options for configuring output. For instance, the user now has full control over how map axes are labeled. In previous releases, the grid coordinates of the map could be turned on or off, but the only options were all or nothing. Now, the user can individually choose whether coordinates are displayed on all four sides, and can even choose in which direction vertical text labels will run (so that they can be correctly justified to the edge of the map, for example). </p>
+        <p>There are, as usual, many more changes than there is room to discuss. Some particularly noteworthy improvements include the ability to save and load bookmarks for frequently used data sources (perhaps most useful for databases, web services, and other non-local data) and improvements to QGIS's server module. This module allows one QGIS instance to serve up data accessible to other QGIS applications (for example, to simply team projects). The server can now be extended with Python plugins and the data layers that it serves can be styled with style rules like those used in the desktop interface. </p>
+        <p>QGIS is one of those rare free-software applications that is both powerful enough for high-end work and yet also straightforward to use for the simple tasks that might attract a newcomer to GIS in the first place. The 2.8 release, particularly with its project-wide commitment to long-term support, appears to be an update well worth checking out, whether one needs to create a simple, custom map or to mine a database for obscure geo-referenced meaning. </p>
+        <p><a href="http://fakehost/Articles/637533/#Comments">Comments (3 posted)</a> </p>
+        <h2 class="SummaryHL"><a href="http://fakehost/Articles/637735/">Development activity in LibreOffice and OpenOffice</a></h2>
+        <p class="FeatureByline"> By <b>Jonathan Corbet</b>
+            <br>March 25, 2015 </p>
+        <p style="display: inline;" class="readability-styled"> The LibreOffice project was </p><a href="http://fakehost/Articles/407383/">announced</a>
+        <p style="display: inline;" class="readability-styled"> with great fanfare in September 2010. Nearly one year later, the OpenOffice.org project (from which LibreOffice was forked) </p><a href="http://fakehost/Articles/446093/">was
+cut loose from Oracle</a>
+        <p style="display: inline;" class="readability-styled"> and found a new home as an Apache project. It is fair to say that the rivalry between the two projects in the time since then has been strong. Predictions that one project or the other would fail have not been borne out, but that does not mean that the two projects are equally successful. A look at the two projects' development communities reveals some interesting differences. </p>
+        <h4>Release histories</h4>
+        <p> Apache OpenOffice has made two releases in the past year: <a href="https://blogs.apache.org/OOo/entry/the_apache_openoffice_project_announce">4.1</a> in April 2014 and <a href="https://blogs.apache.org/OOo/entry/announcing_apache_openoffice_4_1">4.1.1</a> (described as "a micro update" in the release announcement) in August. The main feature added during that time would appear to be significantly improved accessibility support. </p>
+        <p> The release history for LibreOffice tells a slightly different story: </p>
+        <blockquote> </blockquote>
+        <p> It seems clear that LibreOffice has maintained a rather more frenetic release cadence, generally putting out at least one release per month. The project typically keeps at least two major versions alive at any one time. Most of the releases are of the minor, bug-fix variety, but there have been two major releases in the last year as well. </p>
+        <h4>Development statistics</h4>
+        <p> In the one-year period since late March 2014, there have been 381 changesets committed to the OpenOffice Subversion repository. The most active committers are: </p>
+        <blockquote>
+            <table>
+                <tbody>
+                    <tr>
+                        <th colspan="2" align="center">Most active OpenOffice developers</th>
+                    </tr>
+                    <tr>
+                        <td width="50%" valign="top">
+                            <table cellspacing="3">
+                                <tbody>
+                                    <tr>
+                                        <th colspan="3">By changesets</th>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Herbert Dürr</td>
+                                        <td align="right">63</td>
+                                        <td align="right">16.6%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Jürgen&nbsp;Schmidt&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+                                        <td align="right">56</td>
+                                        <td align="right">14.7%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Armin Le Grand</td>
+                                        <td align="right">56</td>
+                                        <td align="right">14.7%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Oliver-Rainer&nbsp;Wittmann</td>
+                                        <td align="right">46</td>
+                                        <td align="right">12.1%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Tsutomu Uchino</td>
+                                        <td align="right">33</td>
+                                        <td align="right">8.7%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Kay Schenk</td>
+                                        <td align="right">27</td>
+                                        <td align="right">7.1%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Pedro Giffuni</td>
+                                        <td align="right">23</td>
+                                        <td align="right">6.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Ariel Constenla-Haile</td>
+                                        <td align="right">22</td>
+                                        <td align="right">5.8%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Andrea Pescetti</td>
+                                        <td align="right">14</td>
+                                        <td align="right">3.7%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Steve Yin</td>
+                                        <td align="right">11</td>
+                                        <td align="right">2.9%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Andre Fischer</td>
+                                        <td align="right">10</td>
+                                        <td align="right">2.6%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Yuri Dario</td>
+                                        <td align="right">7</td>
+                                        <td align="right">1.8%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Regina Henschel</td>
+                                        <td align="right">6</td>
+                                        <td align="right">1.6%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Juan C. Sanz</td>
+                                        <td align="right">2</td>
+                                        <td align="right">0.5%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Clarence Guo</td>
+                                        <td align="right">2</td>
+                                        <td align="right">0.5%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Tal Daniel</td>
+                                        <td align="right">2</td>
+                                        <td align="right">0.5%</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                        <td width="50%" valign="top">
+                            <table cellspacing="3">
+                                <tbody>
+                                    <tr>
+                                        <th colspan="3">By changed lines</th>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Jürgen&nbsp;Schmidt&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+                                        <td align="right">455499</td>
+                                        <td align="right">88.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Andre Fischer</td>
+                                        <td align="right">26148</td>
+                                        <td align="right">3.8%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Pedro Giffuni</td>
+                                        <td align="right">23183</td>
+                                        <td align="right">3.4%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Armin Le Grand</td>
+                                        <td align="right">11018</td>
+                                        <td align="right">1.6%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Juan C. Sanz</td>
+                                        <td align="right">4582</td>
+                                        <td align="right">0.7%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Oliver-Rainer Wittmann</td>
+                                        <td align="right">4309</td>
+                                        <td align="right">0.6%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Andrea Pescetti</td>
+                                        <td align="right">3908</td>
+                                        <td align="right">0.6%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Herbert Dürr</td>
+                                        <td align="right">2811</td>
+                                        <td align="right">0.4%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Tsutomu Uchino</td>
+                                        <td align="right">1991</td>
+                                        <td align="right">0.3%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Ariel Constenla-Haile</td>
+                                        <td align="right">1258</td>
+                                        <td align="right">0.2%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Steve Yin</td>
+                                        <td align="right">1010</td>
+                                        <td align="right">0.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Kay Schenk</td>
+                                        <td align="right">616</td>
+                                        <td align="right">0.1%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Regina Henschel</td>
+                                        <td align="right">417</td>
+                                        <td align="right">0.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Yuri Dario</td>
+                                        <td align="right">268</td>
+                                        <td align="right">0.0%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>tal</td>
+                                        <td align="right">16</td>
+                                        <td align="right">0.0%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Clarence Guo</td>
+                                        <td align="right">11</td>
+                                        <td align="right">0.0%</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </blockquote>
+        <p> In truth, the above list is not just the most active OpenOffice developers — it is all of them; a total of 16 developers have committed changes to OpenOffice in the last year. Those developers changed 528,000 lines of code, but, as can be seen above, Jürgen Schmidt accounted for the bulk of those changes, which were mostly updates to translation files. </p>
+        <p> The top four developers in the "by changesets" column all work for IBM, so IBM is responsible for a minimum of about 60% of the changes to OpenOffice in the last year. </p>
+        <p> The picture for LibreOffice is just a little bit different; in the same one-year period, the project has committed 22,134 changesets from 268 developers. The most active of these developers were: </p>
+        <blockquote>
+            <table>
+                <tbody>
+                    <tr>
+                        <th colspan="2" align="center">Most active LibreOffice developers</th>
+                    </tr>
+                    <tr>
+                        <td width="50%" valign="top">
+                            <table cellspacing="3">
+                                <tbody>
+                                    <tr>
+                                        <th colspan="3">By changesets</th>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Caolán McNamara</td>
+                                        <td align="right">4307</td>
+                                        <td align="right">19.5%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Stephan Bergmann</td>
+                                        <td align="right">2351</td>
+                                        <td align="right">10.6%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Miklos Vajna</td>
+                                        <td align="right">1449</td>
+                                        <td align="right">6.5%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Tor Lillqvist</td>
+                                        <td align="right">1159</td>
+                                        <td align="right">5.2%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Noel Grandin</td>
+                                        <td align="right">1064</td>
+                                        <td align="right">4.8%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Markus Mohrhard</td>
+                                        <td align="right">935</td>
+                                        <td align="right">4.2%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Michael Stahl</td>
+                                        <td align="right">915</td>
+                                        <td align="right">4.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Kohei Yoshida</td>
+                                        <td align="right">755</td>
+                                        <td align="right">3.4%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Tomaž Vajngerl</td>
+                                        <td align="right">658</td>
+                                        <td align="right">3.0%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Thomas Arnhold</td>
+                                        <td align="right">619</td>
+                                        <td align="right">2.8%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Jan Holesovsky</td>
+                                        <td align="right">466</td>
+                                        <td align="right">2.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Eike Rathke</td>
+                                        <td align="right">457</td>
+                                        <td align="right">2.1%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Matteo Casalin</td>
+                                        <td align="right">442</td>
+                                        <td align="right">2.0%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Bjoern Michaelsen</td>
+                                        <td align="right">421</td>
+                                        <td align="right">1.9%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Chris Sherlock</td>
+                                        <td align="right">396</td>
+                                        <td align="right">1.8%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>David Tardon</td>
+                                        <td align="right">386</td>
+                                        <td align="right">1.7%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Julien Nabet</td>
+                                        <td align="right">362</td>
+                                        <td align="right">1.6%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Zolnai Tamás</td>
+                                        <td align="right">338</td>
+                                        <td align="right">1.5%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Matúš Kukan</td>
+                                        <td align="right">256</td>
+                                        <td align="right">1.2%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Robert&nbsp;Antoni&nbsp;Buj&nbsp;Gelonch</td>
+                                        <td align="right">231</td>
+                                        <td align="right">1.0%</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                        <td width="50%" valign="top">
+                            <table cellspacing="3">
+                                <tbody>
+                                    <tr>
+                                        <th colspan="3">By changed lines</th>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Lionel Elie Mamane</td>
+                                        <td align="right">244062</td>
+                                        <td align="right">12.5%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Noel Grandin</td>
+                                        <td align="right">238711</td>
+                                        <td align="right">12.2%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Stephan Bergmann</td>
+                                        <td align="right">161220</td>
+                                        <td align="right">8.3%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Miklos Vajna</td>
+                                        <td align="right">129325</td>
+                                        <td align="right">6.6%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Caolán McNamara</td>
+                                        <td align="right">97544</td>
+                                        <td align="right">5.0%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Tomaž Vajngerl</td>
+                                        <td align="right">69404</td>
+                                        <td align="right">3.6%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Tor Lillqvist</td>
+                                        <td align="right">59498</td>
+                                        <td align="right">3.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Laurent Balland-Poirier</td>
+                                        <td align="right">52802</td>
+                                        <td align="right">2.7%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Markus Mohrhard</td>
+                                        <td align="right">50509</td>
+                                        <td align="right">2.6%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Kohei Yoshida</td>
+                                        <td align="right">45514</td>
+                                        <td align="right">2.3%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Chris Sherlock</td>
+                                        <td align="right">36788</td>
+                                        <td align="right">1.9%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Peter Foley</td>
+                                        <td align="right">34305</td>
+                                        <td align="right">1.8%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Christian Lohmaier</td>
+                                        <td align="right">33787</td>
+                                        <td align="right">1.7%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Thomas Arnhold</td>
+                                        <td align="right">32722</td>
+                                        <td align="right">1.7%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>David Tardon</td>
+                                        <td align="right">21681</td>
+                                        <td align="right">1.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>David Ostrovsky</td>
+                                        <td align="right">21620</td>
+                                        <td align="right">1.1%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Jan Holesovsky</td>
+                                        <td align="right">20792</td>
+                                        <td align="right">1.1%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Valentin Kettner</td>
+                                        <td align="right">20526</td>
+                                        <td align="right">1.1%</td>
+                                    </tr>
+                                    <tr class="Even">
+                                        <td>Robert&nbsp;Antoni&nbsp;Buj&nbsp;Gelonch</td>
+                                        <td align="right">20447</td>
+                                        <td align="right">1.0%</td>
+                                    </tr>
+                                    <tr class="Odd">
+                                        <td>Michael Stahl</td>
+                                        <td align="right">18216</td>
+                                        <td align="right">0.9%</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </blockquote>
+        <p> To a first approximation, the top ten companies supporting LibreOffice in the last year are: </p>
+        <blockquote>
+            <table>
+                <tbody>
+                    <tr>
+                        <th colspan="3">Companies supporting LibreOffice development</th>
+                    </tr>
+                    <tr>
+                        <th colspan="3">(by changesets)</th>
+                    </tr>
+                    <tr class="Even">
+                        <td>Red Hat</td>
+                        <td align="right">8417</td>
+                        <td align="right">38.0%</td>
+                    </tr>
+                    <tr class="Odd">
+                        <td>Collabora <strike>Multimedia</strike></td>
+                        <td align="right">6531</td>
+                        <td align="right">29.5%</td>
+                    </tr>
+                    <tr class="Even">
+                        <td>(Unknown)</td>
+                        <td align="right">5126</td>
+                        <td align="right">23.2%</td>
+                    </tr>
+                    <tr class="Odd">
+                        <td>(None)</td>
+                        <td align="right">1490</td>
+                        <td align="right">6.7%</td>
+                    </tr>
+                    <tr class="Even">
+                        <td>Canonical</td>
+                        <td align="right">422</td>
+                        <td align="right">1.9%</td>
+                    </tr>
+                    <tr class="Odd">
+                        <td>Igalia S.L.</td>
+                        <td align="right">80</td>
+                        <td align="right">0.4%</td>
+                    </tr>
+                    <tr class="Even">
+                        <td>Ericsson</td>
+                        <td align="right">21</td>
+                        <td align="right">0.1%</td>
+                    </tr>
+                    <tr class="Odd">
+                        <td>Yandex</td>
+                        <td align="right">18</td>
+                        <td align="right">0.1%</td>
+                    </tr>
+                    <tr class="Even">
+                        <td>FastMail.FM</td>
+                        <td align="right">17</td>
+                        <td align="right">0.1%</td>
+                    </tr>
+                    <tr class="Odd">
+                        <td>SUSE</td>
+                        <td align="right">7</td>
+                        <td align="right">0.0%</td>
+                    </tr>
+                </tbody>
+            </table>
+        </blockquote>
+        <p> Development work on LibreOffice is thus concentrated in a small number of companies, though it is rather more spread out than OpenOffice development. It is worth noting that the LibreOffice developers with unknown affiliation, who contributed 23% of the changes, make up 82% of the developer base, so there would appear to be a substantial community of developers contributing from outside the above-listed companies. </p>
+        <h4>Some conclusions</h4>
+        <p> Last October, some <a href="http://fakehost/Articles/637742/">concerns</a> were raised on the OpenOffice list about the health of that project's community. At the time, Rob Weir <a href="http://fakehost/Articles/637743/">shrugged them off</a> as the result of a marketing effort by the LibreOffice crowd. There can be no doubt that the war of words between these two projects has gotten tiresome at times, but, looking at the above numbers, it is hard not to conclude that there is an issue that goes beyond marketing hype here. </p>
+        <p> In the 4½ years since its founding, the LibreOffice project has put together a community with over 250 active developers. There is support from multiple companies and an impressive rate of patches going into the project's repository. The project's ability to sustain nearly monthly releases on two branches is a direct result of that community's work. Swearing at LibreOffice is one of your editor's favorite pastimes, but it seems clear that the project is on a solid footing with a healthy community. </p>
+        <p> OpenOffice, instead, is driven by four developers from a single company — a company that appears to have been deemphasizing OpenOffice work for some time. As a result, the project's commit rate is a fraction of what LibreOffice is able to sustain and releases are relatively rare. As of this writing, the <a href="https://blogs.apache.org/OOo/">OpenOffice
+blog</a> shows no posts in 2015. In the October discussion, Rob <a href="http://fakehost/Articles/637750/">said</a> that "<span>the dogs may
+bark but the caravan moves on.</span>" That may be true, but, in this case, the caravan does not appear to be moving with any great speed. </p>
+        <p> Anything can happen in the free-software development world; it is entirely possible that a reinvigorated OpenOffice.org may yet give LibreOffice a run for its money. But something will clearly have to change to bring that future around. As things stand now, it is hard not to conclude that LibreOffice has won the battle for developer participation. </p>
+        <p><a href="http://fakehost/Articles/637735/#Comments">Comments (74 posted)</a> </p>
+        <p> <b>Page editor</b>: Jonathan Corbet
+            <br> </p>
+        <h2>Inside this week's LWN.net Weekly Edition</h2>
+        <ul>
+            <li> <a href="http://fakehost/Articles/637395/">Security</a>: Toward secure package downloads; New vulnerabilities in drupal, mozilla, openssl, python-django ... </li>
+            <li> <a href="http://fakehost/Articles/637396/">Kernel</a>: LSFMM coverage: NFS, defragmentation, epoll(), copy offload, and more. </li>
+            <li> <a href="http://fakehost/Articles/637397/">Distributions</a>: A look at Debian's 2015 DPL candidates; Debian, Fedora, ... </li>
+            <li> <a href="http://fakehost/Articles/637398/">Development</a>: A look at GlusterFS; LibreOffice Online; Open sourcing existing code; Secure Boot in Windows 10; ... </li>
+            <li> <a href="http://fakehost/Articles/637399/">Announcements</a>: A Turing award for Michael Stonebraker, Sébastien Jodogne, ReGlue are Free Software Award winners, Kat Walsh joins FSF board of directors, Cyanogen, ... </li>
+        </ul><b>Next page</b>
+        <p style="display: inline;" class="readability-styled">: </p><a href="http://fakehost/Articles/637395/">Security&gt;&gt;</a>
+        <br>
+    </div>
+</div>

--- a/test/test-pages/lwn-1/source.html
+++ b/test/test-pages/lwn-1/source.html
@@ -1,0 +1,820 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+
+<head>
+    <title>LWN.net Weekly Edition for March 26, 2015 [LWN.net]</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="icon" href="/images/favicon.png" type="image/png">
+    <link rel="alternate" type="application/rss+xml" title="LWN.net headlines" href="http://lwn.net/headlines/newrss">
+    <link rel="stylesheet" href="/CSS/lwn">
+    <link rel="stylesheet" href="/CSS/nosub">
+    <script type="text/javascript">
+        var p = "http",
+            d = "static";
+        if (document.location.protocol == "https:") {
+            p += "s";
+            d = "engine";
+        }
+        var z = document.createElement("script");
+        z.type = "text/javascript";
+        z.async = true;
+        z.src = p + "://" + d + ".adzerk.net/ados.js";
+        var s = document.getElementsByTagName("script")[0];
+        s.parentNode.insertBefore(z, s);
+    </script>
+    <script type="text/javascript">
+        var ados_keywords = ados_keywords || [];
+        if (location.protocol == 'https:') {
+            ados_keywords.push('T:SSL');
+        } else {
+            ados_keywords.push('T:HTTP');
+        }
+        var ados = ados || {};
+        ados.run = ados.run || [];
+        ados.run.push(function() {
+            ados_add_placement(4669, 20979, "azk13321_leaderboard", 4).setZone(16026);
+            ados_add_placement(4669, 20979, "azk93271_right_zone", [5, 10, 6]).setZone(16027);
+            ados_add_placement(4669, 20979, "azk31017_tracking", 20).setZone(20995);
+            ados_setKeywords(ados_keywords.join(', '));
+            ados_load();
+        });
+    </script>
+</head>
+
+<body bgcolor="#ffffff" link="Blue" vlink="Green" alink="Green">
+    <table class="Page">
+        <tbody>
+            <tr>
+                <td class="LeftColumn">
+                    <center>
+                        <a href="/"><img src="/images/lcorner.png" width="153" height="120" border="0" alt="LWN.net Logo"></a>
+                    </center>
+                    <p>
+                        <script type="text/javascript">
+                            <!--
+                            google_ad_client = "pub-4358676377058562";
+                            google_ad_width = 120;
+                            google_ad_height = 240;
+                            google_ad_format = "120x240_as";
+                            google_ad_type = "text_image";
+                            //2007-10-07: side ads
+                            google_ad_channel = "0946045135";
+                            google_color_border = "ffcc99";
+                            google_color_bg = "ffcc99";
+                            google_color_link = "0000FF";
+                            google_color_text = "000000";
+                            google_color_url = "008000";
+                            //-->
+                        </script>
+                        <script type="text/javascript" src="//pagead2.googlesyndication.com/pagead/show_ads.js">
+                        </script>
+                    </p>
+                    <p> </p>
+                    <div class="SideBox">
+                        <p class="Header">Not logged in</p>
+                        <p><a href="/login">Log in now</a></p>
+                        <p> </p>
+                        <p><a href="/newaccount">Create an account</a></p>
+                        <p> </p>
+                        <p><a href="/subscribe/Info">Subscribe to LWN</a></p>
+                    </div>
+                    <div class="SideBox">
+                        <p class="Header">LWN Weekly Edition</p> <a href="/Articles/637393/" class="Current">Front page</a>
+                        <br> <a href="/Articles/637395/" class="Other">Security</a>
+                        <br> <a href="/Articles/637396/" class="Other">Kernel development</a>
+                        <br> <a href="/Articles/637397/" class="Other">Distributions</a>
+                        <br> <a href="/Articles/637398/" class="Other">Development</a>
+                        <br> <a href="/Articles/637399/" class="Other">Announcements</a>
+                        <br> <a href="/Articles/637393/bigpage">-&gt;One big page</a>
+                        <p> &nbsp;
+                            <br>
+                        </p>
+                        <p class="Header">This page</p> <a href="/Articles/636463/">Previous week</a>
+                        <br> <a href="/Articles/638065/">Following week</a>
+                        <br> </div>
+                    <div class="SideBox">
+                        <p class="Header">Recent Features</p>
+                        <p><a href="/Articles/640549/">LWN.net Weekly Edition for April 23, 2015</a></p>
+                        <p><a href="/Articles/641275/">The kdbuswreck</a></p>
+                        <p><a href="/Articles/639894/">LWN.net Weekly Edition for April 16, 2015</a></p>
+                        <p><a href="/Articles/639998/">Plotting tools for networks, part I</a></p>
+                        <p><a href="/Articles/639773/">Report from the Python Language Summit</a></p>
+                    </div>
+                    <div class="SideBox"> <a href="/Articles/637393/?format=printable" rel="nofollow">Printable page</a> </div>
+                </td>
+                <!-- LC -->
+                <td>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td class="MidColumn">
+                                    <table class="TopNavigation">
+                                        <!-- First row - content links -->
+                                        <tbody>
+                                            <tr>
+                                                <td class="NavLink"><a href="/current/">Weekly edition</a></td>
+                                                <td class="NavLink"> <a href="/Kernel/">Kernel</a></td>
+                                                <td class="NavLink"><a href="/Security/">Security</a></td>
+                                                <td class="NavLink"> <a href="http://lwn.net/Distributions/">Distributions</a></td>
+                                                <td class="NavLink"><a href="/op/FAQ.lwn#contact">Contact Us</a> </td>
+                                                <td class="NavLink"><a href="/Search/">Search</a> </td>
+                                            </tr>
+                                            <!-- Second row: navigation links -->
+                                            <tr>
+                                                <td class="NavLink"><a href="/Archives/">Archives</a></td>
+                                                <td class="NavLink"><a href="/Calendar/">Calendar</a></td>
+                                                <td class="NavLink"><a href="/subscribe/Info">Subscribe</a></td>
+                                                <td class="NavLink"><a href="/op/AuthorGuide.lwn">Write for LWN</a></td>
+                                                <td class="NavLink"><a href="/op/FAQ.lwn">LWN.net FAQ</a></td>
+                                                <td class="NavLink"><a href="/op/Sponsors.lwn">Sponsors</a></td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" class="MCTopBanner">
+                                    <div id="azk13321_leaderboard"></div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="MidColumn">
+                                    <div class="PageHeadline">
+                                        <h1>LWN.net Weekly Edition for March 26, 2015</h1> </div>
+                                    <div class="ArticleText">
+                                        <h2 class="SummaryHL"><a href="/Articles/637755/">A trademark battle in the Arduino community</a></h2>
+                                        <div class="FeatureByline"> By <b>Nathan Willis</b>
+                                            <br>March 25, 2015 </div>
+                                        <p>The <a href="https://en.wikipedia.org/wiki/Arduino">Arduino</a> has been one of the biggest success stories of the open-hardware movement, but that success does not protect it from internal conflict. In recent months, two of the project's founders have come into conflict about the direction of future efforts—and that conflict has turned into a legal dispute about who owns the rights to the Arduino trademark. </p>
+                                        <p>The current fight is a battle between two companies that both bear the Arduino name: Arduino LLC and Arduino SRL. The disagreements that led to present state of affairs go back a bit further. </p>
+                                        <p>The Arduino project grew out of 2005-era course work taught at the Interaction Design Institute Ivrea (IDII) in Ivrea, Italy (using <a href="https://en.wikipedia.org/wiki/Processing_(programming_language)">Processing</a>, <a href="https://en.wikipedia.org/wiki/Wiring_%28development_platform%29">Wiring</a>, and pre-existing microcontroller hardware). After the IDII program was discontinued, the open-hardware Arduino project as we know it was launched by Massimo Banzi, David Cuartielles, and David Mellis (who had worked together at IDII), with co-founders Tom Igoe and Gianluca Martino joining shortly afterward. The project released open hardware designs (including full schematics and design files) as well as the microcontroller software to run on the boards and the desktop IDE needed to program it. </p>
+                                        <p>Arduino LLC was incorporated in 2008 by Banzi, Cuartielles, Mellis, Igoe, and Martino. The company is registered in the United States, and it has continued to design the Arduino product line, develop the software, and run the Arduino community site. The hardware devices themselves, however, were manufactured by a separate company, "Smart Projects SRL," that was founded by Martino. "SRL" is essentially the Italian equivalent of "LLC"—Smart Projects was incorporated in Italy. </p>
+                                        <p>This division of responsibilities—with the main Arduino project handling everything except for board manufacturing—may seem like an odd one, but it is consistent with Arduino's marketing story. From its earliest days, the designs for the hardware have been freely available, and outside companies were allowed to make Arduino-compatible devices. The project has long run a <a href="http://arduino.cc/en/ArduinoCertified/Products#program">certification
+program</a> for third-party manufacturers interested in using the "Arduino" branding, but allows (and arguably even encourages) informal software and firmware compatibility. </p>
+                                        <p>The Arduino branding was not formally registered as a trademark in the early days, however. Arduino LLC <a href="http://tsdr.uspto.gov/#caseNumber=3931675&amp;caseType=US_REGISTRATION_NO&amp;searchType=statusSearch">filed</a> to register the US trademark in April 2009, and it was granted in 2011. </p>
+                                        <p>At this point, the exact events begin to be harder to verify, but the original group of founders reportedly had a difference of opinion about how to license out hardware production rights to other companies. Wired Italy <a href="http://www.wired.it/gadget/computer/2015/02/12/arduino-nel-caos-situazione/">reports</a> that Martino and Smart Projects resisted the other four founders' plans to "internationalize" production—although it is not clear if that meant that Smart Projects disapproved of licensing out <em>any</em> official hardware manufacturing to other companies, or had some other concern. Heise Online <a href="http://www.heise.de/make/meldung/Arduino-gegen-Arduino-Gruender-streiten-um-die-Firma-2549653.html">adds</a> that the conflict seemed to be about moving some production to China. </p>
+                                        <p>What is clear is that Smart Projects filed a <a href="http://ttabvue.uspto.gov/ttabvue/v?pno=92060077&amp;pty=CAN&amp;eno=1">petition</a> with the US Patent and Trademark Office (USPTO) in October 2014 asking the USPTO to cancel Arduino LLC's trademark on "Arduino." Then, in November 2014, Smart Projects changed its company's name to Arduino SRL. Somewhere around that time, Martino sold off his ownership stake in Smart Projects SRL and new owner Federico Musto was named CEO. </p>
+                                        <p>Unsurprisingly, Arduino LLC did not care for the petition to the USPTO and, in January 2015, the company filed a trademark-infringement <a href="http://dockets.justia.com/docket/massachusetts/madce/1:2015cv10181/167131">lawsuit</a> against Arduino SRL. Confusing matters further, the re-branded Arduino SRL has set up its own web site using the domain name <tt>arduino.org</tt>, which duplicates most of the site features found on the original Arduino site (<tt>arduino.cc</tt>). That includes both a hardware store and software downloads. </p>
+                                        <p>Musto, the new CEO of the company now called Arduino SRL, has a bit of a history with Arduino as well. His other manufacturing business had <a href="http://www.eetimes.com/document.asp?doc_id=1263246">collaborated</a> with Arduino LLC on the design and production of the Arduino Yún, which has received some <a href="http://hackaday.com/2015/02/24/is-the-arduino-yun-open-hardware/">criticism</a> for including proprietary components. </p>
+                                        <p>Hackaday has run a two-part series (in <a href="http://hackaday.com/2015/02/25/arduino-v-arduino/">February</a> and <a href="http://hackaday.com/2015/03/12/arduino-v-arduino-part-ii/">March</a>) digging into the ins and outs of the dispute, including the suggestion that Arduino LLC's recent release of version 1.6.0 of the Arduino IDE was a move intended to block Arduino SRL from hijacking IDE development. Commenter Paul Stoffregen (who was the author of the Heise story above) <a href="http://hackaday.com/2015/02/25/arduino-v-arduino/comment-page-1/#comment-2453084">noted</a> that Arduino SRL recently created a fork of the Arduino IDE on GitHub. </p>
+                                        <p>Most recently, Banzi broke his silence about the dispute in a <a href="http://makezine.com/2015/03/19/massimo-banzi-fighting-for-arduino">story</a> published at MAKEzine. There, Banzi claims that Martino secretly filed a trademark application on "Arduino" in Italy in 2008 and told none of the other Arduino founders. He also details a series of unpleasant negotiations between the companies, including Smart Projects stopping the royalty payments it had long sent to Arduino LLC for manufacturing devices and re-branding its boards with the Arduino.org URL. </p>
+                                        <p>Users appear to be stuck in the middle. Banzi says that several retail outlets that claim to be selling "official" Arduino boards are actually paying Arduino SRL, not Arduino LLC, but it is quite difficult to determine which retailers are lined up on which side, since there are (typically) several levels of supplier involved. The two Arduino companies' web sites also disagree about the available hardware, with Arduino.org offering the new <a href="http://arduino.org/products/arduino-zero-pro">Arduino Zero</a> model for sale today and Arduino.cc <a href="http://arduino.cc/en/Main/Products">listing it</a> as "Coming soon." </p>
+                                        <p>Furthermore, as Hackaday's March story explains, the recently-released Arduino.cc IDE now reports that boards manufactured by Arduino SRL are "uncertified." That warning does not prevent users from programming the other company's hardware, but it will no doubt confuse quite a few users who believe they possess genuine Arduino-manufactured devices. </p>
+                                        <p>The USPTO page for Arduino SRL's petition notes pre-trial disclosure dates have been set for August and October of 2015 (for Arduino SRL and Arduino LLC, respectively), which suggests that this debate is far from over. Of course, it is always disappointing to observe a falling out between project founders, particularly when the project in question has had such an impact on open-source software and open hardware. </p>
+                                        <p>One could argue that disputes of this sort are proof that even small projects started among friends need to take legal and intellectual-property issues (such as trademarks) seriously from the very beginning—perhaps Arduino and Smart Projects thought that an informal agreement was all that was necessary in the early days, after all. </p>
+                                        <p>But, perhaps, once a project becomes profitable, there is simply no way to predict what might happen. Arduino LLC would seem to have a strong case for continual and rigorous use of the "Arduino" trademark, which is the salient point in US trademark law. It could still be a while before the courts rule on either side of that question, however. </p>
+                                        <p><a href="/Articles/637755/#Comments">Comments (5 posted)</a> </p>
+                                        <p> </p>
+                                        <h2 class="SummaryHL"><a href="/Articles/637533/">Mapping and data mining with QGIS 2.8</a></h2>
+                                        <div class="FeatureByline"> By <b>Nathan Willis</b>
+                                            <br>March 25, 2015 </div>
+                                        <p><a href="http://qgis.org/">QGIS</a> is a free-software geographic information system (GIS) tool; it provides a unified interface in which users can import, edit, and analyze geographic-oriented information, and it can produce output as varied as printable maps or map-based web services. The project recently made its first update to be designated a long-term release (LTR), and that release is both poised for high-end usage and friendly to newcomers alike. </p>
+                                        <p>The new release is version 2.8, which was unveiled on March&nbsp;2. An official <a href="http://qgis.org/en/site/forusers/visualchangelog28/index.html">change
+log</a> is available on the QGIS site, while the release itself was announced primarily through blog posts (such as <a href="http://anitagraser.com/2015/03/02/qgis-2-8-ltr-has-landed/">this
+post</a> by Anita Graser of the project's steering committee). Downloads are <a href="http://qgis.org/en/site/forusers/download.html">available</a> for a variety of platforms, including packages for Ubuntu, Debian, Fedora, openSUSE, and several other distributions.</p>
+                                        <a href="/Articles/637747/"> <img src="/images/2015/03-qgis-map-sm.png" border="0" hspace="5" align="right" width="350" height="264" alt="[QGIS main interface]"> </a>
+                                        <p>As the name might suggest, QGIS is a Qt application; the latest release will, in fact, build on both Qt4 and Qt5, although the binaries released by the project come only in Qt4 form at present. 2.8 has been labeled a long-term release (LTR)—which, in this case, means that the project has committed to providing backported bug fixes for one full calendar year, and that the 2.8.x series is in permanent feature freeze. The goal, according to the change log, is to provide a stable version suitable for businesses and deployments in other large organizations. The change log itself points out that the development of quite a few new features was underwritten by various GIS companies or university groups, which suggests that taking care of these organizations' needs is reaping dividends for the project. </p>
+                                        <p>For those new to QGIS (or GIS in general), there is a detailed new-user <a href="http://docs.qgis.org/testing/en/docs/training_manual/">tutorial</a> that provides a thorough walk-through of the data-manipulation, mapping, and analysis functions. Being a new user, I went through the tutorial; although there are a handful of minor differences between QGIS 2.8 and the version used in the text (primarily whether specific features were accessed through a toolbar or right-click menu), on the whole it is well worth the time. </p>
+                                        <p>QGIS is designed to make short work of importing spatially oriented data sets, mining information from them, and turning the results into a meaningful visualization. Technically speaking, the visualization output is optional: one could simply extract the needed statistics and results and use them to answer some question or, perhaps, publish the massaged data set as a database for others to use. </p>
+                                        <p>But well-made maps are often the easiest way to illuminate facts about populations, political regions, geography, and many other topics when human comprehension is the goal. QGIS makes importing data from databases, web-mapping services (WMS), and even unwieldy flat-file data dumps a painless experience. It handles converting between a variety of map-referencing systems more or less automatically, and allows the user to focus on finding the useful attributes of the data sets and rendering them on screen. </p>
+                                        <h4>Here be data</h4>
+                                        <p>The significant changes in QGIS 2.8 fall into several categories. There are updates to how QGIS handles the mathematical expressions and queries users can use to filter information out of a data set, improvements to the tools used to explore the on-screen map canvas, and enhancements to the "map composer" used to produce visual output. This is on top of plenty of other under-the-hood improvements, naturally.</p>
+                                        <a href="/Articles/637748/"> <img src="/images/2015/03-qgis-query-sm.png" border="0" hspace="5" align="left" width="300" height="302" alt="[QGIS query builder]"> </a>
+                                        <p>In the first category are several updates to the filtering tools used to mine a data set. Generally speaking, each independent data set is added to a QGIS project as its own layer, then transformed with filters to focus in on a specific portion of the original data. For instance, the land-usage statistics for a region might be one layer, while roads and buildings for the same region from OpenStreetMap might be two additional layers. Such filters can be created in several ways: there is a "query builder" that lets the user construct and test expressions on a data layer, then save the results, an SQL console for performing similar queries on a database, and spreadsheet-like editing tools for working directly on data tables. </p>
+                                        <p>All three have been improved in this release. New are support for <tt>if(condition, true, false)</tt> conditional statements, a set of operations for geometry primitives (e.g., to test whether regions overlap or lines intersect), and an "integer divide" operation. Users can also add comments to their queries to annotate their code, and there is a new <a href="http://nathanw.net/2015/01/19/function-editor-for-qgis-expressions/">custom
+function editor</a> for writing Python functions that can be called in mathematical expressions within the query builder. </p>
+                                        <p>It is also now possible to select only some rows in a table, then perform calculations just on the selection—previously, users would have to extract the rows of interest into a new table first. Similarly, in the SQL editor, the user can highlight a subset of the SQL query and execute it separately, which is no doubt helpful for debugging. </p>
+                                        <p>There have also been several improvements to the Python and Processing plugins. Users can now drag-and-drop Python scripts onto QGIS and they will be run automatically. Several new analysis algorithms are now available through the Processing interface that were previously Python-only; they include algorithms for generating grids of points or vectors within a region, splitting layers and lines, generating <a href="http://en.wikipedia.org/wiki/Hypsometric_curve">hypsometric
+curves</a>, refactoring data sets, and more. </p>
+                                        <h4>Maps in, maps out</h4>
+                                        <a href="/Articles/637749/"> <img src="/images/2015/03-qgis-simplify-sm.png" border="0" hspace="5" align="right" width="300" height="303" alt="[QGIS simplify tool]"> </a>
+                                        <p>The process of working with on-screen map data picked up some improvements in the new release as well. Perhaps the most fundamental is that each map layer added to the canvas is now handled in its own thread, so fewer hangs in the user interface are experienced when re-rendering a layer (as happens whenever the user changes the look of points or shapes in a layer). Since remote databases can also be layers, this multi-threaded approach is more resilient against connectivity problems, too. The interface also now supports temporary "scratch" layers that can be used to merge, filter, or simply experiment with a data set, but are not saved when the current project is saved. </p>
+                                        <p>For working on the canvas itself, polygonal regions can now use raster images (tiled, if necessary) as fill colors, the map itself can be rotated arbitrarily, and objects can be "snapped" to align with items on any layer (not just the current layer). For working with raster image layers (e.g., aerial photographs) or simply creating new geometric shapes by hand, there is a new digitizing tool that can offer assistance by locking lines to specific angles, automatically keeping borders parallel, and other niceties. </p>
+                                        <p>There is a completely overhauled "simplify" tool that is used to reduce the number of extraneous vertices of a vector layer (thus reducing its size). The old simplify tool provided only a relative "tolerance" setting that did not correspond directly to any units. With the new tool, users can set a simplification threshold in terms of the underlying map units, layer-specific units, pixels, and more—and, in addition, the tool reports how much the simplify operation has reduced the size of the data.</p>
+                                        <a href="/Articles/637751/"> <img src="/images/2015/03-qgis-style-sm.png" border="0" hspace="5" align="left" width="300" height="286" alt="[QGIS style editing]"> </a>
+                                        <p>There has also been an effort to present a uniform interface to one of the most important features of the map canvas: the ability to change the symbology used for an item based on some data attribute. The simplest example might be to change the line color of a road based on whether its road-type attribute is "highway," "service road," "residential," or so on. But the same feature is used to automatically highlight layer information based on the filtering and querying functionality discussed above. The new release allows many more map attributes to be controlled by these "data definition" settings, and provides a hard-to-miss button next to each attribute, through which a custom data definition can be set. </p>
+                                        <p>QGIS's composer module is the tool used to take project data and generate a map that can be used outside of the application (in print, as a static image, or as a layer for <a href="http://mapserver.org/">MapServer</a> or some other software tool, for example). Consequently, it is not a simple select-and-click-export tool; composing the output can involve a lot of choices about which data to make visible, how (and where) to label it, and how to make it generally accessible. </p>
+                                        <p>The updated composer in 2.8 now has a full-screen mode and sports several new options for configuring output. For instance, the user now has full control over how map axes are labeled. In previous releases, the grid coordinates of the map could be turned on or off, but the only options were all or nothing. Now, the user can individually choose whether coordinates are displayed on all four sides, and can even choose in which direction vertical text labels will run (so that they can be correctly justified to the edge of the map, for example). </p>
+                                        <p>There are, as usual, many more changes than there is room to discuss. Some particularly noteworthy improvements include the ability to save and load bookmarks for frequently used data sources (perhaps most useful for databases, web services, and other non-local data) and improvements to QGIS's server module. This module allows one QGIS instance to serve up data accessible to other QGIS applications (for example, to simply team projects). The server can now be extended with Python plugins and the data layers that it serves can be styled with style rules like those used in the desktop interface. </p>
+                                        <p>QGIS is one of those rare free-software applications that is both powerful enough for high-end work and yet also straightforward to use for the simple tasks that might attract a newcomer to GIS in the first place. The 2.8 release, particularly with its project-wide commitment to long-term support, appears to be an update well worth checking out, whether one needs to create a simple, custom map or to mine a database for obscure geo-referenced meaning. </p>
+                                        <p><a href="/Articles/637533/#Comments">Comments (3 posted)</a> </p>
+                                        <p> </p>
+                                        <h2 class="SummaryHL"><a href="/Articles/637735/">Development activity in LibreOffice and OpenOffice</a></h2>
+                                        <div class="FeatureByline"> By <b>Jonathan Corbet</b>
+                                            <br>March 25, 2015 </div> The LibreOffice project was <a href="/Articles/407383/">announced</a> with great fanfare in September 2010. Nearly one year later, the OpenOffice.org project (from which LibreOffice was forked) <a href="/Articles/446093/">was
+cut loose from Oracle</a> and found a new home as an Apache project. It is fair to say that the rivalry between the two projects in the time since then has been strong. Predictions that one project or the other would fail have not been borne out, but that does not mean that the two projects are equally successful. A look at the two projects' development communities reveals some interesting differences.
+                                        <p> </p>
+                                        <h4>Release histories</h4>
+                                        <p> Apache OpenOffice has made two releases in the past year: <a href="https://blogs.apache.org/OOo/entry/the_apache_openoffice_project_announce">4.1</a> in April 2014 and <a href="https://blogs.apache.org/OOo/entry/announcing_apache_openoffice_4_1">4.1.1</a> (described as "a micro update" in the release announcement) in August. The main feature added during that time would appear to be significantly improved accessibility support. </p>
+                                        <p> The release history for LibreOffice tells a slightly different story: </p>
+                                        <p> </p>
+                                        <blockquote>
+                                            <table class="OddEven">
+                                                <tbody>
+                                                    <tr>
+                                                        <th align="left">Release</th>
+                                                        <th align="left">Date</th>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/04/10/libreoffice-4-2-3-is-now-available-for-download/">4.2.3</a></td>
+                                                        <td>April 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/04/29/the-document-foundation-announces-libreoffice-4-1-6/">4.1.6</a></td>
+                                                        <td>April 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/05/08/libreoffice-4-2-4-at-linuxtag-and-fisl/">4.2.4</a></td>
+                                                        <td>May 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/06/20/libreoffice-4-2-5-hits-the-marketplace/">4.2.5</a></td>
+                                                        <td>June 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/07/30/libreoffice-4-3-today-you-cant-own-a-better-office-suite/">4.3</a></td>
+                                                        <td>July 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/08/05/libreoffice-4-2-6-is-ready/">4.2.6</a></td>
+                                                        <td>August 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/08/28/libreoffice-4-3-1-fresh-announced/">4.3.1</a></td>
+                                                        <td>August 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/09/25/libreoffice-4-3-2-hits-the-marketplace-just-before-the-fourth-anniversary-of-the-project/">4.3.2</a></td>
+                                                        <td>September 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/10/30/the-document-foundation-announces-libreoffice-4-3-3-and-libreoffice-4-2-7/">4.2.7/4.3.3</a></td>
+                                                        <td>October 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/11/14/the-document-foundation-announces-libreoffice-4-3-4/">4.3.4</a></td>
+                                                        <td>November 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/12/12/the-document-foundation-announces-libreoffice-4-2-8/">4.2.8</a></td>
+                                                        <td>December 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2014/12/18/the-document-foundation-announces-libreoffice-4-3-5/">4.3.5</a></td>
+                                                        <td>December 2014</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2015/01/29/libreoffice-4-4-the-most-beautiful-libreoffice-ever/">4.4</a></td>
+                                                        <td>January 2015</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2015/02/20/the-document-foundation-announces-libreoffice-4-3-6/">4.3.6</a></td>
+                                                        <td>February 2015</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td><a href="http://blog.documentfoundation.org/2015/02/26/libreoffice-4-4-1-fresh-is-available-for-download/">4.4.1</a></td>
+                                                        <td>February 2015</td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </blockquote>
+                                        <p> It seems clear that LibreOffice has maintained a rather more frenetic release cadence, generally putting out at least one release per month. The project typically keeps at least two major versions alive at any one time. Most of the releases are of the minor, bug-fix variety, but there have been two major releases in the last year as well. </p>
+                                        <p> </p>
+                                        <h4>Development statistics</h4>
+                                        <p> In the one-year period since late March 2014, there have been 381 changesets committed to the OpenOffice Subversion repository. The most active committers are: </p>
+                                        <p> </p>
+                                        <blockquote>
+                                            <table>
+                                                <tbody>
+                                                    <tr>
+                                                        <th colspan="2" align="center">Most active OpenOffice developers</th>
+                                                    </tr>
+                                                    <tr>
+                                                        <td width="50%" valign="top">
+                                                            <table cellspacing="3">
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <th colspan="3">By changesets</th>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Herbert Dürr</td>
+                                                                        <td align="right">63</td>
+                                                                        <td align="right">16.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Jürgen&nbsp;Schmidt&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+                                                                        <td align="right">56</td>
+                                                                        <td align="right">14.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Armin Le Grand</td>
+                                                                        <td align="right">56</td>
+                                                                        <td align="right">14.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Oliver-Rainer&nbsp;Wittmann</td>
+                                                                        <td align="right">46</td>
+                                                                        <td align="right">12.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Tsutomu Uchino</td>
+                                                                        <td align="right">33</td>
+                                                                        <td align="right">8.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Kay Schenk</td>
+                                                                        <td align="right">27</td>
+                                                                        <td align="right">7.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Pedro Giffuni</td>
+                                                                        <td align="right">23</td>
+                                                                        <td align="right">6.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Ariel Constenla-Haile</td>
+                                                                        <td align="right">22</td>
+                                                                        <td align="right">5.8%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Andrea Pescetti</td>
+                                                                        <td align="right">14</td>
+                                                                        <td align="right">3.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Steve Yin</td>
+                                                                        <td align="right">11</td>
+                                                                        <td align="right">2.9%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Andre Fischer</td>
+                                                                        <td align="right">10</td>
+                                                                        <td align="right">2.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Yuri Dario</td>
+                                                                        <td align="right">7</td>
+                                                                        <td align="right">1.8%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Regina Henschel</td>
+                                                                        <td align="right">6</td>
+                                                                        <td align="right">1.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Juan C. Sanz</td>
+                                                                        <td align="right">2</td>
+                                                                        <td align="right">0.5%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Clarence Guo</td>
+                                                                        <td align="right">2</td>
+                                                                        <td align="right">0.5%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Tal Daniel</td>
+                                                                        <td align="right">2</td>
+                                                                        <td align="right">0.5%</td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                        <td width="50%" valign="top">
+                                                            <table cellspacing="3">
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <th colspan="3">By changed lines</th>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Jürgen&nbsp;Schmidt&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+                                                                        <td align="right">455499</td>
+                                                                        <td align="right">88.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Andre Fischer</td>
+                                                                        <td align="right">26148</td>
+                                                                        <td align="right">3.8%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Pedro Giffuni</td>
+                                                                        <td align="right">23183</td>
+                                                                        <td align="right">3.4%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Armin Le Grand</td>
+                                                                        <td align="right">11018</td>
+                                                                        <td align="right">1.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Juan C. Sanz</td>
+                                                                        <td align="right">4582</td>
+                                                                        <td align="right">0.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Oliver-Rainer Wittmann</td>
+                                                                        <td align="right">4309</td>
+                                                                        <td align="right">0.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Andrea Pescetti</td>
+                                                                        <td align="right">3908</td>
+                                                                        <td align="right">0.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Herbert Dürr</td>
+                                                                        <td align="right">2811</td>
+                                                                        <td align="right">0.4%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Tsutomu Uchino</td>
+                                                                        <td align="right">1991</td>
+                                                                        <td align="right">0.3%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Ariel Constenla-Haile</td>
+                                                                        <td align="right">1258</td>
+                                                                        <td align="right">0.2%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Steve Yin</td>
+                                                                        <td align="right">1010</td>
+                                                                        <td align="right">0.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Kay Schenk</td>
+                                                                        <td align="right">616</td>
+                                                                        <td align="right">0.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Regina Henschel</td>
+                                                                        <td align="right">417</td>
+                                                                        <td align="right">0.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Yuri Dario</td>
+                                                                        <td align="right">268</td>
+                                                                        <td align="right">0.0%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>tal</td>
+                                                                        <td align="right">16</td>
+                                                                        <td align="right">0.0%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Clarence Guo</td>
+                                                                        <td align="right">11</td>
+                                                                        <td align="right">0.0%</td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </blockquote>
+                                        <p> In truth, the above list is not just the most active OpenOffice developers — it is all of them; a total of 16 developers have committed changes to OpenOffice in the last year. Those developers changed 528,000 lines of code, but, as can be seen above, Jürgen Schmidt accounted for the bulk of those changes, which were mostly updates to translation files. </p>
+                                        <p> The top four developers in the "by changesets" column all work for IBM, so IBM is responsible for a minimum of about 60% of the changes to OpenOffice in the last year. </p>
+                                        <p> The picture for LibreOffice is just a little bit different; in the same one-year period, the project has committed 22,134 changesets from 268 developers. The most active of these developers were: </p>
+                                        <p> </p>
+                                        <blockquote>
+                                            <table>
+                                                <tbody>
+                                                    <tr>
+                                                        <th colspan="2" align="center">Most active LibreOffice developers</th>
+                                                    </tr>
+                                                    <tr>
+                                                        <td width="50%" valign="top">
+                                                            <table cellspacing="3">
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <th colspan="3">By changesets</th>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Caolán McNamara</td>
+                                                                        <td align="right">4307</td>
+                                                                        <td align="right">19.5%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Stephan Bergmann</td>
+                                                                        <td align="right">2351</td>
+                                                                        <td align="right">10.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Miklos Vajna</td>
+                                                                        <td align="right">1449</td>
+                                                                        <td align="right">6.5%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Tor Lillqvist</td>
+                                                                        <td align="right">1159</td>
+                                                                        <td align="right">5.2%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Noel Grandin</td>
+                                                                        <td align="right">1064</td>
+                                                                        <td align="right">4.8%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Markus Mohrhard</td>
+                                                                        <td align="right">935</td>
+                                                                        <td align="right">4.2%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Michael Stahl</td>
+                                                                        <td align="right">915</td>
+                                                                        <td align="right">4.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Kohei Yoshida</td>
+                                                                        <td align="right">755</td>
+                                                                        <td align="right">3.4%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Tomaž Vajngerl</td>
+                                                                        <td align="right">658</td>
+                                                                        <td align="right">3.0%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Thomas Arnhold</td>
+                                                                        <td align="right">619</td>
+                                                                        <td align="right">2.8%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Jan Holesovsky</td>
+                                                                        <td align="right">466</td>
+                                                                        <td align="right">2.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Eike Rathke</td>
+                                                                        <td align="right">457</td>
+                                                                        <td align="right">2.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Matteo Casalin</td>
+                                                                        <td align="right">442</td>
+                                                                        <td align="right">2.0%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Bjoern Michaelsen</td>
+                                                                        <td align="right">421</td>
+                                                                        <td align="right">1.9%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Chris Sherlock</td>
+                                                                        <td align="right">396</td>
+                                                                        <td align="right">1.8%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>David Tardon</td>
+                                                                        <td align="right">386</td>
+                                                                        <td align="right">1.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Julien Nabet</td>
+                                                                        <td align="right">362</td>
+                                                                        <td align="right">1.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Zolnai Tamás</td>
+                                                                        <td align="right">338</td>
+                                                                        <td align="right">1.5%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Matúš Kukan</td>
+                                                                        <td align="right">256</td>
+                                                                        <td align="right">1.2%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Robert&nbsp;Antoni&nbsp;Buj&nbsp;Gelonch</td>
+                                                                        <td align="right">231</td>
+                                                                        <td align="right">1.0%</td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                        <td width="50%" valign="top">
+                                                            <table cellspacing="3">
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <th colspan="3">By changed lines</th>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Lionel Elie Mamane</td>
+                                                                        <td align="right">244062</td>
+                                                                        <td align="right">12.5%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Noel Grandin</td>
+                                                                        <td align="right">238711</td>
+                                                                        <td align="right">12.2%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Stephan Bergmann</td>
+                                                                        <td align="right">161220</td>
+                                                                        <td align="right">8.3%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Miklos Vajna</td>
+                                                                        <td align="right">129325</td>
+                                                                        <td align="right">6.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Caolán McNamara</td>
+                                                                        <td align="right">97544</td>
+                                                                        <td align="right">5.0%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Tomaž Vajngerl</td>
+                                                                        <td align="right">69404</td>
+                                                                        <td align="right">3.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Tor Lillqvist</td>
+                                                                        <td align="right">59498</td>
+                                                                        <td align="right">3.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Laurent Balland-Poirier</td>
+                                                                        <td align="right">52802</td>
+                                                                        <td align="right">2.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Markus Mohrhard</td>
+                                                                        <td align="right">50509</td>
+                                                                        <td align="right">2.6%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Kohei Yoshida</td>
+                                                                        <td align="right">45514</td>
+                                                                        <td align="right">2.3%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Chris Sherlock</td>
+                                                                        <td align="right">36788</td>
+                                                                        <td align="right">1.9%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Peter Foley</td>
+                                                                        <td align="right">34305</td>
+                                                                        <td align="right">1.8%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Christian Lohmaier</td>
+                                                                        <td align="right">33787</td>
+                                                                        <td align="right">1.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Thomas Arnhold</td>
+                                                                        <td align="right">32722</td>
+                                                                        <td align="right">1.7%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>David Tardon</td>
+                                                                        <td align="right">21681</td>
+                                                                        <td align="right">1.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>David Ostrovsky</td>
+                                                                        <td align="right">21620</td>
+                                                                        <td align="right">1.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Jan Holesovsky</td>
+                                                                        <td align="right">20792</td>
+                                                                        <td align="right">1.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Valentin Kettner</td>
+                                                                        <td align="right">20526</td>
+                                                                        <td align="right">1.1%</td>
+                                                                    </tr>
+                                                                    <tr class="Even">
+                                                                        <td>Robert&nbsp;Antoni&nbsp;Buj&nbsp;Gelonch</td>
+                                                                        <td align="right">20447</td>
+                                                                        <td align="right">1.0%</td>
+                                                                    </tr>
+                                                                    <tr class="Odd">
+                                                                        <td>Michael Stahl</td>
+                                                                        <td align="right">18216</td>
+                                                                        <td align="right">0.9%</td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </blockquote>
+                                        <p> To a first approximation, the top ten companies supporting LibreOffice in the last year are: </p>
+                                        <p> </p>
+                                        <blockquote>
+                                            <table>
+                                                <tbody>
+                                                    <tr>
+                                                        <th colspan="3">Companies supporting LibreOffice development</th>
+                                                    </tr>
+                                                    <tr>
+                                                        <th colspan="3">(by changesets)</th>
+                                                    </tr>
+                                                    <tr class="Even">
+                                                        <td>Red Hat</td>
+                                                        <td align="right">8417</td>
+                                                        <td align="right">38.0%</td>
+                                                    </tr>
+                                                    <tr class="Odd">
+                                                        <td>Collabora <strike>Multimedia</strike></td>
+                                                        <td align="right">6531</td>
+                                                        <td align="right">29.5%</td>
+                                                    </tr>
+                                                    <tr class="Even">
+                                                        <td>(Unknown)</td>
+                                                        <td align="right">5126</td>
+                                                        <td align="right">23.2%</td>
+                                                    </tr>
+                                                    <tr class="Odd">
+                                                        <td>(None)</td>
+                                                        <td align="right">1490</td>
+                                                        <td align="right">6.7%</td>
+                                                    </tr>
+                                                    <tr class="Even">
+                                                        <td>Canonical</td>
+                                                        <td align="right">422</td>
+                                                        <td align="right">1.9%</td>
+                                                    </tr>
+                                                    <tr class="Odd">
+                                                        <td>Igalia S.L.</td>
+                                                        <td align="right">80</td>
+                                                        <td align="right">0.4%</td>
+                                                    </tr>
+                                                    <tr class="Even">
+                                                        <td>Ericsson</td>
+                                                        <td align="right">21</td>
+                                                        <td align="right">0.1%</td>
+                                                    </tr>
+                                                    <tr class="Odd">
+                                                        <td>Yandex</td>
+                                                        <td align="right">18</td>
+                                                        <td align="right">0.1%</td>
+                                                    </tr>
+                                                    <tr class="Even">
+                                                        <td>FastMail.FM</td>
+                                                        <td align="right">17</td>
+                                                        <td align="right">0.1%</td>
+                                                    </tr>
+                                                    <tr class="Odd">
+                                                        <td>SUSE</td>
+                                                        <td align="right">7</td>
+                                                        <td align="right">0.0%</td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </blockquote>
+                                        <p> Development work on LibreOffice is thus concentrated in a small number of companies, though it is rather more spread out than OpenOffice development. It is worth noting that the LibreOffice developers with unknown affiliation, who contributed 23% of the changes, make up 82% of the developer base, so there would appear to be a substantial community of developers contributing from outside the above-listed companies. </p>
+                                        <p> </p>
+                                        <h4>Some conclusions</h4>
+                                        <p> Last October, some <a href="/Articles/637742/">concerns</a> were raised on the OpenOffice list about the health of that project's community. At the time, Rob Weir <a href="/Articles/637743/">shrugged them off</a> as the result of a marketing effort by the LibreOffice crowd. There can be no doubt that the war of words between these two projects has gotten tiresome at times, but, looking at the above numbers, it is hard not to conclude that there is an issue that goes beyond marketing hype here. </p>
+                                        <p> In the 4½ years since its founding, the LibreOffice project has put together a community with over 250 active developers. There is support from multiple companies and an impressive rate of patches going into the project's repository. The project's ability to sustain nearly monthly releases on two branches is a direct result of that community's work. Swearing at LibreOffice is one of your editor's favorite pastimes, but it seems clear that the project is on a solid footing with a healthy community. </p>
+                                        <p> OpenOffice, instead, is driven by four developers from a single company — a company that appears to have been deemphasizing OpenOffice work for some time. As a result, the project's commit rate is a fraction of what LibreOffice is able to sustain and releases are relatively rare. As of this writing, the <a href="https://blogs.apache.org/OOo/">OpenOffice
+blog</a> shows no posts in 2015. In the October discussion, Rob <a href="/Articles/637750/">said</a> that "<span>the dogs may
+bark but the caravan moves on.</span>" That may be true, but, in this case, the caravan does not appear to be moving with any great speed. </p>
+                                        <p> Anything can happen in the free-software development world; it is entirely possible that a reinvigorated OpenOffice.org may yet give LibreOffice a run for its money. But something will clearly have to change to bring that future around. As things stand now, it is hard not to conclude that LibreOffice has won the battle for developer participation. </p>
+                                        <p><a href="/Articles/637735/#Comments">Comments (74 posted)</a> </p>
+                                        <p> </p>
+                                        <p> <b>Page editor</b>: Jonathan Corbet
+                                            <br> </p>
+                                        <h2>Inside this week's LWN.net Weekly Edition</h2>
+                                        <ul>
+                                            <li> <a href="/Articles/637395/">Security</a>: Toward secure package downloads; New vulnerabilities in drupal, mozilla, openssl, python-django ... </li>
+                                            <li> <a href="/Articles/637396/">Kernel</a>: LSFMM coverage: NFS, defragmentation, epoll(), copy offload, and more. </li>
+                                            <li> <a href="/Articles/637397/">Distributions</a>: A look at Debian's 2015 DPL candidates; Debian, Fedora, ... </li>
+                                            <li> <a href="/Articles/637398/">Development</a>: A look at GlusterFS; LibreOffice Online; Open sourcing existing code; Secure Boot in Windows 10; ... </li>
+                                            <li> <a href="/Articles/637399/">Announcements</a>: A Turing award for Michael Stonebraker, Sébastien Jodogne, ReGlue are Free Software Award winners, Kat Walsh joins FSF board of directors, Cyanogen, ... </li>
+                                        </ul> <b>Next page</b>: <a href="/Articles/637395/">Security&gt;&gt;</a>
+                                        <br> </div>
+                                    <!-- ArticleText -->
+                                </td>
+                                <!-- MC -->
+                                <td class="RightColumn">
+                                    <div id="azk93271_right_zone"></div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <!-- endpage -->
+    <br clear="all">
+    <center>
+        <p> <font size="-2">
+        Copyright © 2015, Eklektix, Inc.<br>
+        
+        Comments and public postings are copyrighted by their creators.<br>
+        Linux  is a registered trademark of Linus Torvalds<br>
+        </font> </p>
+    </center>
+</body>
+
+</html>


### PR DESCRIPTION
We were aggressively stripping out intermediary headings within extracted article contents if they had a link density greater than 1/3rd. 

In real world, I believe these headings can have as many links as they want (none, a single one to link to some other part/page, a few…), so I'm removing the link density rule entirely here, while keeping the class weight check.

This fixes #150.