### PR TITLE
Improved author metadata detection.

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -945,7 +945,7 @@ Readability.prototype = {
       var elementName = element.getAttribute("name");
       var elementProperty = element.getAttribute("property");
 
-      if (elementName === "author") {
+      if ([elementName, elementProperty].indexOf("author") !== -1) {
         metadata.byline = element.getAttribute("content");
         return;
       }

--- a/test/test-pages/buzzfeed-1/expected-metadata.json
+++ b/test/test-pages/buzzfeed-1/expected-metadata.json
@@ -1,0 +1,6 @@
+{
+  "title": "Student Dies After Diet Pills She Bought Online \"Burned Her Up From Within\"",
+  "byline": "Mark Di Stefano",
+  "excerpt": "An inquest into Eloise Parry's death has been adjourned until July...",
+  "readerable": true
+}

--- a/test/test-pages/buzzfeed-1/expected.html
+++ b/test/test-pages/buzzfeed-1/expected.html
@@ -1,0 +1,19 @@
+<div id="readability-page-1" class="page">
+    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547213" rel:buzz_num="2">
+        <p class="sub_buzz_desc">Eloise Parry, 21, was taken to Royal Shrewsbury hospital on 12 April after taking a lethal dose of highly toxic “slimming tablets”. </p>
+        <p>“The drug was in her system, there was no anti-dote, two tablets was a lethal dose – and she had taken eight,” her mother, Fiona, <a href="https://www.westmercia.police.uk/article/9501/A-tribute-to-Eloise-Aimee-Parry-written-by-her-mother-Fiona-Parry">said in a statement</a> yesterday.</p>
+        <p>“As Eloise deteriorated, the staff in A&amp;E did all they could to stabilise her. As the drug kicked in and started to make her metabolism soar, they attempted to cool her down, but they were fighting an uphill battle.</p>
+        <p>“She was literally burning up from within.”</p>
+        <p>She added: “They never stood a chance of saving her. She burned and crashed.”</p>
+    </div>
+    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547284" rel:buzz_num="4">
+        <p class="sub_buzz_desc">West Mercia police <a href="https://www.westmercia.police.uk/article/9500/Warning-Issued-As-Shrewsbury-Woman-Dies-After-Taking-Suspected-Diet-Pills">said the tablets were believed to contain dinitrophenol</a>, known as DNP, which is a highly toxic industrial chemical. </p>
+        <p>“We are undoubtedly concerned over the origin and sale of these pills and are working with partner agencies to establish where they were bought from and how they were advertised,” said chief inspector Jennifer Mattinson from the West Mercia police.</p>
+        <p>The Food Standards Agency warned people to stay away from slimming products that contained DNP.</p>
+        <p>“We advise the public not to take any tablets or powders containing DNP, as it is an industrial chemical and not fit for human consumption,” it said in a statement.</p>
+    </div>
+    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547219" rel:buzz_num="5">
+        <p class="sub_buzz_desc">“[Eloise] just never really understood how dangerous the tablets that she took were,” she said. “Most of us don’t believe that a slimming tablet could possibly kill us.</p>
+        <p>“DNP is not a miracle slimming pill. It is a deadly toxin.”</p>
+    </div>
+</div>

--- a/test/test-pages/buzzfeed-1/source.html
+++ b/test/test-pages/buzzfeed-1/source.html
@@ -1,0 +1,5295 @@
+<html class=" fonts-loaded srcset svg inlinesvg no-webp" xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml" xmlns:og="http://opengraphprotocol.org/schema/" lang="en">
+
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# buzzfeed: http://ogp.me/ns/fb/buzzfeed#">
+    <script src="//connect.facebook.net/en_US/fbds.js" async=""></script>
+    <script src="http://connect.facebook.net/en_US/fbds.js" async=""></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/jemplate/share_button.js" type="text/javascript"></script>
+    <script async="" src="https://apis.google.com/_/scs/apps-static/_/js/k=oz.gapi.fr.4peQ-SxVWjw.O/m=client,plusone/rt=j/sv=1/d=1/ed=1/am=MQ/rs=AGLTcCOf3Ne3HaK2CinW2J4SVei_iFZnMw/t=zcms/cb=gapi.loaded_0"></script>
+    <script gapi_processed="true" src="https://apis.google.com/js/client:plusone.js?onload=GCallback" type="text/javascript"></script>
+    <script gapi_processed="true" src="https://apis.google.com/js/client:plusone.js?onload=GCallback" type="text/javascript"></script>
+    <script src="http://www.googletagservices.com/tag/js/gpt.js" type="text/javascript" async=""></script>
+    <script>
+    window.document.documentElement.className += " fonts-loaded";
+    </script>
+    <title>Student Dies After Diet Pills She Bought Online "Burned Her Up From Within" - BuzzFeed News</title>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <meta name="copyright" content="Copyright 2015 BuzzFeed, Inc. All rights reserved.">
+    <meta name="description" content="An inquest into Eloise Parry's death has been adjourned until July...">
+    <meta property="bf:buzzid" content="3758406">
+    <meta property="bf:userid" content="1687686">
+    <meta property="author" content="Mark Di Stefano">
+    <meta name="news_keywords" content="diet pills, inquests, online shopping, uk">
+    <meta name="sailthru.tags" content="diet pills, inquests, online shopping, uk">
+    <meta name="apple-itunes-app" content="app-id=352969997, affiliate-data=at=10l3HP&amp;ct=Buzz/SmartBanner">
+    <meta name="google-signin-clientid" content="895639880237-tcoheof19odpd88p676rjc70v0iqit0o.apps.googleusercontent.com">
+    <meta name="google-signin-cookiepolicy" content="single_host_origin">
+    <meta name="google-signin-requestvisibleactions" content="https://schemas.google.com/AddActivity">
+    <meta name="google-signin-scope" content="https://www.googleapis.com/auth/plus.login https://www.googleapis.com/auth/plus.profile.emails.read">
+    <meta property="fb:app_id" content="45075597673">
+    <meta property="og:site_name" content="BuzzFeed">
+    <meta property="fb:admins" content="707356852">
+    <meta property="fb:admins" content="689300683">
+    <meta property="fb:admins" content="1065534095">
+    <meta property="fb:admins" content="583832663">
+    <meta property="fb:admins" content="749455540">
+    <meta property="fb:admins" content="560468108">
+    <meta property="fb:admins" content="731012743">
+    <meta property="fb:admins" content="616026830">
+    <meta property="fb:admins" content="509245189">
+    <meta property="fb:admins" content="10903550">
+    <meta property="fb:admins" content="14231094">
+    <meta property="fb:admins" content="1806923">
+    <meta property="fb:admins" content="1554635003">
+    <meta property="fb:admins" content="835967">
+    <meta property="fb:admins" content="1234380730">
+    <meta property="fb:admins" content="743137474">
+    <meta property="fb:admins" content="2208604">
+    <meta property="fb:admins" content="28518">
+    <meta property="fb:admins" content="15920947">
+    <meta property="fb:admins" content="100003945960605">
+    <meta property="fb:admins" content="578226154">
+    <meta property="fb:admins" content="502418534">
+    <meta property="fb:admins" content="5515474">
+    <meta property="fb:admins" content="5525520">
+    <meta property="fb:admins" content="5205449">
+    <meta property="fb:admins" content="648659743">
+    <meta property="fb:admins" content="705370117">
+    <meta property="fb:admins" content="1351920148">
+    <meta property="fb:admins" content="8370474">
+    <meta property="fb:admins" content="1387300103">
+    <meta property="fb:admins" content="1572780204">
+    <meta property="fb:admins" content="100003824101586">
+    <meta property="fb:admins" content="1026583096">
+    <meta property="fb:admins" content="626540352">
+    <meta property="fb:admins" content="1338210367">
+    <meta property="fb:admins" content="43102791">
+    <meta property="fb:admins" content="100005241975163">
+    <meta property="fb:admins" content="1617218809">
+    <meta property="fb:admins" content="1215772645">
+    <meta property="fb:admins" content="100009270720042">
+    <meta property="fb:admins" content="502277904">
+    <meta property="fb:admins" content="544697162">
+    <meta name="title" content="Student Dies After Diet Pills She Bought Online &quot;Burned Her Up From Within&quot;">
+    <meta property="og:title" content="Student Dies After Diet Pills She Bought Online &quot;Burned Her Up From Within&quot;">
+    <meta property="og:description" content="An inquest into Eloise Parry's death has been adjourned until July.">
+    <meta property="og:url" content="http://www.buzzfeed.com/markdistefano/diet-pills-burns-up">
+    <meta name="twitter:creator" content="@MarkDiStef">
+    <meta property="article:tag" content="inquests">
+    <meta property="article:tag" content="online shopping">
+    <meta property="article:tag" content="uk">
+    <meta property="article:section" content="UKNews">
+    <meta property="article:publisher" content="https://www.facebook.com/BuzzFeed">
+    <meta property="og:image" content="http://s3-static-ak.buzzfed.com/static/2015-04/22/5/campaign_images/webdr03/student-dies-after-diet-pills-she-bought-online-b-2-28712-1429696299-24_dblbig.jpg">
+    <meta property="og:image:width" content="625">
+    <meta property="og:image:height" content="415">
+    <meta property="og:image:url" content="http://s3-ak.buzzfeed.com/static/2015-04/21/4/enhanced/webdr10/enhanced-6418-1429605460-16.jpg">
+    <meta property="og:image:width" content="625">
+    <meta property="og:image:height" content="422">
+    <meta property="og:image:url" content="http://s3-ak.buzzfeed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608056-15.jpg">
+    <meta property="og:image:width" content="203">
+    <meta property="og:image:height" content="412">
+    <meta property="og:image:url" content="http://s3-ak.buzzfeed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608057-18.jpg">
+    <meta property="og:image:width" content="412">
+    <meta property="og:image:height" content="412">
+    <link rel="image_src" href="http://s3-static-ak.buzzfed.com/static/2015-04/22/5/campaign_images/webdr03/student-dies-after-diet-pills-she-bought-online-b-2-28712-1429696299-24_big.jpg">
+    <meta property="og:type" content="article">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Student Dies After Diet Pills She Bought Online &quot;Burned Her Up From Within&quot;">
+    <meta name="twitter:description" content="An inquest into Eloise Parry's death has been adjourned until July.">
+    <meta name="twitter:image" content="http://s3-static-ak.buzzfed.com/static/2015-04/22/5/campaign_images/webdr03/student-dies-after-diet-pills-she-bought-online-b-2-28712-1429696299-24_big.jpg">
+    <meta name="twitter:site" content="@buzzfeednews">
+    <meta name="twitter:url" content="http://www.buzzfeed.com/markdistefano/diet-pills-burns-up">
+    <meta name="twitter:title" content="Student Dies After Diet Pills She Bought Online &quot;Burned Her Up From Within&quot;">
+    <meta name="twitter:description" content="An inquest into Eloise Parry's death has been adjourned until July.">
+    <meta name="twitter:app:id:iphone" content="352969997">
+    <meta name="twitter:app:url:iphone" content="buzzfeed://buzz/markdistefano/diet-pills-burns-up">
+    <meta name="twitter:app:id:ipad" content="352969997">
+    <meta name="twitter:app:url:ipad" content="buzzfeed://buzz/markdistefano/diet-pills-burns-up">
+    <meta name="twitter:app:id:googleplay" content="com.buzzfeed.android">
+    <meta name="twitter:app:url:googleplay" content="http://www.buzzfeed.com/markdistefano/diet-pills-burns-up">
+    <link rel="apple-touch-startup-image" href="http://s3-ak.buzzfed.com/static/images/mobile/startup.png">
+    <link rel="apple-touch-icon" href="http://s3-ak.buzzfed.com/static/images/mobile/touch-icons/touch-icon-ios_60.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="http://s3-ak.buzzfed.com/static/images/mobile/touch-icons/touch-icon-ios_76.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="http://s3-ak.buzzfed.com/static/images/mobile/touch-icons/touch-icon-ios_120.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="http://s3-ak.buzzfed.com/static/images/mobile/touch-icons/touch-icon-ios_152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="http://s3-ak.buzzfed.com/static/images/mobile/touch-icons/touch-icon-ios_180.png">
+    <link rel="shortcut icon" sizes="196x196" href="http://s3-ak.buzzfed.com/static/images/mobile/touch-icons/touch-icon-android.png">
+    <link rel="shortcut icon" crossorigin="" href="http://s3-ak.buzzfed.com/static/favicon.ico?v=201504241415" type="image/x-icon">
+    <link rel="canonical" href="http://www.buzzfeed.com/markdistefano/diet-pills-burns-up">
+    <link rel="alternate" href="http://www.buzzfeed.com/markdistefano/diet-pills-burns-up?s=mobile">
+    <link rel="alternate" href="android-app://com.buzzfeed.android/http/www.buzzfeed.com/markdistefano/diet-pills-burns-up?utm_source=google&amp;utm_medium=appindex&amp;utm_campaign=appindex">
+    <link rel="alternate" type="application/rss+xml" title="Mark Di Stefano's Buzz" href="/markdistefano.xml">
+    <link rel="alternate" type="application/rss+xml" title=" Buzz" href="/tag/.xml">
+    <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/ccss/front.desktop.css?v=201504241415" type="text/css">
+    <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/header.css?v=201504241415" type="text/css">
+    <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/legacy/core1.css?v=201504241415" type="text/css">
+    <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/legacy/core2.css?v=201504241415" type="text/css">
+    <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/bf_ui.css?v=201504241415" type="text/css">
+    <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/legacy/sponsorships.css?v=201504241415" type="text/css">
+    <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/permalink.css?v=201504241415" type="text/css">
+    <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/ccss/bpage.desktop.css?v=201504241415" type="text/css">
+    <!--[if IE 9]> <link rel="stylesheet" href="http://s3-ak.buzzfed.com/static/css/buzzfeed-ie9.css?v=201504241415" type="text/css" charset="utf-8" /> <![endif]-->
+    <!-- TO DO - This should be done by adding the class with Javascript -->
+    <script>
+    var rerankable = '';
+    </script>
+    <style>
+    .post2[style="background-color: #FDF6E5;"],
+    #BF_WIDGET_10,
+    [href^="http://www.faceporn.net/free?"],
+    div[id^="zergnet-widget-"],
+    div[id^="mainads"],
+    td[valign="top"] > .mainmenu[style="padding:10px 0 0 0 !important;"],
+    script[src^="http://free-shoutbox.net/app/webroot/shoutbox/sb.php?shoutbox="] + #freeshoutbox_content,
+    p[id^="div-gpt-ad-"],
+    input[onclick^="window.open('http://www.friendlyduck.com/AF_"],
+    input[onclick^="window.open('http://www.FriendlyDuck.com/AF_"],
+    img[alt^="Fuckbook"],
+    iframe[src^="http://cdn2.adexprt.com/"],
+    iframe[src^="http://cdn1.adexprt.com/"],
+    iframe[src^="http://ad.yieldmanager.com/"],
+    iframe[id^="google_ads_iframe"],
+    iframe[id^="google_ads_frame"],
+    div[id^="div-gpt-ad-"],
+    div[id^="acm-ad-tag-"],
+    div[id^="YFBMSN"],
+    div[id^="MarketGid"],
+    a[style="display:block;width:300px;min-height:250px"][href^="http://li.cnet.com/click?"],
+    a[onmousedown^="this.href='https://paid.outbrain.com/network/redir?"][target="_blank"] + .ob_source,
+    a[onmousedown^="this.href='https://paid.outbrain.com/network/redir?"][target="_blank"],
+    a[onmousedown^="this.href='http://staffpicks.outbrain.com/network/redir?"][target="_blank"] + .ob_source,
+    a[onmousedown^="this.href='http://staffpicks.outbrain.com/network/redir?"][target="_blank"],
+    a[onmousedown^="this.href='http://paid.outbrain.com/network/redir?"][target="_blank"] + .ob_source,
+    a[onmousedown^="this.href='http://paid.outbrain.com/network/redir?"][target="_blank"],
+    [href^="http://taboola-"][href*="/redirect.php?app.type="],
+    [href^="http://paid.outbrain.com/network/redir?"][target="_blank"],
+    [href^="http://games.ucoz.ru/"][target="_blank"],
+    [href^="http://api.taboola.com/"][href*="/recommendations.notify-click?app.type="],
+    [href^="http://amzn.to/"] > img[src^="data"],
+    [href^="//ads.ad-center.com/"],
+    [href^="//adbit.co/?a=Advertise&"],
+    [href^=" http://ads.ad-center.com/"],
+    a[href*="/adrotate-out.php?"],
+    a[href$="/vghd.shtml"],
+    a[data-redirect^="this.href='http://paid.outbrain.com/network/redir?"],
+    [onclick^="window.open('http://adultfriendfinder.com/search/"] {
+        display: none !important;
+    }
+    </style>
+    <script>
+    var bf_start_site_time = new Date().getTime();
+    </script>
+    <script>
+    var trans_gif_1x1_base64 = 'data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
+    </script>
+    <script>
+    var trans_gif_3x2_base64 = 'data:image/gif;base64,R0lGODlhAwACAPAAAAAAAAAAACH5BAEAAAAALAAAAAADAAIAAAIChF8AOw==';
+    </script>
+    <script type="text/javascript">
+    //<![CDATA[
+    if (null !== window.location.search.match("adtest")) {
+        BF_DFP_SITE = 'bfd.test.bpage';
+        document.write('<' + 'div style="position:fixed;top:0;left:0;background:#ff0;color:#000;padding:10px;z-index:99999;font:bold 16px arial;">AD TEST<' + '/div>');
+    } else if (null !== window.location.search.match("giraffe_test")) {
+        BF_DFP_SITE = 'bfd.giraffe_test.bpage';
+        document.write('<' + 'div style="position:fixed;top:0;left:0;background:#ff0;color:#000;padding:10px;z-index:99999;font:bold 16px arial;">GIRAFFE TEST<' + '/div>');
+    } else {
+        BF_DFP_SITE = 'bfd.bpage';
+    }
+
+    BF_TAG = 'tag=noads;';
+    BF_DFP_ZONE = '/uknews';
+    if (typeof BF_DFP_ORD == 'undefined') {
+        BF_DFP_ORD = Math.random() * 100000000000000000;
+    }
+    BF_DFP_KVS = 'bid=3758406;badge=viral;user=markdistefano;nsfw=0';
+    BF_NO_QS = true;
+    BF_DFP_NOADS = {};
+
+    var is_referer = "";
+
+    if (is_referer) {
+        BF_REFERER = is_referer;
+    } else if (document.referrer && !is_referer) {
+        BF_REFERER = document.referrer;
+        if (BF_REFERER.search('buzzfeed.com') != -1) BF_REFERER = 'buzzfeed';
+    } else {
+        BF_REFERER = 'undefined';
+    }
+    BF_REFERER = BF_REFERER.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#]/)[0];
+    if (BF_REFERER.match('\.')) BF_REFERER = BF_REFERER.replace(/\./g, '_');
+    else BF_REFERER = BF_REFERER;
+
+
+
+
+    var AB_AD_TEST = false;
+
+    AB_AD_TEST = true;
+
+    var AB_RND_VAL = Math.floor((Math.random() * 100) + 1);
+
+    if (AB_AD_TEST) {
+
+
+
+
+
+
+        if (AB_RND_VAL >= 0 && AB_RND_VAL < 33) {
+            AD_SIDEWIDE_BSU_REDESIGN = 'bsu_a';
+        } else if (AB_RND_VAL > 33 && AB_RND_VAL <= 66) {
+            AD_SIDEWIDE_BSU_REDESIGN = 'bsu_b';
+        } else {
+            AD_SIDEWIDE_BSU_REDESIGN = 'bsu_c'
+        }
+        // GPT B-Page - 100% GPT [excluding f-ad]
+
+
+
+
+
+
+        var AD_DESIGN, AD_THUMBNAIL;
+        AD_THUMBNAIL = 'thumbnailcontrol';
+
+        if (AB_RND_VAL >= 0 && AB_RND_VAL < 0) {
+            AD_DESIGN = 'script';
+        } else {
+            AD_DESIGN = 'gpt';
+        }
+
+        if (window['localStorage'] !== null) {
+
+            if (localStorage.getItem("GPT_BP7") == null) {
+                localStorage.setItem("GPT_BP7", AD_DESIGN);
+            }
+            AD_DESIGN = localStorage.getItem("GPT_BP7");
+
+
+
+            localStorage.setItem("AD_SIDEWIDE_BSU_REDESIGN", AD_SIDEWIDE_BSU_REDESIGN);
+
+        }
+
+        // Add to ab_test.js
+        (function() {
+            if (AB_AD_TEST && AD_DESIGN) {
+                if (typeof abtest != 'undefined' && !abtest.abTests.match(/GPT_BP7/)) {
+                    abtest.addTest("GPT_BP7", AD_DESIGN);
+                } else {
+                    setTimeout(arguments.callee, 100)
+                }
+            }
+        })();
+
+    } else {
+        AD_DESIGN = 'script';
+    }
+
+
+
+
+
+
+
+
+
+    try {
+        if (AB_AD_TEST && AD_DESIGN == 'gpt') {
+
+            var gptadslots = [];
+            var googletag = googletag || {};
+            googletag.cmd = googletag.cmd || [];
+            (function() {
+                var gads = document.createElement('script');
+                gads.async = true;
+                gads.type = 'text/javascript';
+                var useSSL = 'https:' == document.location.protocol;
+                gads.src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';
+                var node = document.getElementsByTagName('script')[0];
+                node.parentNode.insertBefore(gads, node);
+            })();
+
+
+            function loadGPTAd(params) {
+                if (!params || !params['wid']) return false;
+
+                googletag.cmd.push(function() {
+                    if (params.infinite_scroll && typeof infinite_slots[params.wid] != 'undefined') {
+                        gptadslots[params.wid] = googletag.defineSlot('/6556/' + BF_DFP_SITE + BF_DFP_ZONE, [
+                                [5, 5]
+                            ], 'div-gpt-ad-' + params.wid)
+                            .setTargeting('wid', params.wid)
+                            .setTargeting('pos', [infinite_slots[params.wid]])
+                            .addService(googletag.pubads());
+                    } else if (params.sidebar) {
+                        gptadslots[params.wid] = googletag.defineSlot('/6556/' + BF_DFP_SITE + BF_DFP_ZONE, [
+                                [3, 3]
+                            ], 'div-gpt-ad-' + params.wid)
+                            .setTargeting('wid', params.wid)
+                            .setTargeting('pos', ['sidebar'])
+                            .setTargeting('posnum', parseInt(params.wid, 10) - 4)
+                            .setTargeting("nsfw", 0)
+                            .setTargeting("user", 'markdistefano')
+
+                        .setTargeting("bid", '3758406')
+
+
+                        .setTargeting("badge", 'viral')
+
+
+                        .addService(googletag.pubads());
+                    }
+                    /* Weekend Promo Ad Unit */
+                    if (params.sitewideweekend) {
+                        gptadslots[params.wid] = googletag.defineSlot('/6556/' + BF_DFP_SITE + BF_DFP_ZONE, [
+                                [5, 5]
+                            ], 'div-gpt-ad-' + params.wid)
+                            .setTargeting('wid', params.wid)
+                            .setTargeting('pos', ['sitewideweekend'])
+                            .setTargeting("nsfw", 0)
+                            .setTargeting("user", 'markdistefano')
+
+                        .setTargeting("bid", '3758406')
+
+
+                        .setTargeting("badge", 'viral')
+
+
+                        .addService(googletag.pubads());
+                    }
+                    if (params.pos) {
+                        gptadslots[params.wid] = googletag.defineSlot('/6556/' + BF_DFP_SITE + BF_DFP_ZONE, [params.size], 'div-gpt-ad-' + params.wid)
+                            .setTargeting('wid', params.wid)
+                            .setTargeting('pos', [params.pos])
+                            .setTargeting('abtest', params.abtest)
+
+                        .setTargeting("nsfw", 0)
+                            .setTargeting("user", 'markdistefano')
+
+                        .setTargeting("bid", '3758406')
+
+                        .addService(googletag.pubads());
+
+
+                        (function() {
+                            if (AB_AD_TEST) {
+                                if (typeof abtest != 'undefined' && !abtest.abTests.match(new RegExp(params.pos.toUpperCase()))) {
+                                    abtest.addTest(params.pos.toUpperCase(), params.abtest);
+                                } else {
+                                    setTimeout(arguments.callee, 100)
+                                }
+                            }
+                        })();
+
+                    }
+                    /*END Weekend Promo Ad Unit */
+                    googletag.display('div-gpt-ad-' + params.wid);
+                    googletag.pubads().refresh([gptadslots[params.wid]], {
+                        changeCorrelator: false
+                    });
+                });
+            }
+
+            googletag.cmd.push(function() {
+
+
+                // BPAGE GPT ADS (bsu + sitewide)
+                gptadslots[13] = googletag.defineSlot('/6556/' + BF_DFP_SITE + BF_DFP_ZONE, [
+                        [300, 250]
+                    ], 'div-gpt-ad-13')
+                    .setTargeting('wid', '13')
+                    .setTargeting('pos', ['bigstorybpage'])
+                    .setTargeting('flex_medium', ['bigstory'])
+                    .setTargeting("nsfw", 0)
+                    .setTargeting("user", 'markdistefano')
+
+                .setTargeting("bid", '3758406')
+
+                //TODO: remove when sidewide_bsu_redesign test in #81670260 ends
+                .setTargeting('abtest', AD_SIDEWIDE_BSU_REDESIGN)
+
+
+
+                .setTargeting("badge", 'viral')
+
+
+                .addService(googletag.pubads());
+                gptadslots[9] = googletag.defineSlot('/6556/' + BF_DFP_SITE + BF_DFP_ZONE, [
+                        [5, 5]
+                    ], 'div-gpt-ad-9')
+                    .setTargeting('wid', '9')
+                    .setTargeting('pos', ['story-bpage'])
+                    .setTargeting("nsfw", 0)
+                    .setTargeting("user", 'markdistefano')
+
+                .setTargeting("bid", '3758406')
+
+
+                .setTargeting("badge", 'viral')
+
+
+                .addService(googletag.pubads());
+
+
+                googletag.pubads().enableSingleRequest();
+                googletag.pubads().disableInitialLoad();
+                googletag.pubads().setTargeting('poe', BF_REFERER);
+                googletag.pubads().setTargeting('abtest', AD_DESIGN);
+                googletag.pubads().setTargeting('ord', BF_DFP_ORD.toString());
+                googletag.pubads().enableAsyncRendering();
+                googletag.enableServices();
+            });
+
+        }
+    } catch (err) {
+        console.log(err);
+    }
+
+
+    function local_ad_call(wid, uparam, extra_params) {
+        if (BF_STATIC.bf_test_mode && document.cookie.match('sel2_ad') === null && document.cookie.match('sel2_gtrack') === null) {
+            console.info('disable DFP (dfp_tags.tt)');
+            return;
+        }
+
+        (function() {
+            var BF_WIDGET_JS = document.createElement('script');
+            BF_WIDGET_JS.type = "text/javascript";
+            BF_WIDGET_JS.async = true;
+            var BF_WIDGET_SRC = "http://ct.buzzfeed.com/wd/UserWidget?u=" + uparam + "&network=buzzfeed&uo=1&or=v&ct=1&cs=1&wid=" + wid + extra_params + "&cb=" + (new Date()).getTime();
+            setTimeout(function() {
+                document.getElementById('BF_WIDGET_' + wid).appendChild(BF_WIDGET_JS);
+                BF_WIDGET_JS.src = BF_WIDGET_SRC
+            }, 1);
+        })();
+    }
+
+    //]]>
+    </script>
+    <script type="text/javascript">
+    var homePageLink = {
+        'fr': '/' + ('live' == 'dev' ? 'index' : '') + '?country=fr',
+        'es': '/' + ('live' == 'dev' ? 'index' : '') + '?country=es',
+        'pt': '/' + ('live' == 'dev' ? 'index' : '') + '?country=br',
+        'de': '/' + ('live' == 'dev' ? 'index' : '') + '?country=de',
+        'mx': '/' + ('live' == 'dev' ? 'index' : '') + '?country=mx'
+    };
+
+    var countryLangLookup = {
+        'fr': 'fr_FR',
+        'es': 'es_ES',
+        'pt': 'pt_BR',
+        'de': 'de_DE',
+        'mx': 'es_MX'
+    };
+
+    var liveCountries = {
+        'us': 1,
+        'uk': 1,
+        'au': 1,
+        'in': 1,
+        'br': 1,
+        'pt': 1,
+        'es': 1,
+        'fr': 1,
+        'de': 1,
+        'mx': 1
+    };
+
+    var cookieBarVerticalBpageMessage = {
+        'fr': "Vous connaissez BuzzFeed France? <a href='" + homePageLink['fr'] + "'>C'est par ici!</a>",
+        'es': "Ya viste BuzzFeed en Espa&ntilde;ol? <a href='" + homePageLink['es'] + "'>&iexcl;Pasa a darle una mirada!</a>",
+        'pt': "J&aacute; viu BuzzFeed Brasil? <a href='" + homePageLink['pt'] + "'>Venha conferir!</a>"
+    };
+    </script>
+    <script type="text/javascript">
+    /* modernizr v3.0.0-alpha
+     * Build http://modernizr.com/download/#-inlinesvg-srcset-svg-webp-cssclasses
+     */
+    ! function(e, n) {
+        function A(e, n) {
+            return typeof e === n
+        }
+
+        function t() {
+            var e, n, t, o, a, s, f;
+            for (var u in i) {
+                if (e = [], n = i[u], n.name && (e.push(n.name.toLowerCase()), n.options && n.options.aliases && n.options.aliases.length))
+                    for (t = 0; t < n.options.aliases.length; t++) e.push(n.options.aliases[t].toLowerCase());
+                for (o = A(n.fn, "function") ? n.fn() : n.fn, a = 0; a < e.length; a++) s = e[a], f = s.split("."), 1 === f.length ? r[f[0]] = o : 2 === f.length && (!r[f[0]] || r[f[0]] instanceof Boolean || (r[f[0]] = new Boolean(r[f[0]])), r[f[0]][f[1]] = o), l.push((o ? "" : "no-") + f.join("-"))
+            }
+        }
+
+        function o(e) {
+            var n = f.className,
+                A = r._config.classPrefix || "";
+            if (r._config.enableJSClass) {
+                var t = new RegExp("(^|\\s)" + A + "no-js(\\s|$)");
+                n = n.replace(t, "$1" + A + "js$2")
+            }
+            r._config.enableClasses && (n += " " + A + e.join(" " + A), f.className = n)
+        }
+
+        function a(e, n) {
+            if ("object" == typeof e)
+                for (var A in e) c(e, A) && a(A, e[A]);
+            else {
+                e = e.toLowerCase();
+                var t = e.split("."),
+                    i = r[t[0]];
+                if (2 == t.length && (i = i[t[1]]), "undefined" != typeof i) return r;
+                n = "function" == typeof n ? n() : n, 1 == t.length ? r[t[0]] = n : 2 == t.length && (!r[t[0]] || r[t[0]] instanceof Boolean || (r[t[0]] = new Boolean(r[t[0]])), r[t[0]][t[1]] = n), o([(n && 0 != n ? "" : "no-") + t.join("-")]), r._trigger(e, n)
+            }
+            return r
+        }
+        var i = [],
+            s = {
+                _version: "v3.0.0pre",
+                _config: {
+                    classPrefix: "",
+                    enableClasses: !0,
+                    enableJSClass: !0,
+                    usePrefixes: !0
+                },
+                _q: [],
+                on: function(e, n) {
+                    var A = this;
+                    setTimeout(function() {
+                        n(A[e])
+                    }, 0)
+                },
+                addTest: function(e, n, A) {
+                    i.push({
+                        name: e,
+                        fn: n,
+                        options: A
+                    })
+                },
+                addAsyncTest: function(e) {
+                    i.push({
+                        name: null,
+                        fn: e
+                    })
+                }
+            },
+            r = function() {};
+        r.prototype = s, r = new r;
+        var l = [],
+            f = n.documentElement,
+            u = function() {
+                return "function" != typeof n.createElement ? n.createElement(arguments[0]) : n.createElement.apply(n, arguments)
+            };
+        r.addTest("srcset", "srcset" in u("img"));
+        var c;
+        ! function() {
+            var e = {}.hasOwnProperty;
+            c = A(e, "undefined") || A(e.call, "undefined") ? function(e, n) {
+                return n in e && A(e.constructor.prototype[n], "undefined")
+            } : function(n, A) {
+                return e.call(n, A)
+            }
+        }(), s._l = {}, s.on = function(e, n) {
+            this._l[e] || (this._l[e] = []), this._l[e].push(n), r.hasOwnProperty(e) && setTimeout(function() {
+                r._trigger(e, r[e])
+            }, 0)
+        }, s._trigger = function(e, n) {
+            if (this._l[e]) {
+                var A = this._l[e];
+                setTimeout(function() {
+                    var e, t;
+                    for (e = 0; e < A.length; e++)(t = A[e])(n)
+                }, 0), delete this._l[e]
+            }
+        }, r._q.push(function() {
+            s.addTest = a
+        }), r.addAsyncTest(function() {
+            function e(e, n, A) {
+                function t(n) {
+                    var t = "load" === n.type ? 1 == o.width : !1,
+                        i = "webp" === e;
+                    a(e, i ? new Boolean(t) : t), A && A(n)
+                }
+                var o = new Image;
+                o.onerror = t, o.onload = t, o.src = n
+            }
+            var n = [{
+                    uri: "data:image/webp;base64,UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vuUAAA=",
+                    name: "webp"
+                }, {
+                    uri: "data:image/webp;base64,UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAABBxAR/Q9ERP8DAABWUDggGAAAADABAJ0BKgEAAQADADQlpAADcAD++/1QAA==",
+                    name: "webp.alpha"
+                }, {
+                    uri: "data:image/webp;base64,UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA",
+                    name: "webp.animation"
+                }, {
+                    uri: "data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=",
+                    name: "webp.lossless"
+                }],
+                A = n.shift();
+            e(A.name, A.uri, function(A) {
+                if ("load" === A.type)
+                    for (var t = 0; t < n.length; t++) e(n[t].name, n[t].uri)
+            })
+        }), r.addTest("svg", !!n.createElementNS && !!n.createElementNS("http://www.w3.org/2000/svg", "svg").createSVGRect), r.addTest("inlinesvg", function() {
+            var e = u("div");
+            return e.innerHTML = "<svg/>", "http://www.w3.org/2000/svg" == (e.firstChild && e.firstChild.namespaceURI)
+        }), t(), o(l), delete s.addTest, delete s.addAsyncTest;
+        for (var p = 0; p < r._q.length; p++) r._q[p]();
+        e.Modernizr = r
+    }(window, document);
+    </script>
+    <script src="http://s3-ak.buzzfed.com/static/js/prototype/prototype.1.7-compact.js" type="text/javascript"></script>
+    <script type="text/javascript">
+    window.hasOwnProperty = Object.prototype.hasOwnProperty;
+
+    var fb_is_enabled = false;
+
+    fb_is_enabled = true;
+
+
+
+
+
+
+
+
+    var buzzDetails = {
+        ad: 0,
+        raw: 1,
+        nsfw: 0,
+        login: "terminal",
+        editor: "terminal" == "terminal" ? 1 : 0,
+        user: "terminal" == "contribute" ? 1 : 0,
+        trigger: 0,
+        postBadges: "viral" + "," + "",
+        postTags: "--ad-noads" + "," + "--primarykeyword-diet pills" + "," + "inquests" + "," + "online shopping" + "," + "uk" + "," + "",
+        f_partner: 0,
+        published: "2015-04-21 05:29:39",
+        category_name: "UKNews",
+        form: "super",
+        language: "en",
+        breaking: 0,
+        uri: "diet-pills-burns-up"
+    };
+
+
+    var BF_STATIC = {
+        country: 'us',
+        language: 'en',
+        non_english: 0,
+        translation_debug: 0,
+        static_root: 'http://s3-ak.buzzfed.com/static',
+        image_root: 'http://s3-ak.buzzfeed.com',
+        web_root: '',
+        version: '201504241415',
+        facebook_enabled: fb_is_enabled,
+        fb_app_id: '45075597673',
+        fb_api_key: '',
+        fb_api_version: 'v2.2',
+        fb_template_bundle_id: '',
+        fb_quickpost_template_bundle_id: '',
+        fb_badge_vote_template_bundle_id: '',
+        fb_love_vote_template_bundle_id: '',
+        fb_server_root: '',
+        twitter_api_key: 'vQjpMo8qABmqag9607Hg',
+        terminal_root_url: 'http://terminal.buzzfeed.com/',
+        fb_loader_server: '',
+        cookie_age_limit_hours: 24,
+        generated_timestamp: 1430141324,
+        page: 'Buzz',
+        tt_page: 'Buzz',
+        login_cookie_version: '1.0',
+        html5_video: false,
+        front_page_click_sample: 100,
+        bf_env: 'live',
+        referer: "",
+        bf_test_mode: false,
+        bf_category: '122',
+        big_image_root: 'http://ak-hdl.buzzfed.com',
+        image_service_root: 'http://s3-static-ak.buzzfed.com',
+        custom_ga_url: false,
+        BF_Beta_HP: false,
+        react_cam: true,
+        buzz_name: "Student Dies After Diet Pills She Bought Online \"Burned Her Up From Within\"",
+        buzz_blurb: "<b>An inquest into Eloise Parry&#8217;s death has been adjourned until July.</b>",
+        vertical: "uknews",
+        campaignid: "3758406",
+        f_ad: "",
+        username: "markdistefano",
+        user_is_f_ad: "0",
+        google_plus_client_id: "895639880237-tcoheof19odpd88p676rjc70v0iqit0o.apps.googleusercontent.com",
+        google_public_api_browser_key: 'AIzaSyBNj6Jq504-YFNx7I1SQei5x73orklpwnQ',
+        google_plus_client_id: "895639880237-tcoheof19odpd88p676rjc70v0iqit0o.apps.googleusercontent.com",
+        timequeue: [],
+        z: "4FFJJW",
+        hp_type: "",
+        mango_host: 'mango.buzzfeed.com',
+        page_layout: {
+            regions: {
+                bf_comments: false,
+                share_buttons: true,
+                facebook_comments: true,
+                reactions: false,
+                top_thumbstrip: true,
+                nexton: true,
+                sidebar: true,
+                infinite_content: true,
+                related_units: true,
+                hoton: true,
+                text_promo: true
+            }
+        },
+        show_post_content_only: "",
+        public_draft: "0",
+        pixiedust_sampling_rate: 1,
+        pixiedust_pound_sampling_rate: 1,
+        optimization_variations: {
+            control: 0.5,
+            collaborate: 0.5
+        },
+        collaborate_api: "collaborate.buzzfeed.com",
+        buzz_wide: 0
+
+    };
+
+
+    BF_STATIC.socket_server = "http://buzzsockets.buzzfeed.com:80";
+
+
+    var Cloud = {
+        "servers": ['alleyezonme-collection.buzzfeed.com'],
+        "report": 'http://wac.09fc.edgecastcdn.net/8009FC/dg-stats/_stats/buzz',
+        "staging": {
+            server: 'ec2-50-16-13-235.compute-1.amazonaws.com',
+            sample: 0
+        }
+    };
+
+    BF_server = "/buzzzfeed/";
+
+    if (!window.console) {
+        window.console = {};
+    }
+
+    $A(["assert", "count", "debug", "dir", "dirxml", "error", "group", "groupEnd", "info", "log", "profile", "profileEnd", "time", "timeEnd", "trace", "warn"]).each(function(method) {
+        if (!console[method]) {
+            if (method == 'error') {
+                console[method] = function(info) {
+                    var error_image = new Image();
+                    if (typeof(info) == 'object') info = Object.toJSON(info);
+                    var page = window.location.href,
+                        user_agent = navigator.userAgent;
+                    error_image.src = '/go/small.gif?error_info=' + escape(info) + '&page=' + escape(page) + '&useragent=' + escape(user_agent);
+                }
+            } else {
+                console[method] = function() {};
+            }
+        }
+    });
+
+    /* ie? */
+    // even though we don't use IE8 and under we're not touching this code for now
+    var ieV = parseInt(navigator.userAgent.substring(navigator.userAgent.indexOf("MSIE") + 5));
+    Prototype.Browser.IE6 = (Prototype.Browser.IE && ieV == 6);
+    Prototype.Browser.IE7 = (Prototype.Browser.IE && ieV == 7);
+    Prototype.Browser.IE8 = (Prototype.Browser.IE && ieV == 8);
+    Prototype.Browser.IE9 = (Prototype.Browser.IE && ieV == 9);
+    Prototype.Browser.IE10 = (Prototype.Browser.IE && ieV == 1 || ieV == 10);
+
+    /* ff? */
+    Prototype.Browser.FF2 = (navigator.userAgent.indexOf("Firefox/2") != -1 && navigator.userAgent.match(/Firefox\/2\d+/).length == 0);
+    Prototype.Browser.FF3_5 = (navigator.userAgent.indexOf("Firefox/3.5") != -1);
+    Prototype.Browser.FF3_6 = (navigator.userAgent.indexOf("Firefox/3.6") != -1);
+
+    /* clicktrack */
+    function bfct(ct) {
+        var img = new Image();
+        img.src = ct;
+    }
+    </script>
+    <script type="text/javascript" charset="utf-8">
+    BF_STATIC['browser_language_settings'] = 'fr-FR,en-US;q=0.7,en;q=0.3';
+    </script>
+    <script type="text/javascript" charset="utf-8">
+    BF_STATIC['country_track'] = 'FR';
+    </script>
+    <script src="http://s3-ak.buzzfed.com/static/js/General_concat_header.js?v=201504241415" type="text/javascript" ref:jsconf="true"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/User_and_Buzz_concat_header.js?v=201504241415" type="text/javascript" ref:jsconf="true"></script>
+    <style></style>
+    <script type="text/javascript" charset="utf-8">
+    // ***** DFP *****
+
+    //INFLATED-BY-PUBLISHER
+
+    if ('hashtrack' in window) hashtrack.init();
+
+    var tracker = new Tracker();
+    tracker.setDefaults({
+        c: "7FNW2J7",
+        u: "7717MJ7",
+        buzz: "diet-pills-burns-up",
+        user: "markdistefano"
+    });
+    tracker.add();
+    tracker.run();
+    BuzzLoader.register(function() {
+        tracker.attach();
+    }, 5);
+    var _cs = _cs || [];
+    _cs.push({
+        c1: "2",
+        c2: "18415030",
+        ns_site: "buzzfeed-poc"
+    });
+    var _gaq = _gaq || [];
+    var pluginUrl = (('https:' == document.location.protocol) ? 'https://ssl.' : 'http://www.') + 'google-analytics.com/plugins/ga/inpage_linkid.js';
+    _gaq.push(['_require', 'inpage_linkid', pluginUrl]);
+    _gaq.push(['_setAccount', 'UA-1740781-1']);
+    _gaq.push(['_setDomainName', 'buzzfeed.com']);
+    if (typeof window['HASH_REFER'] != 'undefined') _gaq.push(['_setReferrerOverride', window['HASH_REFER']]);
+
+
+    function GAPageLoad() {
+        try {
+            _gaq.push(['_setCampaignCookieTimeout', 0]);
+            _gaq.push(['_setPageGroup', '2', 'buzz']);
+
+            if (BF_STATIC.custom_ga_url != false) {
+                _gaq.push(['_set', 'page', BF_STATIC.custom_ga_url]);
+                _gaq.push(['_trackPageview', BF_STATIC.custom_ga_url]);
+            } else {
+                _gaq.push(['_trackPageview', (window.location.pathname + window.location.search.replace(/[?&]utm_term=[a-z0-9]*/, ''))]);
+            }
+
+            if (typeof BFW_Util == 'object') {
+                var country = (BFW_Util.getCookie("country") != null && BFW_Util.getCookie("country") != 'us' ? BFW_Util.getCookie("country") : 'us');
+                _gaq.push(['_trackPageview', '/_ga/' + country + window.location.pathname]);
+            }
+            _gaq.push(['_trackPageview', '/_ga/news' + window.location.pathname]);
+
+
+            _satellite.pageBottom();
+        } catch (err) {}
+    }
+
+    QuantcastCounter = 0;
+
+    function QuantPageLoad() {
+        if (typeof(_qevents) == 'undefined' && QuantcastCounter < 20) {
+            QuantcastCounter++;
+            setTimeout("QuantPageLoad()", 250);
+            return false;
+        }
+        var quantLabel = "",
+            hasHash = (typeof hashtrack != 'undefined' && typeof hashtrack.tracked_hash_tag != 'undefined' ? true : false);
+
+        quantLabel = "Buzz.markdistefano.diet-pills-burns-up";
+        if (hasHash) {
+            quantLabel += ".Hash." + hashtrack.tracked_hash_tag;
+        }
+        quantLabel += ", uknews";
+        if (hasHash) {
+            quantLabel += ", Hash." + hashtrack.tracked_hash_tag + "." + "markdistefano";
+        }
+
+        _qevents.push({
+            qacct: "p-3aud4J6uA4Z6Y",
+            labels: quantLabel
+        });
+
+    }
+
+
+
+
+
+
+
+    (function() {
+        var ga = document.createElement('script');
+        ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
+        ga.setAttribute('async', 'true');
+        document.documentElement.firstChild.appendChild(ga);
+        gtrack.setCustomVars(3, {
+            1: "Web",
+            3: 'Buzz'
+        });
+        gtrack.setBuzzCVs();
+        gtrack.setVisitCVs();
+        gtrack.setUserCVs();
+        gtrack.abTracking();
+    })();
+
+
+    var _qevents = _qevents || [];
+    (function() {
+        var qc = document.createElement('script');
+        qc.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+        qc.setAttribute('async', 'true');
+        qc.type = "text/javascript";
+        document.documentElement.firstChild.appendChild(qc);
+        QuantPageLoad();
+    })();
+
+
+    var _comscore = _comscore || [];
+    _comscore.push({
+        c1: "2",
+        c2: "6768151"
+    });
+    (function() {
+        var cs = document.createElement("script");
+        cs.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
+        cs.setAttribute('async', 'true');
+        document.documentElement.firstChild.appendChild(cs);
+    })();
+    </script>
+    <script async="true" src="http://stats.g.doubleclick.net/dc.js"></script>
+    <script type="text/javascript" async="true" src="http://edge.quantserve.com/quant.js"></script>
+    <script async="true" src="http://b.scorecardresearch.com/beacon.js"></script>
+    <script language="javascript">
+    acls = eval('({"group:brasil":["1271266","1335930","1335962","1870174","2478580","2478583","298095"],"queue_edit_audio":["1444088","1470778","group:superusers_us"],"queue_add_politics":["1003504","122429","1385295","2170678","2202803","2250863","227410","229172","230577","2328384","233242","259106","2741249","2855175","2870875","2956136","315300","315836","384520","568833","590158","686094","741910","824585","group:superusers_us"],"team_uknews":["1312775","1578896","2546507"],"mobile_homepage_edit":["p_developer_admin"],"brasil_homepage_edit":["1271266","298095","50","p_admin"],"australia_homepage_edit":["1197853","group:aus","group:edit_homepage_superusers","p_admin","p_developer_admin"],"test_oauth":["1","122429","1253","16062","187839","237968","266291","270926","3","336417","498631","55127"],"queue_edit_sports":["122429","1312880","2328384","267816","3","324633","386666","500733","group:superusers_us"],"pound":["p_admin","p_developer_admin"],"string_translation_moderator_purge":["122429","1485480","1717855","2484348","2813670","298095","66780","950397"],"buzz_homepage_edit":["1156822","16062","162354","2231567","266291","267816","364258","671752","736796","group:superusers_us","p_admin","p_developer_admin"],"francenews_homepage_edit":["2704195","2956221","p_developer_admin"],"queue_add_aunews":["1687686","845485","p_developer_admin"],"queue_edit_france":["1171016","238321","50","66780","group:france"],"queue_edit_food":["1273705","1273728","1845123","187839","1941119","2111936","2741249","339859","362601","386666","403790","537989","7","746557","group:superusers_us"],"delete_user_posts":["1003271","1108700","1115321","1253","1271266","1484259","16062","1849464","1896006","2111902","237968","238321","247883","270926","2747382","298095","339859","352440","357755","370320","401153","422680","428","55127","673572","7","707630","710080","751011","822569","84004","845485","935435","group:community_mods","p_admin"],"queue_add_france":["1171016","238321","50","66780","group:france"],"megaphone":["1273705","1273728","2111936","230684","336417","339859","40846","7","p_admin","p_editor_admin"],"queue_edit_francenews":["2704195","2956221","p_developer_admin"],"engagement_calculator":["1434527","176195","1830834","195079","2","270771","330597","54","963073","p_admin"],"advertising_leads":["336548","p_admin"],"queue_super_admin":["1","115350","1171016","1212587","122429","16062","194239","259106","3","386666","471","65","76","group:superusers_us"],"team_health":["1966022","2111936","2388155","2675381"],"queue_edit_health":["1273705","1273728","1966022","2111936","2388155","2675381","2741249","339859","537989","group:superusers_us","p_developer_admin"],"gif_feed_admin":["1171016","288662","p_developer_admin"],"queue_draft_to_publish":["p_developer_admin","p_editor_admin","p_partner_admin"],"queue_add_books":["1171016","p_editor_admin"],"plugin_moderation":["p_admin","p_developer_admin"],"homepage_edit":["1","1171016","1197853","1212587","122429","1904742","2081783","2328384","2854113","3","333563","370234","386666","403790","411700","65","66780","76","group:edit_homepage","group:edit_homepage_superusers"],"rest_api":["1277823","1694553","1745207","2066708","2066727","2066742","2066748","2066785","2138898","2138899","2138900","2212335","2401722","2547499","2580590","852110","899537","p_admin","p_developer_admin","p_editor_admin"],"queue_add_uk":["3","group:superusers_us","group:uk"],"queue_add_lgbt":["1171016","1984323","2081378","2111902","2170678","2231552","2250863","3","315836","376554","418643","462098","471","824585","group:superusers_us"],"pugopticon":["p_admin","p_developer_admin"],"lifestyle_homepage_edit":["1273705","1273728","1845123","1941119","1987041","2077242","2111936","336417","339859","40846","7","group:superusers_us","p_admin","p_developer_admin"],"team_parents":["1848921","792154"],"acl_edit":["1277776","1470778","2680742","p_admin"],"group:germany":["1896006","1923108","1923120","2053449","2591348","2591352"],"mexico_homepage_edit":["1171016","2484348","50","group:mexico","p_admin"],"quizzes_homepage_edit":["251155","267816","323444","group:superusers_us","p_admin","p_developer_admin"],"edit_user_client":["1","1171016","1212587","122429","2854113","3","386666","403790","65","76"],"editors_manage":["p_developer_admin","p_editor_admin"],"queue_edit_politics":["1003504","122429","2170678","2202803","2250863","233242","315300","590158","824585","group:superusers_us"],"queue_edit_style":["1273705","1273728","1661842","1845123","1941119","1987041","2111936","2231441","2236203","2741249","2848235","341645","40846","537989","7","group:superusers_us"],"queue_add_ideas":["1171016","2111902","2250863","2268055","2478648","2666258","group:superusers_us"],"queue_add_sports":["122429","2993270","3","386666","p_editor_admin"],"queue_add_australia":["2111902","238321","84004","group:aus"],"team_germany":["1171016","122429","1485480","1717855","2484348","2557882","2577162","2741611","2925518","66780","882394","963058","group:germany"],"edit_user_accounts":["p_admin","p_developer_admin","p_editor_admin","p_partner_admin"],"buzz_metadata":["1108320","1116949","1171016","12405","1253","1271266","1369134","149163","16062","1661938","1770243","190806","237968","2498866","2604687","266291","2699763","2699765","270926","302504","328249","341645","370320","391947","403774","422680","50","659572","69866","939067","group:aus","group:france","group:germany","group:india","group:mexico","p_admin","p_developer_admin"],"queue_edit_geeky":["115350","1171016","16062","267816","329408","group:superusers_us"],"queue_add_videos":["1000035","1086982","1171016","122429","2328384","240684","2958561","2959236","2961129","2961253","2963038","2966491","31899","386666","545436","545461","771922","963058","group:edit_video","p_editor_admin"],"entertainment_homepage_edit":["1108610","1385527","2478485","2478648","370035","370453","386254","418529","736840","885067","group:superusers_us","p_admin","p_developer_admin"],"hp_drag":["1197853","1470778","1578896","194239","2053449","2081783","2546507","333563","370234","411700","4146","66780","group:edit_homepage","group:superusers_us"],"group:edit_life":["1273728","1845123","1848921","1941119","1966022","1987041","2111936","2138524","2231441","2236203","2388155","2635268","2635279","2635417","2675381","2741249","2741267","2957479","2957481","2957492","336417","339859","362601","40846","7","736795","746557","792154"],"queue_edit_usnews":["2170678","2250863","2318153","2633715","500733","group:superusers_us"],"embed_whitelist":["p_admin"],"queue_edit_india":["1171016","386666","673572"],"unswitch_users":["1","1171016","1212587","122429","2081783","2854113","3","386666"],"queue_add_espanol":["1015411","122429","1253","1485480","238321","298095","427759","50","66780"],"slide_to_publish":["1027352","1089121","1108335","1108610","1108700","1115290","1156822","1171016","1212587","1273705","1273728","1369134","1458590","1661938","185968","2057907","2081698","2231552","2526433","2591352","2699765","370320","370453","386666","418529","532900","575948","659572","683475","736815","736840","76","833164","923522"],"queue_edit_books":["1054915","1171016","1953376","2328384","267816","386666","66780","group:superusers_us"],"queue_edit_music":["1171016","1559191","2053512","2136851","267816","295325","323444","group:superusers_us"],"queue_add_francenews":["2704195","2956221","822569","989100","p_developer_admin"],"picks_delete_from_anywhere":["1171016","1516092","1644469","357755","p_admin"],"uk_homepage_edit":["1253","238321","845485","group:edit_homepage_superusers","group:uk","p_admin"],"dashboard_custom_daterange":["!2031357","!2112279","f_ad","p_admin","p_developer_admin","p_editor_admin","p_partner_admin"],"general_advertiser":["f_ad","p_admin"],"queue_edit_travel":["1171426","1273728","1845123","1941119","2111936","267816","2741249","537989","group:superusers_us"],"queue_add_audio":["1081451","1171016","1444088","1470778","2906221","group:superusers_us"],"assign_bf_contributor":["p_admin"],"edit_user_posts":["1928635","312860","345930","357755","397967","412473","60694","615244","63387","727930","734362","750320","967593","p_admin","p_developer_admin","p_editor_admin"],"buzz_quick_link":["p_admin"],"news_homepage_edit":["1896880","2170678","2250852","2250863","2318153","2633715","2634389","group:superusers_us","p_admin","p_developer_admin"],"group:edit_news":["1003271","1003504","1026792","1089121","1108335","1108610","1156833","1193475","1301639","1312775","1312880","1336055","1353057","1385527","1387362","1434327","1442705","1484259","1559191","1578896","1610676","1614116","1687686","1740300","1823255","1850152","187839","1896880","1946840","1984323","2020696","2053512","2081378","2107477","2111783","2111902","2136851","2170674","2170678","2183452","2202803","2231436","2231552","2250852","226184","227410","229172","230577","2318153","2321795","2325401","233242","238321","2389092","2441426","2478447","2478468","2478478","2478479","2478482","2478485","2478648","2498432","2498866","251155","2512232","2512313","2512317","2546507","2570218","2570956","2577162","259106","260121","2608507","2633715","2634389","2666256","2666258","2671964","2699763","2699765","2704195","2739038","2739043","2777615","2855175","2870875","2883570","2956136","2956221","2965923","2990083","315300","315836","339184","352440","370035","370453","376554","384520","386254","418529","418643","422588","423472","450483","462098","568833","575948","590158","683073","686094","710080","712971","719068","741910","751011","76","780484","824585","836009","84004","841725","845485","885067","893445","935435","963170","991461"],"edit_partner_posts":["1171016","1353444","2493459","p_partner_admin"],"group:edit_homepage":["12405","1253","1484259","16062","1685059","1687686","1740300","2111902","2170674","2250852","2318153","238321","2478468","247883","2739043","300943","352440","423472","710080","741910","751011","780484","84004","935435"],"dashboard_bf_view":["p_admin"],"boost_moderation_view":["p_admin"],"team_comedy":["2396385"],"queue_edit_longform":["1108320","1171016","1212587","1301639","2250863","3","370320","386666","659572","group:superusers_us"],"queue_edit_australia":["1740300","2111902","238321","386666","84004","group:aus"],"queue_add_travel":["1171426","1273705","1273728","1845123","1941119","1987041","2111936","2741249","336417","362601","537989","736795","group:superusers_us"],"image_delete":["300943","364258","p_admin"],"edit_editor_posts":["p_editor_admin"],"queue_add_celebrity":["16191","1869367","2111902","230684","251155","262092","267816","370035","391411","471","962814","group:superusers_us"],"sponsored_stories_admin":["195079","304178","p_admin"],"unlink_users":["1","1171016","1212587","122429","2081783","2854113","3","386666"],"team_espanol":["1171016","1212587","122429","1485480","1717855","1730290","2484348","2557882","2577162","2741611","2854113","2925518","50","66780","882394","group:espanol"],"group:edit_video":["1000007","1075744","1096571","1104104","1115321","1115365","1212103","1212133","1218274","1314219","1353444","1364221","1382171","1438464","1484989","1605446","1718098","1718122","1718451","1722227","1771444","1849464","1873960","1897164","1993144","2022191","2082592","2092345","2097434","2113109","2113144","2113163","2113208","2113276","2117009","2117543","2123592","2215606","2221719","2241160","2332366","2360592","2493459","2519743","2519751","2519760","2519764","2519799","2520684","2522192","2523119","2524011","2555921","2740099","2747382","2758476","2788652","2795825","2799800","281486","2890555","315264","331181","390721","422627","488333","500380","670263","676627","676638","707630","727930","734485","734568","749009","757245","781609","84","881910","954476","954744","967593","969900","969905","997442"],"queue_add_germany":["50","group:germany","p_developer_admin"],"queue_edit_science":["1027352","1058035","923522","group:superusers_us","p_developer_admin"],"queue_add_parents":["1273705","1273728","1845123","1848921","1941119","1987041","2111936","2741249","336417","362601","537989","7","736795","792154","group:superusers_us","p_developer_admin"],"queue_edit_tvandmovies":["1108610","1171016","122429","2328384","2478485","267816","3","370453","386666","418529","575948","66780","885067","group:superusers_us"],"group:edit_homepage_superusers":["1484259","1685059","1687686","1740300","2111902","2170674","2318153","352440","710080","751011","84004"],"queue_add_ukpolitics":["3","group:superusers_us","group:uk"],"sailthru_edit":["p_admin"],"boost_admin":["p_admin"],"queue_edit_comics":["16062","group:superusers_us"],"new_quiz_format":["185968","p_admin"],"queue_edit_community":["1212587","1558928","2053484","2328384","2799084","386666","66780","group:community_mods","group:superusers_us"],"queue_add_science":["1027352","1058035","2283483","923522","group:superusers_us","p_developer_admin"],"queue_edit_diy":["1273705","1273728","1661842","1845123","1941119","2111936","2138524","2741249","2741267","3","336417","537989","7","group:superusers_us"],"queue_edit_mexico":["1171016","1485480","2484348","2813670","298095","50"],"rerankable_posts":["1110308","1116949","1171016","1212587","122429","1253","1273705","1335962","1390596","1444088","1459277","1472002","1558928","190806","1983419","1983731","2081679","2081687","2112694","2355176","251155","266291","2799084","2854113","298095","312860","323444","330597","336417","362601","471","536348","723165","736796","822569","939122","group:aus","p_developer_admin"],"group:superusers_us":["1089121","1108335","1171016","1253","1291311","1484259","1712709","1740300","2111902","2111977","2170674","2250852","2318153","237968","238321","2478468","247883","352440","367201","401153","422680","428","683475","710080","751011","84004","935435"],"gengo_admin":["1108335","1171016","1271266","1485480","2577162","2704195","2956221","298095","333563","50","66780","822569","963058","989100","group:germany"],"espanol_homepage_edit":["1015411","1253","1485480","238321","298095","427759","50","p_admin"],"ukbuzz_homepage_edit":["671752","p_admin","p_developer_admin"],"queue_add_business":["1336055","2170678","2965923","450483","568833","683073","712971","719068","group:superusers_us"],"queue_add_longform":["1108320","1171016","1301639","2111902","2250863","2699765","370320","386666","659572","group:superusers_us"],"creative_byline_in_toolbar":["p_admin","p_partner_admin"],"indepth_homepage_edit":["1108320","2170678","2250863","370320","659572","p_admin","p_developer_admin"],"dateline_locations":["1003271","1108335","1171016","1212587","2081378","2170678","2328384","2478468","2546507","2739799","2956136","386666","428","845485"],"queue_add_geeky":["1027352","115350","1171016","1558928","16062","329408","834236","group:superusers_us"],"germany_homepage_edit":["50","group:germany","p_admin","p_developer_admin"],"user_moderators":["group:community_mods","p_admin"],"queue_add_style":["1273705","1273728","1661842","1845123","1941119","1987041","2111936","2231441","2236203","2741249","2848235","336417","362601","40846","537989","7","736795","group:superusers_us"],"queue_edit_weddings":["1273705","1273728","1845123","1987041","2741249","339859","7","p_developer_admin"],"queue_add_rewind":["1171016","16191","2111902","230684","267816","3","406972","427759","471","group:superusers_us"],"queue_edit_aunews":["845485","p_developer_admin"],"can_boost":[],"buzz_any_embed":["1108320","1116949","12405","1253","1369134","149163","1661938","1770243","2498866","2604687","2699763","2699765","270926","302504","323444","328249","370320","391947","422680","50","659572","939067","group:aus","group:brasil","group:france","group:germany","group:india","group:mexico","p_admin","p_developer_admin"],"queue_add_music":["1559191","187839","2053512","2136851","267816","2920421","295325","323444","group:superusers_us"],"queue_add_brasil":["1271266","1335930","1335962","1870174","238321","2478580","2478583","298095","50"],"queue_edit_business":["1336055","2250863","450483","683073","712971","719068","group:superusers_us"],"amazon_rerank":["p_admin"],"queue_edit_animals":["122429","1770243","266291","267816","2883313","3","498631","group:superusers_us"],"community_manage":["1171016","1212587","122429","1439137","1558928","2053484","2081783","2328384","2854113","915581","group:community_mods","p_developer_admin"],"default_template_article":["group:edit_news"],"terminal_user":["p_admin","p_developer_admin","p_editor_admin"],"queue_add_uknews":["1003271","1026792","1076475","1312775","1578896","1685059","2511644","2546507","2633715","2666587","2739038","2739043","422680","590158","736840","p_developer_admin"],"group:uk":["1003271","1026792","1076475","1081451","1114825","1268340","1273246","1312775","1369060","1401831","1472002","1578896","1597198","1685059","1712709","1740300","1740404","1744199","2003837","2077242","2107477","2268055","2478447","2511644","2546507","2575622","2647836","2666587","2739038","2739043","2761694","2778050","4146","422680","428","537989","590158","671752","710486","736840","773166","923522","962814","991461"],"queue_add_india":["673572"],"queue_add_health":["1273705","1273728","1941119","1966022","1987041","2111936","2388155","2675381","2741249","336417","362601","537989","736795","group:superusers_us","p_developer_admin"],"updated_timestamp":["1108335","1171016","2604679","321271","386666","975974","group:edit_news","p_admin"],"queue_edit_celebrity":["122429","1869367","230684","262092","267816","403790","427759","471","962814","group:superusers_us"],"queue_add_food":["1273705","1273728","1845123","187839","1941119","1987041","2111936","2741249","336417","339859","362601","403790","537989","7","736795","746557","group:superusers_us"],"blog_press":["1","1171016","1212587","122429","201605","2250863","242537","2478482","2498432","2498866","2604672","2699763","3","333563","370234","65","735630","842571","86770","963058"],"lists_homepage_edit":["p_admin"],"longform_edit":["1081451","1108320","1110308","1115290","1197853","1212587","1280610","1290623","1369134","1434356","1471021","1847385","1869367","1928416","2020559","2062840","2112160","2235696","2235704","2250863","2268055","230684","2323166","2355170","247643","2526433","281496","2902196","343520","362317","370320","427637","615244","659572","66780","670266","736815","893420","group:edit_news","group:superusers_us","p_developer_admin"],"queue_add_animals":["2883313","3","p_editor_admin"],"group:mexico":["1485480","2813670","2957479","2957481","2957485","2957492","2957495"],"preview_special_tags":["p_admin"],"boost_button":["1434326","1745595","195079","196197","2","2576205","2644315","304178","328137","p_developer_admin"],"india_homepage_edit":["1904742","673572","group:edit_homepage_superusers","p_admin"],"queue_edit_lgbt":["1171016","1984323","2170678","2231552","2250863","3","315836","376554","418643","462098","824585","group:superusers_us"],"translation_approval":["1108335","2484348","2577162","p_admin"],"trending_moderation":["p_admin"],"sailthru_publish":[],"queue_add_world":["1193475","1434327","2081378","2170678","2250863","2328384","2478479","2739043","462098","824585","841725","893445","963170","group:superusers_us"],"queue_edit_germany":["50","group:germany","p_developer_admin"],"dateline_buzz":["1003271","1003504","1026792","1089121","1108335","1108700","1193475","1312775","1326855","1369134","1434327","1484259","1508517","1559191","1578896","1896880","1984323","2081378","2107477","2111902","2136851","2170674","2170678","2202803","2250852","2250863","229172","238321","2478447","2478468","2478478","2478479","247883","2480099","2512317","2546507","2634389","2666258","2666587","2739038","2761694","2777615","2855175","2870875","2902196","2965923","315300","370320","401153","418643","422680","428","450483","462098","50","590158","659572","710080","710486","751011","824585","84004","841725","845485","885067","893445","963170","981579","p_admin"],"france_homepage_edit":["1171016","238321","2704195","2956221","50","822569","989100","p_admin"],"edit_user_permissions":["1470778","p_admin"],"group:india":["1583184","1594871","1767263","1819831","1963300","2604768","673572"],"acl_view":["1470778","p_admin","p_developer_admin"],"queue_edit_rewind":["2250863","230684","267816","406972","427759","471","group:superusers_us"],"queue_edit_ideas":["1171016","2250863","2268055","2478648","2666258","group:superusers_us","p_developer_admin"],"queue_edit_tech":["1171016","122429","1823255","2250863","2328384","2389092","2512232","260121","2634389","2671964","2777615","2848269","422588","group:superusers_us"],"team_weddings":["p_developer_admin"],"string_translation_moderator":["1171016","122429","1717855","2484348","2741611","2925518","group:brasil","group:espanol","group:france","group:germany","group:mexico","p_developer_admin"],"group:aus":["1042292","1264948","1326855","1687686","1712361","1877436","1921502","1926263","2325401","2526433","2526435","2902184","2902196","845485","966504","967687"],"badge_config_admin":["1171016","1197853","1439137","1873378","915581","p_developer_admin"],"queue_add_diy":["1273705","1273728","1661842","1845123","1848921","1941119","1987041","2111936","2138524","2741249","2741267","336417","362601","537989","7","736795","group:superusers_us"],"queue_edit_uknews":["1076475","1312775","1685059","2546507","422680","590158","736840","p_developer_admin"],"hotlist_moderation":[],"queue_add_tvandmovies":["1108610","1171016","122429","1385527","2111902","2328384","2478485","267816","3","370035","370320","370453","386254","403790","418529","575948","66780","885067","group:superusers_us"],"buzz_promote":["p_admin"],"queue_edit_parents":["1273705","1273728","1845123","1848921","1941119","2111936","2741249","537989","7","792154","group:superusers_us","p_developer_admin"],"partners_manage":["1171016","1353444","2493459","354273","417220","984166","p_admin","p_partner_admin"],"switch_user_menu_option":["anyone"],"in_depth_moderation":["p_admin"],"queue_add_comics":["16062","2111902","267816","group:superusers_us"],"queue_edit_brasil":["1253","1271266","1335962","238321","298095","50"],"group:edit_buzz":["1015411","1042292","1054915","1058035","1076475","1114825","1115439","115350","1156822","1171426","1253","1268340","1271266","1273246","1335930","1335962","1353008","1369060","1401831","1444088","1459277","1459318","1459320","1558933","1597198","16062","16191","162354","1740404","1744199","1745256","1850152","1869367","1870174","1878629","1896006","1899640","1921502","1923120","1926263","1933171","1953376","1963300","2003837","2053449","2053484","207246","2081679","2081680","2081687","2081698","2112694","2231455","2231567","2235696","2235704","226184","2294340","230684","2355176","237968","2396385","2478650","2575622","2591348","2591352","259321","2604768","262092","2634188","2634190","2634194","2634195","2634332","266291","267816","2704195","2777778","2813670","2849654","2883302","2883313","2883359","2955603","2957481","2957485","2976051","2976379","298095","323444","324633","329408","341645","374407","406972","411042","4146","427759","471","498631","500733","532900","536348","670257","670266","671134","671752","696530","736796","736815","74504","773166","774378","799053","822569","82483","834236","923522","939060","939122","962814","963032","966504","983083","989100"],"uk_homepage_splashing":["1026792","1253","1268340","1312775","1578896","1740404","1744199","238321","2546507","2666587","2739038","4146","422680","428","537989","590158","group:edit_homepage_superusers","p_developer_admin"],"queue_add_mexico":["1171016","2484348","50","group:mexico"],"dashboard_admin":["p_admin","p_developer_admin","p_editor_admin","p_partner_admin"],"uknews_homepage_edit":["1003271","1026792","1312775","1685059","2546507","422680","p_admin","p_developer_admin"],"queue_add_weddings":["1273705","1273728","1845123","1987041","2081681","2111936","2741249","336417","339859","362601","40846","7","p_developer_admin"],"events_reorder":["1007381","216369","242537","676593","918039","p_admin"],"queue_edit_world":["1434327","2081378","2170678","2250863","2478479","2739043","824585","group:superusers_us"],"edit_community_posts":["p_editor_admin"],"queue_add_comedy":["115350","16062","2053484","2396385","267816","2777778","3","323444","411042","498631","670257","group:superusers_us"],"general_admin":["p_admin","p_developer_admin","p_editor_admin","p_partner_admin"],"queue_edit_comedy":["16062","2396385","267816","3","group:superusers_us"],"homepage_splashing":["1","1171016","1197853","1212587","122429","2081783","2328384","2854113","3","333563","370234","386666","411700","66780","76","group:edit_homepage","group:edit_homepage_superusers"],"queue_edit_ukpolitics":["1076475","1578896","2478447","2546507","590158","736840","773166","991461","group:superusers_us"],"queue_add_tech":["1171016","122429","1823255","2111902","2170678","2250863","2328384","2389092","251155","2512232","260121","2634389","2671964","2777615","2848269","2883570","422588","group:superusers_us"],"group:france":["2704195","2956221","2976051","822569","989100"],"queue_edit_videos":["1171016","122429","2360592","2394379","281486","2854113","31899","331181","386666","488333","545436","545461","707630","84","963058"],"super_share":[],"queue_edit_uk":["386666","group:superusers_us","group:uk"],"queue_add_usnews":["1156833","2250863","2328384","260121","2633715","2761694","333563","500733","group:superusers_us"],"team_france":["1171016","122429","1485480","1717855","1730290","2484348","2557882","2577162","2741611","2925518","50","66780","group:france"],"give_full_admin":["1","1171016","1212587","122429","2854113","3","403790","66780","76"],"aunews_homepage_edit":["2902196","845485","p_admin"],"team_mexico":["2231455","2321795","50","group:mexico"],"duplicate_post":["1171016","1271266","1335930","1335962","1434527","1439137","187839","195079","196197","2478580","2478583","2484348","2577162","357755","386666","931699","group:espanol","group:france","group:germany","group:mexico","p_developer_admin"],"logged_in":["anyone","p_admin"],"queue_edit_espanol":["1015411","122429","1253","1485480","238321","298095","50","66780"],"facebook_chatter":["p_admin"],"translation_moderator":["1171016","122429","1253","1385516","1470778","1717855","2484348","266291","2854113","50","group:brasil","group:espanol","group:france","group:germany","group:mexico","p_developer_admin"],"queue_add_community":["1353444","1558928","2053484","2493459","386666","816573","group:community_mods","group:superusers_us"],"new_preview":["!2680511","1026792","1108700","1156822","1156833","1171426","1312775","1459277","1459318","1459320","162354","1848921","2020916","2111902","2231552","230577","2389092","247883","248881","281496","2823827","333563","376554","4146","418529","418643","50","500733","536348","55127","590158","6291","683073","710080","736815","736840","74504","751011","845485","885067","954476","983083","991461","group:espanol","group:mexico","p_admin","p_developer_admin"],"group:community_mods":["115350","1558933","2081698","2138526","2557882","2634188","532900","670266","671134","939067"],"group:espanol":["1015411","1771122","1896343","2231455","2321795","298095"],"breaking_homepage":["group:superusers_us"],"team_brasil":["1171016","122429","1271266","1335930","1335962","1385516","1470778","1485480","1717855","1730290","180983","1870174","2478580","2478583","2484348","2557882","2577162","2741611","2925518","298095","333563","404442","50","65","66780"]})');
+    </script>
+    <style type="text/css">
+    .acl_control {
+        display: none
+    }
+
+    .queue_edit_audio {
+        display: none
+    }
+
+    .can_queue_edit_audio .acl_control.queue_edit_audio,
+    .can_queue_edit_audio .queue_edit_audio {
+        display: inherit
+    }
+
+    .queue_add_politics {
+        display: none
+    }
+
+    .can_queue_add_politics .acl_control.queue_add_politics,
+    .can_queue_add_politics .queue_add_politics {
+        display: inherit
+    }
+
+    .team_uknews {
+        display: none
+    }
+
+    .can_team_uknews .acl_control.team_uknews,
+    .can_team_uknews .team_uknews {
+        display: inherit
+    }
+
+    .mobile_homepage_edit {
+        display: none
+    }
+
+    .can_mobile_homepage_edit .acl_control.mobile_homepage_edit,
+    .can_mobile_homepage_edit .mobile_homepage_edit {
+        display: inherit
+    }
+
+    .brasil_homepage_edit {
+        display: none
+    }
+
+    .can_brasil_homepage_edit .acl_control.brasil_homepage_edit,
+    .can_brasil_homepage_edit .brasil_homepage_edit {
+        display: inherit
+    }
+
+    .australia_homepage_edit {
+        display: none
+    }
+
+    .can_australia_homepage_edit .acl_control.australia_homepage_edit,
+    .can_australia_homepage_edit .australia_homepage_edit {
+        display: inherit
+    }
+
+    .test_oauth {
+        display: none
+    }
+
+    .can_test_oauth .acl_control.test_oauth,
+    .can_test_oauth .test_oauth {
+        display: inherit
+    }
+
+    .queue_edit_sports {
+        display: none
+    }
+
+    .can_queue_edit_sports .acl_control.queue_edit_sports,
+    .can_queue_edit_sports .queue_edit_sports {
+        display: inherit
+    }
+
+    .pound {
+        display: none
+    }
+
+    .can_pound .acl_control.pound,
+    .can_pound .pound {
+        display: inherit
+    }
+
+    .string_translation_moderator_purge {
+        display: none
+    }
+
+    .can_string_translation_moderator_purge .acl_control.string_translation_moderator_purge,
+    .can_string_translation_moderator_purge .string_translation_moderator_purge {
+        display: inherit
+    }
+
+    .buzz_homepage_edit {
+        display: none
+    }
+
+    .can_buzz_homepage_edit .acl_control.buzz_homepage_edit,
+    .can_buzz_homepage_edit .buzz_homepage_edit {
+        display: inherit
+    }
+
+    .francenews_homepage_edit {
+        display: none
+    }
+
+    .can_francenews_homepage_edit .acl_control.francenews_homepage_edit,
+    .can_francenews_homepage_edit .francenews_homepage_edit {
+        display: inherit
+    }
+
+    .queue_add_aunews {
+        display: none
+    }
+
+    .can_queue_add_aunews .acl_control.queue_add_aunews,
+    .can_queue_add_aunews .queue_add_aunews {
+        display: inherit
+    }
+
+    .queue_edit_france {
+        display: none
+    }
+
+    .can_queue_edit_france .acl_control.queue_edit_france,
+    .can_queue_edit_france .queue_edit_france {
+        display: inherit
+    }
+
+    .queue_edit_food {
+        display: none
+    }
+
+    .can_queue_edit_food .acl_control.queue_edit_food,
+    .can_queue_edit_food .queue_edit_food {
+        display: inherit
+    }
+
+    .delete_user_posts {
+        display: none
+    }
+
+    .can_delete_user_posts .acl_control.delete_user_posts,
+    .can_delete_user_posts .delete_user_posts {
+        display: inherit
+    }
+
+    .queue_add_france {
+        display: none
+    }
+
+    .can_queue_add_france .acl_control.queue_add_france,
+    .can_queue_add_france .queue_add_france {
+        display: inherit
+    }
+
+    .megaphone {
+        display: none
+    }
+
+    .can_megaphone .acl_control.megaphone,
+    .can_megaphone .megaphone {
+        display: inherit
+    }
+
+    .queue_edit_francenews {
+        display: none
+    }
+
+    .can_queue_edit_francenews .acl_control.queue_edit_francenews,
+    .can_queue_edit_francenews .queue_edit_francenews {
+        display: inherit
+    }
+
+    .engagement_calculator {
+        display: none
+    }
+
+    .can_engagement_calculator .acl_control.engagement_calculator,
+    .can_engagement_calculator .engagement_calculator {
+        display: inherit
+    }
+
+    .advertising_leads {
+        display: none
+    }
+
+    .can_advertising_leads .acl_control.advertising_leads,
+    .can_advertising_leads .advertising_leads {
+        display: inherit
+    }
+
+    .queue_super_admin {
+        display: none
+    }
+
+    .can_queue_super_admin .acl_control.queue_super_admin,
+    .can_queue_super_admin .queue_super_admin {
+        display: inherit
+    }
+
+    .team_health {
+        display: none
+    }
+
+    .can_team_health .acl_control.team_health,
+    .can_team_health .team_health {
+        display: inherit
+    }
+
+    .queue_edit_health {
+        display: none
+    }
+
+    .can_queue_edit_health .acl_control.queue_edit_health,
+    .can_queue_edit_health .queue_edit_health {
+        display: inherit
+    }
+
+    .gif_feed_admin {
+        display: none
+    }
+
+    .can_gif_feed_admin .acl_control.gif_feed_admin,
+    .can_gif_feed_admin .gif_feed_admin {
+        display: inherit
+    }
+
+    .queue_draft_to_publish {
+        display: none
+    }
+
+    .can_queue_draft_to_publish .acl_control.queue_draft_to_publish,
+    .can_queue_draft_to_publish .queue_draft_to_publish {
+        display: inherit
+    }
+
+    .queue_add_books {
+        display: none
+    }
+
+    .can_queue_add_books .acl_control.queue_add_books,
+    .can_queue_add_books .queue_add_books {
+        display: inherit
+    }
+
+    .plugin_moderation {
+        display: none
+    }
+
+    .can_plugin_moderation .acl_control.plugin_moderation,
+    .can_plugin_moderation .plugin_moderation {
+        display: inherit
+    }
+
+    .homepage_edit {
+        display: none
+    }
+
+    .can_homepage_edit .acl_control.homepage_edit,
+    .can_homepage_edit .homepage_edit {
+        display: inherit
+    }
+
+    .rest_api {
+        display: none
+    }
+
+    .can_rest_api .acl_control.rest_api,
+    .can_rest_api .rest_api {
+        display: inherit
+    }
+
+    .queue_add_uk {
+        display: none
+    }
+
+    .can_queue_add_uk .acl_control.queue_add_uk,
+    .can_queue_add_uk .queue_add_uk {
+        display: inherit
+    }
+
+    .queue_add_lgbt {
+        display: none
+    }
+
+    .can_queue_add_lgbt .acl_control.queue_add_lgbt,
+    .can_queue_add_lgbt .queue_add_lgbt {
+        display: inherit
+    }
+
+    .pugopticon {
+        display: none
+    }
+
+    .can_pugopticon .acl_control.pugopticon,
+    .can_pugopticon .pugopticon {
+        display: inherit
+    }
+
+    .lifestyle_homepage_edit {
+        display: none
+    }
+
+    .can_lifestyle_homepage_edit .acl_control.lifestyle_homepage_edit,
+    .can_lifestyle_homepage_edit .lifestyle_homepage_edit {
+        display: inherit
+    }
+
+    .team_parents {
+        display: none
+    }
+
+    .can_team_parents .acl_control.team_parents,
+    .can_team_parents .team_parents {
+        display: inherit
+    }
+
+    .acl_edit {
+        display: none
+    }
+
+    .can_acl_edit .acl_control.acl_edit,
+    .can_acl_edit .acl_edit {
+        display: inherit
+    }
+
+    .mexico_homepage_edit {
+        display: none
+    }
+
+    .can_mexico_homepage_edit .acl_control.mexico_homepage_edit,
+    .can_mexico_homepage_edit .mexico_homepage_edit {
+        display: inherit
+    }
+
+    .quizzes_homepage_edit {
+        display: none
+    }
+
+    .can_quizzes_homepage_edit .acl_control.quizzes_homepage_edit,
+    .can_quizzes_homepage_edit .quizzes_homepage_edit {
+        display: inherit
+    }
+
+    .edit_user_client {
+        display: none
+    }
+
+    .can_edit_user_client .acl_control.edit_user_client,
+    .can_edit_user_client .edit_user_client {
+        display: inherit
+    }
+
+    .editors_manage {
+        display: none
+    }
+
+    .can_editors_manage .acl_control.editors_manage,
+    .can_editors_manage .editors_manage {
+        display: inherit
+    }
+
+    .queue_edit_politics {
+        display: none
+    }
+
+    .can_queue_edit_politics .acl_control.queue_edit_politics,
+    .can_queue_edit_politics .queue_edit_politics {
+        display: inherit
+    }
+
+    .queue_edit_style {
+        display: none
+    }
+
+    .can_queue_edit_style .acl_control.queue_edit_style,
+    .can_queue_edit_style .queue_edit_style {
+        display: inherit
+    }
+
+    .queue_add_ideas {
+        display: none
+    }
+
+    .can_queue_add_ideas .acl_control.queue_add_ideas,
+    .can_queue_add_ideas .queue_add_ideas {
+        display: inherit
+    }
+
+    .queue_add_sports {
+        display: none
+    }
+
+    .can_queue_add_sports .acl_control.queue_add_sports,
+    .can_queue_add_sports .queue_add_sports {
+        display: inherit
+    }
+
+    .queue_add_australia {
+        display: none
+    }
+
+    .can_queue_add_australia .acl_control.queue_add_australia,
+    .can_queue_add_australia .queue_add_australia {
+        display: inherit
+    }
+
+    .team_germany {
+        display: none
+    }
+
+    .can_team_germany .acl_control.team_germany,
+    .can_team_germany .team_germany {
+        display: inherit
+    }
+
+    .edit_user_accounts {
+        display: none
+    }
+
+    .can_edit_user_accounts .acl_control.edit_user_accounts,
+    .can_edit_user_accounts .edit_user_accounts {
+        display: inherit
+    }
+
+    .buzz_metadata {
+        display: none
+    }
+
+    .can_buzz_metadata .acl_control.buzz_metadata,
+    .can_buzz_metadata .buzz_metadata {
+        display: inherit
+    }
+
+    .queue_edit_geeky {
+        display: none
+    }
+
+    .can_queue_edit_geeky .acl_control.queue_edit_geeky,
+    .can_queue_edit_geeky .queue_edit_geeky {
+        display: inherit
+    }
+
+    .queue_add_videos {
+        display: none
+    }
+
+    .can_queue_add_videos .acl_control.queue_add_videos,
+    .can_queue_add_videos .queue_add_videos {
+        display: inherit
+    }
+
+    .entertainment_homepage_edit {
+        display: none
+    }
+
+    .can_entertainment_homepage_edit .acl_control.entertainment_homepage_edit,
+    .can_entertainment_homepage_edit .entertainment_homepage_edit {
+        display: inherit
+    }
+
+    .hp_drag {
+        display: none
+    }
+
+    .can_hp_drag .acl_control.hp_drag,
+    .can_hp_drag .hp_drag {
+        display: inherit
+    }
+
+    .queue_edit_usnews {
+        display: none
+    }
+
+    .can_queue_edit_usnews .acl_control.queue_edit_usnews,
+    .can_queue_edit_usnews .queue_edit_usnews {
+        display: inherit
+    }
+
+    .embed_whitelist {
+        display: none
+    }
+
+    .can_embed_whitelist .acl_control.embed_whitelist,
+    .can_embed_whitelist .embed_whitelist {
+        display: inherit
+    }
+
+    .queue_edit_india {
+        display: none
+    }
+
+    .can_queue_edit_india .acl_control.queue_edit_india,
+    .can_queue_edit_india .queue_edit_india {
+        display: inherit
+    }
+
+    .unswitch_users {
+        display: none
+    }
+
+    .can_unswitch_users .acl_control.unswitch_users,
+    .can_unswitch_users .unswitch_users {
+        display: inherit
+    }
+
+    .queue_add_espanol {
+        display: none
+    }
+
+    .can_queue_add_espanol .acl_control.queue_add_espanol,
+    .can_queue_add_espanol .queue_add_espanol {
+        display: inherit
+    }
+
+    .slide_to_publish {
+        display: none
+    }
+
+    .can_slide_to_publish .acl_control.slide_to_publish,
+    .can_slide_to_publish .slide_to_publish {
+        display: inherit
+    }
+
+    .queue_edit_books {
+        display: none
+    }
+
+    .can_queue_edit_books .acl_control.queue_edit_books,
+    .can_queue_edit_books .queue_edit_books {
+        display: inherit
+    }
+
+    .queue_edit_music {
+        display: none
+    }
+
+    .can_queue_edit_music .acl_control.queue_edit_music,
+    .can_queue_edit_music .queue_edit_music {
+        display: inherit
+    }
+
+    .queue_add_francenews {
+        display: none
+    }
+
+    .can_queue_add_francenews .acl_control.queue_add_francenews,
+    .can_queue_add_francenews .queue_add_francenews {
+        display: inherit
+    }
+
+    .picks_delete_from_anywhere {
+        display: none
+    }
+
+    .can_picks_delete_from_anywhere .acl_control.picks_delete_from_anywhere,
+    .can_picks_delete_from_anywhere .picks_delete_from_anywhere {
+        display: inherit
+    }
+
+    .uk_homepage_edit {
+        display: none
+    }
+
+    .can_uk_homepage_edit .acl_control.uk_homepage_edit,
+    .can_uk_homepage_edit .uk_homepage_edit {
+        display: inherit
+    }
+
+    .dashboard_custom_daterange {
+        display: none
+    }
+
+    .can_dashboard_custom_daterange .acl_control.dashboard_custom_daterange,
+    .can_dashboard_custom_daterange .dashboard_custom_daterange {
+        display: inherit
+    }
+
+    .general_advertiser {
+        display: none
+    }
+
+    .can_general_advertiser .acl_control.general_advertiser,
+    .can_general_advertiser .general_advertiser {
+        display: inherit
+    }
+
+    .queue_edit_travel {
+        display: none
+    }
+
+    .can_queue_edit_travel .acl_control.queue_edit_travel,
+    .can_queue_edit_travel .queue_edit_travel {
+        display: inherit
+    }
+
+    .queue_add_audio {
+        display: none
+    }
+
+    .can_queue_add_audio .acl_control.queue_add_audio,
+    .can_queue_add_audio .queue_add_audio {
+        display: inherit
+    }
+
+    .assign_bf_contributor {
+        display: none
+    }
+
+    .can_assign_bf_contributor .acl_control.assign_bf_contributor,
+    .can_assign_bf_contributor .assign_bf_contributor {
+        display: inherit
+    }
+
+    .edit_user_posts {
+        display: none
+    }
+
+    .can_edit_user_posts .acl_control.edit_user_posts,
+    .can_edit_user_posts .edit_user_posts {
+        display: inherit
+    }
+
+    .buzz_quick_link {
+        display: none
+    }
+
+    .can_buzz_quick_link .acl_control.buzz_quick_link,
+    .can_buzz_quick_link .buzz_quick_link {
+        display: inherit
+    }
+
+    .news_homepage_edit {
+        display: none
+    }
+
+    .can_news_homepage_edit .acl_control.news_homepage_edit,
+    .can_news_homepage_edit .news_homepage_edit {
+        display: inherit
+    }
+
+    .edit_partner_posts {
+        display: none
+    }
+
+    .can_edit_partner_posts .acl_control.edit_partner_posts,
+    .can_edit_partner_posts .edit_partner_posts {
+        display: inherit
+    }
+
+    .dashboard_bf_view {
+        display: none
+    }
+
+    .can_dashboard_bf_view .acl_control.dashboard_bf_view,
+    .can_dashboard_bf_view .dashboard_bf_view {
+        display: inherit
+    }
+
+    .boost_moderation_view {
+        display: none
+    }
+
+    .can_boost_moderation_view .acl_control.boost_moderation_view,
+    .can_boost_moderation_view .boost_moderation_view {
+        display: inherit
+    }
+
+    .team_comedy {
+        display: none
+    }
+
+    .can_team_comedy .acl_control.team_comedy,
+    .can_team_comedy .team_comedy {
+        display: inherit
+    }
+
+    .queue_edit_longform {
+        display: none
+    }
+
+    .can_queue_edit_longform .acl_control.queue_edit_longform,
+    .can_queue_edit_longform .queue_edit_longform {
+        display: inherit
+    }
+
+    .queue_edit_australia {
+        display: none
+    }
+
+    .can_queue_edit_australia .acl_control.queue_edit_australia,
+    .can_queue_edit_australia .queue_edit_australia {
+        display: inherit
+    }
+
+    .queue_add_travel {
+        display: none
+    }
+
+    .can_queue_add_travel .acl_control.queue_add_travel,
+    .can_queue_add_travel .queue_add_travel {
+        display: inherit
+    }
+
+    .image_delete {
+        display: none
+    }
+
+    .can_image_delete .acl_control.image_delete,
+    .can_image_delete .image_delete {
+        display: inherit
+    }
+
+    .edit_editor_posts {
+        display: none
+    }
+
+    .can_edit_editor_posts .acl_control.edit_editor_posts,
+    .can_edit_editor_posts .edit_editor_posts {
+        display: inherit
+    }
+
+    .queue_add_celebrity {
+        display: none
+    }
+
+    .can_queue_add_celebrity .acl_control.queue_add_celebrity,
+    .can_queue_add_celebrity .queue_add_celebrity {
+        display: inherit
+    }
+
+    .sponsored_stories_admin {
+        display: none
+    }
+
+    .can_sponsored_stories_admin .acl_control.sponsored_stories_admin,
+    .can_sponsored_stories_admin .sponsored_stories_admin {
+        display: inherit
+    }
+
+    .unlink_users {
+        display: none
+    }
+
+    .can_unlink_users .acl_control.unlink_users,
+    .can_unlink_users .unlink_users {
+        display: inherit
+    }
+
+    .team_espanol {
+        display: none
+    }
+
+    .can_team_espanol .acl_control.team_espanol,
+    .can_team_espanol .team_espanol {
+        display: inherit
+    }
+
+    .queue_add_germany {
+        display: none
+    }
+
+    .can_queue_add_germany .acl_control.queue_add_germany,
+    .can_queue_add_germany .queue_add_germany {
+        display: inherit
+    }
+
+    .queue_edit_science {
+        display: none
+    }
+
+    .can_queue_edit_science .acl_control.queue_edit_science,
+    .can_queue_edit_science .queue_edit_science {
+        display: inherit
+    }
+
+    .queue_add_parents {
+        display: none
+    }
+
+    .can_queue_add_parents .acl_control.queue_add_parents,
+    .can_queue_add_parents .queue_add_parents {
+        display: inherit
+    }
+
+    .queue_edit_tvandmovies {
+        display: none
+    }
+
+    .can_queue_edit_tvandmovies .acl_control.queue_edit_tvandmovies,
+    .can_queue_edit_tvandmovies .queue_edit_tvandmovies {
+        display: inherit
+    }
+
+    .queue_add_ukpolitics {
+        display: none
+    }
+
+    .can_queue_add_ukpolitics .acl_control.queue_add_ukpolitics,
+    .can_queue_add_ukpolitics .queue_add_ukpolitics {
+        display: inherit
+    }
+
+    .sailthru_edit {
+        display: none
+    }
+
+    .can_sailthru_edit .acl_control.sailthru_edit,
+    .can_sailthru_edit .sailthru_edit {
+        display: inherit
+    }
+
+    .boost_admin {
+        display: none
+    }
+
+    .can_boost_admin .acl_control.boost_admin,
+    .can_boost_admin .boost_admin {
+        display: inherit
+    }
+
+    .queue_edit_comics {
+        display: none
+    }
+
+    .can_queue_edit_comics .acl_control.queue_edit_comics,
+    .can_queue_edit_comics .queue_edit_comics {
+        display: inherit
+    }
+
+    .new_quiz_format {
+        display: none
+    }
+
+    .can_new_quiz_format .acl_control.new_quiz_format,
+    .can_new_quiz_format .new_quiz_format {
+        display: inherit
+    }
+
+    .queue_edit_community {
+        display: none
+    }
+
+    .can_queue_edit_community .acl_control.queue_edit_community,
+    .can_queue_edit_community .queue_edit_community {
+        display: inherit
+    }
+
+    .queue_add_science {
+        display: none
+    }
+
+    .can_queue_add_science .acl_control.queue_add_science,
+    .can_queue_add_science .queue_add_science {
+        display: inherit
+    }
+
+    .queue_edit_diy {
+        display: none
+    }
+
+    .can_queue_edit_diy .acl_control.queue_edit_diy,
+    .can_queue_edit_diy .queue_edit_diy {
+        display: inherit
+    }
+
+    .queue_edit_mexico {
+        display: none
+    }
+
+    .can_queue_edit_mexico .acl_control.queue_edit_mexico,
+    .can_queue_edit_mexico .queue_edit_mexico {
+        display: inherit
+    }
+
+    .rerankable_posts {
+        display: none
+    }
+
+    .can_rerankable_posts .acl_control.rerankable_posts,
+    .can_rerankable_posts .rerankable_posts {
+        display: inherit
+    }
+
+    .gengo_admin {
+        display: none
+    }
+
+    .can_gengo_admin .acl_control.gengo_admin,
+    .can_gengo_admin .gengo_admin {
+        display: inherit
+    }
+
+    .espanol_homepage_edit {
+        display: none
+    }
+
+    .can_espanol_homepage_edit .acl_control.espanol_homepage_edit,
+    .can_espanol_homepage_edit .espanol_homepage_edit {
+        display: inherit
+    }
+
+    .ukbuzz_homepage_edit {
+        display: none
+    }
+
+    .can_ukbuzz_homepage_edit .acl_control.ukbuzz_homepage_edit,
+    .can_ukbuzz_homepage_edit .ukbuzz_homepage_edit {
+        display: inherit
+    }
+
+    .queue_add_business {
+        display: none
+    }
+
+    .can_queue_add_business .acl_control.queue_add_business,
+    .can_queue_add_business .queue_add_business {
+        display: inherit
+    }
+
+    .queue_add_longform {
+        display: none
+    }
+
+    .can_queue_add_longform .acl_control.queue_add_longform,
+    .can_queue_add_longform .queue_add_longform {
+        display: inherit
+    }
+
+    .creative_byline_in_toolbar {
+        display: none
+    }
+
+    .can_creative_byline_in_toolbar .acl_control.creative_byline_in_toolbar,
+    .can_creative_byline_in_toolbar .creative_byline_in_toolbar {
+        display: inherit
+    }
+
+    .indepth_homepage_edit {
+        display: none
+    }
+
+    .can_indepth_homepage_edit .acl_control.indepth_homepage_edit,
+    .can_indepth_homepage_edit .indepth_homepage_edit {
+        display: inherit
+    }
+
+    .dateline_locations {
+        display: none
+    }
+
+    .can_dateline_locations .acl_control.dateline_locations,
+    .can_dateline_locations .dateline_locations {
+        display: inherit
+    }
+
+    .queue_add_geeky {
+        display: none
+    }
+
+    .can_queue_add_geeky .acl_control.queue_add_geeky,
+    .can_queue_add_geeky .queue_add_geeky {
+        display: inherit
+    }
+
+    .germany_homepage_edit {
+        display: none
+    }
+
+    .can_germany_homepage_edit .acl_control.germany_homepage_edit,
+    .can_germany_homepage_edit .germany_homepage_edit {
+        display: inherit
+    }
+
+    .user_moderators {
+        display: none
+    }
+
+    .can_user_moderators .acl_control.user_moderators,
+    .can_user_moderators .user_moderators {
+        display: inherit
+    }
+
+    .queue_add_style {
+        display: none
+    }
+
+    .can_queue_add_style .acl_control.queue_add_style,
+    .can_queue_add_style .queue_add_style {
+        display: inherit
+    }
+
+    .queue_edit_weddings {
+        display: none
+    }
+
+    .can_queue_edit_weddings .acl_control.queue_edit_weddings,
+    .can_queue_edit_weddings .queue_edit_weddings {
+        display: inherit
+    }
+
+    .queue_add_rewind {
+        display: none
+    }
+
+    .can_queue_add_rewind .acl_control.queue_add_rewind,
+    .can_queue_add_rewind .queue_add_rewind {
+        display: inherit
+    }
+
+    .queue_edit_aunews {
+        display: none
+    }
+
+    .can_queue_edit_aunews .acl_control.queue_edit_aunews,
+    .can_queue_edit_aunews .queue_edit_aunews {
+        display: inherit
+    }
+
+    .can_boost {
+        display: none
+    }
+
+    .can_can_boost .acl_control.can_boost,
+    .can_can_boost .can_boost {
+        display: inherit
+    }
+
+    .buzz_any_embed {
+        display: none
+    }
+
+    .can_buzz_any_embed .acl_control.buzz_any_embed,
+    .can_buzz_any_embed .buzz_any_embed {
+        display: inherit
+    }
+
+    .queue_add_music {
+        display: none
+    }
+
+    .can_queue_add_music .acl_control.queue_add_music,
+    .can_queue_add_music .queue_add_music {
+        display: inherit
+    }
+
+    .queue_add_brasil {
+        display: none
+    }
+
+    .can_queue_add_brasil .acl_control.queue_add_brasil,
+    .can_queue_add_brasil .queue_add_brasil {
+        display: inherit
+    }
+
+    .queue_edit_business {
+        display: none
+    }
+
+    .can_queue_edit_business .acl_control.queue_edit_business,
+    .can_queue_edit_business .queue_edit_business {
+        display: inherit
+    }
+
+    .amazon_rerank {
+        display: none
+    }
+
+    .can_amazon_rerank .acl_control.amazon_rerank,
+    .can_amazon_rerank .amazon_rerank {
+        display: inherit
+    }
+
+    .queue_edit_animals {
+        display: none
+    }
+
+    .can_queue_edit_animals .acl_control.queue_edit_animals,
+    .can_queue_edit_animals .queue_edit_animals {
+        display: inherit
+    }
+
+    .community_manage {
+        display: none
+    }
+
+    .can_community_manage .acl_control.community_manage,
+    .can_community_manage .community_manage {
+        display: inherit
+    }
+
+    .default_template_article {
+        display: none
+    }
+
+    .can_default_template_article .acl_control.default_template_article,
+    .can_default_template_article .default_template_article {
+        display: inherit
+    }
+
+    .terminal_user {
+        display: none
+    }
+
+    .can_terminal_user .acl_control.terminal_user,
+    .can_terminal_user .terminal_user {
+        display: inherit
+    }
+
+    .queue_add_uknews {
+        display: none
+    }
+
+    .can_queue_add_uknews .acl_control.queue_add_uknews,
+    .can_queue_add_uknews .queue_add_uknews {
+        display: inherit
+    }
+
+    .queue_add_india {
+        display: none
+    }
+
+    .can_queue_add_india .acl_control.queue_add_india,
+    .can_queue_add_india .queue_add_india {
+        display: inherit
+    }
+
+    .queue_add_health {
+        display: none
+    }
+
+    .can_queue_add_health .acl_control.queue_add_health,
+    .can_queue_add_health .queue_add_health {
+        display: inherit
+    }
+
+    .updated_timestamp {
+        display: none
+    }
+
+    .can_updated_timestamp .acl_control.updated_timestamp,
+    .can_updated_timestamp .updated_timestamp {
+        display: inherit
+    }
+
+    .queue_edit_celebrity {
+        display: none
+    }
+
+    .can_queue_edit_celebrity .acl_control.queue_edit_celebrity,
+    .can_queue_edit_celebrity .queue_edit_celebrity {
+        display: inherit
+    }
+
+    .queue_add_food {
+        display: none
+    }
+
+    .can_queue_add_food .acl_control.queue_add_food,
+    .can_queue_add_food .queue_add_food {
+        display: inherit
+    }
+
+    .blog_press {
+        display: none
+    }
+
+    .can_blog_press .acl_control.blog_press,
+    .can_blog_press .blog_press {
+        display: inherit
+    }
+
+    .lists_homepage_edit {
+        display: none
+    }
+
+    .can_lists_homepage_edit .acl_control.lists_homepage_edit,
+    .can_lists_homepage_edit .lists_homepage_edit {
+        display: inherit
+    }
+
+    .longform_edit {
+        display: none
+    }
+
+    .can_longform_edit .acl_control.longform_edit,
+    .can_longform_edit .longform_edit {
+        display: inherit
+    }
+
+    .queue_add_animals {
+        display: none
+    }
+
+    .can_queue_add_animals .acl_control.queue_add_animals,
+    .can_queue_add_animals .queue_add_animals {
+        display: inherit
+    }
+
+    .preview_special_tags {
+        display: none
+    }
+
+    .can_preview_special_tags .acl_control.preview_special_tags,
+    .can_preview_special_tags .preview_special_tags {
+        display: inherit
+    }
+
+    .boost_button {
+        display: none
+    }
+
+    .can_boost_button .acl_control.boost_button,
+    .can_boost_button .boost_button {
+        display: inherit
+    }
+
+    .india_homepage_edit {
+        display: none
+    }
+
+    .can_india_homepage_edit .acl_control.india_homepage_edit,
+    .can_india_homepage_edit .india_homepage_edit {
+        display: inherit
+    }
+
+    .queue_edit_lgbt {
+        display: none
+    }
+
+    .can_queue_edit_lgbt .acl_control.queue_edit_lgbt,
+    .can_queue_edit_lgbt .queue_edit_lgbt {
+        display: inherit
+    }
+
+    .translation_approval {
+        display: none
+    }
+
+    .can_translation_approval .acl_control.translation_approval,
+    .can_translation_approval .translation_approval {
+        display: inherit
+    }
+
+    .trending_moderation {
+        display: none
+    }
+
+    .can_trending_moderation .acl_control.trending_moderation,
+    .can_trending_moderation .trending_moderation {
+        display: inherit
+    }
+
+    .sailthru_publish {
+        display: none
+    }
+
+    .can_sailthru_publish .acl_control.sailthru_publish,
+    .can_sailthru_publish .sailthru_publish {
+        display: inherit
+    }
+
+    .queue_add_world {
+        display: none
+    }
+
+    .can_queue_add_world .acl_control.queue_add_world,
+    .can_queue_add_world .queue_add_world {
+        display: inherit
+    }
+
+    .queue_edit_germany {
+        display: none
+    }
+
+    .can_queue_edit_germany .acl_control.queue_edit_germany,
+    .can_queue_edit_germany .queue_edit_germany {
+        display: inherit
+    }
+
+    .dateline_buzz {
+        display: none
+    }
+
+    .can_dateline_buzz .acl_control.dateline_buzz,
+    .can_dateline_buzz .dateline_buzz {
+        display: inherit
+    }
+
+    .france_homepage_edit {
+        display: none
+    }
+
+    .can_france_homepage_edit .acl_control.france_homepage_edit,
+    .can_france_homepage_edit .france_homepage_edit {
+        display: inherit
+    }
+
+    .edit_user_permissions {
+        display: none
+    }
+
+    .can_edit_user_permissions .acl_control.edit_user_permissions,
+    .can_edit_user_permissions .edit_user_permissions {
+        display: inherit
+    }
+
+    .acl_view {
+        display: none
+    }
+
+    .can_acl_view .acl_control.acl_view,
+    .can_acl_view .acl_view {
+        display: inherit
+    }
+
+    .queue_edit_rewind {
+        display: none
+    }
+
+    .can_queue_edit_rewind .acl_control.queue_edit_rewind,
+    .can_queue_edit_rewind .queue_edit_rewind {
+        display: inherit
+    }
+
+    .queue_edit_ideas {
+        display: none
+    }
+
+    .can_queue_edit_ideas .acl_control.queue_edit_ideas,
+    .can_queue_edit_ideas .queue_edit_ideas {
+        display: inherit
+    }
+
+    .queue_edit_tech {
+        display: none
+    }
+
+    .can_queue_edit_tech .acl_control.queue_edit_tech,
+    .can_queue_edit_tech .queue_edit_tech {
+        display: inherit
+    }
+
+    .team_weddings {
+        display: none
+    }
+
+    .can_team_weddings .acl_control.team_weddings,
+    .can_team_weddings .team_weddings {
+        display: inherit
+    }
+
+    .string_translation_moderator {
+        display: none
+    }
+
+    .can_string_translation_moderator .acl_control.string_translation_moderator,
+    .can_string_translation_moderator .string_translation_moderator {
+        display: inherit
+    }
+
+    .badge_config_admin {
+        display: none
+    }
+
+    .can_badge_config_admin .acl_control.badge_config_admin,
+    .can_badge_config_admin .badge_config_admin {
+        display: inherit
+    }
+
+    .queue_add_diy {
+        display: none
+    }
+
+    .can_queue_add_diy .acl_control.queue_add_diy,
+    .can_queue_add_diy .queue_add_diy {
+        display: inherit
+    }
+
+    .queue_edit_uknews {
+        display: none
+    }
+
+    .can_queue_edit_uknews .acl_control.queue_edit_uknews,
+    .can_queue_edit_uknews .queue_edit_uknews {
+        display: inherit
+    }
+
+    .hotlist_moderation {
+        display: none
+    }
+
+    .can_hotlist_moderation .acl_control.hotlist_moderation,
+    .can_hotlist_moderation .hotlist_moderation {
+        display: inherit
+    }
+
+    .queue_add_tvandmovies {
+        display: none
+    }
+
+    .can_queue_add_tvandmovies .acl_control.queue_add_tvandmovies,
+    .can_queue_add_tvandmovies .queue_add_tvandmovies {
+        display: inherit
+    }
+
+    .buzz_promote {
+        display: none
+    }
+
+    .can_buzz_promote .acl_control.buzz_promote,
+    .can_buzz_promote .buzz_promote {
+        display: inherit
+    }
+
+    .queue_edit_parents {
+        display: none
+    }
+
+    .can_queue_edit_parents .acl_control.queue_edit_parents,
+    .can_queue_edit_parents .queue_edit_parents {
+        display: inherit
+    }
+
+    .partners_manage {
+        display: none
+    }
+
+    .can_partners_manage .acl_control.partners_manage,
+    .can_partners_manage .partners_manage {
+        display: inherit
+    }
+
+    .switch_user_menu_option {
+        display: none
+    }
+
+    .can_switch_user_menu_option .acl_control.switch_user_menu_option,
+    .can_switch_user_menu_option .switch_user_menu_option {
+        display: inherit
+    }
+
+    .in_depth_moderation {
+        display: none
+    }
+
+    .can_in_depth_moderation .acl_control.in_depth_moderation,
+    .can_in_depth_moderation .in_depth_moderation {
+        display: inherit
+    }
+
+    .queue_add_comics {
+        display: none
+    }
+
+    .can_queue_add_comics .acl_control.queue_add_comics,
+    .can_queue_add_comics .queue_add_comics {
+        display: inherit
+    }
+
+    .queue_edit_brasil {
+        display: none
+    }
+
+    .can_queue_edit_brasil .acl_control.queue_edit_brasil,
+    .can_queue_edit_brasil .queue_edit_brasil {
+        display: inherit
+    }
+
+    .uk_homepage_splashing {
+        display: none
+    }
+
+    .can_uk_homepage_splashing .acl_control.uk_homepage_splashing,
+    .can_uk_homepage_splashing .uk_homepage_splashing {
+        display: inherit
+    }
+
+    .queue_add_mexico {
+        display: none
+    }
+
+    .can_queue_add_mexico .acl_control.queue_add_mexico,
+    .can_queue_add_mexico .queue_add_mexico {
+        display: inherit
+    }
+
+    .dashboard_admin {
+        display: none
+    }
+
+    .can_dashboard_admin .acl_control.dashboard_admin,
+    .can_dashboard_admin .dashboard_admin {
+        display: inherit
+    }
+
+    .uknews_homepage_edit {
+        display: none
+    }
+
+    .can_uknews_homepage_edit .acl_control.uknews_homepage_edit,
+    .can_uknews_homepage_edit .uknews_homepage_edit {
+        display: inherit
+    }
+
+    .queue_add_weddings {
+        display: none
+    }
+
+    .can_queue_add_weddings .acl_control.queue_add_weddings,
+    .can_queue_add_weddings .queue_add_weddings {
+        display: inherit
+    }
+
+    .events_reorder {
+        display: none
+    }
+
+    .can_events_reorder .acl_control.events_reorder,
+    .can_events_reorder .events_reorder {
+        display: inherit
+    }
+
+    .queue_edit_world {
+        display: none
+    }
+
+    .can_queue_edit_world .acl_control.queue_edit_world,
+    .can_queue_edit_world .queue_edit_world {
+        display: inherit
+    }
+
+    .edit_community_posts {
+        display: none
+    }
+
+    .can_edit_community_posts .acl_control.edit_community_posts,
+    .can_edit_community_posts .edit_community_posts {
+        display: inherit
+    }
+
+    .queue_add_comedy {
+        display: none
+    }
+
+    .can_queue_add_comedy .acl_control.queue_add_comedy,
+    .can_queue_add_comedy .queue_add_comedy {
+        display: inherit
+    }
+
+    .general_admin {
+        display: none
+    }
+
+    .can_general_admin .acl_control.general_admin,
+    .can_general_admin .general_admin {
+        display: inherit
+    }
+
+    .queue_edit_comedy {
+        display: none
+    }
+
+    .can_queue_edit_comedy .acl_control.queue_edit_comedy,
+    .can_queue_edit_comedy .queue_edit_comedy {
+        display: inherit
+    }
+
+    .homepage_splashing {
+        display: none
+    }
+
+    .can_homepage_splashing .acl_control.homepage_splashing,
+    .can_homepage_splashing .homepage_splashing {
+        display: inherit
+    }
+
+    .queue_edit_ukpolitics {
+        display: none
+    }
+
+    .can_queue_edit_ukpolitics .acl_control.queue_edit_ukpolitics,
+    .can_queue_edit_ukpolitics .queue_edit_ukpolitics {
+        display: inherit
+    }
+
+    .queue_add_tech {
+        display: none
+    }
+
+    .can_queue_add_tech .acl_control.queue_add_tech,
+    .can_queue_add_tech .queue_add_tech {
+        display: inherit
+    }
+
+    .queue_edit_videos {
+        display: none
+    }
+
+    .can_queue_edit_videos .acl_control.queue_edit_videos,
+    .can_queue_edit_videos .queue_edit_videos {
+        display: inherit
+    }
+
+    .super_share {
+        display: none
+    }
+
+    .can_super_share .acl_control.super_share,
+    .can_super_share .super_share {
+        display: inherit
+    }
+
+    .queue_edit_uk {
+        display: none
+    }
+
+    .can_queue_edit_uk .acl_control.queue_edit_uk,
+    .can_queue_edit_uk .queue_edit_uk {
+        display: inherit
+    }
+
+    .queue_add_usnews {
+        display: none
+    }
+
+    .can_queue_add_usnews .acl_control.queue_add_usnews,
+    .can_queue_add_usnews .queue_add_usnews {
+        display: inherit
+    }
+
+    .team_france {
+        display: none
+    }
+
+    .can_team_france .acl_control.team_france,
+    .can_team_france .team_france {
+        display: inherit
+    }
+
+    .give_full_admin {
+        display: none
+    }
+
+    .can_give_full_admin .acl_control.give_full_admin,
+    .can_give_full_admin .give_full_admin {
+        display: inherit
+    }
+
+    .aunews_homepage_edit {
+        display: none
+    }
+
+    .can_aunews_homepage_edit .acl_control.aunews_homepage_edit,
+    .can_aunews_homepage_edit .aunews_homepage_edit {
+        display: inherit
+    }
+
+    .team_mexico {
+        display: none
+    }
+
+    .can_team_mexico .acl_control.team_mexico,
+    .can_team_mexico .team_mexico {
+        display: inherit
+    }
+
+    .duplicate_post {
+        display: none
+    }
+
+    .can_duplicate_post .acl_control.duplicate_post,
+    .can_duplicate_post .duplicate_post {
+        display: inherit
+    }
+
+    .logged_in {
+        display: none
+    }
+
+    .can_logged_in .acl_control.logged_in,
+    .can_logged_in .logged_in {
+        display: inherit
+    }
+
+    .queue_edit_espanol {
+        display: none
+    }
+
+    .can_queue_edit_espanol .acl_control.queue_edit_espanol,
+    .can_queue_edit_espanol .queue_edit_espanol {
+        display: inherit
+    }
+
+    .facebook_chatter {
+        display: none
+    }
+
+    .can_facebook_chatter .acl_control.facebook_chatter,
+    .can_facebook_chatter .facebook_chatter {
+        display: inherit
+    }
+
+    .translation_moderator {
+        display: none
+    }
+
+    .can_translation_moderator .acl_control.translation_moderator,
+    .can_translation_moderator .translation_moderator {
+        display: inherit
+    }
+
+    .queue_add_community {
+        display: none
+    }
+
+    .can_queue_add_community .acl_control.queue_add_community,
+    .can_queue_add_community .queue_add_community {
+        display: inherit
+    }
+
+    .new_preview {
+        display: none
+    }
+
+    .can_new_preview .acl_control.new_preview,
+    .can_new_preview .new_preview {
+        display: inherit
+    }
+
+    .breaking_homepage {
+        display: none
+    }
+
+    .can_breaking_homepage .acl_control.breaking_homepage,
+    .can_breaking_homepage .breaking_homepage {
+        display: inherit
+    }
+
+    .team_brasil {
+        display: none
+    }
+
+    .can_team_brasil .acl_control.team_brasil,
+    .can_team_brasil .team_brasil {
+        display: inherit
+    }
+    </style>
+    <script src="http://platform.twitter.com/widgets.js"></script>
+</head>
+<!--[if IE 9]>
+<body class="BuzzPage PermalinkPage TwoColumns list_format_article VerticalSection en UKNews ie9">
+<![endif]-->
+<!--[if !IE]><!-->
+
+<body class="bf_dom BuzzPage PermalinkPage TwoColumns list_format_article VerticalSection en UKNews">
+    <!--<![endif]-->
+    <!--[if gte IE 9]><!-->
+    <svg style="display:none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 512 512">
+        <defs>
+            <g id="logo">
+                <path d="M78.992 103.787c0-9.275-6.625-16.785-18.772-16.785h-28.861v33.569h28.861c11.705 0 18.772-6.184 18.772-16.784zm-2.871-59.848c0-9.055-6.625-15.459-17.225-15.459h-27.537v30.918h27.537c10.6 0 17.225-5.963 17.225-15.459zm-76.121 104.237v-147.301h65.741c28.048 0 42.402 17.888 42.402 37.543 0 18.33-11.484 30.918-25.397 33.789 15.901 2.429 28.268 17.667 28.268 35.997 0 22.305-14.576 39.972-42.843 39.972h-68.171z"></path>
+                <path d="M226.649 148.176v-20.979l48.143-61.174h-48.143v-24.513h86.35v20.096l-49.028 62.058h49.911v24.512h-87.233"></path>
+                <path d="M321.066 148.176v-20.979l48.143-61.174h-48.143v-24.513h86.349v20.096l-49.027 62.058h49.91v24.512h-87.232"></path>
+                <path d="M424.783 148.176v-147.301h102.238v27.605h-70.878v30.918h53.333v27.604h-53.333v61.174h-31.36"></path>
+                <path d="M571.223 61.827c-17.447 0-24.956 12.147-26.06 22.747h52.561c-.884-10.159-7.951-22.747-26.501-22.747zm-55.211 32.906c0-30.918 22.967-55.873 55.211-55.873 32.022 0 53.443 23.85 53.443 58.523v6.625h-79.282c1.987 13.03 12.588 23.851 30.697 23.851 9.054 0 21.421-3.755 28.268-10.379l12.588 18.551c-10.601 9.717-27.385 14.796-43.948 14.796-32.463 0-56.977-21.864-56.977-56.094z"></path>
+                <path d="M685.4 61.827c-17.446 0-24.956 12.147-26.059 22.747h52.56c-.883-10.159-7.95-22.747-26.501-22.747zm-55.211 32.906c0-30.918 22.968-55.873 55.211-55.873 32.023 0 53.444 23.85 53.444 58.523v6.625h-79.282c1.988 13.03 12.587 23.851 30.697 23.851 9.054 0 21.421-3.755 28.267-10.379l12.588 18.551c-10.6 9.717-27.385 14.796-43.947 14.796-32.463 0-56.978-21.864-56.978-56.094z"></path>
+                <path d="M819.522 94.746c0-16.557-9.965-30.36-29.553-30.36h-17.51v60.874h17.352c18.793 0 29.711-14.613 29.711-30.514zm-73.719 53.639v-107.124h43.046c33.726 0 57.968 20.243 57.968 53.485 0 33.24-24.242 53.639-57.81 53.639h-43.204z"></path>
+                <path d="M116.619 105.525v-64.015h28.216v63.05c0 12.736 7.741 21.927 22.741 21.927 14.831 0 22.571-9.191 22.571-21.927v-63.05h28.059v63.858c0 26.764-16.124 45.632-50.63 45.632-34.512 0-50.957-19.031-50.957-45.475"></path>
+            </g>
+            <g id="facebook">
+                <path d="M483.743,0H28.259C12.649,0,0,12.649,0,28.259v455.484C0,499.348,12.649,512,28.259,512 h245.218V313.728h-66.724v-77.271h66.724v-56.985c0-66.13,40.39-102.14,99.384-102.14c28.257,0,52.545,2.104,59.621,3.044v69.111 l-40.913,0.019c-32.086,0-38.298,15.246-38.298,37.618v49.334h76.519l-9.964,77.271h-66.555V512h130.473 C499.348,512,512,499.348,512,483.743V28.259C512,12.649,499.348,0,483.743,0z">
+                </path>
+            </g>
+            <g id="facebook-f">
+                <path d="M369 170.013h-76.972v-50.645c0-19.03 12.563-23.458 21.413-23.458h54.32V12.285L292.952 12c-83.037 0-101.934 62.363-101.934 102.276v55.736H143v86.17h48.02v243.817h101.01V256.18h68.16l8.81-86.167z"></path>
+            </g>
+            <g id="google-plus">
+                <path d="M278.43 50h-127.69c-57.245 0-111.12 43.401-111.12 93.675 0 51.375 39.022 92.837 97.261 92.837 4.05 0 7.985-.081 11.839-.359-3.779 7.242-6.482 15.398-6.482 23.865 0 14.278 7.675 25.853 17.379 35.302-7.332 0-14.412.214-22.137.214-70.904-.001-125.479 45.191-125.479 92.052 0 46.154 59.829 75.024 130.737 75.024 80.836 0 125.482-45.899 125.482-92.056 0-37.008-10.911-59.171-44.647-83.045-11.54-8.176-33.612-28.059-33.612-39.747 0-13.697 3.906-20.444 24.509-36.553 21.117-16.512 36.062-39.727 36.062-66.727 0-32.146-14.306-63.475-41.162-73.812h40.486l28.575-20.671zm-44.6 312.591c1.013 4.279 1.565 8.683 1.565 13.176 0 37.294-24.015 66.438-92.917 66.438-49.011 0-84.407-31.048-84.407-68.341 0-36.551 43.904-66.978 92.913-66.448 11.438.121 22.097 1.963 31.772 5.098 26.605 18.516 45.691 28.978 51.074 50.077zm-78.472-139.105c-32.901-.984-64.162-36.829-69.841-80.053-5.679-43.239 16.379-76.325 49.271-75.346 32.888.989 64.163 35.679 69.844 78.908 5.674 43.236-16.389 77.477-49.274 76.492zm253.141-81.921v-91.566h-30.5v91.566h-91.5v30.522h91.5v91.566h30.5v-91.566h91.5v-30.522h-91.5z">
+                </path>
+            </g>
+            <g id="tweet">
+                <path d="M500 103.716c-17.954 8.07-37.251 13.524-57.501 15.974 20.667-12.555 36.544-32.435 44.02-56.126-19.347 11.628-40.772 20.068-63.579 24.618-18.261-19.717-44.281-32.035-73.078-32.035-55.29 0-100.121 45.42-100.121 101.445 0 7.951.886 15.695 2.594 23.119-83.209-4.23-156.982-44.619-206.361-105.996-8.618 14.983-13.557 32.411-13.557 51.003 0 35.197 17.675 66.248 44.54 84.44-16.411-.527-31.849-5.091-45.347-12.688-.01.423-.01.846-.01 1.276 0 49.151 34.511 90.153 80.313 99.474-8.401 2.319-17.246 3.56-26.376 3.56-6.451 0-12.725-.638-18.837-1.822 12.739 40.302 49.713 69.635 93.525 70.451-34.265 27.211-77.433 43.43-124.342 43.43-8.081 0-16.05-.482-23.883-1.419 44.308 28.784 96.934 45.581 153.474 45.581 184.154 0 284.86-154.584 284.86-288.644 0-4.398-.1-8.772-.293-13.123 19.564-14.305 36.537-32.171 49.959-52.516">
+                </path>
+            </g>
+            <g id="pinterest">
+                <path d="M255.459 11.311c-134.45 0-243.459 108.998-243.459 243.455 0 99.689 59.946 185.328 145.726 222.982-.685-17-.122-37.407 4.238-55.904 4.679-19.765 31.326-132.658 31.326-132.658s-7.78-15.543-7.78-38.52c0-36.077 20.913-63.021 46.953-63.021 22.145 0 32.843 16.633 32.843 36.549 0 22.262-14.198 55.559-21.5 86.399-6.099 25.825 12.949 46.889 38.426 46.889 46.126 0 77.193-59.243 77.193-129.437 0-53.357-35.938-93.295-101.302-93.295-73.849 0-119.856 55.073-119.856 116.589 0 21.209 6.253 36.169 16.049 47.749 4.504 5.32 5.13 7.462 3.499 13.57-1.168 4.479-3.849 15.263-4.96 19.538-1.622 6.165-6.617 8.369-12.189 6.092-34.014-13.886-49.858-51.135-49.858-93.009 0-69.156 58.326-152.082 173.996-152.082 92.949 0 154.125 67.261 154.125 139.462 0 95.502-53.094 166.852-131.359 166.852-26.285 0-51.009-14.209-59.477-30.345 0 0-14.134 56.092-17.128 66.923-5.16 18.771-15.265 37.53-24.503 52.152 21.896 6.465 45.026 9.984 68.998 9.984 134.44 0 243.443-109 243.443-243.459 0-134.457-109.003-243.455-243.443-243.455">
+                </path>
+            </g>
+            <g id="youtube">
+                <path d="M506.887,153.482c0,0-5.002-35.282-20.354-50.819c-19.469-20.393-41.293-20.494-51.301-21.688 c-71.646-5.179-179.122-5.179-179.122-5.179h-0.222c0,0-107.472,0-179.121,5.179c-10.009,1.194-31.824,1.294-51.301,21.688 C10.116,118.2,5.121,153.482,5.121,153.482S0,194.915,0,236.348v38.844c0,41.433,5.121,82.865,5.121,82.865 s4.995,35.282,20.346,50.819c19.477,20.393,45.061,19.748,56.456,21.886C122.883,434.688,256,435.904,256,435.904 s107.585-0.162,179.232-5.341c10.008-1.194,31.832-1.295,51.301-21.688c15.352-15.537,20.354-50.819,20.354-50.819 S512,316.624,512,275.191v-38.844C512,194.915,506.887,153.482,506.887,153.482z M203.418,322.262l-0.023-143.858l138.345,72.18 L203.418,322.262z">
+                    <path d="M506.887,153.482c0,0-5.002-35.282-20.354-50.819 c-19.469-20.393-41.293-20.494-51.301-21.688c-71.646-5.179-179.122-5.179-179.122-5.179h-0.222c0,0-107.472,0-179.121,5.179 c-10.009,1.194-31.824,1.294-51.301,21.688C10.116,118.2,5.121,153.482,5.121,153.482S0,194.915,0,236.348v38.844 c0,41.433,5.121,82.865,5.121,82.865s4.995,35.282,20.346,50.819c19.477,20.393,45.061,19.748,56.456,21.886 C122.883,434.688,256,435.904,256,435.904s107.585-0.162,179.232-5.341c10.008-1.194,31.832-1.295,51.301-21.688 c15.352-15.537,20.354-50.819,20.354-50.819S512,316.624,512,275.191v-38.844C512,194.915,506.887,153.482,506.887,153.482z M203.418,322.262l-0.023-143.858l138.345,72.18L203.418,322.262z">
+                    </path>
+                </path>
+            </g>
+            <g id="tumblr">
+                <path d="M378.819,408.955c-9.521,4.533-27.732,8.492-41.311,8.844 c-40.984,1.102-48.926-28.785-49.276-50.48V207.941h102.812v-77.51H288.608V0c0,0-73.777,0-75.004,0s-3.382,1.09-3.683,3.833 c-4.384,39.92-23.073,109.977-100.732,137.972v66.136h51.807v167.293c0,57.27,42.262,138.637,153.792,136.732
+  c37.626-0.65,79.413-16.408,88.657-29.986L378.819,408.955z">
+                </path>
+            </g>
+            <g id="social-icon--email">
+                <path d="M453.433 182.363c-42.482 29.453-85.236 58.91-127.447 88.635-17.7 12.275-47.655 37.365-69.714 37.365h-.542c-22.06 0-52.016-25.09-69.716-37.365-42.21-29.725-84.965-59.182-127.176-88.635C39.503 169.273 12 138.455 12 113.636 12 86.91 26.433 64 55.57 64h400.857C480.117 64 500 83.636 500 107.636c0 30.548-22.602 58.092-46.567 74.727zm46.567 222C500 428.365 480.394 448 456.428 448H55.57C31.607 448 12 428.365 12 404.363V187.82c8.168 8.998 17.43 16.906 27.503 23.725 45.206 30.818 90.955 61.637 135.345 94.092 22.876 16.91 51.196 37.637 80.88 37.637h.542c29.685 0 58.005-20.727 80.882-37.637 44.39-32.182 90.138-63.273 135.615-94.092 9.804-6.818 19.063-14.727 27.232-23.726v216.543z"></path>
+            </g>
+            <g id="icon-caret-right">
+                <path d="M374 243.082l-211.818-211.542c-2.727-2.724-6.818-4.54-10.455-4.54-3.636 0-7.727 1.816-10.455 4.54l-22.727 22.698c-2.727 2.724-4.545 6.809-4.545 10.441 0 3.632 1.818 7.717 4.545 10.441l178.637 178.404-178.637 178.404c-2.727 2.724-4.545 6.809-4.545 10.441 0 4.086 1.818 7.717 4.545 10.441l22.727 22.698c2.727 2.724 6.818 4.54 10.455 4.54 3.636 0 7.727-1.816 10.455-4.54l211.818-211.542c2.727-2.724 4.545-6.809 4.545-10.441 0-3.632-1.818-7.717-4.545-10.441z"></path>
+            </g>
+            <g id="icon-caret-down">
+                <path d="M266.918 384L478.46 172.182c2.724-2.727 4.54-6.818 4.54-10.455 0-3.636-1.816-7.727-4.54-10.455l-22.698-22.727c-2.724-2.727-6.81-4.545-10.44-4.545-3.633 0-7.718 1.818-10.442 4.545L256.476 307.182 78.072 128.545c-2.724-2.727-6.81-4.545-10.44-4.545-4.087 0-7.718 1.818-10.442 4.545l-22.698 22.727c-2.724 2.727-4.54 6.818-4.54 10.455 0 3.636 1.816 7.727 4.54 10.455L246.034 384c2.724 2.727 6.81 4.545 10.44 4.545 3.633 0 7.718-1.818 10.442-4.545h.002z"></path>
+            </g>
+            <g id="icon-search">
+                <path d="M476.41,423.501471 L376.136765,323.228235 C400.303529,288.343412 412.392294,249.457706 412.392294,206.581882 C412.392294,178.712059 406.981235,152.058647 396.162706,126.625235 C385.347765,101.188235 370.729294,79.2641176 352.310882,60.8457059 C333.892471,42.4272941 311.971941,27.8088235 286.538529,16.9938824 C261.097941,6.17535294 234.444529,0.767882353 206.574706,0.767882353 C178.704882,0.767882353 152.051471,6.17535294 126.618059,16.9938824 C101.181059,27.8088235 79.2569412,42.4272941 60.8385294,60.8457059 C42.4201176,79.2641176 27.8016471,101.191824 16.9867059,126.625235 C6.16817647,152.062235 0.760705882,178.712059 0.760705882,206.581882 C0.760705882,234.451706 6.16817647,261.097941 16.9867059,286.538529 C27.8016471,311.971941 42.4201176,333.892471 60.8385294,352.310882 C79.2569412,370.732882 101.184647,385.347765 126.618059,396.166294 C152.055059,406.984824 178.704882,412.392294 206.574706,412.392294 C249.457706,412.392294 288.339824,400.303529 323.224647,376.136765 L423.497882,476.115765 C430.512882,483.521882 439.275353,487.224941 449.806824,487.224941 C459.94,487.224941 468.716824,483.521882 476.115765,476.115765 C483.521882,468.713235 487.224941,459.94 487.224941,449.806824 C487.228529,439.483471 483.625941,430.710235 476.41,423.501471 L476.41,423.501471 Z M299.104529,299.104529 C273.473765,324.735294 242.632882,337.548882 206.574706,337.548882 C170.520118,337.548882 139.679235,324.731706 114.048471,299.104529 C88.4177059,273.473765 75.6041176,242.636471 75.6041176,206.578294 C75.6041176,170.523706 88.4212941,139.679235 114.048471,114.052059 C139.675647,88.4212941 170.520118,75.6077059 206.574706,75.6077059 C242.629294,75.6077059 273.470176,88.4248824 299.104529,114.052059 C324.735294,139.679235 337.552471,170.523706 337.552471,206.578294 C337.552471,242.636471 324.731706,273.473765 299.104529,299.104529 L299.104529,299.104529 Z" id="Shape" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="news-bubble">
+                <path class="news-bubble__bubble" fill="#fff" d="M255.085 474.777c133.477 0 242.086-108.828 242.086-242.526 0-97.492-57.66-181.712-140.585-220.25H153.58C70.66 50.533 13 134.73 13 232.142c0 61.84 23.658 121.262 65.693 166.048L50.353 500H166.49l39.3-30.285c16.286 3.302 32.79 5.062 49.297 5.062z"></path>
+                <path class="news-bubble__bubble" fill="#ED3424" d="M256 42.3c-104.8 0-189.8 85.2-189.8 190.2 0 56.4 24.5 107 63.3 141.8L94.6 500l109.7-84.6c16.4 4.6 33.8 7.198 51.7 7.198 104.8 0 189.8-85.1 189.8-190.2C445.8 127.4 360.8 42.3 256 42.3z"></path>
+                <path class="news-bubble__bubble" fill="#fff" d="M193.3 211.9c13.4 9.9 27 19.9 40.5 29.9 5.6 4.1 15.2 12.6 22.2 12.6h.2c7 0 16.6-8.5 22.2-12.6 13.4-10 27-20 40.6-29.9 7.6-5.6 14.8-14.9 14.8-25.2 0-8.1-6.3-14.7-13.897-14.7H192.2c-9.3 0-13.9 7.7-13.9 16.8.1 8.3 8.8 18.7 15 23.1zM325 221.8c-14.5 10.4-29 20.9-43.2 31.8-7.3 5.7-16.3 12.7-25.7 12.7h-.2c-9.4 0-18.5-7-25.7-12.7-14.1-11-28.7-21.4-43.1-31.8-3.2-2.3-6.2-5-8.8-8v73.1c0 8.1 6.2 14.7 13.9 14.7h127.6c7.602 0 13.9-6.602 13.9-14.7v-73.1c-2.7 3-5.6 5.7-8.7 8z"></path>
+            </g>
+            <g id="icon-wrong-x">
+                <path d="M377.046875,327.516335 C377.046875,332.917377 374.822917,338.318419 371.010417,342.130919 L342.416667,370.724669 C338.604167,374.537169 333.203125,376.761127 327.802083,376.761127 C322.401042,376.761127 317.317708,374.537169 313.505208,370.724669 L256,313.21946 L198.494792,370.724669 C194.682292,374.537169 189.598958,376.761127 184.197917,376.761127 C178.796875,376.761127 173.395833,374.537169 169.583333,370.724669 L140.989583,342.130919 C137.177083,338.318419 134.953125,332.917377 134.953125,327.516335 C134.953125,322.115294 137.177083,317.03196 140.989583,313.21946 L198.494792,255.714252 L140.989583,198.209044 C137.177083,194.396544 134.953125,189.31321 134.953125,183.912169 C134.953125,178.511127 137.177083,173.110085 140.989583,169.297585 L169.583333,140.703835 C173.395833,136.891335 178.796875,134.667377 184.197917,134.667377 C189.598958,134.667377 194.682292,136.891335 198.494792,140.703835 L256,198.209044 L313.505208,140.703835 C317.317708,136.891335 322.401042,134.667377 327.802083,134.667377 C333.203125,134.667377 338.604167,136.891335 342.416667,140.703835 L371.010417,169.297585 C374.822917,173.110085 377.046875,178.511127 377.046875,183.912169 C377.046875,189.31321 374.822917,194.396544 371.010417,198.209044 L313.505208,255.714252 L371.010417,313.21946 C374.822917,317.03196 377.046875,322.115294 377.046875,327.516335 L377.046875,327.516335 Z M500,255.714252 C500,121.005919 390.708333,11.714252 256,11.714252 C121.291667,11.714252 12,121.005919 12,255.714252 C12,390.422585 121.291667,499.714252 256,499.714252 C390.708333,499.714252 500,390.422585 500,255.714252 L500,255.714252 Z" id="ï-2" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="icon-correct-tick">
+                <path d="M422.580374,205.888376 C422.580374,211.289418 420.674124,216.372751 416.861624,220.185251 L244.345999,392.700876 C240.533499,396.513376 235.132457,398.737334 229.731416,398.737334 C224.648082,398.737334 219.247041,396.513376 215.434541,392.700876 L100.424124,277.690459 C96.611624,273.877959 94.705374,268.794626 94.705374,263.393584 C94.705374,257.992543 96.611624,252.591501 100.424124,248.779001 L129.335582,220.185251 C133.148082,216.372751 138.231416,214.148793 143.632457,214.148793 C149.033499,214.148793 154.116832,216.372751 157.929332,220.185251 L229.731416,291.987334 L359.356416,162.680043 C363.168916,158.867543 368.252249,156.643584 373.653291,156.643584 C379.054332,156.643584 384.137666,158.867543 387.950166,162.680043 L416.861624,191.273793 C420.674124,195.086293 422.580374,200.487334 422.580374,205.888376 L422.580374,205.888376 Z M502.642874,257.357126 C502.642874,122.648793 393.351207,13.357126 258.642874,13.357126 C123.934541,13.357126 14.642874,122.648793 14.642874,257.357126 C14.642874,392.065459 123.934541,501.357126 258.642874,501.357126 C393.351207,501.357126 502.642874,392.065459 502.642874,257.357126 L502.642874,257.357126 Z" id="ï-2" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="icon-rss">
+                <path d="M12 433.074c0 36.96 29.963 66.926 66.926 66.926 36.962 0 66.926-29.966 66.926-66.926 0-36.959-29.964-66.926-66.926-66.926-36.963 0-66.926 29.967-66.926 66.926zM12 176.525v94.812c126.286 0 228.663 102.377 228.663 228.663h94.812c0-178.653-144.825-323.475-323.475-323.475zM12 12v97.6c215.613 0 390.4 174.787 390.4 390.4h97.6c0-269.512-218.489-488-488-488z"></path>
+            </g>
+            <g id="icon-envelop">
+                <path d="M256 357.455l-96.557-98.699-134.186 159.699h461.496l-134.195-159.699-96.558 98.699zm229.802-263.91h-459.603l229.801 234.878 229.802-234.878zm-118.967 150.626l133.165 158.499v-294.609l-133.165 136.11zm-354.835-136.11v294.609l133.165-158.499-133.165-136.11z"></path>
+            </g>
+            <g id="podcast">
+                <path d="M198.288 227.356c0-31.86 25.837-57.698 57.717-57.698 31.87 0 57.718 25.837 57.718 57.698 0 31.89-25.847 57.736-57.718 57.736-31.88 0-57.717-25.847-57.717-57.736zm57.716 72.166c-57.717 0-72.145 57.698-50.497 115.414C227.147 472.643 186.633 508 256.004 508c69.38 0 28.86-35.357 50.508-93.065 21.63-57.715 7.21-115.413-50.508-115.413zM256.014 4C132.834 4 32.622 104.183 32.622 227.338c0 69.053 31.185 133.14 85.543 175.825 8.206 6.433 20.06 5.01 26.495-3.194 6.433-8.197 5.01-20.062-3.185-26.504C96.29 337.99 70.37 284.736 70.37 227.34 70.37 125 153.65 41.75 256.013 41.75c102.345 0 185.618 83.252 185.618 185.59 0 57.642-26.112 111.052-71.636 146.536-8.223 6.398-9.69 18.263-3.283 26.476 3.722 4.782 9.28 7.282 14.894 7.282 4.06 0 8.15-1.305 11.59-3.987 54.77-42.695 86.18-106.956 86.18-176.31C479.378 104.184 379.178 4 256.015 4zM416.25 227.356C416.25 139 344.37 67.13 256.004 67.13c-88.364 0-160.254 71.872-160.254 160.226 0 43.498 17.14 84.212 48.252 114.623 7.467 7.282 19.413 7.145 26.695-.302 7.283-7.467 7.146-19.404-.3-26.696-23.803-23.245-36.9-54.376-36.9-87.625 0-67.536 54.962-122.478 122.507-122.478 67.548 0 122.5 54.94 122.5 122.477 0 33.586-13.336 64.927-37.54 88.237-7.5 7.238-7.72 19.184-.492 26.696 3.706 3.84 8.644 5.776 13.6 5.776 4.71 0 9.427-1.762 13.086-5.284 31.652-30.494 49.092-71.49 49.092-115.426z"></path>
+            </g>
+            <g id="icon-user-avatar">
+                <path d="M357.441761,250.236204 C348.700994,250.236204 311.764205,291.963569 256.5,291.963569 C201.235795,291.963569 164.299006,250.236204 155.558239,250.236204 C72.943892,250.236204 58,354.404518 58,422.249011 C58,470.880904 88.4517045,500 133.283381,500 L379.716619,500 C424.548295,500 455,470.880904 455,422.249011 C455,354.404518 440.056108,250.236204 357.441761,250.236204 Z M364.772727,127.275598 C364.772727,63.6338617 316.275568,12 256.5,12 C196.724432,12 148.227273,63.6338617 148.227273,127.275598 C148.227273,190.917335 196.724432,242.551196 256.5,242.551196 C316.275568,242.551196 364.772727,190.917335 364.772727,127.275598 L364.772727,127.275598 Z"></path>
+            </g>
+            <g id="plus">
+                <path d="M500 222.727c0-18.369-14.903-33.273-33.273-33.273h-144.182v-144.182c0-18.369-14.903-33.273-33.273-33.273h-66.545c-18.369 0-33.273 14.903-33.273 33.273v144.182h-144.182c-18.369 0-33.273 14.903-33.273 33.273v66.545c0 18.369 14.903 33.273 33.273 33.273h144.182v144.182c0 18.369 14.903 33.273 33.273 33.273h66.545c18.369 0 33.273-14.903 33.273-33.273v-144.182h144.182c18.369 0 33.273-14.903 33.273-33.273v-66.545z"></path>
+            </g>
+            <g id="minus">
+                <path d="M500 222.321c0-18.396-14.903-33.321-33.273-33.321h-421.455c-18.369 0-33.273 14.925-33.273 33.321v66.643c0 18.396 14.903 33.321 33.273 33.321h421.455c18.369 0 33.273-14.925 33.273-33.321v-66.643z"></path>
+            </g>
+            <g id="pencil">
+                <path d="M127.328 456.277h-33.995v-40.723h-40.667v-34.042l28.911-28.952 74.662 74.766-28.911 28.952zm166.162-295.245c0 1.909-.635 3.818-2.224 5.409l-172.198 172.438c-1.589 1.591-3.495 2.227-5.401 2.227-4.13 0-6.99-2.863-6.99-6.999 0-1.909.635-3.818 2.224-5.409l172.198-172.438c1.589-1.591 3.495-2.227 5.401-2.227 4.13 0 6.99 2.863 6.99 6.999zm-17.156-61.085l-264.334 264.702v132.351h132.167l264.334-264.702-132.167-132.351zm216.995 30.543c0-10.817-4.448-21.316-11.755-28.952l-74.662-74.448c-7.625-7.636-18.109-12.09-28.911-12.09s-21.286 4.454-28.594 12.09l-52.74 52.495 132.167 132.351 52.74-52.813c7.307-7.317 11.755-17.817 11.755-28.634z"></path>
+            </g>
+            <g id="trash">
+                <path d="M194.909 205.167c0-5.719-4.455-10.167-10.182-10.167h-20.364c-5.727 0-10.182 4.448-10.182 10.167v183c0 5.719 4.455 10.167 10.182 10.167h20.364c5.727 0 10.182-4.448 10.182-10.167v-183zm81.455 0c0-5.719-4.455-10.167-10.182-10.167h-20.364c-5.727 0-10.182 4.448-10.182 10.167v183c0 5.719 4.455 10.167 10.182 10.167h20.364c5.727 0 10.182-4.448 10.182-10.167v-183zm81.455 0c0-5.719-4.455-10.167-10.182-10.167h-20.364c-5.727 0-10.182 4.448-10.182 10.167v183c0 5.719 4.455 10.167 10.182 10.167h20.364c5.727 0 10.182-4.448 10.182-10.167v-183zm40.727 230.021c0 15.25-8.591 24.146-10.182 24.146h-264.727c-1.591 0-10.182-8.896-10.182-24.146v-301.188h285.091v301.188zm-213.818-341.854l15.591-37.172c.955-1.271 3.5-3.177 5.409-3.495h100.864c1.591.318 4.455 2.224 5.409 3.495l15.273 37.172h-142.545zm295.273 10.167c0-5.719-4.455-10.167-10.182-10.167h-98.318l-22.273-53.057c-6.364-15.568-25.455-28.276-42.318-28.276h-101.818c-16.864 0-35.955 12.708-42.318 28.276l-22.273 53.057h-98.318c-5.727 0-10.182 4.448-10.182 10.167v20.333c0 5.719 4.455 10.167 10.182 10.167h30.545v302.458c0 34.948 22.909 63.542 50.909 63.542h264.727c28 0 50.909-29.865 50.909-64.813v-301.188h30.545c5.727 0 10.182-4.448 10.182-10.167v-20.333z" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="badge__cute">
+                <path class="badge__text" d="M70.024 366.258l-.196-.342c-14.975-26.16-7.252-59.867 21.986-76.604 18.98-10.864 36.33-9.9 51.342-1.92l-12.662 29.04c-7.97-3.61-14.983-4.362-22.85.14-10.43 5.97-12.84 19.61-6.38 30.894l.197.342c6.853 11.97 19.564 16.725 30.508 10.46 7.695-4.403 10.598-10.833 12.302-19.753l30.72 3.3c-1.308 17.547-8.725 33.143-29.073 44.79-27.87 15.955-60.918 5.814-75.894-20.35m108.297-43.6l-34.647-60.53 32.488-18.595 28.68 50.1c5.773 10.09 14.207 12.526 22.072 8.024 7.695-4.406 10.377-13.205 4.603-23.293l-28.677-50.1 32.488-18.594 52.95 92.505-32.487 18.597-7.244-12.652c-1.58 11.12-6.116 23.024-19.283 30.56-19.663 11.257-38.9 5.014-50.938-16.018m116.588-62.425l-21.533-37.618-10.943 6.265-14.976-26.164 10.947-6.264-13.41-23.426 32.488-18.596 13.41 23.427 21.544-12.333 14.973 26.16-21.544 12.334 17.91 31.29c3.72 6.5 8.192 7.57 14.177 4.146 4.274-2.447 7.694-5.994 10.55-10.125l14.584 25.475c-3.954 6.577-10.474 13.032-19.537 18.22-19.492 11.158-36.014 9.263-48.64-12.794 M405.197 163.734c-7.07-9.574-16.774-12.646-25.666-7.556-8.547 4.894-10.543 14.89-6.48 25.957l32.147-18.4zm-58.324 44.056l-.196-.342c-15.465-27.017-8.378-59.45 18.98-75.11 31.976-18.304 60.09-3.295 75.653 23.892 1.174 2.052 2.545 4.445 3.647 6.766l-61.9 35.432c8.34 8.62 18.63 9.542 28.718 3.766 7.694-4.404 12.185-10.834 15.135-21.15l26.47 4.6c-2.432 16.374-10.95 31.24-29.417 41.81-29.068 16.638-60.648 9.062-77.09-19.664z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__lol">
+                <path class="badge__text" d="M147.455 353.512l-49.683-86.117L57.5 290.662h-.003l69.557 120.566 96.895-55.984-19.87-34.447zM323.048 217.15c-20.172-34.966-64.468-46.116-101.644-24.636-37.175 21.48-49.82 65.99-29.65 100.955l.2.345c20.174 34.963 64.47 46.113 101.644 24.634 37.176-21.48 49.82-65.99 29.65-100.953l-.2-.347zm-49.674 65.446c-15.492 8.95-32.755 1.7-41-12.596l-.2-.346c-8.147-14.122-5.864-32.437 9.453-41.286 15.492-8.95 32.755-1.7 41 12.595l.2.345c8.15 14.124 5.864 32.438-9.453 41.288zM446.062 180.982l-56.623 32.716-49.684-86.12-40.274 23.27h-.002l69.557 120.566 96.898-55.985z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__wtf">
+                <path class="badge__text" d="M66.68 320.108l35.878-20.537 43.728 44.63-14.243-62.017 30.284-17.336 46.678 43.965-16.172-60.915 35.3-20.205 27.962 123.568-31.635 18.108-48-44.487 13.665 64.142-31.442 17.997-92.004-86.912M287.834 289.044l-24.292-42.437-12.346 7.067-16.892-29.514 12.346-7.067-15.128-26.426 36.65-20.98 15.128 26.43 24.304-13.915 16.892 29.514-24.304 13.912 20.205 35.3c4.196 7.33 9.242 8.54 15.994 4.676 4.823-2.762 8.68-6.762 11.903-11.423l16.452 28.743c-4.462 7.42-11.817 14.7-22.04 20.554-21.99 12.587-40.627 10.45-54.87-14.432M346.762 198.714l-12.153 6.956-16.453-28.74 12.153-6.956-1.325-2.316c-6.845-11.96-9.225-22.38-6.585-32.084 2.722-10.01 9.664-17.567 22.008-24.634 11.19-6.404 18.795-9.222 25.576-10.798l14.795 25.848c-5.018 1.08-9.703 2.736-14.91 5.717-6.752 3.865-8.65 9.048-4.787 15.8l1.436 2.507 23.917-13.692 16.122 28.162-23.343 13.36 42.952 75.037-36.46 20.87-42.95-75.038"></path>
+            </g>
+            <g id="badge__geeky">
+                <path class="badge__text" d="M116.894 333.782l-.146-.255c-4.379-7.65-13.454-9.903-21.614-5.232-8.287 4.743-10.868 13.837-6.489 21.487l.146.255c4.379 7.65 13.454 9.903 21.742 5.158 8.159-4.671 10.74-13.765 6.362-21.413zm-20.859 79.477l-1.418-20.516c9.73-.153 18.511-1.963 27.818-7.291 12.112-6.932 14.674-16.355 8.398-27.319l-1.533-2.679c-1.634 8.384-5.308 16.75-15.38 22.515-16.957 9.705-37.604 5.275-48.916-14.487l-.146-.255c-11.384-19.888-4.494-40.083 11.443-49.205 10.327-5.911 18.855-5.207 27.22-2.717l-4.671-8.16 24.224-13.865 29.994 52.4c7.225 12.621 9.456 23.024 6.839 32.647-2.671 9.823-10.39 18.811-24.797 27.058-13.387 7.663-26.212 11.281-39.075 11.873z M191.585 288.32c-5.272-7.139-12.506-9.428-19.137-5.634-6.374 3.65-7.864 11.102-4.833 19.355l23.97-13.721zm-43.488 32.849l-.146-.255c-11.531-20.143-6.246-44.327 14.152-56.004 23.842-13.647 44.804-2.456 56.407 17.815.877 1.529 1.898 3.315 2.718 5.045l-46.152 26.419c6.218 6.427 13.89 7.114 21.412 2.808 5.738-3.284 9.087-8.079 11.285-15.77l19.737 3.429c-1.814 12.21-8.164 23.293-21.933 31.175-21.674 12.406-45.22 6.757-57.48-14.662z M266.167 245.629c-5.27-7.139-12.506-9.43-19.135-5.634-6.376 3.648-7.864 11.102-4.833 19.355l23.968-13.721zm-43.487 32.849l-.146-.255c-11.531-20.145-6.246-44.328 14.152-56.004 23.842-13.647 44.804-2.458 56.407 17.814.875 1.531 1.898 3.315 2.718 5.046l-46.152 26.417c6.218 6.427 13.89 7.115 21.412 2.808 5.738-3.284 9.087-8.079 11.285-15.769l19.737 3.429c-1.814 12.209-8.164 23.292-21.933 31.175-21.674 12.406-45.22 6.756-57.48-14.662z M263.802 176.737l24.223-13.866 27.002 47.173 5.533-33.805 27.412-15.689-8.133 41.386 48.252 27.223-26.647 15.251-27.325-15.503-2.088 10.843 9.269 16.192-24.225 13.866-53.273-93.071 M403.567 239.934l-2.185-21.262c5.139.105 10.022-.828 12.699-2.36 2.422-1.386 3.715-2.972 4.003-6.016l-65.78-52.227 25.371-14.523 37.561 33.682-10.787-49.007 24.861-14.231 13.289 81.766c3.203 19.493.351 29.591-13.419 37.472-8.543 4.889-17.196 6.627-25.614 6.706" fill="#1A1918"></path>
+            </g>
+            <g id="badge__omg">
+                <path class="badge__text" d="M134.132 328.064l-.185-.323c-4.997-8.73-15.443-11.98-23.526-7.354-8.245 4.719-10.247 15.095-5.435 23.501l.185.324c4.997 8.73 15.443 11.98 23.526 7.352 8.245-4.719 10.247-15.094 5.435-23.501zm-64.019 36.646l-.185-.324c-14.251-24.897-5.773-58.081 23.327-74.737 28.938-16.564 61.499-7.301 75.749 17.596l.186.323c14.251 24.897 5.773 58.081-23.327 74.738-28.938 16.564-61.499 7.301-75.75-17.596z M152.172 258.714l36.697-21.007 6.756 11.802c1.494-10.514 6.592-22.231 18.717-29.172 11.963-6.847 24.139-6.949 34.356-.348 2.624-12.664 7.999-23.896 21.58-31.67 18.914-10.827 37.587-5.203 48.969 14.681l33.313 58.199-36.697 21.007-26.743-46.721c-4.257-7.436-11.029-9.141-16.364-6.088-5.334 3.054-7.778 10.034-3.521 17.47l26.744 46.721-36.699 21.005-26.743-46.721c-4.257-7.436-11.029-9.141-16.364-6.087-5.334 3.053-7.778 10.033-3.521 17.469l26.743 46.721-36.697 21.007-50.526-88.269 M397.178 170.413l-.186-.324c-4.35-7.598-13.685-10.41-22.577-5.321-9.053 5.182-11.102 14.727-6.66 22.486l.184.323c4.35 7.598 13.594 10.249 22.485 5.16 9.054-5.182 11.195-14.565 6.754-22.324zm-27.513 101.172l-1.36-28.626c12.822-.471 24.534-2.882 36.659-9.823 13.741-7.865 16.944-19.143 9.912-31.43l-1.479-2.586c-1.774 8.527-6.317 19.713-18.604 26.746-22.795 13.047-48.538 6.32-62.512-18.091l-.184-.324c-14.158-24.734-6.692-50.686 13.678-62.346 12.932-7.403 23.307-6.902 33.568-3.976l-5.366-9.377 36.697-21.006 37.755 65.96c9.346 16.327 12.337 29.426 8.88 42.136-3.387 12.456-12.644 24.407-32.367 35.698-19.561 11.197-36.979 16.015-55.277 17.045z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__trashy">
+                <path class="badge__text" d="M86.781 377.745l-15.555-27.174-7.905 4.525-10.818-18.898 7.905-4.526-9.686-16.922 23.469-13.433 9.686 16.922 15.564-8.908 10.818 18.898-15.564 8.908 12.939 22.605c2.687 4.693 5.918 5.468 10.241 2.993 3.088-1.767 5.557-4.329 7.621-7.314l10.535 18.405c-2.856 4.752-7.566 9.415-14.113 13.162-14.081 8.061-26.016 6.692-35.137-9.241 M107.099 304.946l23.469-13.435 7.707 13.464c-1.403-11.332 1.379-20.796 12.779-26.666l14.14 24.705-1.976 1.13c-12.228 7-15.115 18.001-6.277 33.441l11.878 20.752-23.468 13.433-38.251-66.824 M220.427 296.653l-1.768-3.088c-2.913.355-6.672 1.524-10.13 3.504-6.794 3.888-8.838 9.486-6.01 14.426l.141.248c2.617 4.571 7.631 5.307 12.448 2.551 6.794-3.888 9.137-10.97 5.319-17.64zm-39.593 29.388l-.141-.248c-7.92-13.834-1.521-27.008 14.166-35.989 6.177-3.535 12.937-5.764 17.543-6.597l-.635-1.112c-3.961-6.916-10.545-8.396-19.563-3.234-7.04 4.031-11.698 8.5-16.284 14.241l-14.291-13.794c5.767-7.401 12.593-14.096 24.082-20.672 11.98-6.857 21.76-8.683 30.111-6.412 7.893 2.042 13.952 7.758 19.326 17.145l21.989 38.415-23.223 13.292-3.959-6.916c-1.671 7.68-6.062 14.621-14.832 19.641-12.723 7.283-26.653 5.58-34.288-7.759z M256.775 296.839l.638-19.225c10.557.681 20.442-1.532 27.359-5.493 4.077-2.332 5.222-4.628 3.88-6.975l-.141-.248c-1.485-2.593-5.827-1.584-13.999.47-15.197 4.106-28.241 5.67-35.949-7.794l-.141-.248c-8.13-14.204-1.291-28.614 14.149-37.453 9.757-5.586 21.512-8.541 31.998-7.985l.457 19.418c-9.11.13-17.988 2.097-23.299 5.136-3.582 2.051-4.658 4.47-3.597 6.322l.141.248c1.485 2.593 6.02 1.637 14.264-.293 15.337-3.86 28.452-5.3 35.877 7.671l.141.246c8.413 14.699 1.803 28.651-14.501 37.984-11.239 6.434-24.195 9.586-37.276 8.219 M276.05 177.242l23.47-13.435 18.595 32.486c1.142-8.033 4.419-16.632 13.93-22.076 14.205-8.13 28.101-3.622 36.797 11.571l25.029 43.727-23.469 13.433-20.716-36.192c-4.171-7.288-10.262-9.048-15.822-5.867-5.682 3.252-7.619 9.61-3.448 16.897l20.716 36.192-23.469 13.433-51.614-90.169 M408.124 240.38l-2.116-20.6c4.979.102 9.708-.802 12.303-2.287 2.347-1.344 3.6-2.881 3.88-5.829l-63.73-50.601 24.58-14.07 36.391 32.632-10.451-47.48 24.086-13.787 12.875 79.218c3.105 18.888.339 28.67-13 36.305-8.276 4.737-16.66 6.421-24.817 6.498" fill="#1A1918"></path>
+            </g>
+            <g id="badge__win">
+                <path class="badge__text" d="M52.958 317.774l42.141-24.35 35.541 36.473-12.074-50.55 35.149-20.308 38.126 36.015-13.626-49.652 41.559-24.012 29.234 125.628-36.898 21.319-40.412-37.285 11.671 53.891-36.703 21.207-93.708-88.375 M226.954 217.24l44.083-25.47 61.218 106.111-44.083 25.47-61.218-106.111zm-21.406-35.311l45.636-26.367 16.257 28.18-45.636 26.369-16.257-28.181z M284.629 183.917l44.083-25.47 8.52 14.77c1.752-12.673 7.5-27.395 22.453-36.035 22.332-12.903 44.835-6.212 58.626 17.692l40.362 69.963-44.081 25.47-32.178-55.775c-5.271-9.134-13.735-11.239-20.339-7.425-6.602 3.815-9.595 12.54-4.326 21.674l32.179 55.775-44.083 25.471-61.218-106.111" fill="#1A1918"></path>
+            </g>
+            <g id="badge__fail">
+                <path class="badge__text" d="M93.124 348.203l-13.78 7.961-21.754-37.708 13.78-7.961c-6.904-12.963-9.823-24.491-6.729-36.047 3.367-12.576 11.838-21.78 27.987-31.11 14.426-8.335 23.999-12.143 31.793-14.059l17.652 30.597c-5.359 1.659-10.468 3.75-16.713 7.358-7.535 4.354-9.67 9.61-5.941 16.074l.498.862 27.13-15.676 21.008 36.416-26.052 15.053 46.12 79.942-48.877 28.24-46.119-79.941 M262.073 299.139l-2.859-4.955c-3.42.539-8.223 2.166-12.314 4.529-9.688 5.598-11.715 14.525-7.49 21.852l.249.43c3.978 6.894 11.542 8.559 17.784 4.951 8.613-4.976 11.095-15.604 4.63-26.808zm-67.147 52.301l-.249-.432c-13.551-23.486-3.694-46.706 23.651-62.507 9.904-5.723 23.85-10.908 30.261-11.739l-1.117-1.939c-6.216-10.774-16.496-13.167-31.568-4.457-12.057 6.966-20.685 15.399-28.659 25.465l-27.382-27.562c10.582-13.009 24.094-25.412 44.548-37.232 23.902-13.808 42.261-17.809 58.564-13.438 13.924 3.734 23.958 13.164 33.778 30.186l38.662 67.012-48.877 28.241-6.837-11.851c-3.085 13.561-10.71 25.723-25.35 34.184-22.607 13.062-46 9.34-59.424-13.931z M281.746 188.94l48.877-28.238 67.874 117.649-48.877 28.24-67.874-117.65zm-23.734-39.149l50.599-29.236 18.024 31.244-50.599 29.236-18.024-31.245z M323.251 112.096l48.877-28.239 90.746 157.297-48.875 28.24-90.748-157.298" fill="#1A1918"></path>
+            </g>
+            <g id="badge__trending">
+                <path class="badge__icon-white" d="M415.588 250.187l-19.801-141.264-131.49 53.377 52.118 30.276-49.233 85.799-85.274-49.538-84.015 146.42 47.059 27.336 56.845-99.07 85.274 49.538 76.401-133.149 52.116 30.276" fill="#fff"></path>
+            </g>
+            <g id="badge__election2015">
+                <path d="M377.98 470.274c-116.686 67.368-265.889 27.389-333.255-89.294-67.368-116.686-27.389-265.889 89.294-333.255 116.686-67.368 265.886-27.389 333.255 89.294 67.368 116.686 27.389 265.886-89.294 333.255z" fill="#fe0"></path>
+                <path d="M463.394 144.907v1.464c-1.009 3.03-2.984 5.411-5.157 7.649-3.346 3.445-7.118 6.35-11.227 8.831-.826.498-2.003.651-2.196 1.904-1.379.951-2.602 2.162-3.983 3.034-4.239 2.68-8.731 4.931-13.392 6.802-2.267.91-4.483 1.87-6.472 3.317-.624.454-1.362.749-2.045 1.123-.764.419-1.565.785-2.28 1.278-5.698 3.928-11.495 7.697-17.691 10.797-1.135.568-1.478 1.216-1.475 2.454.041 19.463.04 38.927.001 58.39-.003 1.242.365 2.049 1.307 2.855 10.775 9.229 21.1 18.949 31.214 28.896.372.365.721.754 1.207 1.263-.795.501-1.437.919-2.092 1.315-.791.478-1.633.881-2.381 1.417-1.35.968-1.509 1.761-.857 3.267.6 1.385 1.219 2.765 1.726 4.184 1.78 4.981 1.001 9.401-2.975 13.081l-.303.317c-1.032 1.03-1.457 1.094-2.624.189-.767-.595-1.435-1.316-2.169-1.955-.42-.365-.884-.677-1.368-1.043l-.594.874c-.35-.32-.663-.618-.989-.901-2.24-1.953-4.439-3.956-6.741-5.832-1.315-1.072-2.784-1.959-4.216-2.877-.507-.325-1.087-.661-1.798-.338 0 .361-.102.732.016 1.01.849 2.008 1.478 4.122 3.064 5.757 1.526 1.573 2.995 3.207 4.417 4.875.818.959 1.595 1.982 2.213 3.077 1.528 2.707.861 5.011-1.824 6.551-.928.532-1.959.893-2.849 1.477-.838.55-1.671 1.196-2.289 1.973-.804 1.01-.674 1.458.238 2.372 2.169 2.174 4.346 4.338 6.508 6.518.887.894.939 1.598.084 2.515-.453.487-1.041.881-1.632 1.197-.726.387-1.535.616-2.279.973-.498.239-.946.582-1.454.903l.409.79c2.313 4.237 5.447 7.838 8.81 11.243 3.595 3.641 7.268 7.205 10.902 10.808.402.399.773.83 1.137 1.223-.573.914-1.043 1.71-1.559 2.475-.867 1.288-1.816 1.6-3.269 1.083-1.124-.399-2.015-1.134-2.867-1.959-7.461-7.216-14.94-14.415-22.417-21.615-.441-.425-.914-.816-1.607-1.431-.031.855-.07 1.413-.07 1.972-.004 11.561-.027 23.121.004 34.683.027 10.045-6.16 17.899-14.015 21.097-3.121 1.27-6.369 1.656-9.716 1.654-65.159-.017-130.318-.008-195.476-.043-1.322-.001-2.088.43-2.851 1.478-6.566 9.025-13.193 18.005-19.799 27.001-1.193 1.625-2.514 3.104-4.37 4.001h-.584c-.354-.641-.382-1.309-.061-1.954.497-.999.95-2.037 1.577-2.952 5.979-8.724 11.992-17.424 17.993-26.133.264-.384.507-.783.911-1.41-2.045 0-3.828.05-5.606-.021-.93-.037-1.506.261-2.054 1.028-2.805 3.927-5.667 7.812-8.522 11.702-.322.44-.725.821-1.09 1.229l-.299-.199c.229-.453.423-.93.694-1.357 2.348-3.704 4.712-7.398 7.067-11.097.223-.351.418-.719.705-1.219-.561-.029-.934-.063-1.308-.064-1.899-.005-3.8.043-5.697-.022-.92-.031-1.507.251-2.076 1.002-3.767 4.973-7.591 9.904-11.394 14.85-1.931 2.512-3.854 5.031-5.795 7.534-.295.381-.519.926-1.414.875.393-.581.655-1.021.966-1.424 2.653-3.432 5.329-6.847 7.97-10.289 2.789-3.635 5.551-7.291 8.311-10.949.299-.397.846-.737.52-1.38-1.66-.379-2.402-.287-3.754.395-.548.276-1.239.757-1.664.007-.355-.627-.801-.598-1.327-.601-.633-.004-1.268.03-1.899-.009-.727-.046-1.297.114-1.778.737-.323.419-.843.685-1.537 1.224l.24-1.982c-1.926 0-3.777.054-5.623-.01-6.082-.211-11.237-2.564-15.445-6.939-4.381-4.555-6.302-10.116-6.303-16.36-.012-78.934-.009-157.868.002-236.803 0-1.459.081-2.924.23-4.376 1.023-9.967 8.328-17.943 18.102-19.808.902-.172 1.8-.362 2.701-.543h242.557c.323.091.64.22.969.267 8.425 1.193 14.44 5.647 18.059 13.357.136.289.308.562.486.885.395-.195.704-.33.996-.494 2.731-1.538 5.587-2.742 8.684-3.325 4.396-.827 8.78-1.713 13.184-2.488 2.103-.37 4.24-.546 6.363-.796.122-.014.259.094.388.145l.394 1.236c.741-.241 1.375-.511 2.036-.646 1.184-.243 2.382-.433 3.581-.593.964-.129 1.527.372 1.861 1.267.592 1.585.516 3.191.031 4.737-.4 1.275-.373 2.434.132 3.561.78.155 1.543.182 2.184.475.529.241 1.211.742 1.3 1.225.154.836.66 1.176 1.411 1.543l-1.346 2.081c.772-.046 1.482-.216 2.078-.576 1.792-1.081 3.509-2.288 5.313-3.35 1.909-1.124 3.903-1.954 6.233-1.436.997.222 1.83.504 2.047 1.605 1.454-.464 2.645-1.956 4.226-.613-.172 1.88-1.214 3.111-2.839 3.916-.475.017-.952.015-1.426.056-.841.074-1.32.49-1.228 1.398-.139.011-.316-.029-.412.042-1.972 1.459-4.028 2.75-5.776 4.574-1.544 1.61-3.666 2.724-5.664 3.817-1.425.779-2.531 1.923-3.857 2.796-.28.184-.423.575-.63.871.549-.079.969-.285 1.363-.534 3.375-2.127 6.754-4.247 10.112-6.401.856-.549 1.669-1.175 2.451-1.826 1.73-1.44 3.551-2.725 5.643-3.588 1.231-.508 2.356-.598 3.525.347 1.175.951 1.363 1.156.734 2.508-.917 1.972-2.325 3.587-3.799 5.149l-1.024 1.074c.678-.046 1.19-.319 1.734-.482 1.438-.431 2.873-.899 4.342-1.188 1.204-.237 2.31.081 2.932 1.313zm-281.99 215.761c-.321.268-.691.495-.957.809-7.084 8.354-14.157 16.716-21.228 25.082-.235.278-.414.603-.66.969 1.37.373 2.24.071 3.084-1.035 6.262-8.202 12.6-16.347 18.905-24.517.317-.412.553-.888.826-1.335l.804-.748-.248-.198-.527.973zm4.288-29.067c-1.06 1.2-2.15 2.375-3.175 3.604-8.124 9.735-15.688 19.907-23.302 30.039-1.962 2.611-3.823 5.307-5.919 7.805-2.118 2.525-3.313 5.6-5.244 8.22-.202.274-.356.59-.588.835-.201.212-.479.351-.723.522-.042-.447.056-.755.217-1.027 1.165-1.971 2.37-3.918 3.507-5.904.693-1.21 1.188-2.541 1.942-3.707 2.303-3.56 4.633-7.105 7.051-10.587 7.766-11.178 16.222-21.83 24.741-32.432 1.085-1.351 2.111-2.655 2.598-4.454.591-2.184 2.238-3.849 3.886-5.396.781-.735 1.598-1.431 2.375-2.169 5.761-5.47 11.517-10.947 17.273-16.424.282-.268.571-.535.814-.838 3.352-4.183 6.686-8.381 10.046-12.557 2.473-3.074 4.978-6.123 7.546-9.279-1.036-.454-.655-1.127-.281-1.788.218-.385.464-.754.697-1.13-1.978 1.436-3.829 2.946-5.519 4.619-16.522 16.353-31.612 33.958-45.574 52.537-4.743 6.312-9.314 12.754-13.965 19.135-.351.481-.611 1.076-1.536 1.273.27-.561.428-.945.631-1.302 2.553-4.49 5.114-8.977 7.671-13.465 5.915-10.385 12.19-20.534 19.414-30.075 11.956-15.791 24.644-30.973 37.846-45.728 2.957-3.305 5.849-6.685 8.996-9.802 6.891-6.825 13.926-13.504 20.899-20.246.26-.251.483-.541.765-.859-.439-.277-.758-.494-1.09-.687-15.197-8.861-30.773-16.987-46.936-23.934-7.238-3.111-14.628-5.868-21.922-8.853-1.423-.582-2.825-1.338-4.047-2.264-1.56-1.182-1.417-2.451.207-3.511.565-.369 1.183-.708 1.824-.901 1.767-.533 3.555-.998 5.343-1.455.83-.211 1.68-.339 2.576-.514-.401-.595-.774-1.041-1.027-1.548-.47-.943-1.104-1.602-2.499-1.524.535-.838.879-1.536 1.368-2.109 1.395-1.636 3.212-2.666 5.209-3.386 3.128-1.128 6.348-1.411 9.638-.999.456.057.916.08 1.374.119-.242-.358-.535-.495-.839-.599-1.381-.472-2.766-.933-4.148-1.401-1.777-.601-2.169-1.67-1.11-3.207.766-1.112 1.615-2.167 2.46-3.291.568.176 1.114.373 1.674.511.849.209 1.703.418 2.566.548.593.089 1.229.003 1.482-.657.602-1.572 1.153-3.164 1.758-4.842l-7.167-2.407c1.908-.246 1.909-.245 2.426-1.741.456-1.321.909-2.642 1.405-4.086 1.283.321 2.458.478 3.522.908 2.388.965 4.723 2.061 7.075 3.111 1.998.892 3.976 1.833 5.995 2.675.879.366 1.838.538 2.836.819l1.525-3.704c-5.989-3.641-12.638-5.234-19.152-7.391 2.389-.296 3.425-1.926 4.035-4.066.865.222 1.644.325 2.345.616 3.095 1.29 6.163 2.646 9.251 3.956 2.639 1.12 5.264 2.284 7.948 3.288 1.811.677 3.735.976 5.718.907-2.29-1.407-4.871-2.195-7.393-3.392 1.712-.841 3.318-1.033 5.265-.73 2.777.433 5.354 1.453 7.804 2.776 3.083 1.666 6.082 3.489 9.178 5.13 2.23 1.182 4.495 2.352 6.858 3.217 5.033 1.845 9.974 3.88 14.775 6.264 8.565 4.251 16.677 9.271 24.645 14.538.599.395 1.202.784 1.805 1.177l1.104-.939c10.223-8.89 20.343-17.903 30.695-26.639 10.575-8.925 21.379-17.58 32.082-26.354 4.197-3.441 8.659-6.471 13.579-8.791.204-.096.392-.229.714-.419-.406-.252-.671-.441-.956-.59-2.084-1.091-4.326-1.374-6.646-1.374-79.049.009-158.099.007-237.148.008-.536 0-1.072-.007-1.607.023-5.545.301-10.124 3.94-11.461 9.236-.329 1.305-.429 2.699-.429 4.052-.019 79.28-.017 158.559-.017 237.838 0 .391-.011.781.004 1.171.099 2.497.796 4.806 2.271 6.836 2.561 3.524 6.045 5.248 10.39 5.246 3.361-.002 6.724-.075 10.081.038 1.38.047 2.191-.4 2.991-1.509 10.954-15.194 22.559-29.875 34.74-44.101.819-.958 1.571-1.989 2.24-3.058 3.415-5.452 6.794-10.926 10.182-16.395.164-.265.296-.55.503-.938-.264.066-.372.059-.423.11-.347.341-.692.686-1.022 1.044-8.368 9.089-15.884 18.86-23.079 28.889-6.904 9.624-13.796 19.257-20.697 28.884-.255.356-.517.715-.827 1.02-.158.155-.429.197-.65.289.291-.829.733-1.462 1.177-2.093 11.169-15.863 22.215-31.814 34.097-47.16.234-.301.397-.657.593-.988l.808-.94-.244-.176-.694.997zm120.884-69.392c-1.407 1.3-2.693 2.484-3.976 3.674-11.718 10.873-23.327 21.86-34.473 33.326-1.019 1.048-2.016 2.12-3.058 3.143-.534.525-1.097 1.079-2.072 1.033.075-.893.595-1.402 1.072-1.923 3.093-3.379 6.111-6.832 9.306-10.113 6.833-7.017 13.759-13.944 20.647-20.908.364-.368.721-.743 1.082-1.115-.434.056-.7.267-.963.48-13.486 10.934-26.162 22.77-38.63 34.836-10.017 9.694-19.89 19.534-29.151 29.965-14.766 16.633-28.528 34.076-41.634 52.043-.188.258-.328.551-.612 1.035h1.919c28.536.001 57.071.001 85.607.001 33.99 0 67.98.002 101.97-.01 1.262-.001 2.552.005 3.78-.239 5.87-1.168 9.937-6.155 9.948-12.219l.029-45.07c.002-.917-.288-1.528-.956-2.139-20.612-18.856-41.828-36.992-64.027-53.956-5.185-3.962-10.445-7.829-15.809-11.843zm49.009-39.806c11.185 7.029 21.496 14.579 31.569 22.655.105-.33.181-.456.181-.582-.012-15.169-.03-30.337-.05-45.507l-.085-.1-.24-.139-1.834.877.867.687c-2.577 1.936-5.072 3.795-7.551 5.677-2.445 1.856-4.856 3.755-7.312 5.596-2.494 1.87-4.991 3.74-7.548 5.522-2.54 1.771-5.157 3.433-7.997 5.313zm-183.604 165.162c.471.055.74.113 1.01.114 1.461.01 2.925-.054 4.381.027.948.053 1.485-.331 2.045-1.057 6.432-8.331 12.781-16.729 19.386-24.922 11.97-14.845 24.745-28.978 38.297-42.396 3.877-3.839 7.784-7.649 11.673-11.469l-.469-1.777c-3.34 3.123-6.605 6.118-9.8 9.185-1.684 1.615-3.311 3.3-4.856 5.048-7.52 8.507-14.96 17.085-22.511 25.564-8.726 9.798-18.24 18.825-27.648 27.95-2.808 2.723-5.446 5.566-7.749 8.726-.947 1.299-1.951 2.556-2.924 3.837-.254.335-.489.685-.835 1.172zm-5.772-5.748l.197.15c.488-.571.974-1.145 1.466-1.713 4.048-4.677 8.154-9.304 12.132-14.039 6.641-7.904 13.201-15.877 19.792-23.823.227-.272.422-.572.7-.952-.955.218-1.76.357-2.535.596-.39.121-.794.359-1.07.657-1.058 1.143-2.128 2.285-3.084 3.512-9.013 11.561-18.004 23.139-26.998 34.714-.22.283-.4.598-.599.898zm258.203-214.233c-.409.26-.824.512-1.227.781-3.479 2.318-6.889 4.748-10.449 6.932-4.771 2.926-9.362 6.106-13.912 9.355-.316.226-.641.442-.943.686-.393.318-.485.699-.124 1.202.29-.154.603-.275.865-.466 6.535-4.753 13.423-8.961 20.363-13.074 2.297-1.361 3.962-3.212 5.428-5.415zm9.538-17.471c-1.918 1.861-3.268 4.17-5.526 5.55.462.875.936.447 1.371.174 4.531-2.839 9.068-5.669 13.575-8.546.622-.397 1.09-1.036 1.63-1.563-.583-.042-1.018.125-1.431.337-2.635 1.356-5.267 2.721-7.898 4.086-.589.306-1.17.715-1.722-.038zm-13.988 9.954l-.07-.17c-1.545.402-3.093.789-4.63 1.219-.313.087-.6.31-.866.513-4.334 3.306-8.661 6.621-12.995 9.928-.58.443-1.187.852-1.78 1.278-.372.267-.553.585-.286 1.135l20.627-13.904zm-252.309 209.396l-.276-.248c-5.423 6.007-10.79 12.063-16.169 18.346 1.218.203 2.004.193 2.713-.709 3.855-4.898 7.777-9.743 11.664-14.616.719-.901 1.38-1.848 2.068-2.775zm2.006 17.5l-.738.163c-1.889.524-2.482.018-2.194-1.877.057-.372.132-.742.212-1.186-1.332 1.204-2.422 2.591-2.774 3.494 1.683 0 3.37.007 5.057-.017.102-.002.2-.255.436-.576z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__ha-ha-ha">
+                <path class="badge__text" d="M189.44 210.697l-25.824-44.724c-4.8-8.313-10.92-8.548-18.07-4.42-6.817 3.935-8.293 9.442-9.154 13.71l28.605 49.545-29.927 17.278-61.375-106.3 29.93-17.282 20.29 35.144c1.583-8.008 7.034-18.915 21.167-27.075 18.62-10.75 33.102-4.482 41.166 9.485l33.117 57.36-29.925 17.28 M277.615 159.787l-4.417-7.647c-1.225 8.245-8.73 17.898-18.706 23.656-11.97 6.91-32.304 7.79-42.862-10.5-11.52-19.952.847-34.63 12.818-41.54 10.473-6.046 21.87-8.194 29.36-5.202l-4.8-8.313c-3.264-5.653-10.913-7-20.722-1.336-7.48 4.32-14.233 12.208-17.77 20.677l-20.796-12.6c5.817-14.883 18.764-27.015 30.9-34.02 19.95-11.52 43.437-15.77 58.892 11l28.03 48.55-29.928 17.277zm-12.576-21.78l-2.592-4.49c-3.626-1.674-9.646-.195-14.3 2.494-4.99 2.88-9.515 7.712-6.636 12.7 2.882 4.986 9.23 3.315 14.22.436 4.654-2.69 8.946-7.162 9.307-11.14zM255.752 325.555L229.93 280.83c-4.8-8.312-10.92-8.547-18.07-4.418-6.818 3.936-8.294 9.443-9.155 13.708l28.607 49.545-29.93 17.28-61.372-106.303 29.927-17.278 20.29 35.142c1.583-8.008 7.034-18.915 21.167-27.075 18.623-10.75 33.104-4.48 41.166 9.488l33.12 57.36-29.928 17.277 M343.93 274.648l-4.415-7.65c-1.227 8.245-8.733 17.898-18.708 23.656-11.97 6.913-32.304 7.79-42.862-10.5-11.52-19.95.847-34.627 12.818-41.54 10.473-6.046 21.873-8.194 29.36-5.202l-4.8-8.313c-3.264-5.652-10.91-7.002-20.722-1.338-7.48 4.32-14.232 12.208-17.768 20.677l-20.794-12.6c5.815-14.886 18.762-27.015 30.898-34.023 19.952-11.52 43.436-15.768 58.89 11.002l28.03 48.546-29.927 17.28zm-12.575-21.782l-2.59-4.487c-3.63-1.677-9.647-.196-14.302 2.49-4.987 2.88-9.514 7.71-6.635 12.698 2.88 4.987 9.228 3.318 14.218.437 4.656-2.687 8.945-7.16 9.31-11.14zM322.066 440.416l-25.82-44.726c-4.8-8.313-10.923-8.548-18.072-4.42-6.818 3.937-8.29 9.444-9.155 13.71l28.606 49.547-29.927 17.278-61.376-106.3 29.927-17.282 20.29 35.144c1.584-8.008 7.035-18.915 21.168-27.075 18.623-10.75 33.104-4.482 41.17 9.485l33.116 57.36-29.927 17.28 M410.242 389.507l-4.414-7.647c-1.225 8.245-8.73 17.898-18.708 23.656-11.97 6.91-32.302 7.79-42.862-10.5-11.52-19.952.847-34.63 12.818-41.54 10.475-6.05 21.873-8.194 29.36-5.202l-4.8-8.313c-3.26-5.653-10.91-7-20.72-1.336-7.484 4.32-14.235 12.208-17.77 20.677l-20.796-12.6c5.815-14.883 18.762-27.015 30.898-34.023 19.952-11.517 43.436-15.765 58.89 11.002l28.032 48.55-29.93 17.277zm-12.574-21.78l-2.59-4.49c-3.63-1.676-9.647-.195-14.302 2.49-4.987 2.883-9.514 7.712-6.635 12.7 2.88 4.986 9.232 3.317 14.22.438 4.655-2.69 8.944-7.162 9.308-11.14z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__fofo">
+                <path class="badge__text" d="M129.457 414.473l-37.46-64.884-15.875 9.164-17.87-30.954 15.874-9.165-2.52-4.363c-11.572-20.042-4.427-42.95 16.804-55.207 11.112-6.417 25.05-10.228 35.92-6.98l-1.442 27.286c-3.672-1.317-6.94-1.02-10.91 1.272-4.56 2.635-7.408 8.247-4.658 13.01l2.52 4.365 19.446-11.226 17.87 30.952-19.444 11.226 37.46 64.884-35.715 20.62 M156.547 334.81c-15.465-26.786-9.14-61.656 24.79-81.247 34.13-19.703 67.49-7.745 82.956 19.042 15.465 26.786 9.255 61.854-24.874 81.557-33.93 19.59-67.405 7.435-82.873-19.352zm71.037-41.014c-6.07-10.514-16.92-15.1-28.03-8.684-10.915 6.303-12.37 17.988-6.296 28.504 6.186 10.714 17.032 15.3 27.946 9 11.112-6.416 12.566-18.103 6.38-28.82zM307.738 311.544l-37.462-64.882-15.873 9.165-17.87-30.954 15.872-9.165-2.52-4.365c-11.572-20.04-4.427-42.95 16.806-55.207 11.11-6.415 25.048-10.226 35.92-6.978l-1.443 27.287c-3.672-1.318-6.937-1.02-10.907 1.27-4.563 2.636-7.408 8.248-4.66 13.01l2.52 4.364 19.447-11.227 17.87 30.954-19.446 11.226 37.463 64.884-35.715 20.618 M337.277 230.468c-15.465-26.786-9.14-61.656 24.79-81.247 34.128-19.702 67.49-7.744 82.956 19.043 15.465 26.786 9.255 61.854-24.874 81.557-33.932 19.588-67.408 7.435-82.873-19.352zm71.037-41.014c-6.073-10.516-16.922-15.1-28.03-8.684-10.915 6.303-12.37 17.988-6.296 28.504 6.186 10.714 17.032 15.3 27.946 9 11.112-6.418 12.566-18.103 6.38-28.82z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__meu-deus">
+                <path class="badge__text" d="M191.945 262.15l-24.69-42.764c-2.54-4.397-7.002-6.873-13.066-3.372-6.07 3.5-7.304 9.067-7.897 12.24l26.092 45.188-27.297 15.76-24.69-42.763c-2.54-4.398-6.85-6.962-13.068-3.373-5.915 3.414-7.15 8.98-7.742 12.154l26.09 45.19-27.296 15.758-42.286-73.24 27.295-15.76 4.815 8.34c.822-5.933 6.57-17.34 18.398-24.167 10.312-5.953 19.93-6.45 28.52.72.568-8.82 6.355-20.856 18.185-27.683 13.496-7.793 26.536-6.222 35.29 8.943l30.643 53.072-27.296 15.76 M201.75 207.56c-12.255-21.23-5.923-47.735 17.733-61.39 21.534-12.433 46.993-6.508 61.878 19.27l3.24 5.61-49.74 28.716c4.232 3.826 12.165 5.31 21.112.144 4.094-2.362 12.054-9.587 13.855-14.874l20.94 10.355c-3.688 10.42-15.066 20.83-25.986 27.134-22.894 13.22-49.108 9.145-63.028-14.965zm29.728-40.617c-8.34 4.817-7.918 11.85-6.903 15.71l24.113-13.92c-2.596-2.744-8.413-6.868-17.21-1.79zM355.434 167.76l-4.73-8.186c-1.53 7.15-6.502 17.097-19.393 24.54-16.982 9.805-30.126 3.847-37.393-8.74l-30.206-52.313 27.296-15.76 23.464 40.64c4.29 7.43 9.897 8.036 16.57 4.184 6.064-3.5 7.41-8.525 8.196-12.417l-26.09-45.186 27.296-15.76 42.29 73.242-27.298 15.758 M177.768 414.737l-4.465-7.735c-2.19 10.565-7.676 17.17-15.11 21.46-17.74 10.243-40 5.305-54.534-19.87-14.01-24.26-7.897-46.593 10.147-57.01 7.432-4.292 16.35-6.002 26.14-2.355l-20.575-35.634 27.295-15.76 58.398 101.143-27.297 15.76zm-15.76-27.296l-10.856-18.802c-4.417-1.696-10.534-.388-14.174 1.713-7.43 4.29-10.67 13.038-5.417 22.134 5.254 9.1 14.536 10.817 21.966 6.527 3.638-2.1 7.745-6.897 8.482-11.57zM189.693 358.922c-12.256-21.228-5.924-47.73 17.732-61.39 21.534-12.432 46.993-6.507 61.878 19.27l3.238 5.613-49.737 28.714c4.23 3.825 12.166 5.31 21.11.145 4.095-2.364 12.057-9.59 13.858-14.874l20.94 10.354c-3.69 10.42-15.068 20.83-25.985 27.133-22.898 13.22-49.11 9.145-63.032-14.965zm29.727-40.616c-8.34 4.817-7.918 11.85-6.9 15.714l24.11-13.92c-2.596-2.747-8.413-6.87-17.21-1.793zM343.32 319.157l-4.725-8.19c-1.535 7.153-6.505 17.098-19.396 24.54-16.984 9.806-30.128 3.848-37.395-8.738L251.6 274.454l27.294-15.76 23.464 40.638c4.29 7.432 9.897 8.037 16.568 4.185 6.066-3.5 7.413-8.525 8.2-12.415l-26.09-45.19 27.295-15.76 42.287 73.242-27.295 15.76M369.79 291.34l.326-24.652c8.39 1.222 23.537-1.257 31.728-5.985 5.61-3.238 6.49-5.566 5.44-7.386-4.027-6.976-40.413 25.96-57.923-4.368-7.614-13.194-2.92-31.675 18.31-43.933 12.282-7.09 25.39-9.6 37.122-8.894l.237 23.52c-6.74-1.165-17.423-.055-25.914 4.85-3.943 2.277-5.95 5.453-4.985 7.125 3.502 6.063 40.677-25.505 58.272 4.973 8.406 14.558 1.493 32.702-20.192 45.222-13.496 7.79-30.767 11.495-42.418 9.528 M431.26 218.246l-40.782-61.173 32.453-18.734 32.893 65.723-24.564 14.184zm9.6 25.388c-5.077-8.794-2.088-20.428 6.71-25.505 8.793-5.08 20.364-1.85 25.442 6.943 4.99 8.645 2 20.276-6.796 25.356-8.794 5.077-20.362 1.85-25.355-6.796z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__o-melhor">
+                <path class="badge__text" d="M184.62 204.955c-10.07-17.44-5.954-40.145 16.14-52.9 22.223-12.83 43.944-5.042 54.014 12.4s6.027 40.274-16.195 53.103c-22.096 12.754-43.89 4.84-53.96-12.603zm46.254-26.703c-3.955-6.847-11.02-9.83-18.254-5.653-7.105 4.1-8.052 11.71-4.1 18.558 4.03 6.976 11.094 9.96 18.2 5.858 7.234-4.177 8.18-11.785 4.154-18.764zM183.92 381.14l-21.037-36.434c-2.162-3.745-5.966-5.856-11.134-2.872s-6.22 7.725-6.726 10.43l22.23 38.5-23.257 13.425-21.036-36.433c-2.163-3.748-5.836-5.934-11.133-2.874-5.04 2.908-6.09 7.65-6.598 10.353l22.228 38.5-23.254 13.428-36.03-62.4 23.256-13.428 4.102 7.105c.7-5.055 5.597-14.77 15.675-20.59 8.787-5.07 16.98-5.497 24.298.615.486-7.515 5.417-17.77 15.494-23.587 11.5-6.64 22.606-5.302 30.065 7.618l26.11 45.218-23.257 13.427 M190.066 335.905c-10.44-18.088-5.048-40.667 15.11-52.304 18.343-10.59 40.036-5.543 52.717 16.42l2.76 4.78-42.377 24.466c3.604 3.26 10.363 4.524 17.986.122 3.49-2.013 10.27-8.17 11.805-12.67l17.84 8.82c-3.144 8.877-12.836 17.746-22.14 23.117-19.508 11.263-41.84 7.793-53.7-12.75zm25.328-34.604c-7.105 4.103-6.747 10.095-5.88 13.387l20.542-11.86c-2.213-2.34-7.17-5.852-14.662-1.526zM276.676 327.59l-49.753-86.173 23.256-13.427 49.752 86.173-23.256 13.427M347.525 286.685l-20.065-34.753c-3.73-6.46-8.487-6.644-14.043-3.436-5.297 3.057-6.444 7.337-7.113 10.653l22.23 38.5-23.257 13.425-49.755-86.173 23.256-13.425 17.83 30.878c1.23-6.224 5.466-14.7 16.448-21.04 14.47-8.355 25.723-3.482 31.99 7.37l25.732 44.572-23.254 13.427 M355.84 240.2c-10.07-17.442-5.952-40.146 16.14-52.903 22.222-12.83 43.943-5.043 54.013 12.398s6.027 40.275-16.195 53.104c-22.092 12.755-43.89 4.84-53.96-12.6zm46.253-26.704c-3.953-6.85-11.017-9.833-18.252-5.656-7.107 4.102-8.05 11.712-4.098 18.56 4.03 6.977 11.09 9.962 18.196 5.857 7.237-4.175 8.184-11.785 4.155-18.76zM446.84 230.487l-36.03-62.403 23.257-13.425 3.953 6.846c1.266-6.76 7.018-15.592 14.123-19.696l12.832 22.22c-1.388.286-3.475 1.145-5.67 2.414-4.91 2.835-10.496 7.78-11.29 12.373l22.08 38.242-23.255 13.426" fill="#1A1918"></path>
+            </g>
+            <g id="badge__sub">
+                <path class="badge__text" d="M95.84 407.88l.476-35.707c12.152 1.768 34.1-1.826 45.963-8.675 8.128-4.693 9.403-8.065 7.882-10.7-5.833-10.102-58.55 37.61-83.91-6.31-11.03-19.11-4.224-45.88 26.534-63.638 17.795-10.274 36.783-13.917 53.78-12.895l.333 34.067c-9.76-1.684-25.235-.072-37.538 7.03-5.712 3.3-8.618 7.907-7.223 10.322 5.07 8.783 58.93-36.952 84.415 7.19 12.173 21.084 2.154 47.366-29.263 65.505-19.554 11.29-44.576 16.658-61.453 13.81 M287.587 315.327l-6.848-11.86c-2.223 10.36-9.428 24.77-28.102 35.553-24.607 14.207-43.65 5.58-54.173-12.647l-43.746-75.767 39.545-22.833 33.98 58.856c6.215 10.76 14.336 11.636 24.004 6.054 8.785-5.073 10.736-12.35 11.878-17.985l-37.786-65.447 39.546-22.833 61.244 106.075-39.546 22.833zm-106.404-93.47c-10.985 6.34-24.498 2.723-30.838-8.257s-2.718-24.494 8.267-30.836c10.985-6.342 24.5-2.723 30.84 8.258 6.34 10.98 2.716 24.492-8.27 30.835zm47.456-27.4c-10.766 6.215-24.5 2.725-30.84-8.255s-2.497-24.62 8.27-30.837c10.984-6.342 24.717-2.85 31.057 8.13s2.497 24.62-8.488 30.962zM436.3 232.978c-19.772 11.416-37.258 13.604-54.607 10.444l-.436-35.765c9.896 3.95 27.068 2.234 38.053-4.108 6.373-3.68 8.4-7.778 7.004-10.194-5.58-9.663-51.282 29.9-75.373-11.825-12.552-21.74 5.486-41.234 2.443-46.505-2.79-4.83-9.55-3.856-16.36.076-10.765 6.216-15.193 15.8-9.74 25.244l57.186 99.048-39.546 22.832-57.187-99.048c-15.342-26.573-7.785-61.682 30.003-83.5 26.584-15.35 59.93-16.447 72.737 5.734 14.582 25.257-7.58 44.2-2.763 52.546 4.438 7.686 49.634-32.755 74.994 11.167 12.934 22.402.62 48.253-26.405 63.855" fill="#1A1918"></path>
+            </g>
+            <g id="badge__fallo">
+                <path class="badge__text" d="M130.645 422.49l-35.33-61.19-14.968 8.643-16.853-29.19 14.972-8.642-2.377-4.115c-10.913-18.9-4.176-40.504 15.847-52.065 10.477-6.05 23.622-9.645 33.872-6.58l-1.363 25.73c-3.46-1.243-6.542-.96-10.285 1.2-4.302 2.483-6.988 7.778-4.394 12.267l2.377 4.116 18.34-10.587 16.852 29.19-18.34 10.587 35.327 61.19-33.68 19.444 M245.34 356.27l-4.968-8.607c-1.38 9.28-9.828 20.142-21.055 26.623-13.474 7.78-36.356 8.767-48.24-11.817-12.962-22.454.953-38.973 14.427-46.75 11.788-6.81 24.615-9.222 33.045-5.855l-5.403-9.357c-3.672-6.364-12.28-7.88-23.322-1.505-8.423 4.863-16.02 13.74-19.998 23.27l-23.404-14.18c6.542-16.75 21.116-30.4 34.777-38.29 22.453-12.964 48.885-17.746 66.278 12.38l31.547 54.64-33.684 19.447zm-14.152-24.513l-2.916-5.05c-4.082-1.887-10.856-.22-16.094 2.803-5.614 3.243-10.707 8.68-7.466 14.29 3.24 5.615 10.387 3.734 16 .494 5.238-3.026 10.07-8.06 10.476-12.537zM292.378 329.112L220.32 204.304 254 184.86l72.057 124.808-33.68 19.444M339.42 301.953l-72.06-124.806 33.68-19.447 72.058 124.808-33.68 19.444 M354.53 232.852c-14.584-25.26-8.62-58.145 23.378-76.618 32.186-18.583 63.643-7.305 78.23 17.958 14.583 25.26 8.727 58.328-23.457 76.91-31.997 18.475-63.566 7.014-78.15-18.25zm66.988-38.674c-5.727-9.92-15.955-14.242-26.433-8.194-10.294 5.944-11.666 16.963-5.94 26.88 5.835 10.105 16.064 14.43 26.358 8.485 10.48-6.05 11.85-17.07 6.015-27.173zm-40.843-54.76l-22.453 12.963 6.895-39.908 29.004-16.746-13.446 43.69z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__lindo">
+                <path class="badge__text" d="M110.01 419.902L41.813 301.79l31.877-18.403 68.2 118.113-31.88 18.402 M89.63 285.514c-5.724-9.916-2.356-22.487 7.56-28.21 9.918-5.728 22.49-2.358 28.215 7.558 5.725 9.916 2.357 22.487-7.56 28.21-9.917 5.728-22.487 2.358-28.214-7.558zm65.24 108.49l-49.385-85.532 31.877-18.402 49.388 85.532-31.88 18.402zM255.45 335.94l-27.298-47.28c-5.115-8.856-11.838-9.46-19.454-5.064-7.26 4.192-8.83 10.06-9.75 14.6l30.468 52.773-31.877 18.4-49.387-85.53 31.877-18.403 5.625 9.74c1.686-8.53 7.494-20.147 22.548-28.836 19.837-11.45 35.467-4.418 44.054 10.456l35.074 60.74-31.878 18.4 M353.74 279.197l-5.213-9.03c-2.56 12.34-8.968 20.052-17.645 25.06-20.723 11.964-46.723 6.196-63.695-23.2-16.36-28.332-9.22-54.413 11.855-66.58 8.678-5.008 19.095-7.01 30.527-2.75l-24.028-41.61 31.88-18.406 68.196 118.114-31.88 18.402zm-18.405-31.874l-12.677-21.958c-5.16-1.98-12.306-.454-16.557 2-8.677 5.01-12.46 15.227-6.327 25.85 6.135 10.624 16.974 12.63 25.654 7.62 4.25-2.455 9.044-8.054 9.907-13.513zM365.477 215.286c-13.804-23.907-8.16-55.027 22.123-72.51 30.462-17.584 60.237-6.912 74.042 16.996 13.804 23.905 8.26 55.2-22.2 72.785-30.287 17.483-60.16 6.637-73.965-17.27zm63.402-36.602c-5.42-9.387-15.104-13.48-25.02-7.752-9.742 5.624-11.04 16.053-5.62 25.44 5.52 9.56 15.202 13.653 24.943 8.03 9.92-5.728 11.215-16.156 5.696-25.72z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__jajaja">
+                <path class="badge__text" d="M109.48 436.812l-5.115-23.9c4.34.522 6.506.08 10.747-2.367 4.998-2.887 5.927-8.27 1.906-15.234l-42.895-74.297 27.255-15.735 42.895 74.296c10.842 18.778 9.734 38.192-11.464 50.433-11.055 6.38-15.323 7.03-23.33 6.806zm-48.912-135.43c-4.898-8.48-2.016-19.23 6.462-24.126 8.482-4.895 19.23-2.016 24.124 6.467 4.895 8.477 2.018 19.227-6.464 24.122-8.477 4.895-19.227 2.016-24.122-6.462zM196.55 347.848l-4.02-6.964c-1.116 7.51-7.954 16.3-17.04 21.545-10.902 6.295-29.42 7.095-39.036-9.564-10.49-18.17.77-31.538 11.672-37.834 9.54-5.505 19.922-7.46 26.743-4.737l-4.374-7.572c-2.97-5.146-9.937-6.376-18.873-1.218-6.813 3.934-12.963 11.118-16.18 18.83L116.5 308.863c5.296-13.558 17.09-24.605 28.144-30.986 18.17-10.49 39.56-14.36 53.634 10.017l25.53 44.217-27.258 15.737zM185.1 328.01l-2.36-4.086c-3.305-1.525-8.786-.178-13.027 2.27-4.54 2.622-8.665 7.022-6.042 11.563 2.624 4.544 8.408 3.02 12.95.398 4.24-2.448 8.147-6.52 8.478-10.144zM232.298 365.904l-5.115-23.9c4.34.522 6.506.08 10.747-2.37 4.998-2.883 5.927-8.267 1.906-15.23l-42.895-74.3 27.256-15.734 42.897 74.296c10.84 18.778 9.732 38.192-11.467 50.433-11.054 6.38-15.322 7.03-23.33 6.805zm-48.912-135.43c-4.898-8.48-2.016-19.23 6.462-24.125 8.482-4.896 19.23-2.017 24.127 6.466 4.895 8.477 2.016 19.227-6.467 24.122-8.477 4.895-19.227 2.016-24.122-6.464zM319.368 276.94l-4.022-6.964c-1.115 7.51-7.953 16.3-17.038 21.545-10.903 6.297-29.42 7.095-39.037-9.562-10.49-18.17.772-31.538 11.675-37.834 9.54-5.505 19.92-7.462 26.74-4.737l-4.37-7.572c-2.972-5.15-9.94-6.376-18.873-1.218-6.816 3.934-12.965 11.118-16.184 18.83l-18.94-11.473c5.294-13.558 17.088-24.605 28.142-30.986 18.172-10.49 39.56-14.36 53.634 10.017l25.53 44.217-27.258 15.737zm-11.452-19.837l-2.36-4.087c-3.304-1.525-8.785-.178-13.024 2.27-4.544 2.622-8.668 7.022-6.044 11.563 2.623 4.543 8.407 3.02 12.95.397 4.24-2.448 8.146-6.52 8.477-10.144zM355.118 294.993L350 271.096c4.342.522 6.507.08 10.748-2.37 4.998-2.883 5.927-8.267 1.906-15.23l-42.895-74.3 27.254-15.736 42.897 74.298c10.84 18.778 9.735 38.192-11.466 50.433-11.052 6.382-15.322 7.03-23.326 6.804zm-48.915-135.43c-4.895-8.48-2.016-19.228 6.462-24.123 8.482-4.895 19.23-2.016 24.127 6.467 4.895 8.477 2.016 19.227-6.467 24.122-8.477 4.894-19.227 2.015-24.122-6.465zM442.186 206.03l-4.022-6.963c-1.115 7.51-7.953 16.298-17.038 21.545-10.903 6.293-29.42 7.094-39.037-9.563-10.492-18.17.77-31.54 11.673-37.835 9.54-5.508 19.92-7.462 26.74-4.737l-4.37-7.572c-2.972-5.15-9.94-6.376-18.873-1.218-6.816 3.934-12.965 11.118-16.184 18.83l-18.94-11.473c5.294-13.558 17.088-24.605 28.142-30.986 18.172-10.494 39.56-14.362 53.634 10.016l25.53 44.217-27.258 15.737zm-11.452-19.836l-2.36-4.087c-3.304-1.525-8.785-.178-13.024 2.27-4.544 2.622-8.668 7.022-6.044 11.563 2.623 4.544 8.407 3.02 12.95.398 4.24-2.448 8.146-6.52 8.477-10.144z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__genial">
+                <path class="badge__text" d="M109.283 430.58l.305-24.998c8.49 2.277 17.83-.015 25.393-4.38 6.11-3.53 14.947-11.733 7.81-24.097l-2.182-3.777c-2.018 10.276-7.052 16.672-14.324 20.87-16.87 9.74-37.214 6.748-51.067-17.247-13.52-23.416-6.71-42.86 10.596-52.852 7.272-4.197 15.535-5.67 25.07-2.257l-4.284-7.417 26.178-15.112 36.19 62.684c17.55 30.396-4.19 50.51-21.642 60.586-12.072 6.97-24.683 9.985-38.043 8.002zm20.827-75.433l-8.563-14.834c-4.153-1.484-10.022-.23-13.368 1.703-7.127 4.114-11.158 10.903-6.204 19.485 4.954 8.578 12.848 8.48 19.973 4.367 3.345-1.93 7.366-6.386 8.16-10.72zM156.365 332.426c-11.755-20.36-5.68-45.78 17.006-58.88 20.653-11.924 45.072-6.243 59.345 18.48l3.106 5.382-47.7 27.54c4.057 3.67 11.666 5.096 20.246.14 3.926-2.267 11.562-9.195 13.29-14.263l20.083 9.93c-3.54 9.992-14.452 19.977-24.926 26.022-21.96 12.68-47.1 8.773-60.45-14.35zm28.51-38.956c-8 4.62-7.593 11.367-6.62 15.07l23.125-13.352c-2.49-2.633-8.07-6.59-16.506-1.718zM301.625 295.486l-22.42-38.832c-4.2-7.272-9.72-7.767-15.973-4.158-5.964 3.443-7.255 8.263-8.01 11.994l25.023 43.34-26.18 15.114-40.556-70.247 26.178-15.112 4.62 8c1.385-7.007 6.153-16.546 18.516-23.684 16.29-9.404 29.127-3.628 36.18 8.586l28.8 49.886-26.18 15.115 M280.302 187.763c-4.702-8.146-1.935-18.47 6.208-23.17 8.146-4.702 18.468-1.938 23.17 6.208 4.702 8.147 1.938 18.47-6.208 23.17-8.146 4.703-18.468 1.936-23.17-6.207zm53.576 89.1L293.32 206.62l26.18-15.116 40.557 70.247-26.18 15.113zM408.79 233.613l-3.86-6.69c-1.073 7.212-7.64 15.655-16.363 20.694-10.47 6.044-28.258 6.813-37.494-9.185-10.076-17.453.74-30.29 11.213-36.338 9.16-5.288 19.132-7.167 25.684-4.55l-4.2-7.273c-2.855-4.943-9.546-6.122-18.126-1.168-6.545 3.78-12.453 10.68-15.544 18.087l-18.19-11.02c5.085-13.022 16.413-23.632 27.028-29.762 17.453-10.076 37.997-13.792 51.516 9.622l24.517 42.468-26.178 15.115zm-10.997-19.05l-2.267-3.927c-3.175-1.467-8.438-.17-12.51 2.18-4.365 2.52-8.323 6.744-5.804 11.107 2.518 4.363 8.075 2.9 12.438.38 4.07-2.35 7.826-6.26 8.143-9.74zM443.123 213.794l-56.006-97.007 26.176-15.115L469.3 198.68l-26.178 15.114" fill="#1A1918"></path>
+            </g>
+            <g id="badge__fail">
+                <path class="badge__text" d="M130.645 422.49l-35.33-61.19-14.968 8.643-16.853-29.19 14.972-8.642-2.377-4.115c-10.913-18.9-4.176-40.504 15.847-52.065 10.477-6.05 23.622-9.645 33.872-6.58l-1.363 25.73c-3.46-1.243-6.542-.96-10.285 1.2-4.302 2.483-6.988 7.778-4.394 12.267l2.377 4.116 18.34-10.587 16.852 29.19-18.34 10.587 35.327 61.19-33.68 19.444 M245.34 356.27l-4.968-8.607c-1.38 9.28-9.828 20.142-21.055 26.623-13.474 7.78-36.356 8.767-48.24-11.817-12.962-22.454.953-38.973 14.427-46.75 11.788-6.81 24.615-9.222 33.045-5.855l-5.403-9.357c-3.672-6.364-12.28-7.88-23.322-1.505-8.423 4.863-16.02 13.74-19.998 23.27l-23.404-14.18c6.542-16.75 21.116-30.4 34.777-38.29 22.453-12.964 48.885-17.746 66.278 12.38l31.547 54.64-33.684 19.447zm-14.152-24.513l-2.916-5.05c-4.082-1.887-10.856-.22-16.094 2.803-5.614 3.243-10.707 8.68-7.466 14.29 3.24 5.615 10.387 3.734 16 .494 5.238-3.026 10.07-8.06 10.476-12.537zM292.378 329.112L220.32 204.304 254 184.86l72.057 124.808-33.68 19.444M339.42 301.953l-72.06-124.806 33.68-19.447 72.058 124.808-33.68 19.444 M354.53 232.852c-14.584-25.26-8.62-58.145 23.378-76.618 32.186-18.583 63.643-7.305 78.23 17.958 14.583 25.26 8.727 58.328-23.457 76.91-31.997 18.475-63.566 7.014-78.15-18.25zm66.988-38.674c-5.727-9.92-15.955-14.242-26.433-8.194-10.294 5.944-11.666 16.963-5.94 26.88 5.835 10.105 16.064 14.43 26.358 8.485 10.48-6.05 11.85-17.07 6.015-27.173zm-40.843-54.76l-22.453 12.963 6.895-39.908 29.004-16.746-13.446 43.69z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__lindo">
+                <path class="badge__text" d="M110.01 419.902L41.813 301.79l31.877-18.403 68.2 118.113-31.88 18.402 M89.63 285.514c-5.724-9.916-2.356-22.487 7.56-28.21 9.918-5.728 22.49-2.358 28.215 7.558 5.725 9.916 2.357 22.487-7.56 28.21-9.917 5.728-22.487 2.358-28.214-7.558zm65.24 108.49l-49.385-85.532 31.877-18.402 49.388 85.532-31.88 18.402zM255.45 335.94l-27.298-47.28c-5.115-8.856-11.838-9.46-19.454-5.064-7.26 4.192-8.83 10.06-9.75 14.6l30.468 52.773-31.877 18.4-49.387-85.53 31.877-18.403 5.625 9.74c1.686-8.53 7.494-20.147 22.548-28.836 19.837-11.45 35.467-4.418 44.054 10.456l35.074 60.74-31.878 18.4 M353.74 279.197l-5.213-9.03c-2.56 12.34-8.968 20.052-17.645 25.06-20.723 11.964-46.723 6.196-63.695-23.2-16.36-28.332-9.22-54.413 11.855-66.58 8.678-5.008 19.095-7.01 30.527-2.75l-24.028-41.61 31.88-18.406 68.196 118.114-31.88 18.402zm-18.405-31.874l-12.677-21.958c-5.16-1.98-12.306-.454-16.557 2-8.677 5.01-12.46 15.227-6.327 25.85 6.135 10.624 16.974 12.63 25.654 7.62 4.25-2.455 9.044-8.054 9.907-13.513zM365.477 215.286c-13.804-23.907-8.16-55.027 22.123-72.51 30.462-17.584 60.237-6.912 74.042 16.996 13.804 23.905 8.26 55.2-22.2 72.785-30.287 17.483-60.16 6.637-73.965-17.27zm63.402-36.602c-5.42-9.387-15.104-13.48-25.02-7.752-9.742 5.624-11.04 16.053-5.62 25.44 5.52 9.56 15.202 13.653 24.943 8.03 9.92-5.728 11.215-16.156 5.696-25.72z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__jajaja">
+                <path class="badge__text" d="M109.48 436.812l-5.115-23.9c4.34.522 6.506.08 10.747-2.367 4.998-2.887 5.927-8.27 1.906-15.234l-42.895-74.297 27.255-15.735 42.895 74.296c10.842 18.778 9.734 38.192-11.464 50.433-11.055 6.38-15.323 7.03-23.33 6.806zm-48.912-135.43c-4.898-8.48-2.016-19.23 6.462-24.126 8.482-4.895 19.23-2.016 24.124 6.467 4.895 8.477 2.018 19.227-6.464 24.122-8.477 4.895-19.227 2.016-24.122-6.462zM196.55 347.848l-4.02-6.964c-1.116 7.51-7.954 16.3-17.04 21.545-10.902 6.295-29.42 7.095-39.036-9.564-10.49-18.17.77-31.538 11.672-37.834 9.54-5.505 19.922-7.46 26.743-4.737l-4.374-7.572c-2.97-5.146-9.937-6.376-18.873-1.218-6.813 3.934-12.963 11.118-16.18 18.83L116.5 308.863c5.296-13.558 17.09-24.605 28.144-30.986 18.17-10.49 39.56-14.36 53.634 10.017l25.53 44.217-27.258 15.737zM185.1 328.01l-2.36-4.086c-3.305-1.525-8.786-.178-13.027 2.27-4.54 2.622-8.665 7.022-6.042 11.563 2.624 4.544 8.408 3.02 12.95.398 4.24-2.448 8.147-6.52 8.478-10.144zM232.298 365.904l-5.115-23.9c4.34.522 6.506.08 10.747-2.37 4.998-2.883 5.927-8.267 1.906-15.23l-42.895-74.3 27.256-15.734 42.897 74.296c10.84 18.778 9.732 38.192-11.467 50.433-11.054 6.38-15.322 7.03-23.33 6.805zm-48.912-135.43c-4.898-8.48-2.016-19.23 6.462-24.125 8.482-4.896 19.23-2.017 24.127 6.466 4.895 8.477 2.016 19.227-6.467 24.122-8.477 4.895-19.227 2.016-24.122-6.464zM319.368 276.94l-4.022-6.964c-1.115 7.51-7.953 16.3-17.038 21.545-10.903 6.297-29.42 7.095-39.037-9.562-10.49-18.17.772-31.538 11.675-37.834 9.54-5.505 19.92-7.462 26.74-4.737l-4.37-7.572c-2.972-5.15-9.94-6.376-18.873-1.218-6.816 3.934-12.965 11.118-16.184 18.83l-18.94-11.473c5.294-13.558 17.088-24.605 28.142-30.986 18.172-10.49 39.56-14.36 53.634 10.017l25.53 44.217-27.258 15.737zm-11.452-19.837l-2.36-4.087c-3.304-1.525-8.785-.178-13.024 2.27-4.544 2.622-8.668 7.022-6.044 11.563 2.623 4.543 8.407 3.02 12.95.397 4.24-2.448 8.146-6.52 8.477-10.144zM355.118 294.993L350 271.096c4.342.522 6.507.08 10.748-2.37 4.998-2.883 5.927-8.267 1.906-15.23l-42.895-74.3 27.254-15.736 42.897 74.298c10.84 18.778 9.735 38.192-11.466 50.433-11.052 6.382-15.322 7.03-23.326 6.804zm-48.915-135.43c-4.895-8.48-2.016-19.228 6.462-24.123 8.482-4.895 19.23-2.016 24.127 6.467 4.895 8.477 2.016 19.227-6.467 24.122-8.477 4.894-19.227 2.015-24.122-6.465zM442.186 206.03l-4.022-6.963c-1.115 7.51-7.953 16.298-17.038 21.545-10.903 6.293-29.42 7.094-39.037-9.563-10.492-18.17.77-31.54 11.673-37.835 9.54-5.508 19.92-7.462 26.74-4.737l-4.37-7.572c-2.972-5.15-9.94-6.376-18.873-1.218-6.816 3.934-12.965 11.118-16.184 18.83l-18.94-11.473c5.294-13.558 17.088-24.605 28.142-30.986 18.172-10.494 39.56-14.362 53.634 10.016l25.53 44.217-27.258 15.737zm-11.452-19.836l-2.36-4.087c-3.304-1.525-8.785-.178-13.024 2.27-4.544 2.622-8.668 7.022-6.044 11.563 2.623 4.544 8.407 3.02 12.95.398 4.24-2.448 8.146-6.52 8.477-10.144z" fill="#1A1918"></path>
+            </g>
+            <g id="badge__chido">
+                <path class="badge__text" d="M138.276991,406.635862 C155.215665,396.856314 161.152691,382.95739 161.754166,374.397438 L134.112017,367.771742 C133.758107,372.493051 131.224545,378.06215 125.373003,381.440539 C117.519618,385.974693 107.810284,384.80491 102.298175,375.257658 C96.7860665,365.710405 100.716577,356.870972 108.569962,352.336818 C114.421503,348.958429 120.333455,349.240872 124.688089,351.44902 L132.860048,324.351357 C125.057269,320.438286 110.14084,318.784427 93.2021664,328.563975 C69.6420113,342.166437 60.3619321,368.056019 73.964394,391.616174 C87.6557609,415.330317 114.716836,420.238323 138.276991,406.635862 L138.276991,406.635862 Z M256.088822,336.153362 L225.416604,283.027522 C217.948586,270.092535 204.535448,264.285675 187.288799,274.243033 C174.199824,281.799956 169.150137,291.901498 167.683434,299.318451 L146.435144,262.515333 L118.717314,278.51823 L178.016936,381.228187 L205.734765,365.22529 L179.241081,319.336884 C180.039516,315.385514 181.406258,310.284763 187.719764,306.639659 C194.341245,302.816744 200.010304,303.034105 204.455553,310.733502 L228.370993,352.156258 L256.088822,336.153362 Z M239.293752,239.495662 C247.917076,234.516983 250.84581,223.586802 245.867131,214.963477 C240.888452,206.340152 229.958271,203.411419 221.334946,208.390098 C212.711621,213.368777 209.782888,224.298958 214.761567,232.922283 C219.740245,241.545608 230.670427,244.474341 239.293752,239.495662 L239.293752,239.495662 Z M299.205446,311.259968 L256.264341,236.883792 L228.546511,252.886688 L271.487616,327.262864 L299.205446,311.259968 Z M390.982259,258.2726 L331.682638,155.562643 L303.964808,171.565539 L324.857478,207.752705 C314.916308,204.047649 305.859514,205.786198 298.314105,210.142542 C279.98954,220.722235 273.782836,243.400182 288.007633,268.038252 C302.765859,293.600251 325.37234,298.616311 343.388929,288.214429 C350.934338,283.858085 356.506399,277.150661 358.730276,266.422111 L363.26443,274.275496 L390.982259,258.2726 Z M338.646302,258.307142 C331.100893,262.663486 321.675713,260.919013 316.341414,251.679736 C311.007115,242.44046 314.297852,233.559765 321.843261,229.203421 C325.538971,227.069702 331.752516,225.7408 336.237316,227.463162 L347.261533,246.557667 C346.510743,251.302798 342.342013,256.173423 338.646302,258.307142 L338.646302,258.307142 Z M444.097043,230.070572 C470.582969,214.778916 475.402071,187.563853 463.399898,166.775481 C451.397726,145.987108 425.508144,136.707029 399.022218,151.998686 C372.69028,167.201437 367.782274,194.262512 379.784446,215.050884 C391.786618,235.839257 417.765105,245.273324 444.097043,230.070572 L444.097043,230.070572 Z M429.961151,205.586489 C421.491815,210.476263 413.073084,206.918812 408.272215,198.603463 C403.560251,190.442102 404.688773,181.372542 413.15811,176.482768 C421.781435,171.50409 430.200165,175.061541 434.912129,183.222902 C439.712998,191.538251 438.584476,200.607811 429.961151,205.586489 L429.961151,205.586489 Z" fill="#1A1918"></path>
+            </g>
+            <symbol id="bf-news-logo" viewBox="0 0 372 43">
+                <g class="bf-news-logo__bf">
+                    <path d="M0 42v-42h18.358c7.832 0 11.841 5.1 11.841 10.705 0 5.226-3.207 8.816-7.092 9.634 4.44.693 7.894 5.037 7.894 10.264 0 6.36-4.07 11.398-11.964 11.398h-19.036zm21.256-29.721c0-2.582-1.85-4.408-4.81-4.408h-7.689v8.816h7.689c2.96 0 4.81-1.7 4.81-4.408zm.802 17.064c0-2.645-1.85-4.786-5.242-4.786h-8.059v9.572h8.059c3.269 0 5.242-1.763 5.242-4.786z"></path>
+                    <path d="M63 42v-5.9l13.797-17.205h-13.797v-6.895h24.747v5.652l-14.051 17.453h14.304v6.894h-25"></path>
+                    <path d="M89 42v-5.9l13.797-17.205h-13.797v-6.895h24.747v5.652l-14.051 17.453h14.304v6.894h-25"></path>
+                    <path d="M117 42v-42h29v7.871h-20.105v8.816h15.128v7.871h-15.128v17.443h-8.895"></path>
+                    <path d="M143 26.468c0-9.113 6.553-16.468 15.752-16.468 9.136 0 15.248 7.029 15.248 17.249v1.953h-22.62c.567 3.84 3.591 7.03 8.758 7.03 2.583 0 6.112-1.107 8.065-3.059l3.591 5.468c-3.025 2.864-7.813 4.361-12.539 4.361-9.262 0-16.256-6.444-16.256-16.532zm15.752-9.698c-4.978 0-7.12 3.58-7.435 6.704h14.996c-.252-2.994-2.268-6.704-7.561-6.704z"></path>
+                    <path d="M175 26.468c0-9.113 6.553-16.468 15.752-16.468 9.136 0 15.248 7.029 15.248 17.249v1.953h-22.62c.567 3.84 3.591 7.03 8.758 7.03 2.583 0 6.112-1.107 8.065-3.059l3.591 5.468c-3.024 2.864-7.813 4.361-12.538 4.361-9.262 0-16.256-6.444-16.256-16.532zm15.752-9.698c-4.977 0-7.12 3.58-7.435 6.704h14.996c-.252-2.994-2.268-6.704-7.561-6.704z"></path>
+                    <path d="M207 42v-31h12.784c10.016 0 17.216 5.858 17.216 15.477s-7.2 15.523-17.169 15.523h-12.831zm21.894-15.523c0-4.791-2.959-8.785-8.777-8.785h-5.2v17.616h5.153c5.582 0 8.824-4.229 8.824-8.831z"></path>
+                    <path d="M32 12h8.144v17.996c0 3.635 2.234 6.258 6.563 6.258 4.281 0 6.514-2.623 6.514-6.258v-17.996h8.098v18.226c0 7.639-4.653 13.024-14.612 13.024-9.961 0-14.707-5.432-14.707-12.979v-18.271z"></path>
+                </g>
+                <g class="bf-news-logo__news">
+                    <path d="M252.853 38.174v3.826h-12.853v-3.826l3.324-1.099v-20.887l-3.324-1.319v-3.65l10.637-.22 11.967 20.315v-15.126l-3.235-1.319v-3.65l12.632-.22v3.87l-3.324 1.319v25.811h-7.402l-11.878-19.919v14.994l3.457 1.099zm30.722-21.986v7.343h9.287v4.837h-9.287v8.487h8.138l1.057-3.65h4.23v8.794h-24v-3.826l3.448-1.099v-20.887l-3.448-1.319v-3.65l10.575-.22h12.874v8.487h-4.276l-1.149-3.298h-7.448zm24.837 25.811l-7.27-25.855-3.141-1.275v-3.65l13.329-.22v3.87l-3.276 1.319 3.86 15.918 6.283-20.755 6.059-.352 6.014 21.062 4.308-15.874-3.366-1.319v-3.65l12.79-.22v3.87l-3.231 1.319-7.674 25.811h-6.373l-5.879-20.887c-.718 2.873-1.892 6.926-3.523 12.158-1.631 5.233-2.536 8.142-2.715 8.728h-6.193zm40.211-9.767l.667 3.567c1.185.595 2.637.892 4.356.892 1.511 0 2.785-.304 3.822-.913s1.556-1.451 1.556-2.527c0-.764-.37-1.43-1.111-1.996-.741-.566-1.667-1.005-2.778-1.316-1.111-.311-2.319-.729-3.622-1.253-1.304-.524-2.511-1.09-3.622-1.699-1.111-.609-2.037-1.515-2.778-2.718-.741-1.203-1.111-2.626-1.111-4.268 0-2.859 1.044-5.075 3.133-6.646 2.089-1.571 4.807-2.357 8.156-2.357 1.481 0 3.037.142 4.667.425 1.63.283 2.889.566 3.778.849l1.333.425-.222 7.729h-4.089l-1.111-3.61c-1.333-.425-2.637-.637-3.911-.637-1.511 0-2.674.283-3.489.849-.815.566-1.222 1.288-1.222 2.166 0 .764.37 1.43 1.111 1.996.741.566 1.667 1.012 2.778 1.338 1.111.326 2.311.743 3.6 1.253 1.289.51 2.489 1.062 3.6 1.656 1.111.595 2.037 1.472 2.778 2.633.741 1.161 1.111 2.52 1.111 4.077 0 3.086-1.119 5.499-3.356 7.24-2.237 1.741-5.119 2.612-8.644 2.612-1.481 0-3.052-.134-4.711-.403-1.659-.269-2.948-.545-3.867-.828l-1.333-.382v-8.153h4.533z"></path>
+                </g>
+            </symbol>
+        </defs>
+    </svg>
+    <!--<![endif]-->
+    <script>
+    (function() {
+        if (typeof(BFW_Util) == 'undefined' || typeof(buzzDetails) == 'undefined')
+            setTimeout(arguments.callee, 50);
+        else {
+            try {
+                var HT_PRIMARY = BFW_Util.getCookie('HT_PRIMARY');
+                if (HT_PRIMARY && typeof BFW_Util.getCookie('HT_PRIMARY') == 'string' && HT_PRIMARY.match(/COUNTED/) && HT_PRIMARY.match(buzzDetails.uri)) {
+                    window.ISSEED = true;
+                } else {
+                    window.ISSEED = false;
+                }
+            } catch (e) {
+                window.ISSEED = false;
+            }
+        }
+    })()
+    </script>
+    <div class="cookie_notice hidden" id="cookie_notice" rel:gt_cat="cookie_notice" country="us">
+        <p>
+            <span id="cookie-set-message" class="hidden">
+        This BuzzFeed homepage is tailored for our readers in the USA.
+        <a href="javascript:;" class="bf_dom" rel:gt_act="set-default-cookie" rel:gt_label="us" rel:bf_bucket_data="{'set_country_cookie':{'country':'us'}}">Make it your default.</a>
+      </span>
+            <span id="cookie-us-message" class="hidden">
+        This BuzzFeed homepage is tailored for our readers in the USA.
+        <a href="/?country=us">Switch to US</a>
+      </span>
+            <span id="have-you-seen-message" class="hidden">
+        Have you seen BuzzFeed English? <a href="/?country=en">Come check it out!</a>
+      </span>
+            <span class="remove_notice_wrp">
+        <a href="javascript:;" class="bf_dom remove_notice" rel:gt_act="remove_cookie_notice" rel:gt_label="us" rel:bf_bucket="remove_cookie_notice">&nbsp;</a>
+
+      </span>
+        </p>
+    </div>
+    <div id="header_wrapper" class="page-head">
+        <header id="page-header" class="unified_header full-width " rel:gt_cat="[ttp]:header">
+            <div id="upper-background">
+                <div id="upper-wrapper" class="page-wrapper">
+                    <div class="upper">
+                        <div id="logo" class="social page-logo">
+                            <a class="logo bfnews-logo" rel:gt_act="home" href="/">BuzzFeed News</a>
+                            <a href="/news" rel:gt_act="vertical-home">
+                                <div class="bf-tagline news-page"></div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="lower-background" class="nav-page">
+                <div id="lower-wrapper" class="page-wrapper">
+                    <div class="lower">
+                        <div id="nav-left" class="bf_dom nav-page__menu" rel:bf_bucket="gtrack" rel:gt_cat="[ttp]:header/menu">
+                            <div id="menu-news" class="menu-item ">
+                                <span><a href="/news" rel:gt_act="news">News</a></span>
+                            </div>
+                            <div id="menu-buzz" class="menu-item ">
+                                <span><a href="/buzz" rel:gt_act="buzz">Buzz</a></span>
+                            </div>
+                            <div id="menu-life" class="menu-item ">
+                                <span><a href="/life" rel:gt_act="life">Life</a></span>
+                            </div>
+                            <div id="menu-quiz" class="menu-item ">
+                                <span><a href="/quizzes" rel:gt_act="quizzes">Quizzes</a></span>
+                            </div>
+                            <div id="video-more" class="menu-item ">
+                                <span><a href="/videos" rel:gt_act="videos">Videos</a></span>
+                            </div>
+                            <div id="menu-more" class="page-nav__item page-nav__item--dropdown menu-item last-child header_dropdown" menu_group="more">
+                                <span class="page-nav__link">
+                <span>More</span>
+                                <span class="fa fa-chevron-down more-caret">&nbsp;</span>
+                                <div class="more-menu">
+                                    <div class="more-menu__community">
+                                        <a class="more-menu__community-link" href="/community" rel:gt_act="community">BuzzFeed Community</a>
+                                        <a class="more-menu__make-post-link btn-action" href="/post" rel:gt_act="make-a-post"> Make A Post!</a>
+                                    </div>
+                                    <div class="more-menu__sections">
+                                        <span class="more-menu__sections-header">SECTIONS</span>
+                                        <ul class="more-menu__sections-link-container">
+                                            <li id="nav_menu_animals" class="more-menu__section-link">
+                                                <a href="/animals" rel:gt_act="animals">Animals</a>
+                                            </li>
+                                            <li id="nav_menu_audio" class="more-menu__section-link">
+                                                <a href="/audio" rel:gt_act="audio">Audio</a>
+                                            </li>
+                                            <li id="nav_menu_books" class="more-menu__section-link">
+                                                <a href="/books" rel:gt_act="books">Books</a>
+                                            </li>
+                                            <li id="nav_menu_business" class="more-menu__section-link">
+                                                <a href="/business" rel:gt_act="business">Business</a>
+                                            </li>
+                                            <li id="nav_menu_bigstories" class="more-menu__section-link">
+                                                <a href="/bigstories" rel:gt_act="bigstories">Big Stories</a>
+                                            </li>
+                                            <li id="nav_menu_celebrity" class="more-menu__section-link">
+                                                <a href="/celebrity" rel:gt_act="celebrity">Celebrity</a>
+                                            </li>
+                                            <li id="nav_menu_diy" class="more-menu__section-link">
+                                                <a href="/diy" rel:gt_act="diy">DIY</a>
+                                            </li>
+                                            <li id="nav_menu_entertainment" class="more-menu__section-link">
+                                                <a href="/entertainment" rel:gt_act="entertainment">Entertainment</a>
+                                            </li>
+                                            <li id="nav_menu_food" class="more-menu__section-link">
+                                                <a href="/food" rel:gt_act="food">Food</a>
+                                            </li>
+                                            <li id="nav_menu_geeky" class="more-menu__section-link">
+                                                <a href="/geeky" rel:gt_act="geeky">Geeky</a>
+                                            </li>
+                                            <li id="nav_menu_giffeed" class="more-menu__section-link">
+                                                <a href="/giffeed" rel:gt_act="giffeed">Gif Feed</a>
+                                            </li>
+                                            <li id="nav_menu_health" class="more-menu__section-link">
+                                                <a href="/health" rel:gt_act="health">Health</a>
+                                            </li>
+                                            <li id="nav_menu_ideas" class="more-menu__section-link">
+                                                <a href="/ideas" rel:gt_act="ideas">Ideas</a>
+                                            </li>
+                                            <li id="nav_menu_lgbt" class="more-menu__section-link">
+                                                <a href="/lgbt" rel:gt_act="lgbt">LGBT</a>
+                                            </li>
+                                            <li id="nav_menu_music" class="more-menu__section-link">
+                                                <a href="/music" rel:gt_act="music">Music</a>
+                                            </li>
+                                            <li id="nav_menu_parents" class="more-menu__section-link">
+                                                <a href="/parents" rel:gt_act="parents">Parents</a>
+                                            </li>
+                                            <li id="nav_menu_podcasts" class="more-menu__section-link">
+                                                <a href="/podcasts" rel:gt_act="podcasts">Podcasts</a>
+                                            </li>
+                                            <li id="nav_menu_politics" class="more-menu__section-link">
+                                                <a href="/politics" rel:gt_act="politics">Politics</a>
+                                            </li>
+                                            <li id="nav_menu_rewind" class="more-menu__section-link">
+                                                <a href="/rewind" rel:gt_act="rewind">Rewind</a>
+                                            </li>
+                                            <li id="nav_menu_science" class="more-menu__section-link">
+                                                <a href="/science" rel:gt_act="science">Science</a>
+                                            </li>
+                                            <li id="nav_menu_sports" class="more-menu__section-link">
+                                                <a href="/sports" rel:gt_act="sports">Sports</a>
+                                            </li>
+                                            <li id="nav_menu_style" class="more-menu__section-link">
+                                                <a href="/style" rel:gt_act="style">Style</a>
+                                            </li>
+                                            <li id="nav_menu_tech" class="more-menu__section-link">
+                                                <a href="/tech" rel:gt_act="tech">Tech</a>
+                                            </li>
+                                            <li id="nav_menu_travel" class="more-menu__section-link">
+                                                <a href="/travel" rel:gt_act="travel">Travel</a>
+                                            </li>
+                                            <li id="nav_menu_weekend" class="more-menu__section-link">
+                                                <a href="/weekend" rel:gt_act="weekend">Weekend</a>
+                                            </li>
+                                            <li id="nav_menu_world" class="more-menu__section-link">
+                                                <a href="/world" rel:gt_act="world">World</a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                    <div class="more-menu__footer">
+                                        <ul class="more-menu__footer-main-content">
+                                            <li><a href="/advertise">Advertise</a></li>
+                                            <li><a href="/about/jobs">Jobs</a></li>
+                                            <li><a href="/tools/mobile-ios">Mobile</a></li>
+                                            <li><a href="/tools/email">Newsletters</a></li>
+                                            <li>
+                                                <div class="more-menu__country-toggle country-toggle bf_dom country_switch" rel:bf_bucket_data="{'country_switch_menu':{}}">
+                                                    <a class="btn-toggle" href="javascript:;">
+              US Edition
+              <svg viewBox="0 0 517 517" class="more-menu__country-toggle-icon"><use xlink:href="#icon-caret-down"></use></svg>
+            </a>
+                                                    <div class="country_switch_menu country-toggle-menu" style="display: none;">
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=us' }}">US Edition</a>
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=uk' }}">UK Edition</a>
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=au' }}">Australia</a>
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=br' }}">Brasil</a>
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=de' }}">Deutschland</a>
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=es' }}">Español</a>
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=fr' }}">France</a>
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=in' }}">India Edition</a>
+                                                        <a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=mx' }}">México</a>
+                                                    </div>
+                                                </div>
+                                            </li>
+                                        </ul>
+                                        <ul class="more-menu__footer-sub-content">
+                                            <li><a rel:gt_act="about" href="/about">About</a></li>
+                                            <li><a rel:gt_act="press" href="/press">Press</a></li>
+                                            <li><a rel:gt_act="rss" href="/tools/more">RSS</a></li>
+                                            <li><a rel:gt_act="privacy" href="/about/privacy">Privacy</a></li>
+                                            <li><a rel:gt_act="user-terms" href="/about/useragreement">User Terms</a></li>
+                                            <li><a rel:gt_act="ad-choices" href="/about/privacy#adchoices">Ad Choices</a></li>
+                                            <li><a rel:gt_act="help" href="/help/faq">Help</a></li>
+                                            <li><a rel:gt_act="contact" href="/about/contact">Contact</a></li>
+                                            <li class="more-menu__copyright">© 2014 BuzzFeed, Inc</li>
+                                        </ul>
+                                        <a rel:gt_act="made-in-nyc" class="made-in-nyc" href="http://wearemadeinny.com/">Made in NY</a>
+                                    </div>
+                                </div>
+                                </span>
+                            </div>
+                            <div class="new-vertical-callout" id="app-callout"><a rel:gt_act="get-app" href="/tools/mobile-ios">Get Our App!</a></div>
+                        </div>
+                        <div id="nav-right">
+                            <div class="page-search inactive">
+                                <form class="page-search__form" action="/search" method="get">
+                                    <input placeholder="Search" class="page-search__input" autocomplete="off" rel:gt_act="ignore" value="" name="q" type="text">
+                                    <button class="page-search__search-button" rel:gt_act="search">
+                                        <svg viewBox="0 0 517 517" class="page-search__search-icon">
+                                            <use xlink:href="#icon-search"></use>
+                                        </svg>
+                                    </button>
+                                </form>
+                            </div>
+                            <div id="nav-signin" class="nav-signin" rel:gt_cat="[ttp]:header/menu">
+                                <div id="usernav-signin" style="">
+                                    <a class="nav-signin-icon fa fa-user bf_dom" rel:gt_act="sign-in" rel:bf_bucket_data="{'signin':{'signin_type':'initial', 'location':'header'}}" id="header-signin"></a>
+                                </div>
+                                <div id="usernav-profile" style="display: none;" class="header_dropdown">
+                                    <a rel:gt_act="user" href="javascript:;" id="usernav-profile-link" rel:bf_bucket="usernav-profile-link" class="bf_dom dropdown_heading">
+                                        <span class="image" id="usernav-image" style="display:none;">
+                    <img nopin="nopin" src="" alt="" height="24" width="24">
+                  </span>
+                                        <span class="image fa fa-user default-user-image" id="default-user-image" style="display:none;">
+                  </span>
+                                    </a>
+                                    <ul id="usernav-menu" class="menu unstyled-list">
+                                        <li id="usernav-new-post" class="SL_hide"><a rel:gt_act="new-post" href="/post">NEW POST</a></li>
+                                        <li id="usernav-my-feed"><a rel:gt_act="myfeed" id="usernav-profile-link2" rel:bf_bucket="usernav-profile-link" class="bf_dom" href="javascript:;">MY FEED</a></li>
+                                        <li id="usernav-dashboard" class="hidden SL_hide"><a rel:gt_act="dashboard" href="/dashboard">DASHBOARD</a></li>
+                                        <li id="usernav-switch" style="display:none;" class="switch_user_menu_option"><a rel:gt_act="feeds/users" href="javascript:;" onclick="return false;" id="usernav-switch-link">FEEDS/USERS<img id="switch-list-spinner" src="http://s3-ak.buzzfed.com/static/images/public/spinners/small_on_f6f6f6.gif" style="display:none;" height="16" width="16"></a></li>
+                                        <li id="usernav-settings" style="display:none;"><a rel:gt_act="settings" href="/settings" id="usernav-settings-link">SETTINGS</a></li>
+                                        <li id="usernav-signout" style="display:none;" class="last"><a rel:gt_act="sign-out" href="javascript:;">SIGN OUT</a></li>
+                                    </ul>
+                                </div>
+                                <div id="usernav-switch-list" class="SwitchUser list-users" style="display: none;"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </header>
+    </div>
+    <!--[if gte IE 9]>
+  <div class="PageContainer c   ie9   " id="page_container" >
+<![endif]-->
+    <!--[if !IE]><!-->
+    <div class="PageContainer c    " id="page_container">
+        <!--<![endif]-->
+        <div class="PageContent section UKNews  bf_dom">
+            <div></div>
+            <div id="new-header-hot-nav" class="vertical-hot-nav unified">
+                <!-- X---HEADER-STRIP---X -@- /plugin/headerstrip/v:1.1 -->
+                <!-- BEGIN OF public/includes/header/_header_buzz_hoton.tt -->
+                <script type="text/javascript">
+                AD_THUMBNAIL = 'thumbnailtest';
+                </script>
+                <script type="text/javascript">
+                if (AD_THUMBNAIL && typeof BF_STATIC != 'undefined' && typeof BF_STATIC['tt_page'] != 'undefined' && BF_STATIC.tt_page == 'Buzz') {
+                    AD_THUMBNAIL += '_bp';
+                } else {
+                    AD_THUMBNAIL += '_hp';
+                }
+                </script>
+                <script type="text/javascript">
+                if (typeof(window.BF_NO_DUPES) == 'undefined') window.BF_NO_DUPES = {};
+                window.BF_NO_DUPES[3759586] = true;
+                window.BF_NO_DUPES[3752466] = true;
+                window.BF_NO_DUPES[3760401] = true;
+                window.BF_NO_DUPES[3754654] = true;
+                window.BF_NO_DUPES[3762016] = true;
+                window.BF_NO_DUPES[3760563] = true;
+                window.BF_NO_DUPES[3761951] = true;
+                window.BF_NO_DUPES[3753891] = true;
+                </script>
+                <section id="hothead" class="rel bf_dom" rel:gt_cat="[ttp]:thumbstrip" pound_position="4ldqpi4">
+                    <div class="HotHead" id="hothead-unscripted">
+                        <!-- first slot begin - do not remove-->
+                        <div class="unit abtrack bf_dom thumb1" onmouseover="header &amp;&amp; header.fix_length(event);" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FO2FZ7&quot;,&quot;u&quot;:&quot;759SBH7&quot;,&quot;buzz&quot;:&quot;choses-que-les-filles-des-annees-2000-faisaient-19dho&quot;,&quot;user&quot;:&quot;jemimaskelley&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" track_load="{&quot;PROMO_IMPRESSION&quot;:&quot;8&quot;}" track_mousedown="{&quot;PROMO_CLICK&quot;:&quot;8&quot;}">
+                            <a rel:gt_act="post/thumb:1" rel:gt_label="editor/jemimaskelley" rel:buzz_id="3759586" class="thumbbb bf_dom" rel:bf_bucket="abtrack" href="/jemimaskelley/choses-que-les-filles-des-annees-2000-faisaient-19dho">
+                                <span class="title">23 choses que toutes les filles des années 2000…</span>
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/23/7/campaign_images/webdr13/23-choses-que-toutes-les-filles-des-annees-2000-f-2-22479-1429786805-12.jpg" alt="">
+                            </a>
+                        </div>
+                        <!-- first slot end -->
+                        <div class="bf-widget unit bf_dom gpt" onmouseover="header &amp;&amp; header.fix_length(event);" id="BF_WIDGET_10" rel:bf_ad_position="1">
+                            <div id="bf-item-10-1" class="bf-item">
+                                <div id="div-gpt-ad-10" style="position:absolute;overflow:hidden;z-index:-1"></div>
+                                <script type="text/javascript">
+                                if (AD_DESIGN == 'gpt') {
+                                    loadGPTAd({
+                                        'wid': 10,
+                                        'pos': "header",
+                                        'size': [3, 3],
+                                        'abtest': AD_THUMBNAIL + "_2"
+                                    });
+                                }
+                                </script>
+                                <a rel:gt_act="dfp/badge:2" rel:gtrack_id="dfp/badge" class="badge bf-url" href="">
+                                    <div class="partner-sash">Sponsorisé</div>
+                                </a>
+                                <a rel:gt_act="dfp/thumb:2" rel:gtrack_id="dfp/thumb" class="thumbbb bf-url" rel:bf_bucket="abtrack" rel:gt_label="partner" href="">
+                                    <span class="title small">
+        <span class="bf-name" rel:bf_truncate="55"></span>
+                                    <small class="partner-info">
+          <span>→ </span> <span class="bf-display_name" rel:bf_truncate="15"></span>
+        </small>
+                                    </span>
+                                    <img nopin="nopin" class="bf-image partner" src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+                                </a>
+                            </div>
+                        </div>
+                        <script type="text/javascript">
+                        (function() {
+                            var AD = document.getElementById('BF_WIDGET_' + 10) || document.getElementById('BF_IFRAME_' + 10);
+                            if (AB_AD_TEST && AD && AD_DESIGN) {
+                                AD.className = AD.className + " " + AD_DESIGN;
+                            }
+                        })()
+                        </script>
+                        <script type="text/javascript">
+                        if (AD_DESIGN != 'gpt') {
+
+                            if (!window['win8AdCall']) {
+                                window['win8AdCall'] = function() { /* do nothing */ };
+                            }
+                            var ad_tag = 'http://ad.doubleclick.net/N6556/adj/' + BF_DFP_SITE + BF_DFP_ZONE + ';wid=10;sz=3x3;pos=header;tile=10;thumb_count=2;' + BF_DFP_KVS + ';' + BF_TAG + win8AdCall() + '';
+                            if (typeof AD_DESIGN != 'undefined') {
+                                ad_tag += ';abtest=' + AD_DESIGN + ';'
+                            }
+
+                            //Loreal MUC channel
+                            if (window.location.search.match('loreal_feed=1') && BF_STATIC.tt_page === "Buzz") {
+                                ad_tag += 'loreal_feed=1;'
+                            }
+
+                            ad_tag += 'poe=' + BF_REFERER + ';';
+                            ad_tag += 'ord=' + BF_DFP_ORD + '?';
+
+
+
+                            if (ad_tag) {
+                                if (!('wid=10;sz=3x3;pos=header;tile=10;thumb_count=2').match(/pos=300x250/) && null !== window.location.search.match("skipdfp")) {
+                                    window.addEventListener('load', function() {
+                                        var query = (typeof String.prototype.toQueryParams != 'undefined') ? window.location.search.toQueryParams() : $.deparam.querystring();
+                                        var ad_user = (query['skipdfp']) ? query['skipdfp'] : 'boost';
+                                        var extra_params = (/bigstory/.test('wid=10;sz=3x3;pos=header;tile=10;thumb_count=2')) ? '&flex_medium=bigstory' : '';
+                                        local_ad_call(10, ad_user, extra_params);
+                                    })
+                                } else {
+                                    if (!BF_STATIC.bf_test_mode || document.cookie.match('sel2_ad') !== null) {
+                                        document.write('<' + 'scr' + 'ipt type="text/javascr' + 'ipt" src="' + ad_tag + '"><\/scr' + 'ipt' + '>');
+                                    } else {
+                                        console.info('disable DFP (dfp_tags.tt)');
+                                    }
+                                }
+                            }
+
+                            if (null !== window.location.search.match("adtest") && console !== undefined && typeof ad_tag != "undefined") console.log(ad_tag);
+                        }
+                        </script>
+                        <script type="text/javascript">
+                        AD_THUMBNAIL += '_' + 2;
+                        </script>
+                        <div class="unit abtrack bf_dom thumb3" onmouseover="header &amp;&amp; header.fix_length(event);" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FMZZJ7&quot;,&quot;u&quot;:&quot;764NN7&quot;,&quot;buzz&quot;:&quot;21-tatouages-qui-ont-recouvert-des-cicatrices&quot;,&quot;user&quot;:&quot;juliegerstein&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" track_load="{&quot;PROMO_IMPRESSION&quot;:&quot;8&quot;}" track_mousedown="{&quot;PROMO_CLICK&quot;:&quot;8&quot;}">
+                            <a rel:gt_act="post/thumb:3" rel:gt_label="editor/juliegerstein" rel:buzz_id="3752466" class="thumbbb bf_dom" rel:bf_bucket="abtrack" href="/juliegerstein/21-tatouages-qui-ont-recouvert-des-cicatrices">
+                                <span class="title">21 tatouages qui ont merveilleusement bien…</span>
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/16/9/campaign_images/webdr09/21-tatouages-qui-ont-merveilleusement-bien-recouv-2-4152-1429189266-0.jpg" alt="">
+                            </a>
+                        </div>
+                        <div class="unit abtrack bf_dom thumb4" onmouseover="header &amp;&amp; header.fix_length(event);" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FO6UG7&quot;,&quot;u&quot;:&quot;7386MV7&quot;,&quot;buzz&quot;:&quot;mannequins-mensongers&quot;,&quot;user&quot;:&quot;kristinchirico&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" track_load="{&quot;PROMO_IMPRESSION&quot;:&quot;8&quot;}" track_mousedown="{&quot;PROMO_CLICK&quot;:&quot;8&quot;}">
+                            <a rel:gt_act="post/thumb:4" rel:gt_label="editor/kristinchirico" rel:buzz_id="3760401" class="thumbbb bf_dom" rel:bf_bucket="abtrack" href="/kristinchirico/mannequins-mensongers">
+                                <span class="title">Voici à quoi ressemblent des vêtements «grande…</span>
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/23/9/campaign_images/webdr09/voici-a-quoi-ressemblent-des-vetements-grande-tai-2-2167-1429795022-0.jpg" alt="">
+                            </a>
+                        </div>
+                        <div class="unit abtrack bf_dom thumb5" onmouseover="header &amp;&amp; header.fix_length(event);" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FNBSZ7&quot;,&quot;u&quot;:&quot;73FEXC7&quot;,&quot;buzz&quot;:&quot;34-raisons-de-ne-jamais-aller-au-pays-basque&quot;,&quot;user&quot;:&quot;marietelling&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" track_load="{&quot;PROMO_IMPRESSION&quot;:&quot;8&quot;}" track_mousedown="{&quot;PROMO_CLICK&quot;:&quot;8&quot;}">
+                            <a rel:gt_act="post/thumb:5" rel:gt_label="editor/marietelling" rel:buzz_id="3754654" class="thumbbb bf_dom" rel:bf_bucket="abtrack" href="/marietelling/34-raisons-de-ne-jamais-aller-au-pays-basque">
+                                <span class="title">34 raisons de ne jamais aller au Pays basque</span>
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/18/10/campaign_images/webdr06/34-raisons-de-ne-jamais-aller-au-pays-basque-2-5868-1429368600-5.jpg" alt="">
+                            </a>
+                        </div>
+                        <div class="unit abtrack bf_dom thumb6" onmouseover="header &amp;&amp; header.fix_length(event);" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOFKH7&quot;,&quot;u&quot;:&quot;7CEIDY7&quot;,&quot;buzz&quot;:&quot;pourquoi-tu-fais-ca-shonda&quot;,&quot;user&quot;:&quot;jenniferpadjemi&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" track_load="{&quot;PROMO_IMPRESSION&quot;:&quot;8&quot;}" track_mousedown="{&quot;PROMO_CLICK&quot;:&quot;8&quot;}">
+                            <a rel:gt_act="post/thumb:6" rel:gt_label="editor/jenniferpadjemi" rel:buzz_id="3762016" class="thumbbb bf_dom" rel:bf_bucket="abtrack" href="/jenniferpadjemi/pourquoi-tu-fais-ca-shonda">
+                                <span class="title">Les 43 fois où Grey’s Anatomy a fait couler toutes…</span>
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/24/16/campaign_images/webdr01/les-43-fois-ou-greys-anatomy-a-fait-couler-toutes-2-4861-1429906011-15.jpg" alt="">
+                            </a>
+                        </div>
+                        <div class="unit abtrack bf_dom thumb7" onmouseover="header &amp;&amp; header.fix_length(event);" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FO7PY7&quot;,&quot;u&quot;:&quot;74N9GW7&quot;,&quot;buzz&quot;:&quot;oui-ceci-est-mon-metier&quot;,&quot;user&quot;:&quot;floperry&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" track_load="{&quot;PROMO_IMPRESSION&quot;:&quot;8&quot;}" track_mousedown="{&quot;PROMO_CLICK&quot;:&quot;8&quot;}">
+                            <a rel:gt_act="post/thumb:7" rel:gt_label="editor/floperry" rel:buzz_id="3760563" class="thumbbb bf_dom" rel:bf_bucket="abtrack" href="/floperry/oui-ceci-est-mon-metier">
+                                <span class="title">23 réactions que toute personne ayant travaillé…</span>
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/23/8/campaign_images/webdr08/23-reactions-que-toute-personne-ayant-travaille-d-2-11535-1429792966-16.jpg" alt="">
+                            </a>
+                        </div>
+                        <div class="unit abtrack bf_dom thumb8" onmouseover="header &amp;&amp; header.fix_length(event);" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOF7U7&quot;,&quot;u&quot;:&quot;762Y617&quot;,&quot;buzz&quot;:&quot;pas-dans-les-yeux&quot;,&quot;user&quot;:&quot;christianzamora&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" track_load="{&quot;PROMO_IMPRESSION&quot;:&quot;8&quot;}" track_mousedown="{&quot;PROMO_CLICK&quot;:&quot;8&quot;}">
+                            <a rel:gt_act="post/thumb:8" rel:gt_label="editor/christianzamora" rel:buzz_id="3761951" class="thumbbb bf_dom" rel:bf_bucket="abtrack" href="/christianzamora/pas-dans-les-yeux">
+                                <span class="title">19 réactions que tous les gens ayant déjà eu…</span>
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/5/campaign_images/webdr05/19-reactions-que-tous-les-gens-ayant-deja-eu-affa-2-13034-1430125613-16.jpg" alt="">
+                            </a>
+                        </div>
+                        <div class="unit abtrack bf_dom thumb9" onmouseover="header &amp;&amp; header.fix_length(event);" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FN7OM7&quot;,&quot;u&quot;:&quot;764NN7&quot;,&quot;buzz&quot;:&quot;ces-femmes-postent-fierement-des-photos-de-leurs-vergetures&quot;,&quot;user&quot;:&quot;juliegerstein&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" track_load="{&quot;PROMO_IMPRESSION&quot;:&quot;8&quot;}" track_mousedown="{&quot;PROMO_CLICK&quot;:&quot;8&quot;}">
+                            <a rel:gt_act="post/thumb:9" rel:gt_label="editor/juliegerstein" rel:buzz_id="3753891" class="thumbbb bf_dom" rel:bf_bucket="abtrack" href="/juliegerstein/ces-femmes-postent-fierement-des-photos-de-leurs-vergetures">
+                                <span class="title">Ces femmes postent fièrement des photos de leurs…</span>
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/16/3/campaign_images/webdr09/ces-femmes-postent-fierement-des-photos-de-leurs--2-30384-1429168480-26.jpg" alt="">
+                            </a>
+                        </div>
+                    </div>
+                    <!-- #hothead-unscripted -->
+                    <div class="HotHead" id="hothead-scripted" style="display: none;"></div>
+                </section>
+                <script type="text/javascript">
+                if ('undefined' !== typeof BF_STATIC) {
+                    BF_STATIC.thumbstrip_initial_buzzes = ["3759586", "3752466", "3760401", "3754654", "3762016", "3760563", "3761951", "3753891"];
+                }
+                </script>
+                <!-- END OF public/includes/header/_header_buzz_hoton.tt -->
+                <!-- UNIT:Headerstrip generated on  9:30:30,  4/27/2015 -->
+            </div>
+            <script type="text/javascript">
+            $$('.not_clickable').each(function(el) {
+                el.observe('click', function(e) {
+                    e.stop();
+                });
+            });
+            </script>
+            <div class="c"></div>
+            <script type="text/javascript">
+            </script>
+            <div class="Content Page bf_dom ">
+                <article class="c viral-buzz bf_dom" rel:bf_bucket="abtest" rel:ab_test="pinterest_subbuzz_share" rel:gt_cat="Buzz">
+                    <aside id="post_launch_success" class="launch-success-message" style="display:none;">
+                        <div class="launch-success-wrap">
+                            <div class="headline-1">Your Post Has Been Launched!</div>
+                            <div class="headline-4">Fabulous! Don't forget to share with your friends on Twitter and Facebook.</div>
+                        </div>
+                    </aside>
+                    <aside class="section hot_stats_bar c bf_dom  " id="hot-buzz-stats" rel:bf_bucket="gtrack" rel:gt_cat="[ttp]:stats-bar">
+                        <div class="trending-badge-header">
+                            <span class="title">TOP POST</span>
+                            <p class="num views"><span>653,817 VIEWS</span> </p>
+                        </div>
+                        <div class="trending-badge">
+                            <div class="badge viral">
+                                <a rel:gt_act="post/badge:viral" href="/trending"><img nopin="nopin" src="http://s3-ak.buzzfeed.com/static/badge_images/viral.png?v=201504241415" alt="viral" title="Click for More..." height="42" width="42"></a>
+                            </div>
+                        </div>
+                        <div class="badges">
+                        </div>
+                    </aside>
+                    <div class="bf_dom c">
+                        <div class="buzz no-border bf_dom c" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FNW2J7&quot;,&quot;u&quot;:&quot;7717MJ7&quot;,&quot;buzz&quot;:&quot;diet-pills-burns-up&quot;,&quot;user&quot;:&quot;markdistefano&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}">
+                            <header id="post-3758406" class="post2 super_format  bf_dom c" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FNW2J7&quot;,&quot;u&quot;:&quot;7717MJ7&quot;,&quot;buzz&quot;:&quot;diet-pills-burns-up&quot;,&quot;user&quot;:&quot;markdistefano&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" rel:ptool="true" rel:ptool_code="0.0.1.2.0.0" rel:owner="markdistefano" rel:advertiser="0" rel:partner="0" rel:data="{&quot;buzz_id&quot;:&quot;3758406&quot;,&quot;type&quot;:&quot;super&quot;,&quot;uri&quot;:&quot;diet-pills-burns-up&quot;,&quot;form_id&quot;:&quot;20&quot;,&quot;category&quot;:&quot;UKNews&quot;}" rel:ptool_stats="{&quot;impressions&quot;:&quot;653,817&quot;,&quot;email_shares&quot;:&quot;81&quot;,&quot;pinterest_count&quot;:&quot;&quot;,&quot;twitter_count&quot;:&quot;251&quot;,&quot;viral_lift&quot;:&quot;1.7X&quot;,&quot;facebook_count&quot;:&quot;665&quot;}">
+                                <div id="buzz_header" class=" no_custom_header_image" rel:gt_cat="[ttp]:header">
+                                    <hgroup>
+                                        <a name="post-title"></a>
+                                        <h1 id="post-title">Student Dies After Diet Pills She Bought Online “Burned Her Up From&nbsp;Within”</h1>
+                                        <p class="description">
+                                            <b>An inquest into Eloise Parry’s death has been adjourned until July.</b>
+                                        </p>
+                                        <span class="post_datetimes">
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <span id="update_posted_time_3758406" class="buzz_datetime converted_buzz_datetime">posted on  April 21, 2015, at 11:29 a.m.</span>
+                                        </span>
+                                    </hgroup>
+                                    <div class="c user-bg">
+                                        <div class="user-bylines  ">
+                                            <div class="byline
+
+
+            ">
+                                                <a href="/markdistefano" rel:gt_act="user/avatar" rel:gt_label="editor/markdistefano">
+                                                    <img nopin="nopin" src="http://s3-ak.buzzfeed.com/static/2014-06/30/20/user_images/webdr09/markdistefano-30063-1404175854-8_large.jpg" class="byline__avatar" alt="Mark Di Stefano">
+                                                </a>
+                                                <div class="byline__body">
+                                                    <a href="/markdistefano" class="byline__author" rel:gt_act="user/username" rel:gt_label="editor/markdistefano">Mark Di Stefano</a>
+                                                    <div class="byline__title">BuzzFeed News Reporter</div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div id="share_control" class="bf_dom square_shares  shown" rel:bf_bucket="abtest" rel:ab_test="fwd_linkedin" rel:gt_cat="Buzz">
+                                    <div class="horizontal-share-buttons upper-share-buttons c bf_dom" rel:gt_cat="[ttp]:sharing-upper" rel:bf_bucket="gtrack">
+                                        <div class="fb_share">
+                                            <a rel:gt_act="share/facebook/share" href="javascript:;" class="bf_dom shareBtn square">
+                                                <i class="fb_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="tweet_share">
+                                            <a href="javascript:;" rel:gt_act="share/twitter/tweet" class="bf_dom shareBtn square">
+                                                <i class="twitter_icon fa"></i><span>Tweet</span></a>
+                                        </div>
+                                        <div class="email_share">
+                                            <a href="javascript:;" rel:data="{&quot;share_email&quot;:{&quot;buzz_id&quot;:&quot;3758406&quot;}}" rel:bf_bucket="event_handler sticky_popup_button" rel:actions="click:share_email" rel:gt_act="share/email" class="bf_dom shareBtn square">
+                                                <i class="email_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="pinterest_share">
+                                            <a href="javascript:;" rel:bf_bucket="pinterest" rel:gt_act="share/pinterest" class="bf_dom shareBtn square">
+                                                <i class="pi_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="gplus_share">
+                                            <a href="javascript:;" rel:gt_act="share/googleplus/plus-one" class="bf_dom shareBtn square">
+                                                <i class="gplus_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="bookmark_share">
+                                            <a class="bf_dom shareBtn big square" rel:gt_cat="Buzz:sharing-upper" rel:gt_act="bookmark" rel:bf_bucket="add_bookmark" href="javascript:;">
+                                                <div class="fa fa-bookmark"></div>
+                                                <div class="label">Bookmark it</div>
+                                            </a>
+                                            <div class="bookmark-tooltip" style="display:none;"></div>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </div>
+                                </div>
+                                <div class="hidden square_shares " id="pin_ref">
+                                    <div class="horizontal-share-buttons upper-share-buttons c bf_dom" rel:gt_cat="[ttp]:sharing-upper" rel:bf_bucket="gtrack">
+                                        <div class="pinterest_share">
+                                            <a href="javascript:;" rel:bf_bucket="pinterest" rel:gt_act="share/pinterest" class="bf_dom shareBtn square">
+                                                <i class="pi_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="fb_share">
+                                            <a rel:gt_act="share/facebook/share" href="javascript:;" class="bf_dom shareBtn square">
+                                                <i class="fb_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="email_share">
+                                            <a href="javascript:;" rel:data="{&quot;share_email&quot;:{&quot;buzz_id&quot;:&quot;3758406&quot;}}" rel:bf_bucket="event_handler sticky_popup_button" rel:actions="click:share_email" rel:gt_act="share/email" class="bf_dom shareBtn square">
+                                                <i class="email_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="tweet_share">
+                                            <a href="javascript:;" rel:gt_act="share/twitter/tweet" class="bf_dom shareBtn square">
+                                                <i class="twitter_icon fa"></i><span>Tweet</span></a>
+                                        </div>
+                                        <div class="gplus_share">
+                                            <a href="javascript:;" rel:gt_act="share/googleplus/plus-one" class="bf_dom shareBtn square">
+                                                <i class="gplus_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </div>
+                                </div>
+                                <div class="hidden square_shares " id="tweet_ref">
+                                    <div class="horizontal-share-buttons upper-share-buttons c bf_dom" rel:gt_cat="[ttp]:sharing-upper" rel:bf_bucket="gtrack">
+                                        <div class="tweet_share">
+                                            <a href="javascript:;" rel:gt_act="share/twitter/tweet" class="bf_dom shareBtn square">
+                                                <i class="twitter_icon fa"></i><span>Tweet</span></a>
+                                        </div>
+                                        <div class="fb_share">
+                                            <a rel:gt_act="share/facebook/share" href="javascript:;" class="bf_dom shareBtn square">
+                                                <i class="fb_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="email_share">
+                                            <a href="javascript:;" rel:data="{&quot;share_email&quot;:{&quot;buzz_id&quot;:&quot;3758406&quot;}}" rel:bf_bucket="event_handler sticky_popup_button" rel:actions="click:share_email" rel:gt_act="share/email" class="bf_dom shareBtn square">
+                                                <i class="email_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="pinterest_share">
+                                            <a href="javascript:;" rel:bf_bucket="pinterest" rel:gt_act="share/pinterest" class="bf_dom shareBtn square">
+                                                <i class="pi_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="gplus_share">
+                                            <a href="javascript:;" rel:gt_act="share/googleplus/plus-one" class="bf_dom shareBtn square">
+                                                <i class="gplus_icon fa"></i><span></span></a>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </div>
+                                </div>
+                            </header>
+                            <div data-print="body" rel:gt_cat="[ttp]:content">
+                                <div id="buzz_sub_buzz" class="c suplist_article suplist_list_show ">
+                                    <div class="buzz_superlist_item buzz_superlist_item_image  buzz_superlist_item_wide image_hit no_caption " id="superlist_3758406_5547137" rel:buzz_num="1">
+                                        <h2>The mother of a woman who took suspected diet pills bought online has described how her daughter was “literally burning up from within” moments before her death.</h2>
+                                        <div class="sub_buzz_content">
+                                            <img src="http://ak-hdl.buzzfed.com/static/2015-04/21/4/enhanced/webdr10/enhanced-6418-1429605460-16.jpg" rel:bf_image_src="http://ak-hdl.buzzfed.com/static/2015-04/21/4/enhanced/webdr10/enhanced-6418-1429605460-16.jpg" class="bf_dom" rel:bf_bucket="progload" alt="The mother of a woman who took suspected diet pills bought online has described how her daughter was &quot;literally burning up from within&quot; moments before her death." height="422" width="625">
+                                            <div class="pinit" style="left: 542px; top: 374px;">
+                                                <a class="pin sub-buzz-pinterest-share bf_dom" href="javascript:;" rel:gt_act="share/pinterest/pin/list-item:1" rel:bf_bucket_data="{'pin-share':{'id':'3758406_5547137','not_a_sub':true}}" rel:sub_title="">
+                                                    <span class="icon"></span>
+                                                </a>
+                                            </div>
+                                            <p class="print"><a href="http://ak-hdl.buzzfed.com/static/2015-04/21/4/enhanced/webdr10/enhanced-6418-1429605460-16.jpg" rel="nofollow"><b>View this image ›</b></a></p>
+                                        </div>
+                                        <p class="article_caption_w_attr"> <span class="sub_buzz_source_via buzz_attribution buzz_attr_no_caption">West Merica Police</span></p>
+                                    </div>
+                                    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547213" rel:buzz_num="2">
+                                        <p class="sub_buzz_desc">Eloise Parry, 21, was taken to Royal Shrewsbury hospital on 12 April after taking a lethal dose of highly toxic “slimming tablets”. </p>
+                                        <p>“The drug was in her system, there was no anti-dote, two tablets was a lethal dose – and she had taken eight,” her mother, Fiona, <a href="https://www.westmercia.police.uk/article/9501/A-tribute-to-Eloise-Aimee-Parry-written-by-her-mother-Fiona-Parry">said in a statement</a> yesterday.</p>
+                                        <p>“As Eloise deteriorated, the staff in A&amp;E did all they could to stabilise her. As the drug kicked in and started to make her metabolism soar, they attempted to cool her down, but they were fighting an uphill battle.</p>
+                                        <p>“She was literally burning up from within.”</p>
+                                        <p>She added: “They never stood a chance of saving her. She burned and crashed.”</p>
+                                    </div>
+                                    <div class="buzz_superlist_item buzz_superlist_item_grid_row  buzz_superlist_item_wide  no_caption " id="superlist_3758406_5547140" rel:buzz_num="3">
+                                        <div class="grid_row two_pl grid_height_l">
+                                            <div class="grid_cell cell_1">
+                                                <div class="grid_cell_image_wrapper">
+                                                    <img src="http://ak-hdl.buzzfed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608056-15.jpg" rel:bf_image_src="http://ak-hdl.buzzfed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608056-15.jpg" height="412" width="203">
+                                                    <div class="pinit">
+                                                        <a class="pin sub-buzz-pinterest-share bf_dom" href="javascript:;" rel:gt_act="share/pinterest/pin/list-item:1" rel:bf_bucket_data="{'pin-share':{'id':'3758406_5547140','not_a_sub':true}}" rel:sub_title="">
+                                                            <span class="icon"></span>
+                                                        </a>
+                                                    </div>
+                                                </div>
+                                                <div class="sub_buzz_grid_cell_caption">
+                                                    <p class="sub_buzz_grid_source_via">Facebook</p>
+                                                </div>
+                                            </div>
+                                            <div class="grid_cell cell_2">
+                                                <div class="grid_cell_image_wrapper">
+                                                    <img src="http://ak-hdl.buzzfed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608057-18.jpg" rel:bf_image_src="http://ak-hdl.buzzfed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608057-18.jpg" height="412" width="412">
+                                                    <div class="pinit">
+                                                        <a class="pin sub-buzz-pinterest-share bf_dom" href="javascript:;" rel:gt_act="share/pinterest/pin/list-item:2" rel:bf_bucket_data="{'pin-share':{'id':'3758406_5547140','not_a_sub':true}}" rel:sub_title="">
+                                                            <span class="icon"></span>
+                                                        </a>
+                                                    </div>
+                                                </div>
+                                                <div class="sub_buzz_grid_cell_caption">
+                                                    <p class="sub_buzz_grid_source_via">Facebook</p>
+                                                </div>
+                                            </div>
+                                            <div class="sub_buzz_content">
+                                            </div>
+                                        </div>
+                                        <div class="grid_clear">&nbsp;</div>
+                                    </div>
+                                    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547284" rel:buzz_num="4">
+                                        <p class="sub_buzz_desc">West Mercia police <a href="https://www.westmercia.police.uk/article/9500/Warning-Issued-As-Shrewsbury-Woman-Dies-After-Taking-Suspected-Diet-Pills">said the tablets were believed to contain dinitrophenol</a>, known as DNP, which is a highly toxic industrial chemical. </p>
+                                        <p>“We are undoubtedly concerned over the origin and sale of these pills and are working with partner agencies to establish where they were bought from and how they were advertised,” said chief inspector Jennifer Mattinson from the West Mercia police.</p>
+                                        <p>The Food Standards Agency warned people to stay away from slimming products that contained DNP.</p>
+                                        <p>“We advise the public not to take any tablets or powders containing DNP, as it is an industrial chemical and not fit for human consumption,” it said in a statement.</p>
+                                    </div>
+                                    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547219" rel:buzz_num="5">
+                                        <h2>Fiona Parry issued a plea for people to stay away from pills containing the chemical.</h2>
+                                        <br>
+                                        <p class="sub_buzz_desc">“[Eloise] just never really understood how dangerous the tablets that she took were,” she said. “Most of us don’t believe that a slimming tablet could possibly kill us.</p>
+                                        <p>“DNP is not a miracle slimming pill. It is a deadly toxin.”</p>
+                                    </div>
+                                </div>
+                                <p class="print c"><a href="http://buzzfeed.com"><b>Check out more articles on BuzzFeed.com!</b></a></p>
+                            </div>
+                            <div class="user-bio">
+                                <div class="user-bio__main-text">Mark di Stefano is a breaking news reporter for BuzzFeed News and is based in Sydney, Australia. </div>
+                                <div class="user-bio__user-contact">
+                                    Contact Mark Di Stefano at <a href="mailto:mark.distefano@buzzfeed.com">mark.distefano@buzzfeed.com</a>
+                                </div>
+                            </div>
+                            <section class="c bottom_shares square_shares">
+                                <div class="bf_dom">
+                                    <div class="referrer_shares">
+                                        <div class=" bottom-share-buttons  bf_dom" rel:gt_cat="[ttp]:sharing-bottom" rel:bf_bucket="gtrack">
+                                            <div class="fb_share">
+                                                <a rel:gt_act="share/facebook/share" href="javascript:;" class="bf_dom shareBtn square">
+                                                    <i class="fb_icon fa"></i><span></span></a>
+                                            </div>
+                                            <div class="clear"></div>
+                                        </div>
+                                    </div>
+                                    <div class="vertical_shares">
+                                        <div class=" bottom-share-buttons  bf_dom" rel:gt_cat="[ttp]:sharing-bottom" rel:bf_bucket="gtrack">
+                                            <div class="tweet_share">
+                                                <a href="javascript:;" rel:gt_act="share/twitter/tweet" class="bf_dom shareBtn square">
+                                                    <i class="twitter_icon fa"></i><span>Tweet</span></a>
+                                            </div>
+                                            <div class="clear"></div>
+                                        </div>
+                                    </div>
+                                    <div class="other_shares">
+                                        <div class=" bottom-share-buttons  bf_dom" rel:gt_cat="[ttp]:sharing-bottom" rel:bf_bucket="gtrack">
+                                            <div class="email_share">
+                                                <a href="javascript:;" rel:data="{&quot;share_email&quot;:{&quot;buzz_id&quot;:&quot;3758406&quot;}}" rel:bf_bucket="event_handler sticky_popup_button" rel:actions="click:share_email" rel:gt_act="share/email" class="bf_dom shareBtn square">
+                                                    <i class="email_icon fa"></i><span></span></a>
+                                            </div>
+                                            <div class="gplus_share">
+                                                <a href="javascript:;" rel:gt_act="share/googleplus/plus-one" class="bf_dom shareBtn square">
+                                                    <i class="gplus_icon fa"></i><span></span></a>
+                                            </div>
+                                            <div class="pinterest_share">
+                                                <a href="javascript:;" rel:bf_bucket="pinterest" rel:gt_act="share/pinterest" class="bf_dom shareBtn square">
+                                                    <i class="pi_icon fa"></i><span></span></a>
+                                            </div>
+                                            <div class="clear"></div>
+                                        </div>
+                                    </div>
+                                    <a href="javascript:;" class="more_shares bf_dom" rel:bf_bucket="more_shares">More <span class="ie-arrow">▾</span></a>
+                                    <div id="more_shares_box" class="bf_dom" style="display: none;">
+                                        <div class="arrow arrowBorder"></div>
+                                        <div class="arrow arrowFill"></div>
+                                        <div class="vertical-share-buttons bottom-more-share-buttons  bf_dom" rel:gt_cat="[ttp]:sharing-bottom-more" rel:bf_bucket="gtrack">
+                                            <div rel:buzz_id="3758406" class="rebuzz_share hidden">
+                                                <a rel:data="{&quot;username&quot;:&quot;markdistefano&quot;}" id="3758406-make_pick-add" rel:gt_act="share/rebuzz" class="add-pick bf_dom make_pick shareBtn big square hidden">
+                                                    <div class="rebuzz_icon fa">&nbsp;</div>
+                                                    <div class="label">Rebuzz</div>
+                                                </a>
+                                            </div>
+                                            <div class="reddit_share">
+                                                <a href="javascript:;" rel:gt_act="share/reddit" class="bf_dom shareBtn square">
+                                                    <i class="reddit_icon fa"></i><span></span></a>
+                                            </div>
+                                            <div class="stumbleupon_share">
+                                                <a href="javascript:;" rel:gt_act="share/su" class="bf_dom shareBtn square">
+                                                    <i class="su_icon fa"></i><span>Stumble</span></a>
+                                            </div>
+                                            <div class="link_share">
+                                                <a rel:link="http://www.buzzfeed.com/markdistefano/diet-pills-burns-up" rel:bf_bucket="share_link sticky_popup_button" href="javascript:;" rel:gt_act="share/link" class="bf_dom shareBtn square">
+                                                    <i class="copy_icon fa"></i><span></span></a>
+                                            </div>
+                                            <div class="clear"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </section>
+                        </div>
+                    </div>
+                    <div id="preFacebookComment" class="bf_dom" rel:bf_bucket_data="{&quot;progLoaderElement&quot;:{},&quot;scrollDifference&quot;:&quot;2000&quot;,&quot;reachElementMark&quot;:&quot;.bottom-share-buttons&quot;,&quot;name&quot;:&quot;fb_comments_nexton&quot;}">&nbsp;</div>
+                    <section class="section hidden" id="fb_comments_nexton">
+                        <header class="header">
+                            <div class="headline-1">Facebook Conversations</div>
+                        </header>
+                        <div class="fb_comments_wrapper">
+                            <img nopin="nopin" class="load-spinner" src="http://s3-ak.buzzfeed.com/static/images/public/spinners/big_on_white.gif?v=201504241415">
+                        </div>
+                    </section>
+                    <!-- X---NEXT-ON-UNIT---X -@- /plugin/nexton/v:1.0/vt:news -->
+                    <div class="bf_dom" rel:bf_bucket="abtest" rel:ab_test="next_on_same_vertical">
+                        <div id="next_on" class="next_on_news" rel:gt_cat="[ttp]:next-on-news">
+                            <ul id="next_on_same_vertical--same-vertical" class="hidden">
+                                <li id="next_on_ab_1" rel:buzz_id="3749467">
+                                    <div class="leftPage">
+                                        <a href="/jayasaxena/the-bride-paradox" rel:gt_act="post/thumb" rel:gt_label="user/jayasaxena">
+                                            <img nopin="nopin" class="bf_dom" rel:bf_bucket="progload" src="http://s3-static-ak.buzzfed.com/static/2015-04/12/10/campaign_images/webdr15/the-bride-paradox-2-24817-1428850014-4_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/12/10/campaign_images/webdr15/the-bride-paradox-2-24817-1428850014-4_wide.jpg" alt="">
+                                        </a>
+                                    </div>
+                                    <div class="bf_dom rightPage" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FMJSE7&quot;,&quot;u&quot;:&quot;74ASTR7&quot;,&quot;buzz&quot;:&quot;the-bride-paradox&quot;,&quot;user&quot;:&quot;jayasaxena&quot;,&quot;types&quot;:[],&quot;queries&quot;:[]}">
+                                        <a rel:gt_act="vertical/title" href="/news">
+                                            <span> Next On BuzzFeed News <span class="next_arrow">›</span></span>
+                                        </a>
+                                        <a href="/jayasaxena/the-bride-paradox" rel:gt_act="post/title" rel:gt_label="user/jayasaxena">
+                                            <h3>The Bride Paradox Of "Four Weddings"</h3>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li id="next_on_ab_2" style="display:none;" rel:buzz_id="3746270">
+                                    <div class="leftPage">
+                                        <a href="/hgiorgis/rihanna-da-gawd" rel:gt_act="post/thumb" rel:gt_label="user/hgiorgis">
+                                            <img nopin="nopin" class="bf_dom" rel:bf_bucket="progload" src="http://s3-static-ak.buzzfed.com/static/2015-04/7/15/campaign_images/webdr03/rihanna-da-gawd-2-17340-1428435377-8_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/7/15/campaign_images/webdr03/rihanna-da-gawd-2-17340-1428435377-8_wide.jpg" alt="">
+                                        </a>
+                                    </div>
+                                    <div class="bf_dom rightPage" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FM2IR7&quot;,&quot;u&quot;:&quot;7B8LV67&quot;,&quot;buzz&quot;:&quot;rihanna-da-gawd&quot;,&quot;user&quot;:&quot;hgiorgis&quot;,&quot;types&quot;:[],&quot;queries&quot;:[]}">
+                                        <a rel:gt_act="vertical/title" href="/news">
+                                            <span> Next On BuzzFeed News <span class="next_arrow">›</span></span>
+                                        </a>
+                                        <a href="/hgiorgis/rihanna-da-gawd" rel:gt_act="post/title" rel:gt_label="user/hgiorgis">
+                                            <h3>Rihanna And The Radical Power Of "Carefree Black Girl"...</h3>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                            <ul id="next_on_same_vertical--control" class="">
+                                <li id="next_on_1" rel:buzz_id="3763833">
+                                    <div class="leftPage">
+                                        <a href="/richardhjames/this-is-why-streaking-during-a-rugby-match-is-never-a-good-i" rel:gt_act="post/thumb" rel:gt_label="user/richardhjames">
+                                            <img nopin="nopin" class="bf_dom" rel:bf_bucket="progload" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/7/campaign_images/webdr15/this-is-why-streaking-during-a-rugby-match-is-nev-2-21907-1430135173-1_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/7/campaign_images/webdr15/this-is-why-streaking-during-a-rugby-match-is-nev-2-21907-1430135173-1_wide.jpg" alt="">
+                                        </a>
+                                    </div>
+                                    <div class="bf_dom rightPage" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOPDS7&quot;,&quot;u&quot;:&quot;75GYN67&quot;,&quot;use&quot;:&quot;richardhjames&quot;,&quot;buzz&quot;:&quot;this-is-why-streaking-during-a-rugby-match-is-never-a-good-i&quot;,&quot;types&quot;:[],&quot;queries&quot;:[]}">
+                                        <a rel:gt_act="vertical/title" href="/news">
+                                            <span> Next On BuzzFeed News <span class="next_arrow">›</span></span>
+                                        </a>
+                                        <a href="/richardhjames/this-is-why-streaking-during-a-rugby-match-is-never-a-good-i" rel:gt_act="post/title" rel:gt_label="user/richardhjames">
+                                            <h3>This Is Why Streaking During A Rugby Match Is Never...</h3>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li id="next_on_2" style="display:none;" rel:buzz_id="3762896">
+                                    <div class="leftPage">
+                                        <a href="/stephaniemcneal/people-in-nepal-are-letting-their-loved-ones-know-they-are-s" rel:gt_act="post/thumb" rel:gt_label="user/stephaniemcneal">
+                                            <img nopin="nopin" class="bf_dom" rel:bf_bucket="progload" src="http://s3-static-ak.buzzfed.com/static/2015-04/25/15/campaign_images/webdr07/people-in-nepal-are-letting-their-loved-ones-know-2-22144-1429990512-0_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/25/15/campaign_images/webdr07/people-in-nepal-are-letting-their-loved-ones-know-2-22144-1429990512-0_wide.jpg" alt="">
+                                        </a>
+                                    </div>
+                                    <div class="bf_dom rightPage" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOKBL7&quot;,&quot;u&quot;:&quot;7A6AR37&quot;,&quot;use&quot;:&quot;stephaniemcneal&quot;,&quot;buzz&quot;:&quot;people-in-nepal-are-letting-their-loved-ones-know-they-are-s&quot;,&quot;types&quot;:[],&quot;queries&quot;:[]}">
+                                        <a rel:gt_act="vertical/title" href="/news">
+                                            <span> Next On BuzzFeed News <span class="next_arrow">›</span></span>
+                                        </a>
+                                        <a href="/stephaniemcneal/people-in-nepal-are-letting-their-loved-ones-know-they-are-s" rel:gt_act="post/title" rel:gt_label="user/stephaniemcneal">
+                                            <h3>People In Nepal Are Letting Their Loved Ones Know They...</h3>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <!-- UNIT:Nexton generated on  9:23:23,  4/27/2015 -->
+                    <div id="social-actions" class="section SocialActions social-actions social-actions-hybrid" rel:gt_cat="[ttp]:reactions">
+                        <div class="social-actions-buttons c">
+                            <div id="spinner-sams_react" class="section social-message" style="display:none;">
+                                <span class="spinner-text">Saving...</span>
+                            </div>
+                            <div id="spinner-love_or_hate" class="section social-message" style="display:none;">
+                                <span class="spinner-text">Saving...</span>
+                            </div>
+                            <div id="spinner-badge" class="section social-message" style="display:none;">
+                                <span class="spinner-text">Saving...</span>
+                            </div>
+                            <div id="social_message-rebuzz" class="section social-message" style="display:none;">
+                                <div class="headline-5">Rebuzzed! This post has been added to <a href="/signin">your Feed</a></div>
+                            </div>
+                            <div id="social_message" class="section social-message" style="display:none;">
+                                <div class="headline-5" id="badge-message"><span class="highlight">I know, right?</span> And <a rel:gt_act="feed-teaser/react" href="/badges">there’s more</a> where that came from.</div>
+                            </div>
+                            <div id="social_message-loves" class="section social-message" style="display:none;">
+                                <div class="headline-5"><span class="highlight">Totally!</span> And there’s plenty <a rel:gt_act="feed-teaser/love" href="/badge/most-shared">more to love</a>!</div>
+                            </div>
+                            <div id="social_message-hates" class="section social-message" style="display:none;">
+                                <div class="headline-5"><span class="highlight">Broken hearted?</span> Maybe you’ll like something <a rel:gt_act="feed-teaser/hate" href="/badges">over here</a> instead?</div>
+                            </div>
+                        </div>
+                        <div id="share-reaction-box" style="display:none;" rel:gt_cat="[ttp]:reaction-box">
+                            <div id="share-reaction-content-wrapper" style="display:none;">
+                                <div id="share-reaction-box_title" class="headline-1">I know, right? Will your friends agree?</div>
+                                <div id="fb-promo">Share this Link</div>
+                                <div id="message-wrapper">
+                                    <textarea id="reaction-sharing-message"></textarea>
+                                </div>
+                                <div id="sharing-link-preview">
+                                    <img nopin="nopin" src="http://s3-ak.buzzfeed.com/static/2015-04/22/5/campaign_images/webdr03/student-dies-after-diet-pills-she-bought-online-b-2-28712-1429696299-24_small.jpg">
+                                    <div id="share-link-details">
+                                        <div class="headline-1">Student Dies After Diet Pills She Bought Online "Burned Her Up From Within"</div>
+                                        <span class="link">http://www.buzzfeed.com/markdistefano/diet-pill...</span>
+                                        <span class="blurb">An inquest into Eloise Parry's death has been adjourned until July.</span>
+                                    </div>
+                                </div>
+                                <div id="social-share-box-buttons">
+                                    <input id="reaction-share-submit" value="Share Link" rel:gt_act="share/facebook/share" class="submit button2" type="button">
+                                </div>
+                            </div>
+                            <div id="share-reaction-success-wrapper" style="display:none;">
+                                <div class="success_icon"></div><b>Your link was successfully shared!</b>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="hotOnPinterestWrap"></div>
+                    <div class="normal_reactions">
+                        <aside id="bpage_ad_bottom" class="bf_dom std-posts section c" rel:bf_bucket="gtrack" rel:gt_cat="[ttp]:story-bpage">
+                            <div class="bf-widget post partner-area viral-post  bf_dom gpt" style="display:none;" id="BF_WIDGET_9" rel:bf_ad_position="27">
+                                <div id="bf-item-9-1" class="bf-item">
+                                    <div id="div-gpt-ad-9" style="position:absolute;overflow:hidden;z-index:-1"></div>
+                                    <script type="text/javascript">
+                                    if (AD_DESIGN == 'gpt') {
+                                        loadGPTAd({
+                                            'wid': 9
+                                        });
+                                    }
+                                    </script>
+                                    <div class="thumb-unit">
+                                        <a rel:gt_act="dfp/thumb" data-label="9" href="" class="bf-url"><img nopin="nopin" class="bf-image-big" src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" height="195" width="293"></a>
+                                    </div>
+                                    <div class="pull-left">
+                                        <h2 class="bf-item-title"><a rel:gt_act="dfp/title" href="" class="bf-url bf-name"></a></h2>
+                                        <p class="bf-blurb description"></p>
+                                        <div class="media media-cleared">
+                                            <div class="pull-left">
+                                                <a rel:gt_act="dfp/avatar" href="" class="bf-user-url media__object">
+                                                    <img nopin="nopin" class="bf-user_image_large" src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" height="36" width="36">
+                                                </a>
+                                            </div>
+                                            <div class="media__body">
+                                                <div class="by-line by-line--f-ad cf">
+                                                    <div class="rect pull-left bf-byline_prefix">Promoted by</div>
+                                                </div>
+                                                <div class="type-6 by-line by-line--f-other bf-byline-other">BuzzFeed Staff</div>
+                                                <div class="media__heading">
+                                                    <a rel:gt_act="dfp/username" href="" class="bf-user-url bf-display_name type-5"></a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <script type="text/javascript">
+                            (function() {
+                                var AD = document.getElementById('BF_WIDGET_' + 9) || document.getElementById('BF_IFRAME_' + 9);
+                                if (AB_AD_TEST && AD && AD_DESIGN) {
+                                    AD.className = AD.className + " " + AD_DESIGN;
+                                }
+                            })()
+                            </script>
+                            <script type="text/javascript">
+                            if (AD_DESIGN != 'gpt') {
+
+                                if (!window['win8AdCall']) {
+                                    window['win8AdCall'] = function() { /* do nothing */ };
+                                }
+                                var ad_tag = 'http://ad.doubleclick.net/N6556/adj/' + BF_DFP_SITE + BF_DFP_ZONE + ';wid=9;page=1;sz=5x5;pos=story-bpage;tile=9;' + BF_DFP_KVS + ';' + BF_TAG + win8AdCall() + '';
+                                if (typeof AD_DESIGN != 'undefined') {
+                                    ad_tag += ';abtest=' + AD_DESIGN + ';'
+                                }
+
+                                //Loreal MUC channel
+                                if (window.location.search.match('loreal_feed=1') && BF_STATIC.tt_page === "Buzz") {
+                                    ad_tag += 'loreal_feed=1;'
+                                }
+
+                                ad_tag += 'poe=' + BF_REFERER + ';';
+                                ad_tag += 'ord=' + BF_DFP_ORD + '?';
+
+
+
+                                if (ad_tag) {
+                                    if (!('wid=9;page=1;sz=5x5;pos=story-bpage;tile=9').match(/pos=300x250/) && null !== window.location.search.match("skipdfp")) {
+                                        window.addEventListener('load', function() {
+                                            var query = (typeof String.prototype.toQueryParams != 'undefined') ? window.location.search.toQueryParams() : $.deparam.querystring();
+                                            var ad_user = (query['skipdfp']) ? query['skipdfp'] : 'boost';
+                                            var extra_params = (/bigstory/.test('wid=9;page=1;sz=5x5;pos=story-bpage;tile=9')) ? '&flex_medium=bigstory' : '';
+                                            local_ad_call(9, ad_user, extra_params);
+                                        })
+                                    } else {
+                                        if (!BF_STATIC.bf_test_mode || document.cookie.match('sel2_ad') !== null) {
+                                            document.write('<' + 'scr' + 'ipt type="text/javascr' + 'ipt" src="' + ad_tag + '"><\/scr' + 'ipt' + '>');
+                                        } else {
+                                            console.info('disable DFP (dfp_tags.tt)');
+                                        }
+                                    }
+                                }
+
+                                if (null !== window.location.search.match("adtest") && console !== undefined && typeof ad_tag != "undefined") console.log(ad_tag);
+                            }
+                            </script>
+                        </aside>
+                        <script type="text/javascript">
+                        document.observe('dom:loaded', function() {
+                            if (acl.user_can('general_admin')) $('related-post-tools').removeClassName('hidden');
+                        });
+                        </script>
+                        <div class="bf_dom" rel:bf_bucket="abtest" rel:ab_test="collaborate_more_buzz">
+                            <div id="collaborate" class="hidden">
+                                <section id="related-links" class="related-links-full bckg_img_aaa_png c js_site_unit_more_buzz" rel:gt_cat="[ttp]:related-links" pound_position="4ldqpev">
+                                    <div id="related-post-tools" class="hidden">
+                                        <a id="edit-related-button" rel:bf_bucket_data="{'update-related':{'buzz_id':'3758406'}}" class="bf_dom edit-related" onclick="return false" href="javascript:;">EDIT</a>
+                                    </div>
+                                    <header>
+                                        <div class="headline-2">More Buzz</div>
+                                    </header>
+                                    <ul>
+                                        <li class="related-big js_opt_unit_more_buzz hidden">
+                                            <a rel:gt_act="related-link/thumb" rel:gt_label="editor/sirajdatoo" href="/sirajdatoo/police-arrest-3-students-and-use-cs-spray-during-anti-fees-p" class="related-thumb" track_load="imp_attr_" track_mousedown="click_attr_" rel:buzz_id="3758406" rel:opt_variation="control" rel:fallback="true">
+                                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2014-12/4/5/campaign_images/webdr06/police-arrest-three-students-and-use-cs-spray-dur-2-19155-1417690696-19_big.jpg" alt="">
+                                            </a>
+                                            <span>
+        <a rel:gt_act="related-link/name" rel:gt_label="editor/sirajdatoo" class="related-title" href="/sirajdatoo/police-arrest-3-students-and-use-cs-spray-during-anti-fees-p" track_load="imp_attr_" track_mousedown="click_attr_" rel:buzz_id="3758406" rel:opt_variation="control" rel:fallback="true">Police Arrest Three Students And Use CS Spray During Anti-Fees Protest At Warwick</a>
+        <a rel:gt_act="related-link/remove" rel:gt_label="editor/sirajdatoo" href="javascript:;" class="editor-delete_related_links delete_related_links" onclick="return false;" rel:campaignid="3758406" rel:related_campaignid="3533389" rel:buzz_name="Police%20Arrest%20Three%20Students%20And%20Use%20CS%20Spray%20During%20Anti-Fees%20Protest%20At%20Warwick" style="display:none">×</a>
+      </span>
+                                        </li>
+                                        <li>
+                                            <span><a rel:gt_act="related-link/name" rel:gt_label="editor/richardhjames" href="/richardhjames/durham-student-newspaper-publishes-powerful-front-page-calli" rel:buzz_id="3758406" rel:opt_variation="control" rel:fallback="true">Durham Student Newspaper Publishes Powerful Front Page Calling For Action After Student Drownings</a>
+        <a rel:gt_act="related-link/remove" rel:gt_label="editor/richardhjames" href="javascript:;" class="editor-delete_related_links delete_related_links" onclick="return false;" rel:campaignid="3758406" rel:related_campaignid="3645732" rel:buzz_name="Durham%20Student%20Newspaper%20Publishes%20Powerful%20Front%20Page%20Calling%20For%20Action%20After%20Student%20Drownings" style="display:none">×</a>
+      </span>
+                                        </li>
+                                        <li>
+                                            <span><a rel:gt_act="related-link/name" rel:gt_label="editor/floperry" href="/floperry/university-college-london-closed-an-exhibition-that-displaye" rel:buzz_id="3758406" rel:opt_variation="control" rel:fallback="true">University College London Closed An Exhibition That Displayed Students’ Stories Of Sexual Harrassment</a>
+        <a rel:gt_act="related-link/remove" rel:gt_label="editor/floperry" href="javascript:;" class="editor-delete_related_links delete_related_links" onclick="return false;" rel:campaignid="3758406" rel:related_campaignid="3536836" rel:buzz_name="University%20College%20London%20Closed%20An%20Exhibition%20That%20Displayed%20Students'%20Stories%20Of%20Sexual%20Harrassment" style="display:none">×</a>
+      </span>
+                                        </li>
+                                        <li>
+                                            <span><a rel:gt_act="related-link/name" rel:gt_label="editor/richardhjames" href="/richardhjames/durham-student-lucky-to-be-alive-after-being-rescued-from-ri" rel:buzz_id="3758406" rel:opt_variation="control" rel:fallback="true">Durham Student  Rescued From River “Lucky To Be Alive” Following Deaths Of Three Others</a>
+        <a rel:gt_act="related-link/remove" rel:gt_label="editor/richardhjames" href="javascript:;" class="editor-delete_related_links delete_related_links" onclick="return false;" rel:campaignid="3758406" rel:related_campaignid="3596109" rel:buzz_name="Durham%20Student%20%20Rescued%20From%20River%20%E2%80%9CLucky%20To%20Be%20Alive%E2%80%9D%20Following%20Deaths%20Of%20Three%20Others" style="display:none">×</a>
+      </span>
+                                        </li>
+                                    </ul>
+                                    <span style="display:none;" class="alert_box popup_box update_related">
+    <form class="alert_form" id="related_links_form" method="post">
+      <div class="form_header">
+                <div class="headline-1">Related Links</div>
+        <a class="alert_close_btn bf_dom" rel:bf_bucket="related-cancel">×</a>
+      </div>
+      <div class="form_body">
+                <div class="headline-2">Note: once you save these links, they will no longer update automatically.</div>
+
+        <div class="related_input">1. <input id="related1" class="bf_dom" placeholder="http://www.buzzfeed.com/username/uri" value="http://www.buzzfeed.com/sirajdatoo/police-arrest-3-students-and-use-cs-spray-during-anti-fees-p" name="related1" size="75" type="text"></div>
+
+        <div class="related_input">2. <input id="related2" class="bf_dom" placeholder="http://www.buzzfeed.com/username/uri" value="http://www.buzzfeed.com/richardhjames/durham-student-newspaper-publishes-powerful-front-page-calli" name="related2" size="75" type="text"></div>
+
+        <div class="related_input">3. <input id="related3" class="bf_dom" placeholder="http://www.buzzfeed.com/username/uri" value="http://www.buzzfeed.com/floperry/university-college-london-closed-an-exhibition-that-displaye" name="related3" size="75" type="text"></div>
+
+        <div class="related_input">4. <input id="related4" class="bf_dom" placeholder="http://www.buzzfeed.com/username/uri" value="http://www.buzzfeed.com/richardhjames/durham-student-lucky-to-be-alive-after-being-rescued-from-ri" name="related4" size="75" type="text"></div>
+
+      </div>
+      <div class="form_btns">
+        <span id="save_spinner" style="display: none;">
+          <img nopin="nopin" src="http://s3-ak.buzzfed.com/static/images/public/spinners/big_on_white.gif">
+        </span>
+                                    <a class="button2 smaller bf_dom" rel:bf_bucket_data="{'related-save':{'buzz_id':'3758406'}}" onclick="return false" href="javascript:;">Save Changes</a>
+                                    <a class="button2 smaller grey bf_dom" rel:bf_bucket="related-cancel" onclick="return false" href="javascript:;">Cancel</a>
+                            </div>
+                            </form>
+                            </span>
+                            </section>
+                        </div>
+                        <div id="control" class="">
+                            <section id="related-links" class="related-links-full bckg_img_aaa_png c js_site_unit_more_buzz" rel:gt_cat="[ttp]:related-links" pound_position="4ldqpdu">
+                                <div id="related-post-tools" class="hidden">
+                                    <a id="edit-related-button" rel:bf_bucket_data="{'update-related':{'buzz_id':'3758406'}}" class="bf_dom edit-related" onclick="return false" href="javascript:;">EDIT</a>
+                                </div>
+                                <header>
+                                    <div class="headline-2">More Buzz</div>
+                                </header>
+                                <ul>
+                                    <li class="related-big ">
+                                        <a rel:gt_act="related-link/thumb" rel:gt_label="editor/sirajdatoo" href="/sirajdatoo/police-arrest-3-students-and-use-cs-spray-during-anti-fees-p" class="related-thumb" track_load="imp_attr_" track_mousedown="click_attr_" rel:buzz_id="3758406" rel:opt_variation="control">
+                                            <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2014-12/4/5/campaign_images/webdr06/police-arrest-three-students-and-use-cs-spray-dur-2-19155-1417690696-19_big.jpg" alt="">
+                                        </a>
+                                        <span>
+        <a rel:gt_act="related-link/name" rel:gt_label="editor/sirajdatoo" class="related-title" href="/sirajdatoo/police-arrest-3-students-and-use-cs-spray-during-anti-fees-p" track_load="imp_attr_" track_mousedown="click_attr_" rel:buzz_id="3758406" rel:opt_variation="control">Police Arrest Three Students And Use CS Spray During Anti-Fees Protest At Warwick</a>
+        <a rel:gt_act="related-link/remove" rel:gt_label="editor/sirajdatoo" href="javascript:;" class="editor-delete_related_links delete_related_links" onclick="return false;" rel:campaignid="3758406" rel:related_campaignid="3533389" rel:buzz_name="Police%20Arrest%20Three%20Students%20And%20Use%20CS%20Spray%20During%20Anti-Fees%20Protest%20At%20Warwick" style="display:none">×</a>
+      </span>
+                                    </li>
+                                    <li>
+                                        <span><a rel:gt_act="related-link/name" rel:gt_label="editor/richardhjames" href="/richardhjames/durham-student-newspaper-publishes-powerful-front-page-calli" rel:buzz_id="3758406" rel:opt_variation="control">Durham Student Newspaper Publishes Powerful Front Page Calling For Action After Student Drownings</a>
+        <a rel:gt_act="related-link/remove" rel:gt_label="editor/richardhjames" href="javascript:;" class="editor-delete_related_links delete_related_links" onclick="return false;" rel:campaignid="3758406" rel:related_campaignid="3645732" rel:buzz_name="Durham%20Student%20Newspaper%20Publishes%20Powerful%20Front%20Page%20Calling%20For%20Action%20After%20Student%20Drownings" style="display:none">×</a>
+      </span>
+                                    </li>
+                                    <li>
+                                        <span><a rel:gt_act="related-link/name" rel:gt_label="editor/floperry" href="/floperry/university-college-london-closed-an-exhibition-that-displaye" rel:buzz_id="3758406" rel:opt_variation="control">University College London Closed An Exhibition That Displayed Students’ Stories Of Sexual Harrassment</a>
+        <a rel:gt_act="related-link/remove" rel:gt_label="editor/floperry" href="javascript:;" class="editor-delete_related_links delete_related_links" onclick="return false;" rel:campaignid="3758406" rel:related_campaignid="3536836" rel:buzz_name="University%20College%20London%20Closed%20An%20Exhibition%20That%20Displayed%20Students'%20Stories%20Of%20Sexual%20Harrassment" style="display:none">×</a>
+      </span>
+                                    </li>
+                                    <li>
+                                        <span><a rel:gt_act="related-link/name" rel:gt_label="editor/richardhjames" href="/richardhjames/durham-student-lucky-to-be-alive-after-being-rescued-from-ri" rel:buzz_id="3758406" rel:opt_variation="control">Durham Student  Rescued From River “Lucky To Be Alive” Following Deaths Of Three Others</a>
+        <a rel:gt_act="related-link/remove" rel:gt_label="editor/richardhjames" href="javascript:;" class="editor-delete_related_links delete_related_links" onclick="return false;" rel:campaignid="3758406" rel:related_campaignid="3596109" rel:buzz_name="Durham%20Student%20%20Rescued%20From%20River%20%E2%80%9CLucky%20To%20Be%20Alive%E2%80%9D%20Following%20Deaths%20Of%20Three%20Others" style="display:none">×</a>
+      </span>
+                                    </li>
+                                </ul>
+                                <span style="display:none;" class="alert_box popup_box update_related">
+    <form class="alert_form" id="related_links_form" method="post">
+      <div class="form_header">
+                <div class="headline-1">Related Links</div>
+        <a class="alert_close_btn bf_dom" rel:bf_bucket="related-cancel">×</a>
+      </div>
+      <div class="form_body">
+                <div class="headline-2">Note: once you save these links, they will no longer update automatically.</div>
+
+        <div class="related_input">1. <input id="related1" class="bf_dom" placeholder="http://www.buzzfeed.com/username/uri" value="http://www.buzzfeed.com/sirajdatoo/police-arrest-3-students-and-use-cs-spray-during-anti-fees-p" name="related1" size="75" type="text"></div>
+
+        <div class="related_input">2. <input id="related2" class="bf_dom" placeholder="http://www.buzzfeed.com/username/uri" value="http://www.buzzfeed.com/richardhjames/durham-student-newspaper-publishes-powerful-front-page-calli" name="related2" size="75" type="text"></div>
+
+        <div class="related_input">3. <input id="related3" class="bf_dom" placeholder="http://www.buzzfeed.com/username/uri" value="http://www.buzzfeed.com/floperry/university-college-london-closed-an-exhibition-that-displaye" name="related3" size="75" type="text"></div>
+
+        <div class="related_input">4. <input id="related4" class="bf_dom" placeholder="http://www.buzzfeed.com/username/uri" value="http://www.buzzfeed.com/richardhjames/durham-student-lucky-to-be-alive-after-being-rescued-from-ri" name="related4" size="75" type="text"></div>
+
+      </div>
+      <div class="form_btns">
+        <span id="save_spinner" style="display: none;">
+          <img nopin="nopin" src="http://s3-ak.buzzfed.com/static/images/public/spinners/big_on_white.gif">
+        </span>
+                                <a class="button2 smaller bf_dom" rel:bf_bucket_data="{'related-save':{'buzz_id':'3758406'}}" onclick="return false" href="javascript:;">Save Changes</a>
+                                <a class="button2 smaller grey bf_dom" rel:bf_bucket="related-cancel" onclick="return false" href="javascript:;">Cancel</a>
+                        </div>
+                        </form>
+                        </span>
+                        </section>
+                    </div>
+            </div>
+        </div>
+        <aside class="views-tags">
+            <p>
+                <span class="tags">Tagged:<a rel:gt_act="post/tag" class="tag pub" href="/tag/diet_pills">diet pills</a>, <a rel:gt_act="post/tag" class="tag pub" href="/tag/inquests">inquests</a>, <a rel:gt_act="post/tag" class="tag pub" href="/tag/online_shopping">online shopping</a>, <a rel:gt_act="post/tag" class="tag pub" href="/tag/uk">uk</a>, <a class="tag" href="/badge/viral">viral</a>      </span>
+            </p>
+        </aside>
+        <div id="preFacebookComment" class="bf_dom" rel:bf_bucket_data="{&quot;progLoaderElement&quot;:{},&quot;scrollDifference&quot;:&quot;2000&quot;,&quot;reachElementMark&quot;:&quot;.bottom-share-buttons&quot;,&quot;name&quot;:&quot;fb_comments_control&quot;}">&nbsp;</div>
+        <section class="section hidden" id="fb_comments_control">
+            <header class="header">
+                <div class="headline-1">Facebook Conversations</div>
+            </header>
+            <div class="fb_comments_wrapper">
+                <img nopin="nopin" class="load-spinner" src="http://s3-ak.buzzfeed.com/static/images/public/spinners/big_on_white.gif?v=201504241415">
+            </div>
+        </section>
+        </article>
+    </div>
+    <div class="Column2  ">
+        <div class="featured_section section c dfp_bigstory" rel:gt_cat="[ttp]:bigstory">
+            <div class="bf-widget partner-area  bf_dom gpt bsu_b" style="display:none;" id="BF_WIDGET_13" rel:bf_ad_position="30" rel:bf_bucket="abtest" rel:ab_test="AD_SIDEWIDE_BSU_REDESIGN">
+                <div id="bf-item-13-1" class="bf-item lede lede--stacked">
+                    <div class="partner-sash abtest">Promoted</div>
+                    <div id="div-gpt-ad-13" style="position:absolute;overflow:hidden;z-index:-1"></div>
+                    <script type="text/javascript">
+                    if (AD_DESIGN == 'gpt') {
+                        loadGPTAd({
+                            'wid': 13
+                        });
+                    }
+                    </script>
+                    <a rel:gt_act="dfp/thumb" href="" class="bf-url lede__link">
+                        <div class="lede__media">
+                            <img nopin="nopin" class="flex-wide-thumb bf-image-bigstory media__object" src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" width="300">
+                        </div>
+                    </a>
+                    <h2 class="bf-item-title lede__title">
+      <a rel:gt_act="dfp/title" href="" class="bf-url bf-name lede__link"></a>
+    </h2>
+                    <p class="bf-blurb description" rel:bf_truncate="120"></p>
+                    <div class="media">
+                        <div class="pull-left">
+                            <a rel:gt_act="dfp/avatar" href="" class="bf-user-url media__object pull-left">
+                                <img nopin="nopin" class="bf-user_image_large media__object" src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" height="35" width="35">
+                            </a>
+                        </div>
+                        <div class="media__body">
+                            <div class="by-line by-line--f-ad cf">
+                                <div class="rect pull-left promoted-label bf-byline_prefix">Promoted by</div>
+                            </div>
+                            <div class="type-6 by-line by-line--f-other bf-byline-other">BuzzFeed Staff</div>
+                            <div class="media__heading">
+                                <a rel:gt_act="dfp/username" href="" class="bf-user-url bf-display_name type-5 byline__author"></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <script type="text/javascript">
+            (function() {
+                var AD = document.getElementById('BF_WIDGET_' + 13) || document.getElementById('BF_IFRAME_' + 13);
+                if (AB_AD_TEST && AD && AD_DESIGN) {
+                    AD.className = AD.className + " " + AD_DESIGN;
+                }
+            })()
+            </script>
+            <script type="text/javascript">
+            if (AD_DESIGN != 'gpt') {
+
+                if (!window['win8AdCall']) {
+                    window['win8AdCall'] = function() { /* do nothing */ };
+                }
+                var ad_tag = 'http://ad.doubleclick.net/N6556/adj/' + BF_DFP_SITE + BF_DFP_ZONE + ';wid=13;page=1;sz=300x250;pos=bigstorybpage;tile=13;flex_medium=bigstory;' + BF_DFP_KVS + ';' + BF_TAG + win8AdCall() + '';
+                if (typeof AD_DESIGN != 'undefined') {
+                    ad_tag += ';abtest=' + AD_DESIGN + ';'
+                }
+
+                //Loreal MUC channel
+                if (window.location.search.match('loreal_feed=1') && BF_STATIC.tt_page === "Buzz") {
+                    ad_tag += 'loreal_feed=1;'
+                }
+
+                ad_tag += 'poe=' + BF_REFERER + ';';
+                ad_tag += 'ord=' + BF_DFP_ORD + '?';
+
+
+
+                if (ad_tag) {
+                    if (!('wid=13;page=1;sz=300x250;pos=bigstorybpage;tile=13;flex_medium=bigstory').match(/pos=300x250/) && null !== window.location.search.match("skipdfp")) {
+                        window.addEventListener('load', function() {
+                            var query = (typeof String.prototype.toQueryParams != 'undefined') ? window.location.search.toQueryParams() : $.deparam.querystring();
+                            var ad_user = (query['skipdfp']) ? query['skipdfp'] : 'boost';
+                            var extra_params = (/bigstory/.test('wid=13;page=1;sz=300x250;pos=bigstorybpage;tile=13;flex_medium=bigstory')) ? '&flex_medium=bigstory' : '';
+                            local_ad_call(13, ad_user, extra_params);
+                        })
+                    } else {
+                        if (!BF_STATIC.bf_test_mode || document.cookie.match('sel2_ad') !== null) {
+                            document.write('<' + 'scr' + 'ipt type="text/javascr' + 'ipt" src="' + ad_tag + '"><\/scr' + 'ipt' + '>');
+                        } else {
+                            console.info('disable DFP (dfp_tags.tt)');
+                        }
+                    }
+                }
+
+                if (null !== window.location.search.match("adtest") && console !== undefined && typeof ad_tag != "undefined") console.log(ad_tag);
+            }
+            </script>
+        </div>
+        <!-- \dfp_bigstory -->
+        <!-- X---IN-DEPTH---X -@- /plugin/indepth/v:1.0 -->
+        <div class="indepth-module bf_dom" rel:bf_bucket_data="{'indepth_buzz':{'indepth_buzz_id':3755831}}">
+            <div class="indepth-module__logo-wrap">
+                <a href="/news" class="indepth-module__logo-wrap__logo-image" rel:gt_act="indepth-module:buzzfeed-news-logo"></a>
+            </div>
+            <a class="indepth-module__thumbnail" href="/ellievhall/gone-girl-an-interview-with-an-american-in-isis" rel:gt_label="3755831" rel:gt_act="indepth-module:image"><img nopin="nopin" src="http://s3-ak.buzzfeed.com/static/2015-04/22/14/campaign_images/webdr15/gone-girl-an-interview-with-an-american-in-isis-2-4632-1429727152-8_wide.jpg" height="118" width="336"></a>
+            <div class="indepth-module__text">
+                <a class="indepth-module__title" href="/ellievhall/gone-girl-an-interview-with-an-american-in-isis" rel:gt_label="3755831" rel:gt_act="indepth-module:title">Gone Girl: An Interview With An American In ISIS</a>
+                <p class="indepth-module__subtitle">
+                    by <a href="/ellievhall" rel:gt_act="indepth-module:author">Ellie Hall</a>
+                </p>
+            </div>
+        </div>
+        <!-- UNIT:Indepth generated on  9:20:20,  4/27/2015 -->
+        <!-- \in_depth -->
+        <div class="vertical-sidebar-info">
+            <div class="connect-widget connect-widget--uknews">
+                <h4 class="connect-widget__title">
+    <span>
+      Connect With
+
+      <svg viewBox="0 0 847 151" class="connect-widget__svg-logo">
+        <use xlink:href="#logo"></use>
+      </svg>
+
+
+      News
+
+    </span>
+  </h4>
+                <a href="http://www.facebook.com/BuzzFeedUKNews" class="connect-widget__button btn--facebook" rel:gt_act="share/facebook/like">
+                    <svg viewBox="0 0 512 512" class="connect-widget__btn-svg">
+                        <use xlink:href="#facebook"></use>
+                    </svg>
+                    Like Us On Facebook
+                </a>
+                <a href="http://www.twitter.com/BuzzFeedUK" class="connect-widget__button btn--twitter" rel:gt_act="share/twitter/follow">
+                    <svg viewBox="0 0 512 512" class="connect-widget__btn-svg">
+                        <use xlink:href="#tweet"></use>
+                    </svg>
+                    Follow Us On Twitter
+                </a>
+            </div>
+        </div>
+        <!-- /.vertical-sidebar-info -->
+        <!-- \sidebar_info -->
+        <!-- X---MORE-NEWS---X -@- /plugin/morenews/v:1.0 -->
+        <div class="section block bf_dom   js-rightcol--control" rel:bf_bucket="abtest" rel:ab_test="bpage_sticking_rightcol" rel:gt_cat="[ttp]:sidebar/more-news" pound_position="4ldqpjb">
+            <div class="vertical-info-banner">
+                <span class="text">More News</span>
+                <div class="notch"></div>
+            </div>
+            <div class="content">
+                <ul>
+                    <script type="text/javascript">
+                    var imp_attr_3763538_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3763538_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  top bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FONSF7&quot;,&quot;u&quot;:&quot;71GVND7&quot;,&quot;buzz&quot;:&quot;family-friends-mourn-freddie-gray-at-wake-one-night-after-ch&quot;,&quot;user&quot;:&quot;mbvd&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-family-friends-mourn-freddie-gray-at-wake-one-night-after-ch">
+                        <a href="/mbvd/family-friends-mourn-freddie-gray-at-wake-one-night-after-ch" rel:gt_act="buzzing/thumb" rel:buzz_id="3763538">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/5/campaign_images/webdr01/family-friends-mourn-freddie-gray-at-wake-one-nig-2-15357-1430127651-1_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/5/campaign_images/webdr01/family-friends-mourn-freddie-gray-at-wake-one-nig-2-15357-1430127651-1_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3763538&quot;}"></a>
+                        <h2><a href="/mbvd/family-friends-mourn-freddie-gray-at-wake-one-night-after-ch" rel:gt_act="buzzing/title" rel:buzz_id="3763538">Family, Friends Mourn Freddie Gray At Wake One Night After Chaotic Protests</a></h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3762718_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3762718_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOJCZ7&quot;,&quot;u&quot;:&quot;7BEY927&quot;,&quot;buzz&quot;:&quot;nepal-shaken-up-by-major-earthquake&quot;,&quot;user&quot;:&quot;felipearaujo&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-nepal-shaken-up-by-major-earthquake">
+                        <a href="/felipearaujo/nepal-shaken-up-by-major-earthquake" rel:gt_act="buzzing/thumb" rel:buzz_id="3762718">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/8/campaign_images/webdr02/death-toll-in-nepal-rises-to-3600-2-8835-1430139002-18_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/8/campaign_images/webdr02/death-toll-in-nepal-rises-to-3600-2-8835-1430139002-18_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3762718&quot;}"></a>
+                        <h2><a href="/felipearaujo/nepal-shaken-up-by-major-earthquake" rel:gt_act="buzzing/title" rel:buzz_id="3762718">Death Toll In Nepal Rises To 3,600</a></h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3763853_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3763853_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOPHO7&quot;,&quot;u&quot;:&quot;71V1G7&quot;,&quot;buzz&quot;:&quot;tsarnaev-to-launch-defense-against-death-penalty&quot;,&quot;user&quot;:&quot;mikehayes&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-tsarnaev-to-launch-defense-against-death-penalty">
+                        <a href="/mikehayes/tsarnaev-to-launch-defense-against-death-penalty" rel:gt_act="buzzing/thumb" rel:buzz_id="3763853">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/9/campaign_images/webdr04/tsarnaev-to-launch-defense-against-death-penalty-2-8928-1430139758-25_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/9/campaign_images/webdr04/tsarnaev-to-launch-defense-against-death-penalty-2-8928-1430139758-25_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3763853&quot;}"></a>
+                        <h2><a href="/mikehayes/tsarnaev-to-launch-defense-against-death-penalty" rel:gt_act="buzzing/title" rel:buzz_id="3763853">Tsarnaev To Launch Defense Against Death Penalty</a></h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3763894_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3763894_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOPPN7&quot;,&quot;u&quot;:&quot;7793T17&quot;,&quot;buzz&quot;:&quot;ultra-patriotic-russian-biker-gang-refused-entry-to-poland&quot;,&quot;user&quot;:&quot;franciswhittaker&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-ultra-patriotic-russian-biker-gang-refused-entry-to-poland">
+                        <a href="/franciswhittaker/ultra-patriotic-russian-biker-gang-refused-entry-to-poland" rel:gt_act="buzzing/thumb" rel:buzz_id="3763894">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/9/campaign_images/webdr05/ultra-patriotic-russian-biker-gang-refused-entry--2-17023-1430140685-30_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/9/campaign_images/webdr05/ultra-patriotic-russian-biker-gang-refused-entry--2-17023-1430140685-30_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3763894&quot;}"></a>
+                        <h2><a href="/franciswhittaker/ultra-patriotic-russian-biker-gang-refused-entry-to-poland" rel:gt_act="buzzing/title" rel:buzz_id="3763894">Ultra-Patriotic Russian Biker Gang Refused Entry To Poland</a></h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3763883_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3763883_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOPNI7&quot;,&quot;u&quot;:&quot;7843DL7&quot;,&quot;buzz&quot;:&quot;swastikas-painted-on-sae-fraternity-house-at-stanford-univer&quot;,&quot;user&quot;:&quot;maryanngeorgantopoulos&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-swastikas-painted-on-sae-fraternity-house-at-stanford-univer">
+                        <a href="/maryanngeorgantopoulos/swastikas-painted-on-sae-fraternity-house-at-stanford-univer" rel:gt_act="buzzing/thumb" rel:buzz_id="3763883">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/8/campaign_images/webdr06/swastikas-painted-on-sae-fraternity-house-at-stan-2-29351-1430137347-1_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/8/campaign_images/webdr06/swastikas-painted-on-sae-fraternity-house-at-stan-2-29351-1430137347-1_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3763883&quot;}"></a>
+                        <h2><a href="/maryanngeorgantopoulos/swastikas-painted-on-sae-fraternity-house-at-stanford-univer" rel:gt_act="buzzing/title" rel:buzz_id="3763883">Swastikas Painted On SAE Fraternity House At Stanford University</a></h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3763873_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3763873_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOPLK7&quot;,&quot;u&quot;:&quot;7C3FH97&quot;,&quot;buzz&quot;:&quot;andrew-chan-marries-partner-a-day-before-execution&quot;,&quot;user&quot;:&quot;robstott&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-andrew-chan-marries-partner-a-day-before-execution">
+                        <a href="/robstott/andrew-chan-marries-partner-a-day-before-execution" rel:gt_act="buzzing/thumb" rel:buzz_id="3763873">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/8/campaign_images/webdr07/andrew-chan-marries-partner-a-day-before-execution-2-26101-1430136567-7_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/8/campaign_images/webdr07/andrew-chan-marries-partner-a-day-before-execution-2-26101-1430136567-7_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3763873&quot;}"></a>
+                        <h2><a href="/robstott/andrew-chan-marries-partner-a-day-before-execution" rel:gt_act="buzzing/title" rel:buzz_id="3763873">Andrew Chan Marries Partner A Day Before Execution</a></h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3763406_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3763406_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FON2R7&quot;,&quot;u&quot;:&quot;71BDXX7&quot;,&quot;buzz&quot;:&quot;supreme-courts-simple-marriage-case-questions-lead-to-comple&quot;,&quot;user&quot;:&quot;chrisgeidner&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-supreme-courts-simple-marriage-case-questions-lead-to-comple">
+                        <a href="/chrisgeidner/supreme-courts-simple-marriage-case-questions-lead-to-comple" rel:gt_act="buzzing/thumb" rel:buzz_id="3763406">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/1/campaign_images/webdr08/supreme-courts-simple-marriage-case-questions-lea-2-3565-1430112279-6_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/1/campaign_images/webdr08/supreme-courts-simple-marriage-case-questions-lea-2-3565-1430112279-6_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3763406&quot;}"></a>
+                        <h2><a href="/chrisgeidner/supreme-courts-simple-marriage-case-questions-lead-to-comple" rel:gt_act="buzzing/title" rel:buzz_id="3763406">Supreme Court’s Simple Marriage Case Questions Lead To Complex Arguments</a></h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3739824_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3739824_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FL3PD7&quot;,&quot;u&quot;:&quot;7YLFS7&quot;,&quot;buzz&quot;:&quot;the-south-carolina-audition-to-be-hillary-clintons-most-seri&quot;,&quot;user&quot;:&quot;rubycramer&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-the-south-carolina-audition-to-be-hillary-clintons-most-seri">
+                        <a href="/rubycramer/the-south-carolina-audition-to-be-hillary-clintons-most-seri" rel:gt_act="buzzing/thumb" rel:buzz_id="3739824">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/26/22/campaign_images/webdr06/the-south-carolina-audition-to-be-hillary-clinton-2-11926-1430100389-5_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/26/22/campaign_images/webdr06/the-south-carolina-audition-to-be-hillary-clinton-2-11926-1430100389-5_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3739824&quot;}"></a>
+                        <h2><a href="/rubycramer/the-south-carolina-audition-to-be-hillary-clintons-most-seri" rel:gt_act="buzzing/title" rel:buzz_id="3739824">The South Carolina Audition To Be Hillary Clinton’s Most Serious Challenger</a></h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3762507_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3762507_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+
+                    var promotions = [{
+                        "width": "125",
+                        "extra_fields": {
+                            "small": {
+                                "width": 870,
+                                "left": 0,
+                                "top": 0,
+                                "height": "578"
+                            },
+                            "big": {
+                                "width": 870,
+                                "left": 119.518072289157,
+                                "top": 0,
+                                "height": 578
+                            },
+                            "wide": {
+                                "width": 870,
+                                "left": 119.518072289157,
+                                "top": 192,
+                                "height": 306
+                            }
+                        },
+                        "image_dblwide": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_dblwide.jpg",
+                        "clicks": null,
+                        "dud": "0",
+                        "added": "2015-04-27 09:08:40",
+                        "campaign_id": "3762507",
+                        "rate": 0,
+                        "impressions": null,
+                        "image_id": "175776",
+                        "original_image_width": "990",
+                        "promoter": "2666258",
+                        "updated": null,
+                        "id": "269482",
+                        "image_dblbig": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_dblbig.jpg",
+                        "is_default": "0",
+                        "promotion_image_id": "175776",
+                        "sub_buzz_id": "0",
+                        "image_big": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_big.jpg",
+                        "probability": 0.25,
+                        "active": "1",
+                        "original_image_height": "578",
+                        "height": "83",
+                        "description": "<b>In my secular life, I'm a marathoner and stand-up comic.</b> In the eyes of the church, I'm a charity case.",
+                        "image": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12.jpg",
+                        "old": "0",
+                        "promotion_medium_id": "1",
+                        "flexpro_recipients": "",
+                        "title": "Rejecting Motherhood As A Mormon Woman",
+                        "image_wide": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_wide.jpg",
+                        "original_image": "/static/2015-04/25/20/enhanced/webdr13/original-25550-1430009073-11.jpg"
+                    }, {
+                        "width": "125",
+                        "extra_fields": {
+                            "small": {
+                                "width": 870,
+                                "left": 0,
+                                "top": 0,
+                                "height": "578"
+                            },
+                            "big": {
+                                "width": 870,
+                                "left": 119.518072289157,
+                                "top": 0,
+                                "height": 578
+                            },
+                            "wide": {
+                                "width": 870,
+                                "left": 119.518072289157,
+                                "top": 192,
+                                "height": 306
+                            }
+                        },
+                        "image_dblwide": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_dblwide.jpg",
+                        "clicks": null,
+                        "dud": "0",
+                        "added": "2015-04-27 09:08:43",
+                        "campaign_id": "3762507",
+                        "rate": 0,
+                        "impressions": null,
+                        "image_id": "175776",
+                        "original_image_width": "990",
+                        "promoter": "2666258",
+                        "updated": null,
+                        "id": "269485",
+                        "image_dblbig": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_dblbig.jpg",
+                        "is_default": "0",
+                        "promotion_image_id": "175776",
+                        "sub_buzz_id": "0",
+                        "image_big": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_big.jpg",
+                        "probability": 0.25,
+                        "active": "1",
+                        "original_image_height": "578",
+                        "height": "83",
+                        "description": "<b>In my secular life, I'm a marathoner and stand-up comic.</b> In the eyes of the church, I'm a charity case.",
+                        "image": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12.jpg",
+                        "old": "0",
+                        "promotion_medium_id": "1",
+                        "flexpro_recipients": "",
+                        "title": "Mormon, Childless, And Constantly Condescended To",
+                        "image_wide": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_wide.jpg",
+                        "original_image": "/static/2015-04/25/20/enhanced/webdr13/original-25550-1430009073-11.jpg"
+                    }, {
+                        "width": "125",
+                        "extra_fields": {
+                            "small": {
+                                "width": 870,
+                                "left": 0,
+                                "top": 0,
+                                "height": "578"
+                            },
+                            "big": {
+                                "width": 870,
+                                "left": 119.518072289157,
+                                "top": 0,
+                                "height": 578
+                            },
+                            "wide": {
+                                "width": 870,
+                                "left": 119.518072289157,
+                                "top": 192,
+                                "height": 306
+                            }
+                        },
+                        "image_dblwide": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_dblwide.jpg",
+                        "clicks": null,
+                        "dud": "0",
+                        "added": "2015-04-27 09:08:43",
+                        "campaign_id": "3762507",
+                        "rate": 0,
+                        "impressions": null,
+                        "image_id": "175776",
+                        "original_image_width": "990",
+                        "promoter": "2666258",
+                        "updated": null,
+                        "id": "269484",
+                        "image_dblbig": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_dblbig.jpg",
+                        "is_default": "0",
+                        "promotion_image_id": "175776",
+                        "sub_buzz_id": "0",
+                        "image_big": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_big.jpg",
+                        "probability": 0.25,
+                        "active": "1",
+                        "original_image_height": "578",
+                        "height": "83",
+                        "description": "<b>In my secular life, I'm a marathoner and stand-up comic.</b> In the eyes of the church, I'm a charity case.",
+                        "image": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12.jpg",
+                        "old": "0",
+                        "promotion_medium_id": "1",
+                        "flexpro_recipients": "",
+                        "title": "Mormon And Childless By Choice",
+                        "image_wide": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_wide.jpg",
+                        "original_image": "/static/2015-04/25/20/enhanced/webdr13/original-25550-1430009073-11.jpg"
+                    }, {
+                        "width": "125",
+                        "extra_fields": {
+                            "small": {
+                                "width": 870,
+                                "left": 0,
+                                "top": 0,
+                                "height": "578"
+                            },
+                            "big": {
+                                "width": 870,
+                                "left": 119.518072289157,
+                                "top": 0,
+                                "height": 578
+                            },
+                            "wide": {
+                                "width": 870,
+                                "left": 119.518072289157,
+                                "top": 192,
+                                "height": 306
+                            }
+                        },
+                        "image_dblwide": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140122-14_dblwide.jpg",
+                        "clicks": null,
+                        "dud": "0",
+                        "added": "2015-04-27 09:08:43",
+                        "campaign_id": "3762507",
+                        "rate": 0,
+                        "impressions": null,
+                        "image_id": "175777",
+                        "original_image_width": "990",
+                        "promoter": "2666258",
+                        "updated": null,
+                        "id": "269483",
+                        "image_dblbig": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140122-14_dblbig.jpg",
+                        "is_default": "0",
+                        "promotion_image_id": "175777",
+                        "sub_buzz_id": "0",
+                        "image_big": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140122-14_big.jpg",
+                        "probability": 0.25,
+                        "active": "1",
+                        "original_image_height": "578",
+                        "height": "83",
+                        "description": "<b>In my secular life, I'm a marathoner and stand-up comic.</b> In the eyes of the church, I'm a charity case.",
+                        "image": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140122-14.jpg",
+                        "old": "0",
+                        "promotion_medium_id": "1",
+                        "flexpro_recipients": "",
+                        "title": "I'm Mormon But I Don't Want Children. Really.",
+                        "image_wide": "/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140122-14_wide.jpg",
+                        "original_image": "/static/2015-04/25/20/enhanced/webdr13/original-25550-1430009073-11.jpg"
+                    }];
+                    var opts = [];
+                    for (var i = 0; i < promotions.length; i++)
+                        for (var j = 0; j < (promotions[i].probability * 100); j++) opts.push(promotions[i]);
+                    var sel_promo = opts[Math.floor(Math.random() * opts.length)];
+                    imp_attr_3762507_13.FLEX_PRO_IMP = sel_promo.id;
+                    click_attr_3762507_13.FLEX_PRO_CLICK = sel_promo.id;
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOI7Y7&quot;,&quot;u&quot;:&quot;7C8UNP7&quot;,&quot;buzz&quot;:&quot;mormon-childless-and-constantly-condescended-to&quot;,&quot;user&quot;:&quot;jenniferpurdie&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-mormon-childless-and-constantly-condescended-to">
+                        <script type="text/javascript">
+                        document.write('\
+                <a href="/jenniferpurdie/mormon-childless-and-constantly-condescended-to" rel:gt_act="buzzing/thumb" rel:buzz_id="3762507">\
+                  <div style="float:left; position:relative;">\
+                    <img src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" rel:bf_image_src="http://s3-ak.buzzfeed.com' + sel_promo.image_wide + '" class="bf_dom thumb" rel:bf_bucket="progload" alt="" />\
+                    \
+                  </div>\
+                </a>\
+                <a class="qe editor-admin" style="display:none"  rel:data=\'{"buzz_id":"3762507"}\'></a>\
+                <h2>\
+                  <a href="/jenniferpurdie/mormon-childless-and-constantly-condescended-to" rel:gt_act="buzzing/title">' + sel_promo.title + '</a>\
+                </h2>\
+                ');
+                        </script>
+                        <a href="/jenniferpurdie/mormon-childless-and-constantly-condescended-to" rel:gt_act="buzzing/thumb" rel:buzz_id="3762507">
+                            <div style="float:left; position:relative;"> <img nopin="nopin" src="http://s3-ak.buzzfeed.com/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_wide.jpg" rel:bf_image_src="http://s3-ak.buzzfeed.com/static/2015-04/27/9/campaign_images/webdr02/mormon-childless-and-constantly-condescended-to-2-8804-1430140118-12_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt=""> </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3762507&quot;}"></a>
+                        <h2>                  <a href="/jenniferpurdie/mormon-childless-and-constantly-condescended-to" rel:gt_act="buzzing/title">Rejecting Motherhood As A Mormon Woman</a>               </h2>
+                    </li>
+                    <script type="text/javascript">
+                    var imp_attr_3763007_13 = {
+                        "PROMO_IMPRESSION": "13"
+                    };
+                    var click_attr_3763007_13 = {
+                        "PROMO_CLICK": "13"
+                    };
+                    </script>
+                    <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOKX67&quot;,&quot;u&quot;:&quot;766OVA7&quot;,&quot;buzz&quot;:&quot;windows-broken-scuffles-break-out-at-baltimore-protests&quot;,&quot;user&quot;:&quot;jimdalrympleii&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-windows-broken-scuffles-break-out-at-baltimore-protests">
+                        <a href="/jimdalrympleii/windows-broken-scuffles-break-out-at-baltimore-protests" rel:gt_act="buzzing/thumb" rel:buzz_id="3763007">
+                            <div style="float:left; position:relative;">
+                                <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/26/20/campaign_images/webdr11/35-arrested-after-windows-are-broken-and-clashes--2-10900-1430094476-14_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/26/20/campaign_images/webdr11/35-arrested-after-windows-are-broken-and-clashes--2-10900-1430094476-14_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                            </div>
+                        </a>
+                        <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3763007&quot;}"></a>
+                        <h2><a href="/jimdalrympleii/windows-broken-scuffles-break-out-at-baltimore-protests" rel:gt_act="buzzing/title" rel:buzz_id="3763007">35 Arrested After Windows Are Broken And Clashes Break Out At Baltimore Protests</a></h2>
+                    </li>
+                </ul>
+            </div>
+            <div class="footer" style="margin-bottom: 35px;">
+                <a class="button2" rel:gt_act="morenews/more-buzz" href="/news">More News ›</a>
+            </div>
+            <script type="text/javascript">
+            var promoted_switch = function() {
+                if (typeof(promoted_match) != 'undefined' && $(promoted_match)) {
+                    $(promoted_match).hide();
+                    $('promoted-extra-hidden').show();
+                }
+            }
+            promoted_switch();
+            </script>
+        </div>
+        <!-- UNIT:Morenews generated on  9:22:22,  4/27/2015 -->
+        <!-- \morenews -->
+        <div>
+            <!-- X---NOW-BUZZING---X -@- /plugin/nowbuzzing/v:1.0 -->
+            <div class="section block bf_dom fr  js-rightcol--control" rel:bf_bucket="abtest" rel:ab_test="bpage_sticking_rightcol" rel:gt_cat="[ttp]:sidebar/now-buzzing" pound_position="4ldqpjc">
+                <div class="vertical-info-banner">
+                    <span class="text">Le buzz du moment</span>
+                    <div class="notch"></div>
+                </div>
+                <div class="content">
+                    <ul>
+                        <script type="text/javascript">
+                        var imp_attr_3763815_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3763815_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  top bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOPAA7&quot;,&quot;u&quot;:&quot;7CBJA47&quot;,&quot;buzz&quot;:&quot;le-nepal-avant-et-apres-le-dramatique-seisme-de-ce-week-end&quot;,&quot;user&quot;:&quot;adriensenecat&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-le-nepal-avant-et-apres-le-dramatique-seisme-de-ce-week-end">
+                            <a href="/adriensenecat/le-nepal-avant-et-apres-le-dramatique-seisme-de-ce-week-end" rel:gt_act="buzzing/thumb" rel:buzz_id="3763815">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/27/6/campaign_images/webdr12/le-nepal-avant-et-apres-le-dramatique-seisme-de-c-2-18873-1430131833-3_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/27/6/campaign_images/webdr12/le-nepal-avant-et-apres-le-dramatique-seisme-de-c-2-18873-1430131833-3_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3763815&quot;}"></a>
+                            <h2><a href="/adriensenecat/le-nepal-avant-et-apres-le-dramatique-seisme-de-ce-week-end" rel:gt_act="buzzing/title" rel:buzz_id="3763815">Le Népal avant et après le dramatique séisme de ce week-end</a></h2>
+                        </li>
+                        <script type="text/javascript">
+                        var imp_attr_3754380_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3754380_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FNABP7&quot;,&quot;u&quot;:&quot;7AQFKR7&quot;,&quot;buzz&quot;:&quot;les-relations-au-debut-et-apres-deux-ans&quot;,&quot;user&quot;:&quot;remeepatel&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-les-relations-au-debut-et-apres-deux-ans">
+                            <a href="/remeepatel/les-relations-au-debut-et-apres-deux-ans" rel:gt_act="buzzing/thumb" rel:buzz_id="3754380">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/16/10/campaign_images/webdr03/les-relations-au-debut-vs-apres-deux-ans-2-12797-1429193278-36_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/16/10/campaign_images/webdr03/les-relations-au-debut-vs-apres-deux-ans-2-12797-1429193278-36_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3754380&quot;}"></a>
+                            <h2><a href="/remeepatel/les-relations-au-debut-et-apres-deux-ans" rel:gt_act="buzzing/title" rel:buzz_id="3754380">Les relations au début VS après deux ans</a></h2>
+                        </li>
+                        <script type="text/javascript">
+                        var imp_attr_3752639_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3752639_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FN0X67&quot;,&quot;u&quot;:&quot;79OCLI7&quot;,&quot;buzz&quot;:&quot;13-photos-impressionnantes-de-femmes-qui-accouchent-a-la-mai&quot;,&quot;user&quot;:&quot;agustinacaferri&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-13-photos-impressionnantes-de-femmes-qui-accouchent-a-la-mai">
+                            <a href="/agustinacaferri/13-photos-impressionnantes-de-femmes-qui-accouchent-a-la-mai" rel:gt_act="buzzing/thumb" rel:buzz_id="3752639">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/15/6/campaign_images/webdr14/13-photos-impressionnantes-de-femmes-qui-accouche-2-2246-1429095089-16_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/15/6/campaign_images/webdr14/13-photos-impressionnantes-de-femmes-qui-accouche-2-2246-1429095089-16_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3752639&quot;}"></a>
+                            <h2><a href="/agustinacaferri/13-photos-impressionnantes-de-femmes-qui-accouchent-a-la-mai" rel:gt_act="buzzing/title" rel:buzz_id="3752639">13 photos impressionnantes de femmes qui accouchent à domicile au Brésil</a></h2>
+                        </li>
+                        <li class="bf-widget post sidebar-post  bf_dom lede--stacked gpt" style="display:none;" id="BF_WIDGET_6" rel:bf_ad_position="6">
+                            <div id="bf-item-6-1" class="bf-item lede">
+                                <div class="partner-sash">Sponsorisé</div>
+                                <div id="div-gpt-ad-6" style="position:absolute;overflow:hidden;z-index:-1"></div>
+                                <script type="text/javascript">
+                                if (AD_DESIGN == 'gpt' && !BF_STATIC.buzz_wide) {
+                                    loadGPTAd({
+                                        'wid': 6,
+                                        'sidebar': 1
+                                    });
+                                }
+                                </script>
+                                <a rel:gt_act="dfp/thumb" rel:gt_label="partner" href="" class="bf-url lede__media" rel:gtrack_id="dfp_ad"><img nopin="nopin" class="bf-image-widestory" src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" height="119" width="338"></a>
+                                <h2 class="bf-item-title lede__title"><a href="" class="bf-url bf-name lede__link" rel:gtrack_id="dfp_ad" rel:bf_truncate="100" rel:gt_act="dfp/title" rel:gt_label="partner"></a></h2>
+                            </div>
+                        </li>
+                        <script type="text/javascript">
+                        (function() {
+                            var AD = document.getElementById('BF_WIDGET_' + 6) || document.getElementById('BF_IFRAME_' + 6);
+                            if (AB_AD_TEST && AD && AD_DESIGN) {
+                                AD.className = AD.className + " " + AD_DESIGN;
+                            }
+                        })()
+                        </script>
+                        <script type="text/javascript">
+                        if (AD_DESIGN != 'gpt') {
+
+                            if (!window['win8AdCall']) {
+                                window['win8AdCall'] = function() { /* do nothing */ };
+                            }
+                            var ad_tag = 'http://ad.doubleclick.net/N6556/adj/' + BF_DFP_SITE + BF_DFP_ZONE + ';wid=6;posnum=2;sz=3x3;pos=sidebar;tile=6;' + BF_DFP_KVS + ';' + BF_TAG + win8AdCall() + '';
+                            if (typeof AD_DESIGN != 'undefined') {
+                                ad_tag += ';abtest=' + AD_DESIGN + ';'
+                            }
+
+                            //Loreal MUC channel
+                            if (window.location.search.match('loreal_feed=1') && BF_STATIC.tt_page === "Buzz") {
+                                ad_tag += 'loreal_feed=1;'
+                            }
+
+                            ad_tag += 'poe=' + BF_REFERER + ';';
+                            ad_tag += 'ord=' + BF_DFP_ORD + '?';
+
+                            ad_tag += ';large_images=1?';
+
+                            if (ad_tag) {
+                                if (!('wid=6;posnum=2;sz=3x3;pos=sidebar;tile=6').match(/pos=300x250/) && null !== window.location.search.match("skipdfp")) {
+                                    window.addEventListener('load', function() {
+                                        var query = (typeof String.prototype.toQueryParams != 'undefined') ? window.location.search.toQueryParams() : $.deparam.querystring();
+                                        var ad_user = (query['skipdfp']) ? query['skipdfp'] : 'boost';
+                                        var extra_params = (/bigstory/.test('wid=6;posnum=2;sz=3x3;pos=sidebar;tile=6')) ? '&flex_medium=bigstory' : '';
+                                        local_ad_call(6, ad_user, extra_params);
+                                    })
+                                } else {
+                                    if (!BF_STATIC.bf_test_mode || document.cookie.match('sel2_ad') !== null) {
+                                        document.write('<' + 'scr' + 'ipt type="text/javascr' + 'ipt" src="' + ad_tag + '"><\/scr' + 'ipt' + '>');
+                                    } else {
+                                        console.info('disable DFP (dfp_tags.tt)');
+                                    }
+                                }
+                            }
+
+                            if (null !== window.location.search.match("adtest") && console !== undefined && typeof ad_tag != "undefined") console.log(ad_tag);
+                        }
+                        </script>
+                        <script type="text/javascript">
+                        var imp_attr_3749666_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3749666_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FMKV37&quot;,&quot;u&quot;:&quot;76NMVN7&quot;,&quot;buzz&quot;:&quot;14-choses-les-plus-sadiques-imposees-aux-sims&quot;,&quot;user&quot;:&quot;jamiejones&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-14-choses-les-plus-sadiques-imposees-aux-sims">
+                            <a href="/jamiejones/14-choses-les-plus-sadiques-imposees-aux-sims" rel:gt_act="buzzing/thumb" rel:buzz_id="3749666">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/14/10/campaign_images/webdr13/les-14-choses-les-plus-sadiques-quon-ait-pu-infli-2-14077-1429021136-14_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/14/10/campaign_images/webdr13/les-14-choses-les-plus-sadiques-quon-ait-pu-infli-2-14077-1429021136-14_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3749666&quot;}"></a>
+                            <h2><a href="/jamiejones/14-choses-les-plus-sadiques-imposees-aux-sims" rel:gt_act="buzzing/title" rel:buzz_id="3749666">Les 14 choses les plus sadiques qu’on ait pu infliger aux Sims</a></h2>
+                        </li>
+                        <li class="bf-widget post sidebar-post  bf_dom lede--stacked gpt" style="display:none;" id="BF_WIDGET_7" rel:bf_ad_position="6">
+                            <div id="bf-item-7-1" class="bf-item lede">
+                                <div class="partner-sash">Sponsorisé</div>
+                                <div id="div-gpt-ad-7" style="position:absolute;overflow:hidden;z-index:-1"></div>
+                                <script type="text/javascript">
+                                if (AD_DESIGN == 'gpt' && !BF_STATIC.buzz_wide) {
+                                    loadGPTAd({
+                                        'wid': 7,
+                                        'sidebar': 1
+                                    });
+                                }
+                                </script>
+                                <a rel:gt_act="dfp/thumb" rel:gt_label="partner" href="" class="bf-url lede__media" rel:gtrack_id="dfp_ad"><img nopin="nopin" class="bf-image-widestory" src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" height="119" width="338"></a>
+                                <h2 class="bf-item-title lede__title"><a href="" class="bf-url bf-name lede__link" rel:gtrack_id="dfp_ad" rel:bf_truncate="100" rel:gt_act="dfp/title" rel:gt_label="partner"></a></h2>
+                            </div>
+                        </li>
+                        <script type="text/javascript">
+                        (function() {
+                            var AD = document.getElementById('BF_WIDGET_' + 7) || document.getElementById('BF_IFRAME_' + 7);
+                            if (AB_AD_TEST && AD && AD_DESIGN) {
+                                AD.className = AD.className + " " + AD_DESIGN;
+                            }
+                        })()
+                        </script>
+                        <script type="text/javascript">
+                        if (AD_DESIGN != 'gpt') {
+
+                            if (!window['win8AdCall']) {
+                                window['win8AdCall'] = function() { /* do nothing */ };
+                            }
+                            var ad_tag = 'http://ad.doubleclick.net/N6556/adj/' + BF_DFP_SITE + BF_DFP_ZONE + ';wid=7;posnum=3;sz=3x3;pos=sidebar;tile=7;' + BF_DFP_KVS + ';' + BF_TAG + win8AdCall() + '';
+                            if (typeof AD_DESIGN != 'undefined') {
+                                ad_tag += ';abtest=' + AD_DESIGN + ';'
+                            }
+
+                            //Loreal MUC channel
+                            if (window.location.search.match('loreal_feed=1') && BF_STATIC.tt_page === "Buzz") {
+                                ad_tag += 'loreal_feed=1;'
+                            }
+
+                            ad_tag += 'poe=' + BF_REFERER + ';';
+                            ad_tag += 'ord=' + BF_DFP_ORD + '?';
+
+                            ad_tag += ';large_images=1?';
+
+                            if (ad_tag) {
+                                if (!('wid=7;posnum=3;sz=3x3;pos=sidebar;tile=7').match(/pos=300x250/) && null !== window.location.search.match("skipdfp")) {
+                                    window.addEventListener('load', function() {
+                                        var query = (typeof String.prototype.toQueryParams != 'undefined') ? window.location.search.toQueryParams() : $.deparam.querystring();
+                                        var ad_user = (query['skipdfp']) ? query['skipdfp'] : 'boost';
+                                        var extra_params = (/bigstory/.test('wid=7;posnum=3;sz=3x3;pos=sidebar;tile=7')) ? '&flex_medium=bigstory' : '';
+                                        local_ad_call(7, ad_user, extra_params);
+                                    })
+                                } else {
+                                    if (!BF_STATIC.bf_test_mode || document.cookie.match('sel2_ad') !== null) {
+                                        document.write('<' + 'scr' + 'ipt type="text/javascr' + 'ipt" src="' + ad_tag + '"><\/scr' + 'ipt' + '>');
+                                    } else {
+                                        console.info('disable DFP (dfp_tags.tt)');
+                                    }
+                                }
+                            }
+
+                            if (null !== window.location.search.match("adtest") && console !== undefined && typeof ad_tag != "undefined") console.log(ad_tag);
+                        }
+                        </script>
+                        <script type="text/javascript">
+                        var imp_attr_3760955_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3760955_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FO9U67&quot;,&quot;u&quot;:&quot;7CEIDY7&quot;,&quot;buzz&quot;:&quot;49-choses-que-ceux-qui-ont-grandi-avec-kd2a-noublieront-jama&quot;,&quot;user&quot;:&quot;jenniferpadjemi&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-49-choses-que-ceux-qui-ont-grandi-avec-kd2a-noublieront-jama">
+                            <a href="/jenniferpadjemi/49-choses-que-ceux-qui-ont-grandi-avec-kd2a-noublieront-jama" rel:gt_act="buzzing/thumb" rel:buzz_id="3760955">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/25/4/campaign_images/webdr11/49-choses-que-ceux-qui-ont-grandi-avec-kd2a-noubl-2-19465-1429948902-10_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/25/4/campaign_images/webdr11/49-choses-que-ceux-qui-ont-grandi-avec-kd2a-noubl-2-19465-1429948902-10_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3760955&quot;}"></a>
+                            <h2><a href="/jenniferpadjemi/49-choses-que-ceux-qui-ont-grandi-avec-kd2a-noublieront-jama" rel:gt_act="buzzing/title" rel:buzz_id="3760955">49 choses que ceux qui ont grandi avec KD2A n’oublieront jamais</a></h2>
+                        </li>
+                        <script type="text/javascript">
+                        var imp_attr_3762016_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3762016_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FOFKH7&quot;,&quot;u&quot;:&quot;7CEIDY7&quot;,&quot;buzz&quot;:&quot;pourquoi-tu-fais-ca-shonda&quot;,&quot;user&quot;:&quot;jenniferpadjemi&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-pourquoi-tu-fais-ca-shonda">
+                            <a href="/jenniferpadjemi/pourquoi-tu-fais-ca-shonda" rel:gt_act="buzzing/thumb" rel:buzz_id="3762016">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/24/16/campaign_images/webdr01/les-43-fois-ou-greys-anatomy-a-fait-couler-toutes-2-4861-1429906011-15_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/24/16/campaign_images/webdr01/les-43-fois-ou-greys-anatomy-a-fait-couler-toutes-2-4861-1429906011-15_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3762016&quot;}"></a>
+                            <h2><a href="/jenniferpadjemi/pourquoi-tu-fais-ca-shonda" rel:gt_act="buzzing/title" rel:buzz_id="3762016">Les 43 fois où Grey’s Anatomy a fait couler toutes les larmes de notre corps</a></h2>
+                        </li>
+                        <script type="text/javascript">
+                        var imp_attr_3759579_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3759579_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FO2EM7&quot;,&quot;u&quot;:&quot;7CBJA47&quot;,&quot;buzz&quot;:&quot;photos-marine-le-pen-contre-le-systeme&quot;,&quot;user&quot;:&quot;adriensenecat&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-photos-marine-le-pen-contre-le-systeme">
+                            <a href="/adriensenecat/photos-marine-le-pen-contre-le-systeme" rel:gt_act="buzzing/thumb" rel:buzz_id="3759579">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/22/4/campaign_images/webdr08/8-photos-de-marine-le-pen-luttant-contre-le-syste-2-15395-1429693174-4_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/22/4/campaign_images/webdr08/8-photos-de-marine-le-pen-luttant-contre-le-syste-2-15395-1429693174-4_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3759579&quot;}"></a>
+                            <h2><a href="/adriensenecat/photos-marine-le-pen-contre-le-systeme" rel:gt_act="buzzing/title" rel:buzz_id="3759579">8 photos de Marine Le Pen luttant contre le système</a></h2>
+                        </li>
+                        <script type="text/javascript">
+                        var imp_attr_3760563_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3760563_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FO7PY7&quot;,&quot;u&quot;:&quot;74N9GW7&quot;,&quot;buzz&quot;:&quot;oui-ceci-est-mon-metier&quot;,&quot;user&quot;:&quot;floperry&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-oui-ceci-est-mon-metier">
+                            <a href="/floperry/oui-ceci-est-mon-metier" rel:gt_act="buzzing/thumb" rel:buzz_id="3760563">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/23/8/campaign_images/webdr08/23-reactions-que-toute-personne-ayant-travaille-d-2-11535-1429792966-16_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/23/8/campaign_images/webdr08/23-reactions-que-toute-personne-ayant-travaille-d-2-11535-1429792966-16_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3760563&quot;}"></a>
+                            <h2><a href="/floperry/oui-ceci-est-mon-metier" rel:gt_act="buzzing/title" rel:buzz_id="3760563">23 réactions que toute personne ayant travaillé dans un centre d’appels reconnaîtra</a></h2>
+                        </li>
+                        <script type="text/javascript">
+                        var imp_attr_3759567_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3759567_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FO2CA7&quot;,&quot;u&quot;:&quot;7AEY4T7&quot;,&quot;buzz&quot;:&quot;15-emojis-qui-manquent-e-toutes-les-meilleures-ami&quot;,&quot;user&quot;:&quot;crystalro&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-15-emojis-qui-manquent-e-toutes-les-meilleures-ami">
+                            <a href="/crystalro/15-emojis-qui-manquent-e-toutes-les-meilleures-ami" rel:gt_act="buzzing/thumb" rel:buzz_id="3759567">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/22/4/campaign_images/webdr03/15-emojis-qui-manquent-a-toutes-les-meilleures-am-2-404-1429691042-15_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/22/4/campaign_images/webdr03/15-emojis-qui-manquent-a-toutes-les-meilleures-am-2-404-1429691042-15_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3759567&quot;}"></a>
+                            <h2><a href="/crystalro/15-emojis-qui-manquent-e-toutes-les-meilleures-ami" rel:gt_act="buzzing/title" rel:buzz_id="3759567">15 emojis qui manquent à toutes les meilleures amies</a></h2>
+                        </li>
+                        <script type="text/javascript">
+                        var imp_attr_3759586_13 = {
+                            "PROMO_IMPRESSION": "13"
+                        };
+                        var click_attr_3759586_13 = {
+                            "PROMO_CLICK": "13"
+                        };
+                        </script>
+                        <li class="post sidebar-post  bf_dom  sidebar-post-wide" rel:bf_bucket="track" track="{&quot;c&quot;:&quot;7FO2FZ7&quot;,&quot;u&quot;:&quot;759SBH7&quot;,&quot;buzz&quot;:&quot;choses-que-les-filles-des-annees-2000-faisaient-19dho&quot;,&quot;user&quot;:&quot;jemimaskelley&quot;,&quot;types&quot;:[100],&quot;queries&quot;:[]}" id="promoted-choses-que-les-filles-des-annees-2000-faisaient-19dho">
+                            <a href="/jemimaskelley/choses-que-les-filles-des-annees-2000-faisaient-19dho" rel:gt_act="buzzing/thumb" rel:buzz_id="3759586">
+                                <div style="float:left; position:relative;">
+                                    <img nopin="nopin" src="http://s3-static-ak.buzzfed.com/static/2015-04/23/7/campaign_images/webdr13/23-choses-que-toutes-les-filles-des-annees-2000-f-2-22479-1429786805-12_wide.jpg" rel:bf_image_src="http://s3-static-ak.buzzfed.com/static/2015-04/23/7/campaign_images/webdr13/23-choses-que-toutes-les-filles-des-annees-2000-f-2-22479-1429786805-12_wide.jpg" class="bf_dom thumb" rel:bf_bucket="progload" alt="">
+                                </div>
+                            </a>
+                            <a class="qe editor-admin" style="display:none" rel:data="{&quot;buzz_id&quot;:&quot;3759586&quot;}"></a>
+                            <h2><a href="/jemimaskelley/choses-que-les-filles-des-annees-2000-faisaient-19dho" rel:gt_act="buzzing/title" rel:buzz_id="3759586">23 choses que toutes les filles des années 2000 faisaient</a></h2>
+                        </li>
+                    </ul>
+                </div>
+                <div class="footer" style="margin-bottom: 35px;">
+                    <a class="button2" rel:gt_act="buzzing/more-buzz" href="/?country=fr">Plus de Buzz ›</a>
+                </div>
+                <script type="text/javascript">
+                var promoted_switch = function() {
+                    if (typeof(promoted_match) != 'undefined' && $(promoted_match)) {
+                        $(promoted_match).hide();
+                        $('promoted-extra-hidden').show();
+                    }
+                }
+                promoted_switch();
+                </script>
+            </div>
+            <!-- UNIT:Nowbuzzing generated on  9:23:23,  4/27/2015 -->
+        </div>
+        <!-- \nowbuzzing -->
+    </div>
+    <div id="more_stuff">
+        <div class="lower-infinite-content" pound_position="4ldqpja">
+            <ul id="lower-more-content" rel:plugin_version="1.0"></ul>
+        </div>
+    </div>
+    </div>
+    </div>
+    <div class="clear"></div>
+    <footer class="page-footer-wrapper">
+        <div class="page-footer" rel:gt_cat="[ttp]:footer">
+            <ul class="list--unstyled footer-menu footer-menu--main">
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="advertise" href="/advertise">advertise</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="jobs" href="/about/jobs">jobs</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="mobile" href="/tools/mobile-ios">mobile</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="newsletter" href="/tools/email">newsletter</a>
+                </li>
+                <li>
+                    <div class="country_switch country-toggle bf_dom" rel:bf_bucket_data="{'country_switch_menu':{}}">
+                        US Edition
+                        <span class="fa fa-chevron-down"></span>
+                        <ul class="country_switch_menu country-toggle-menu list--unstyled" style="display:none;">
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=us' }}">US</a></li>
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=uk' }}">UK</a></li>
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=au' }}">Australia</a></li>
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=br' }}">Brasil</a></li>
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=de' }}">Deutschland</a></li>
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=es' }}">Español</a></li>
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=fr' }}">France</a></li>
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=in' }}">India</a></li>
+                            <li><a class="bf_dom" rel:bf_bucket_data="{'country_switch':{ 'r': '/?country=mx' }}">México</a></li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+            <ul class="list--inline footer-menu footer-menu--sub">
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="about" href="/about">about</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="press" href="/press">press</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="RSS" href="/tools/more">RSS</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="privacy" href="/about/privacy">privacy</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="user terms" href="/about/useragreement">user terms</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="ad Choices" href="/about/privacy#adchoices">ad Choices</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="Help" href="/help/faq">Help</a>
+                </li>
+                <li>
+                    <a class="footer-menu__item" rel:gt_act="Contact" href="/about/contact">Contact</a>
+                </li>
+            </ul>
+            <ul class="list--unstyled footer-copyright">
+                <li>
+                    <p> © 2015 BuzzFeed, Inc </p>
+                </li>
+                <li>
+                    <a rel:gt_act="made-in-nyc" class="made-in-nyc-logo" href="http://wearemadeinny.com/" target="_blank"></a>
+                </li>
+            </ul>
+        </div>
+    </footer>
+    <div id="suplist-modal-confirm" class="suplist-modal effect-fade-in-scale">
+        <div class="modal-content">
+            <div class="overlay-text">Are you sure you want to remove this item? You can\'t restore it with "Cancel" button!</div>
+            <div class="buttons">
+                <div class="bf_dom btn modal-cancel" rel:bf_bucket="confirm_cancel">NO</div>
+                <div class="bf_dom btn confirm-ok" rel:bf_bucket="confirm_ok">YES</div>
+            </div>
+        </div>
+    </div>
+    <div id="suplist-modal-spinner" class="suplist-modal effect-fade-in-scale">
+        <div class="modal-content">
+            <div class="overlay-text"></div>
+            <div class="waiting">Please wait...</div>
+            <div class="loader loader-6"></div>
+            <div class="buttons hidden">
+                <div class="bf_dom btn modal-cancel" rel:bf_bucket="spinner_cancel">Cancel</div>
+            </div>
+        </div>
+    </div>
+    <div id="suplist-modal-post-lock" class="suplist-modal effect-fade-in-scale">
+        <div class="modal-content">
+            <div id="post-lock-dialog" rel:gt_cat="[ttp]:special">
+                <div class="post-lock-locked">
+                    <div class="post-lock-icon"></div>
+                    <div class="headline-2">This Post Is Locked</div>
+                    <p>
+                        <a href="" class="post-lock-username"></a> has been editing this post since <b class="post-lock-time"></b>.</p>
+                    <button class="bf_dom btn confirm-ok" rel:bf_bucket="break_only" rel:gt_act="post-unlock">Unlock and edit anyway</button>
+                </div>
+                <div class="post-lock-unlocked">
+                    <div class="post-lock-icon"></div>
+                    <div class="headline-2">Uh Oh!</div>
+                    <p>
+                        <a href="" class="post-lock-username"></a> took your lock at <b class="post-lock-time"></b>.</p>
+                    <!-- <button class="bf_dom bf_button bf_submit" rel:bf_bucket="post-lock-duplicate">Save as a new post</button> -->
+                    <button class="bf_dom btn confirm-ok" rel:bf_bucket="break_only">Refresh the post</button>
+                </div>
+                <div class="post-lock-error">
+                    <div class="post-lock-icon"></div>
+                    <div class="headline-2">Super Uh Oh!</div>
+                    <p>Something's wrong, a mini-history of this post:</p>
+                    <ul id="post-lock-audit">
+                    </ul>
+                    <button class="bf_dom btn confirm-ok" rel:bf_bucket="reload">Reload the page</button>
+                    <br>
+                </div>
+                <div class="post-view-draft">
+                    <button id="quickpost-view-draft-dialog" type="button" class="bf_dom btn confirm-ok quickpost-view-draft" style="display: none;">View Draft</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="suplist-modal-content-type" class="suplist-modal effect-fade-in-scale">
+        <div class="modal-content">
+            <div class="overlay-text">What type of post are you making?</div>
+            <div class="buttons">
+                <div class="bf_dom btn content-type-btn longform"><span class="icon bf_dom" rel:bf_bucket_data="{'suplist_modal_content_format':{'format_type':'long'}}">New Article</span></div>
+                <div class="bf_dom btn content-type-btn list"><span class="icon bf_dom" rel:bf_bucket_data="{'suplist_modal_content_format':{'format_type':'none'}}">List</span></div>
+                <div class="bf_dom btn content-type-btn breaking breaking_post_summary acl_control breaking_post"><span class="icon bf_dom" rel:bf_bucket_data="{'suplist_modal_content_format':{'format_type':'breaking'}}">Breaking</span></div>
+            </div>
+        </div>
+    </div>
+    <div id="suplist_disable_overlay"></div>
+    <div class="bf_canvas" id="user-image-edit" style="display:none">
+        <div class="bf_overlay_mask"></div>
+        <div class="bf_dialog">
+            <div class="bf_dialog_header"><span class="title">Crop Image</span> <a href="javascript:;" onclick="BF_UI.closeDialog('user-image-edit');return false;" class="close">×</a></div>
+            <div class="bf_dialog_content">
+                <iframe data-value="Buzz" id="user-image-edit-iframe" src="about:blank" name="iframe_upload" scrolling="no" allowtransparency="true" height="465" width="800"></iframe>
+            </div>
+        </div>
+    </div>
+    <div class="bf_canvas" id="super-image-edit" style="display:none">
+        <div class="bf_overlay_mask"></div>
+        <div class="bf_dialog">
+            <div class="bf_dialog_content">
+                <iframe data-value="Buzz" id="super-image-edit-iframe" name="iframe_upload_super" scrolling="no" allowtransparency="true" height="600" width="800"></iframe>
+            </div>
+        </div>
+    </div>
+    <div id="modal-super-image-edit" class="modal thumbnail-modal cropperbody superpost" style="display:none">
+        <div class="modal-header">
+            <span class="modal-headline upload-title">Upload an Image</span>
+            <span class="modal-headline crop-title">Crop Image</span>
+            <span class="modal-headline thumbs-title">Are These Thumbnails Okay?</span>
+            <a class="modal-close" id="image-cancel" href="javascript:;">×</a>
+        </div>
+        <div class="modal-body" id="modal-super-image-edit-container">
+        </div>
+        <div class="modal-footer" id="save-button">
+            <button id="preview-thumbs" class="hidden bf_button bf_submit">Preview Thumbnails</button>
+            <button id="approve-thumbs" class="hidden bf_button bf_submit">Save Thumbnails</button>
+            <span class="bf_button" id="modal-insert-upload-button">Choose a new image</span>
+            <button id="save-image" class="hidden bf_button bf_submit">Save</button>
+        </div>
+    </div>
+    <div id="social-sharing-box" style="display:none;" rel:gt_cat="Buzz:social-share-box">
+        <div id="fill">
+            <div id="sharing-box-caption">
+                I know, right? Will your friends agree?
+            </div>
+            <textarea id="sharing-message"></textarea>
+            <a href="javascript:;" class="grey button2" onclick="javascript:$('social-sharing-box').hide();" rel:gt_act="facebook-box/close" id="social-close-btn" style="line-height:1;font-weight:normal;font-size:14px;">Close</a>
+            <input value="Post to Facebook" rel:gt_act="share/facebook" rel:gt_label="post/wall" class="submit button2" id="sharing-box-submit" style="float:right;margin-right:5px;font-size: 14px;padding: 3px 8px;" type="button">
+        </div>
+        <div id="arrowBorder" class="arrow"></div>
+        <div id="arrowFill" class="arrow"></div>
+    </div>
+    <div id="pin_bg" style="display: none"></div>
+    <div id="pin_bd" style="display: none">
+        <div style="display: block; height: 50px;"></div>
+        <div id="pin_header">
+            <span></span>
+            <a id="pin_close" onclick="if($('pin_bg')) $('pin_bg').hide(); if($('pin_bd')) $('pin_bd').hide(); window.scrollTo(0, bpage.lastScrollPos);">Cancel</a>
+        </div>
+        <span id="pin_img_container"></span>
+        <noembed id="pin_img_template">
+            <span class="pin_img">
+      <img style="#{img_style}" src="#{img_src}" width="#{img_width}px" height="#{img_height}px">
+    </span>
+            <cite>
+                <span class="pin_mask"></span>
+                <span>#{img_n_width}x#{img_n_height}</span>
+            </cite>
+            <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" onload="sharing.buttons.pinterest({
+                replace: this,
+                type: 'pin_image',
+                media: '#{media}',
+                description: '#{desc}'
+            });" />
+        </noembed>
+    </div>
+    <div id="share_email" class="section sticky-popup" style="display:none;">
+        <div id="share_email_cancel" class="bf_dom" rel:bf_bucket="share-email-cancel">x</div>
+        <form id="share_email_form" class="v signin-or-signup share_email_popup">
+            <div class="share_box_header headline-1">Email this to a friend</div>
+            <div id="share_email_message" class="message" style="display:none"></div>
+            <fieldset>
+                <input name="bid" value="3758406" id="bid" type="hidden">
+                <input name="sub_buzz_id" value="" id="sub_buzz_id" type="hidden">
+                <div class="field">
+                    <input placeholder="Friend's email (separate multiple with comma)" rel:gt_act="ignore" class="text" name="b2" value="" id="b2" type="text">
+                </div>
+                <div class="field">
+                    <input placeholder="Your email" rel:gt_act="ignore" class="text" name="bf" value="" id="bf" type="text">
+                </div>
+                <div class="field">
+                    <textarea id="note" rel:gt_act="email/note" name="note" cols="10" rows="5">Hey, I saw this on BuzzFeed and thought of you.</textarea>
+                </div>
+                <div class="bf_dom catcha_service" style="display:none" rel:bf_bucket="catcha-email_a_friend">
+                    <div class="share_box_header headline-1">Please enter the CAT-CHA</div>
+                    <img nopin="nopin" src="data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+                    <span class="catcha_question share_box_header headline-1">Catcha question...</span>
+                    <div class="field">
+                        <input class="text" style="width:320px;height:22px" name="catcha_answer" value="" onblur="bf_catcha.catcha_answer=this.value" type="text">
+                    </div>
+                </div>
+                <div class="field">
+                    <input id="share_email_submit" rel:gt_act="ignore" name="submit" value="Send It!" class="button2 grey submit action bf_dom" rel:bf_bucket_data="{'share-email-submit':{'vertical':'UKNews'}}" type="button">
+                </div>
+            </fieldset>
+        </form>
+        <form id="newsletter_signup_form" style="display:none;" class="share_email_popup" rel:gt_cat="[ttp]:Newsletters">
+            <div id="empty_sign_up_message" class="hidden">
+                <p><span class="error_icon"></span>Please select the newsletters you'd like to receive.</p>
+            </div>
+            <div id="email_sent_success_message"><span class="success_icon"></span>
+                <p>Your email has been sent!</p>
+            </div>
+            <p>Get our awesome newsletter at <span id="from_address"></span></p>
+            <div id="newsletter_signups">
+                <div class="email_box">
+                    <div class="email_box_wrapper">
+                        <div id="buzzfeed_signup" class="sprite checkOn checkBox pointer bf_dom" rel:bf_bucket_data="{'newsletter_checkbox':{'id':'buzzfeed_signup'}}" rel:gt_act="buzzfeed"></div>
+                        <div class="logo_block bf_dom" rel:bf_bucket_data="{'newsletter_checkbox':{'id':'buzzfeed_signup'}}">
+                            <div class="BFLogo pointer">BuzzFeeᴅ</div>
+                            <div class="email_frequency">7x per week</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <fieldset>
+                <div class="field form-controls pull-right">
+                    <input id="email_signup" value="Sign me up!" class="button2 grey submit action bf_dom" rel:bf_bucket="email-signup" rel:gt_act="newsletters/signup" type="button">
+                    <div class="plain_cancel">
+                        <a id="email_cancel" href="" onclick="return false" class="bf_dom" rel:bf_bucket="share-email-cancel">No thanks</a>
+                    </div>
+                </div>
+            </fieldset>
+        </form>
+        <div id="share_email_error" class="section social-message sticky-popup share_email_popup" style="display:none">
+            <p id="share_email_error_text">Oops! We had a problem sending your message. Please try again later.</p>
+        </div>
+        <div id="share_email_confirm" class="section social-message sticky-popup share_email_popup" style="display:none">
+            <span class="success_icon"></span>
+            <p id="share_email_confirm_text">Great! You'll get your first email soon.</p>
+        </div>
+    </div>
+    <!-- #share_email -->
+    <div style="display: none" id="shares-copy-link" class="sticky-popup">
+        <div class="arrow arrowBorder"></div>
+        <div class="arrow arrowFill"></div>
+        <div class="share_box_header headline-1">Share This Link</div>
+        <input class="email_copy_link_text" value="http://www.buzzfeed.com/markdistefano/diet-pills-burns-up" type="text">
+    </div>
+    <script src="http://s3-ak.buzzfed.com/static/js/User_and_Buzz_concat_footer.js?v=201504241415" type="text/javascript" ref:jsconf="true"></script>
+    <script src="http://s3-ak.buzzfed.com/static/js/General_concat_footer.js?v=201504241415" type="text/javascript" ref:jsconf="true"></script>
+    <noscript><img src="http://b.scorecardresearch.com/p?c1=2&c2=6768151&c4=buzzfeed.com/markdistefano/diet-pills-burns-up" /></noscript>
+    <noscript><img src='http://pixel.quantserve.com/pixel/p-3aud4J6uA4Z6Y.gif' height='1' width='1' alt='Quantcast' /></noscript>
+    <div id="FB_HiddenContainer" style="position:absolute; top:-10000px; left:-10000px; width:0px; height:0px;"></div>
+    <script src="http://s3-ak.buzzfed.com/static/js/public/bpage-pinterest-nopin.js?v=201504241415" type="text/javascript"></script>
+    <script type="text/javascript">
+    var uagent = this.agent = navigator.userAgent.toLowerCase();
+
+
+    var post_success_cookie = BFW_Util.getCookie('qp_post_success');
+    if (post_success_cookie && location.pathname.replace(/^\/bf2/, '').replace(/^\/h[\d]+\/h[A-Z0-9]+/i, '') == post_success_cookie) {
+        $('post_launch_success').show();
+        BFW_Util.deleteCookie('qp_post_success');
+    }
+
+
+    var buzz_profile = {
+        category: 'UKNews',
+        badges: [],
+        nsfw: 0
+    };
+    buzz_profile.badges.push('viral');
+
+
+
+
+
+
+
+
+
+
+    sailthru_horizon = {
+        "domain": "horizon.buzzfeed.com",
+        "tags": ["UKNews", "--ad-noads", "--primarykeyword-diet pills", "inquests", "online shopping", "uk", "viral"]
+    };
+    sailthru_horizon_track(sailthru_horizon);
+
+
+
+
+
+
+
+
+
+
+    if (typeof bf_contribute !== "undefined") {
+        bf_contribute.enableForm('contribute-text-form');
+        bf_contribute.buttonToggle('text-contribute-activate');
+    }
+    </script>
+    <script type="text/javascript">
+    (function() {
+        window._fbds = window._fbds || {};
+        _fbds.pixelId = 224284281076687;
+        var e = document.createElement("script");
+        e.async = true;
+        e.src = ("https:" == document.location.protocol ? "https:" : "http:") + "//connect.facebook.net/en_US/fbds.js";
+        var t = document.getElementsByTagName("script")[0];
+        t.parentNode.insertBefore(e, t)
+    })();
+    window._fbq = window._fbq || [];
+    window._fbq.push(["track", "PixelInitialized", {}]);
+    window._fbq.push(['track', 'Section', {
+        'section': "UKNews" ? "UKNews" : buzzDetails.category_name
+    }]);
+    </script>
+    <noscript><img height="1" width="1" border="0" alt="" style="display:none" src="https://www.facebook.com/tr?id=224284281076687&amp;ev=NoScript" /></noscript>
+    <script>
+    (function() {
+        var _fbq = window._fbq || (window._fbq = []);
+        if (!_fbq.loaded) {
+            var fbds = document.createElement('script');
+            fbds.async = true;
+            fbds.src = '//connect.facebook.net/en_US/fbds.js';
+            var s = document.getElementsByTagName('script')[0];
+            s.parentNode.insertBefore(fbds, s);
+            _fbq.loaded = true;
+        }
+        _fbq.push(['addPixelId', '260954170738952']);
+    })();
+    window._fbq = window._fbq || [];
+    window._fbq.push(['track', 'PixelInitialized', {}]);
+    </script>
+    <noscript><img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=260954170738952&amp;ev=PixelInitialized" /></noscript>
+    <script src="//platform.twitter.com/oct.js" type="text/javascript"></script>
+    <script type="text/javascript">
+    twttr.conversion.trackPid('l4lgt');
+    </script>
+    <noscript>
+        <img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=l4lgt&p_id=Twitter" />
+        <img height="1" width="1" style="display:none;" alt="" src="//t.co/i/adsct?txn_id=l4lgt&p_id=Twitter" />
+    </noscript>
+    <div id="buzz-body" style="display:none"></div>
+    <script>
+    try {
+        bf_site_speed.dom_time_spent('Buzz Body Load');
+    } catch (err) {
+        console.log(err);
+    }
+    </script>
+    <script type="text/javascript">
+    var pixelDataLogix = new Image();
+    pixelDataLogix.src = 'http://h.nexac.com/e/a-1177/s-2113/c-386/g-1107.xgi?pkey=bijo15bijox40&chpcm=&chpsg=&chpcr=' + BF_STATIC.campaignid + '&chpck=&rand=' + (Math.random() * 100000000000000000) + '&chpth=';
+    </script>
+    <iframe tabindex="-1" style="width: 1px; height: 1px; position: absolute; top: -100px;" src="https://accounts.google.com/o/oauth2/postmessageRelay?parent=http%3A%2F%2Fwww.buzzfeed.com#rpctoken=416601695&amp;forcesecure=1" id="oauth2relay2056065538" name="oauth2relay2056065538"></iframe>
+    <script src="/static/js/adobe/adobe_tracking.js" type="text/javascript"></script>
+    <div id="fb-root">
+        <script async="" src="http://connect.facebook.net/en_US/sdk.js"></script>
+    </div>
+    <div style="" class="show" id="back_to_top"></div>
+    <div class="bookmark-white-overlay" style="display: none;">
+        <div id="bookmark-popup" style="display: none;">
+            <a href="javascript:;" class="bookmark-popup-close bf_dom fa fa-times" rel:bf_bucket="close_bookmark_popup"></a>
+            <div class="bookmark-popup-content"></div>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Some pages declare byline using a `<meta property="author" content="*">` tag, while we're only checking for `<meta name=` attr.

This patch addresses that and adds a test case.

r=? @gijsk @leibovic 