### PR TITLE
Refs #195 - Exclude nodes likely to be related content.

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -107,7 +107,7 @@ Readability.prototype = {
   // All of the regular expressions in use within readability.
   // Defined up here so we don't instantiate them repeatedly in loops.
   REGEXPS: {
-    unlikelyCandidates: /banner|combx|comment|community|disqus|extra|foot|header|menu|remark|rss|share|shoutbox|sidebar|skyscraper|sponsor|ad-break|agegate|pagination|pager|popup/i,
+    unlikelyCandidates: /banner|combx|comment|community|disqus|extra|foot|header|menu|related|remark|rss|share|shoutbox|sidebar|skyscraper|sponsor|ad-break|agegate|pagination|pager|popup/i,
     okMaybeItsACandidate: /and|article|body|column|main|shadow/i,
     positive: /article|body|content|entry|hentry|main|page|pagination|post|text|blog|story/i,
     negative: /hidden|banner|combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|tool|widget/i,

--- a/test/test-pages/liberation-1/expected-metadata.json
+++ b/test/test-pages/liberation-1/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Un troisième Français mort dans le séisme au Népal",
-  "byline": "Par Sébastien Farcis",
+  "byline": "AFP",
   "excerpt": "Laurent Fabius a accueilli jeudi matin à Roissy un premier avion spécial ramenant des rescapés.",
   "readerable": true
 }

--- a/test/test-pages/liberation-1/expected.html
+++ b/test/test-pages/liberation-1/expected.html
@@ -1,11 +1,5 @@
 <div id="readability-page-1" class="page">
     <div class="article-body mod" itemprop="articleBody" id="article-body">
-        <aside class="related" id="related-content"> <span class="name">Sur le même sujet</span>
-            <ul>
-                <li> </li>
-                <li> </li>
-            </ul>
-        </aside>
         <div>
             <p>Un troisième Français a été tué dans le tremblement de terre samedi au Népal, emporté par une avalanche, <a href="http://www.liberation.fr/video/2015/04/30/laurent-fabius-plus-de-200-francais-n-ont-pas-ete-retrouves_1278687" target="_blank">a déclaré jeudi le ministre des Affaires étrangères</a>.&nbsp;Les autorités françaises sont toujours sans nouvelles <em>«d’encore plus de 200»&nbsp;</em>personnes.&nbsp;<em>«Pour certains d’entre eux on est très interrogatif»</em>, a ajouté&nbsp;Laurent Fabius. Il accueillait à Roissy un premier avion spécial ramenant des&nbsp;rescapés. <a href="http://www.liberation.fr/video/2015/04/30/seisme-au-nepal-soulages-mais-inquiets-206-survivants-de-retour-en-france_1278758" target="_blank">L’Airbus A350 affrété par les autorités françaises s’est posé peu avant 5h45</a> avec à son bord 206&nbsp;passagers, dont 12&nbsp;enfants et 26&nbsp;blessés, selon une source du Quai d’Orsay. Quasiment tous sont français, à l’exception d’une quinzaine de ressortissants allemands, suisses, italiens, portugais ou encore turcs. Des psychologues, une équipe médicale et des personnels du centre de crise du Quai d’Orsay les attendent.</p>
             <p>L’appareil, mis à disposition par Airbus, était arrivé à Katmandou mercredi matin avec 55&nbsp;personnels de santé et humanitaires, ainsi que 25&nbsp;tonnes de matériel (abris, médicaments, aide alimentaire). Un deuxième avion dépêché par Paris, qui était immobilisé aux Emirats depuis mardi avec 20&nbsp;tonnes de matériel, est arrivé jeudi à Katmandou, <a href="http://www.liberation.fr/monde/2015/04/29/embouteillages-et-retards-a-l-aeroport-de-katmandou_1276612" target="_blank">dont le petit aéroport est engorgé</a> par le trafic et l’afflux d’aide humanitaire. Il devait lui aussi ramener des Français, <em>«les plus éprouvés»</em> par la catastrophe et les <em>«plus vulnérables (blessés, familles avec enfants)»</em>, selon le ministère des Affaires étrangères.</p>


### PR DESCRIPTION
This partially fixes #195, excluding nodes with class names containing the word `related`, so we avoid including what is likely to be *related contents* lists of links.

r=? @gijsk @leibovic 