### PR TITLE
Fixes #180 - Score intermediary headings.

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -102,7 +102,7 @@ Readability.prototype = {
   DEFAULT_MAX_PAGES: 5,
 
   // Element tags to score by default.
-  DEFAULT_TAGS_TO_SCORE: ["SECTION", "P", "TD", "PRE"],
+  DEFAULT_TAGS_TO_SCORE: "section,h2,h3,h4,h5,h6,p,td,pre".toUpperCase().split(","),
 
   // All of the regular expressions in use within readability.
   // Defined up here so we don't instantiate them repeatedly in loops.

--- a/test/test-pages/buzzfeed-1/expected.html
+++ b/test/test-pages/buzzfeed-1/expected.html
@@ -1,19 +1,38 @@
 <div id="readability-page-1" class="page">
-    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547213" rel:buzz_num="2">
-        <p class="sub_buzz_desc">Eloise Parry, 21, was taken to Royal Shrewsbury hospital on 12 April after taking a lethal dose of highly toxic “slimming tablets”. </p>
-        <p>“The drug was in her system, there was no anti-dote, two tablets was a lethal dose – and she had taken eight,” her mother, Fiona, <a href="https://www.westmercia.police.uk/article/9501/A-tribute-to-Eloise-Aimee-Parry-written-by-her-mother-Fiona-Parry">said in a statement</a> yesterday.</p>
-        <p>“As Eloise deteriorated, the staff in A&amp;E did all they could to stabilise her. As the drug kicked in and started to make her metabolism soar, they attempted to cool her down, but they were fighting an uphill battle.</p>
-        <p>“She was literally burning up from within.”</p>
-        <p>She added: “They never stood a chance of saving her. She burned and crashed.”</p>
-    </div>
-    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547284" rel:buzz_num="4">
-        <p class="sub_buzz_desc">West Mercia police <a href="https://www.westmercia.police.uk/article/9500/Warning-Issued-As-Shrewsbury-Woman-Dies-After-Taking-Suspected-Diet-Pills">said the tablets were believed to contain dinitrophenol</a>, known as DNP, which is a highly toxic industrial chemical. </p>
-        <p>“We are undoubtedly concerned over the origin and sale of these pills and are working with partner agencies to establish where they were bought from and how they were advertised,” said chief inspector Jennifer Mattinson from the West Mercia police.</p>
-        <p>The Food Standards Agency warned people to stay away from slimming products that contained DNP.</p>
-        <p>“We advise the public not to take any tablets or powders containing DNP, as it is an industrial chemical and not fit for human consumption,” it said in a statement.</p>
-    </div>
-    <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547219" rel:buzz_num="5">
-        <p class="sub_buzz_desc">“[Eloise] just never really understood how dangerous the tablets that she took were,” she said. “Most of us don’t believe that a slimming tablet could possibly kill us.</p>
-        <p>“DNP is not a miracle slimming pill. It is a deadly toxin.”</p>
+    <div id="buzz_sub_buzz" class="c suplist_article suplist_list_show ">
+        <div class="buzz_superlist_item buzz_superlist_item_image  buzz_superlist_item_wide image_hit no_caption " id="superlist_3758406_5547137" rel:buzz_num="1">
+            <h2>The mother of a woman who took suspected diet pills bought online has described how her daughter was “literally burning up from within” moments before her death.</h2>
+            <p class="article_caption_w_attr"> <span class="sub_buzz_source_via buzz_attribution buzz_attr_no_caption">West Merica Police</span></p>
+        </div>
+        <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547213" rel:buzz_num="2">
+            <p class="sub_buzz_desc">Eloise Parry, 21, was taken to Royal Shrewsbury hospital on 12 April after taking a lethal dose of highly toxic “slimming tablets”. </p>
+            <p>“The drug was in her system, there was no anti-dote, two tablets was a lethal dose – and she had taken eight,” her mother, Fiona, <a href="https://www.westmercia.police.uk/article/9501/A-tribute-to-Eloise-Aimee-Parry-written-by-her-mother-Fiona-Parry">said in a statement</a> yesterday.</p>
+            <p>“As Eloise deteriorated, the staff in A&amp;E did all they could to stabilise her. As the drug kicked in and started to make her metabolism soar, they attempted to cool her down, but they were fighting an uphill battle.</p>
+            <p>“She was literally burning up from within.”</p>
+            <p>She added: “They never stood a chance of saving her. She burned and crashed.”</p>
+        </div>
+        <div class="buzz_superlist_item buzz_superlist_item_grid_row  buzz_superlist_item_wide  no_caption " id="superlist_3758406_5547140" rel:buzz_num="3">
+            <div class="grid_row two_pl grid_height_l">
+                <div class="grid_cell cell_1">
+                    <div class="grid_cell_image_wrapper"><img src="http://ak-hdl.buzzfed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608056-15.jpg" rel:bf_image_src="http://ak-hdl.buzzfed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608056-15.jpg" height="412" width="203"></div>
+                    <p class="sub_buzz_grid_source_via">Facebook</p>
+                </div>
+                <div class="grid_cell cell_2">
+                    <div class="grid_cell_image_wrapper"><img src="http://ak-hdl.buzzfed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608057-18.jpg" rel:bf_image_src="http://ak-hdl.buzzfed.com/static/2015-04/21/5/enhanced/webdr12/grid-cell-2501-1429608057-18.jpg" height="412" width="412"></div>
+                    <p class="sub_buzz_grid_source_via">Facebook</p>
+                </div>
+            </div>
+        </div>
+        <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547284" rel:buzz_num="4">
+            <p class="sub_buzz_desc">West Mercia police <a href="https://www.westmercia.police.uk/article/9500/Warning-Issued-As-Shrewsbury-Woman-Dies-After-Taking-Suspected-Diet-Pills">said the tablets were believed to contain dinitrophenol</a>, known as DNP, which is a highly toxic industrial chemical. </p>
+            <p>“We are undoubtedly concerned over the origin and sale of these pills and are working with partner agencies to establish where they were bought from and how they were advertised,” said chief inspector Jennifer Mattinson from the West Mercia police.</p>
+            <p>The Food Standards Agency warned people to stay away from slimming products that contained DNP.</p>
+            <p>“We advise the public not to take any tablets or powders containing DNP, as it is an industrial chemical and not fit for human consumption,” it said in a statement.</p>
+        </div>
+        <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547219" rel:buzz_num="5">
+            <h2>Fiona Parry issued a plea for people to stay away from pills containing the chemical.</h2>
+            <p class="sub_buzz_desc">“[Eloise] just never really understood how dangerous the tablets that she took were,” she said. “Most of us don’t believe that a slimming tablet could possibly kill us.</p>
+            <p>“DNP is not a miracle slimming pill. It is a deadly toxin.”</p>
+        </div>
     </div>
 </div>

--- a/test/test-pages/buzzfeed-1/source.html
+++ b/test/test-pages/buzzfeed-1/source.html
@@ -3550,7 +3550,6 @@
                                             <div class="sub_buzz_content">
                                             </div>
                                         </div>
-                                        <div class="grid_clear">&nbsp;</div>
                                     </div>
                                     <div class="buzz_superlist_item buzz_superlist_item_text  buzz_superlist_item_wide   " id="superlist_3758406_5547284" rel:buzz_num="4">
                                         <p class="sub_buzz_desc">West Mercia police <a href="https://www.westmercia.police.uk/article/9500/Warning-Issued-As-Shrewsbury-Woman-Dies-After-Taking-Suspected-Diet-Pills">said the tablets were believed to contain dinitrophenol</a>, known as DNP, which is a highly toxic industrial chemical. </p>


### PR DESCRIPTION
Intermediary headings are part of content, and they most often carry weight; this patch extends the default tags to score to support them.

r=? @gijsk @leibovic 