### PR TITLE
Refs #209 - Increase score for elements containing large amount of text.

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -110,7 +110,7 @@ Readability.prototype = {
     unlikelyCandidates: /banner|combx|comment|community|disqus|extra|foot|header|menu|related|remark|rss|share|shoutbox|sidebar|skyscraper|sponsor|ad-break|agegate|pagination|pager|popup/i,
     okMaybeItsACandidate: /and|article|body|column|main|shadow/i,
     positive: /article|body|content|entry|hentry|main|page|pagination|post|text|blog|story/i,
-    negative: /hidden|banner|combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|tool|widget/i,
+    negative: /hidden|banner|combx|comment|com-|contact|control-?bar|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|tool|widget/i,
     extraneous: /print|archive|comment|discuss|e[\-]?mail|share|reply|all|login|sign|single|utility/i,
     byline: /byline|author|dateline|writtenby/i,
     replaceFonts: /<(\/?)font[^>]*>/gi,
@@ -721,6 +721,10 @@ Readability.prototype = {
 
         // For every 100 characters in this paragraph, add another point. Up to 3 points.
         contentScore += Math.min(Math.floor(innerText.length / 100), 3);
+
+        if (elementToScore.tagName !== "section" && innerText.length > 300) {
+          contentScore *= 1.5;
+        }
 
         // Initialize and score ancestors.
         this._forEachNode(ancestors, function(ancestor, level) {

--- a/test/test-pages/ars-1/expected.html
+++ b/test/test-pages/ars-1/expected.html
@@ -1,15 +1,18 @@
 <div id="readability-page-1" class="page">
-    <div itemprop="articleBody" class="article-content clearfix">
-        <figure class="intro-image image center full-width"> <img src="http://cdn.arstechnica.net/wp-content/uploads/2015/04/server-crash-640x426.jpg" width="640" height="331">
-            <figcaption class="caption"> </figcaption>
-        </figure>
-        <p>A flaw in the wildly popular online game <em>Minecraft</em> makes it easy for just about anyone to crash the server hosting the game, according to a computer programmer who has released proof-of-concept code that exploits the vulnerability.</p>
-        <p>"I thought a lot before writing this post," Pakistan-based developer Ammar Askar wrote in a <a href="http://blog.ammaraskar.com/minecraft-vulnerability-advisory">blog post published Thursday</a>, 21 months, he said, after privately reporting the bug to <em>Minecraft</em> developer Mojang. "On the one hand I don't want to expose thousands of servers to a major vulnerability, yet on the other hand Mojang has failed to act on it."</p>
-        <p>The bug resides in the <a href="https://github.com/ammaraskar/pyCraft">networking internals of the <em>Minecraft </em>protocol</a>. It allows the contents of inventory slots to be exchanged, so that, among other things, items in players' hotbars are displayed automatically after logging in. <em>Minecraft</em> items can also store arbitrary metadata in a file format known as <a href="http://wiki.vg/NBT">Named Binary Tag (NBT)</a>, which allows complex data structures to be kept in hierarchical nests. Askar has released <a href="https://github.com/ammaraskar/pyCraft/tree/nbt_exploit">proof-of-concept attack code</a> he said exploits the vulnerability to crash any server hosting the game. Here's how it works.</p>
-        <blockquote>
-            <p>The vulnerability stems from the fact that the client is allowed to send the server information about certain slots. This, coupled with the NBT format’s nesting allows us to <em>craft</em> a packet that is incredibly complex for the server to deserialize but trivial for us to generate.</p>
-            <p>In my case, I chose to create lists within lists, down to five levels. This is a json representation of what it looks like.</p>
-            <div class="highlight"><pre><code class="language-javascript" data-lang="javascript"><span class="nx">rekt</span><span class="o">:</span> <span class="p">{</span>
+    <article itemscope="" itemtype="http://schema.org/NewsArticle" class="standalone">
+        <header> </header>
+        <section id="article-guts">
+            <div itemprop="articleBody" class="article-content clearfix">
+                <figure class="intro-image image center full-width"> <img src="http://cdn.arstechnica.net/wp-content/uploads/2015/04/server-crash-640x426.jpg" width="640" height="331">
+                    <figcaption class="caption"> </figcaption>
+                </figure>
+                <p>A flaw in the wildly popular online game <em>Minecraft</em> makes it easy for just about anyone to crash the server hosting the game, according to a computer programmer who has released proof-of-concept code that exploits the vulnerability.</p>
+                <p>"I thought a lot before writing this post," Pakistan-based developer Ammar Askar wrote in a <a href="http://blog.ammaraskar.com/minecraft-vulnerability-advisory">blog post published Thursday</a>, 21 months, he said, after privately reporting the bug to <em>Minecraft</em> developer Mojang. "On the one hand I don't want to expose thousands of servers to a major vulnerability, yet on the other hand Mojang has failed to act on it."</p>
+                <p>The bug resides in the <a href="https://github.com/ammaraskar/pyCraft">networking internals of the <em>Minecraft </em>protocol</a>. It allows the contents of inventory slots to be exchanged, so that, among other things, items in players' hotbars are displayed automatically after logging in. <em>Minecraft</em> items can also store arbitrary metadata in a file format known as <a href="http://wiki.vg/NBT">Named Binary Tag (NBT)</a>, which allows complex data structures to be kept in hierarchical nests. Askar has released <a href="https://github.com/ammaraskar/pyCraft/tree/nbt_exploit">proof-of-concept attack code</a> he said exploits the vulnerability to crash any server hosting the game. Here's how it works.</p>
+                <blockquote>
+                    <p>The vulnerability stems from the fact that the client is allowed to send the server information about certain slots. This, coupled with the NBT format’s nesting allows us to <em>craft</em> a packet that is incredibly complex for the server to deserialize but trivial for us to generate.</p>
+                    <p>In my case, I chose to create lists within lists, down to five levels. This is a json representation of what it looks like.</p>
+                    <div class="highlight"><pre><code class="language-javascript" data-lang="javascript"><span class="nx">rekt</span><span class="o">:</span> <span class="p">{</span>
     <span class="nx">list</span><span class="o">:</span> <span class="p">[</span>
         <span class="nx">list</span><span class="o">:</span> <span class="p">[</span>
             <span class="nx">list</span><span class="o">:</span> <span class="p">[</span>
@@ -35,14 +38,24 @@
     <span class="p">]</span>
     <span class="p">...</span>
 <span class="p">}</span></code></pre></div>
-            <p>The root of the object, <code>rekt</code>, contains 300 lists. Each list has a list with 10 sublists, and each of those sublists has 10 of their own, up until 5 levels of recursion. That’s a total of <code>10^5 * 300 = 30,000,000</code> lists.</p>
-            <p>And this isn’t even the theoretical maximum for this attack. Just the nbt data for this payload is 26.6 megabytes. But luckily Minecraft implements a way to compress large packets, lucky us! zlib shrinks down our evil data to a mere 39 kilobytes.</p>
-            <p>Note: in previous versions of Minecraft, there was no protocol wide compression for big packets. Previously, NBT was sent compressed with gzip and prefixed with a signed short of its length, which reduced our maximum payload size to <code>2^15 - 1</code>. Now that the length is a varint capable of storing integers up to <code>2^28</code>, our potential for attack has increased significantly.</p>
-            <p>When the server will decompress our data, it’ll have 27 megs in a buffer somewhere in memory, but that isn’t the bit that’ll kill it. When it attempts to parse it into NBT, it’ll create java representations of the objects meaning suddenly, the sever is having to create several million java objects including ArrayLists. This runs the server out of memory and causes tremendous CPU load.</p>
-            <p>This vulnerability exists on almost all previous and current Minecraft versions as of 1.8.3, the packets used as attack vectors are the <a href="http://wiki.vg/Protocol#Player_Block_Placement">0x08: Block Placement Packet</a> and <a href="http://wiki.vg/Protocol#Creative_Inventory_Action">0x10: Creative Inventory Action</a>.</p>
-            <p>The fix for this vulnerability isn’t exactly that hard, the client should never really send a data structure as complex as NBT of arbitrary size and if it must, some form of recursion and size limits should be implemented.</p>
-            <p>These were the fixes that I recommended to Mojang 2 years ago.</p>
-        </blockquote>
-        <p>Ars is asking Mojang for comment and will update this post if company officials respond.</p>
-    </div>
+                    <p>The root of the object, <code>rekt</code>, contains 300 lists. Each list has a list with 10 sublists, and each of those sublists has 10 of their own, up until 5 levels of recursion. That’s a total of <code>10^5 * 300 = 30,000,000</code> lists.</p>
+                    <p>And this isn’t even the theoretical maximum for this attack. Just the nbt data for this payload is 26.6 megabytes. But luckily Minecraft implements a way to compress large packets, lucky us! zlib shrinks down our evil data to a mere 39 kilobytes.</p>
+                    <p>Note: in previous versions of Minecraft, there was no protocol wide compression for big packets. Previously, NBT was sent compressed with gzip and prefixed with a signed short of its length, which reduced our maximum payload size to <code>2^15 - 1</code>. Now that the length is a varint capable of storing integers up to <code>2^28</code>, our potential for attack has increased significantly.</p>
+                    <p>When the server will decompress our data, it’ll have 27 megs in a buffer somewhere in memory, but that isn’t the bit that’ll kill it. When it attempts to parse it into NBT, it’ll create java representations of the objects meaning suddenly, the sever is having to create several million java objects including ArrayLists. This runs the server out of memory and causes tremendous CPU load.</p>
+                    <p>This vulnerability exists on almost all previous and current Minecraft versions as of 1.8.3, the packets used as attack vectors are the <a href="http://wiki.vg/Protocol#Player_Block_Placement">0x08: Block Placement Packet</a> and <a href="http://wiki.vg/Protocol#Creative_Inventory_Action">0x10: Creative Inventory Action</a>.</p>
+                    <p>The fix for this vulnerability isn’t exactly that hard, the client should never really send a data structure as complex as NBT of arbitrary size and if it must, some form of recursion and size limits should be implemented.</p>
+                    <p>These were the fixes that I recommended to Mojang 2 years ago.</p>
+                </blockquote>
+                <p>Ars is asking Mojang for comment and will update this post if company officials respond.</p>
+            </div>
+            <p><a href="http://arstechnica.com/security/2015/04/16/just-released-minecraft-exploit-makes-it-easy-to-crash-game-servers/">Expand full story</a></p>
+        </section>
+        <div id="article-footer-wrap">
+            <aside class="thin-divide-bottom"> </aside>
+            <section class="article-author clearfix-redux">
+                <a href="http://fakehost/author/dan-goodin"><img width="47" height="47" src="http://cdn.arstechnica.net/wp-content/uploads/authors/Dan-Goodin-sq.jpg"></a>
+                <p><a href="http://fakehost/author/dan-goodin" class="author-name">Dan Goodin</a> / Dan is the Security Editor at Ars Technica, which he joined in 2012 after working for The Register, the Associated Press, Bloomberg News, and other publications.</p>
+            </section>
+        </div>
+    </article>
 </div>

--- a/test/test-pages/sfgate-1/expected-metadata.json
+++ b/test/test-pages/sfgate-1/expected-metadata.json
@@ -1,0 +1,6 @@
+{
+  "title": "Nob Hill one-bedroom sells for $2.3 million",
+  "byline": "By Emily Landes",
+  "excerpt": "In early March, we told you about a one-bedroom in the prestigious Comstock in Nob Hill, which came to market at $2.495 million, making it the most expensive one-bedroom on the market at the time. The northwest facing unit—with amazing panoramic views of Twin Peaks, the Golden Gate Bridge, the",
+  "readerable": true
+}

--- a/test/test-pages/sfgate-1/expected.html
+++ b/test/test-pages/sfgate-1/expected.html
@@ -1,0 +1,292 @@
+<div id="readability-page-1" class="page">
+    <div class="entry">
+        <div class="gallery clearfix">
+            <div class="galleria asset_gallery" id="galleria_31011101">
+                <div id="hst-resgallery-31011101" class="hst-resgallery-container clearfix"><span gallery_title="1333 Jones St. #806" gallery_id="31011" class="gallery-metadata"></span>
+                    <div class="control-panel"><span data="" id="gallerySection"></span>
+                        <div class="control-panel-inner">
+                            <div class="caption ">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">1</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The one-bedroom just came to market at $2.495 million</p>
+                                <div class="caption_480">
+                                    <p> The one-bedroom just came to market at $2.495 million </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">The one-bedroom just came to market at $2.495 million</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">2</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Before the massive renovation, the living area still had great views, but was dated.</p>
+                                <div class="caption_480">
+                                    <p> Before the massive renovation, the living area still had great views, but was dated. </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">Before the massive renovation, the living area still had great views,...but was dated.</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">3</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Beautiful views from the floor-to-ceiling windows.</p>
+                                <div class="caption_480">
+                                    <p> Beautiful views from the floor-to-ceiling windows. </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">Beautiful views from the floor-to-ceiling windows.</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">4</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The open concept living room</p>
+                                <div class="caption_480">
+                                    <p> The open concept living room </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">The open concept living room</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">5</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The dining area</p>
+                            </div>
+                            <p class="MsoNormal">The dining area</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">6</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The open entertaining space</p>
+                                <div class="caption_480">
+                                    <p> The open entertaining space </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">The open entertaining space</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">7</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The dining area before</p>
+                            </div>
+                            <p class="MsoNormal">The dining area before</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">8</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The den</p>
+                            </div>
+                            <p class="MsoNormal">The den</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">9</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Another view of the den</p>
+                            </div>
+                            <p class="MsoNormal">Another view of the den</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">10</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The kitchen</p>
+                            </div>
+                            <p class="MsoNormal">The kitchen</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">11</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The kitchen</p>
+                            </div>
+                            <p class="MsoNormal">The kitchen</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">12</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Custom cabinets and granite counters</p>
+                                <div class="caption_480">
+                                    <p> Custom cabinets and granite counters </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">Custom cabinets and granite counters</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">13</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Another shot of the kitchen</p>
+                                <div class="caption_480">
+                                    <p> Another shot of the kitchen </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">Another shot of the kitchen</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">14</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The old, enclosed kitchen</p>
+                                <div class="caption_480">
+                                    <p> The old, enclosed kitchen </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">The old, enclosed kitchen</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">15</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Views from the kitchen</p>
+                            </div>
+                            <p class="MsoNormal">Views from the kitchen</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">16</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Built-in office nook</p>
+                            </div>
+                            <p class="MsoNormal">Built-in office nook</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">17</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The only bedroom also takes advantage of the views. </p>
+                                <div class="caption_480">
+                                    <p> The only bedroom also takes advantage of the views. </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">The only bedroom also takes advantage of the views. </p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">18</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Another shot of the bedroom</p>
+                                <div class="caption_480">
+                                    <p> Another shot of the bedroom </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">Another shot of the bedroom</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">19</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The bedroom before</p>
+                            </div>
+                            <p class="MsoNormal">The bedroom before</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">20</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Master closet</p>
+                            </div>
+                            <p class="MsoNormal">Master closet</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">21</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Master bath</p>
+                            </div>
+                            <p class="MsoNormal">Master bath</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">22</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Another shot of the master bath</p>
+                                <div class="caption_480">
+                                    <p> Another shot of the master bath </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">Another shot of the master bath</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">23</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Soaking tub</p>
+                            </div>
+                            <p class="MsoNormal">Soaking tub</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">24</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Entry</p>
+                            </div>
+                            <p class="MsoNormal">Entry</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">25</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Standing on the balcony</p>
+                            </div>
+                            <p class="MsoNormal">Standing on the balcony</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">26</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Views from the northwest facing condo</p>
+                                <div class="caption_480">
+                                    <p> Views from the northwest facing condo </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">Views from the northwest facing condo</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">27</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">More views</p>
+                            </div>
+                            <p class="MsoNormal">More views</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">28</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Golden Gate Bridge views</p>
+                            </div>
+                            <p class="MsoNormal">Golden Gate Bridge views</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">29</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">From inside the condo</p>
+                            </div>
+                            <p class="MsoNormal">From inside the condo</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">30</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">This corner window before</p>
+                                <div class="caption_480">
+                                    <p> This corner window before </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">This corner window before</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">31</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The Comstock</p>
+                            </div>
+                            <p class="MsoNormal">The Comstock</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">32</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">The lobby</p>
+                            </div>
+                            <p class="MsoNormal">The lobby</p>
+                            <div class="caption staged">
+                                <div class="slide-count">
+                                    <p class="nav-stats"> <span class="label">Image </span> <span class="item-count-current">33</span> <span> of </span><span class="item-count-total">33</span> <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span> </p>
+                                </div><span class="credit">MLS  </span>
+                                <p class="MsoNormal">Another view of the lobby</p>
+                                <div class="caption_480">
+                                    <p> Another view of the lobby </p>
+                                </div>
+                            </div>
+                            <p class="MsoNormal">Another view of the lobby</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <p>In early March, we told you about <a href="http://blog.sfgate.com/ontheblock/2015/03/05/2-495-million-for-s-f-s-most-expensive-one-bedroom/">a one-bedroom in the prestigious Comstock </a>in Nob Hill, which came to market at $2.495 million, making it the most expensive one-bedroom on the market at the time. The northwest facing unit—with amazing panoramic views of Twin Peaks, the Golden Gate Bridge, the North Bay, Alcatraz and Coit Tower in almost every room—has now sold for $2.3 million, or 8% under the asking price.</p>
+        <p>At just over 1,800 square feet, the sale works out to about $1,250 a square foot for the completely gutted and remodeled unit. That price is also about $700K higher than when the unit last sold at the end of 2006. Of course, it was also in a very different state at the time, with old carpeting; a closed-off, very outdated kitchen; and two bedrooms. (<strong>Before and afters are in the gallery above.</strong>)</p>
+        <p>Almost all the walls came down during the remodel and the carpeting was changed out for hardwoods, not to mention the addition of a completely new open concept kitchen and modern bathrooms. Also, the second bedroom was changed into a den/office with a glass wall separating it from the rest of the large entertaining space. Even the windows were updated to take better advantage of the unbelievable views.</p>
+        <p>By the way, if you’re looking for the same great views with a (slightly) smaller price tag, <a href="http://www.comstock1402.com">a 1,200-square-foot one-bedroom</a> just came to market in the same building. You’ll get less indoor space but what appears to be a larger balcony to take in those incredible San Francisco sights, all for the bargain price of $1.75 million.</p>
+        <p><em>Emily Landes is a writer and editor who is obsessed with all things real estate.</em></p>
+    </div>
+</div>

--- a/test/test-pages/sfgate-1/source.html
+++ b/test/test-pages/sfgate-1/source.html
@@ -1,0 +1,9373 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xmlns:fb="http://ogp.me/ns/fb#" xmlns:og="http://ogp.me/ns#" class="ui-mobile js flexbox canvas canvastext webgl no-touch geolocation postmessage no-websqldatabase indexeddb hashchange history draganddrop websockets rgba hsla multiplebgs backgroundsize borderimage borderradius boxshadow textshadow opacity cssanimations csscolumns cssgradients no-cssreflections csstransforms csstransforms3d csstransitions fontface generatedcontent video audio localstorage sessionstorage webworkers applicationcache svg inlinesvg smil svgclippaths gecko mac js gecko mac js" style="">
+
+<head>
+    <script src="//sfgate-com.c.richmetrics.com/log?type=activity&amp;sn=12&amp;ct=6377&amp;pi=NNXIOGANTJ70&amp;mk=SFGH9VMY1NKD&amp;wn=sfgate.com&amp;ui=NNXI4VU07DJL&amp;av=x1.9.0-d1-JS&amp;ty=blur&amp;wd=1920x974&amp;ws=0x0;type=activity&amp;sn=13&amp;ct=8281&amp;pi=NNXIOGANTJ70&amp;mk=SFGH9VMY1NKD&amp;wn=sfgate.com&amp;ui=NNXI4VU07DJL&amp;av=x1.9.0-d1-JS&amp;ty=focus&amp;wd=1920x974&amp;ws=0x0" type="text/javascript"></script>
+    <script src="http://s0.2mdn.net/instream/video/client.js" async="" type="text/javascript"></script>
+    <script src="http://dnn506yrbagrg.cloudfront.net/pages/scripts/0018/4708.js?397476" async="" type="text/javascript"></script>
+    <script type="text/javascript" src="http://odb.outbrain.com/utils/get?url=%24permalink&amp;settings=true&amp;recs=true&amp;widgetJSId=SB_2&amp;key=NANOWDGT01&amp;idx=2&amp;version=248244&amp;ref=&amp;apv=true&amp;sig=VSZGNB8U&amp;format=html&amp;rand=59788&amp;lsd=79cdd733-1588-4471-862e-f5a97a05ce55&amp;t=MV83OTlhMDA2NzMyNDE2MDdmMTEyZWRkN2YxODAyM2Q5NF8w&amp;winW=1920&amp;winH=974" charset="UTF-8" async=""></script>
+    <script async="" src="/external/weather/weather.json?_=1430917070636"></script>
+    <iframe style="width: 0px; height: 0px; border: 0px none;" src="javascript:false"></iframe>
+    <script type="text/javascript" async="" src="//cdn.viafoura.net/vf.js"></script>
+    <script type="text/javascript" id="SailThruHorizon" async="" src="http://ak.sail-horizon.com/horizon/v1.js"></script>
+    <script async="" src="http://b.scorecardresearch.com/beacon.js"></script>
+    <script async="" src="//www.google-analytics.com/analytics.js"></script>
+    <script type="text/javascript" src="http://odb.outbrain.com/utils/get?url=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F&amp;settings=true&amp;recs=true&amp;widgetJSId=AR_3&amp;key=NANOWDGT01&amp;idx=1&amp;version=248244&amp;ref=&amp;apv=true&amp;sig=VSZGNB8U&amp;format=html&amp;rand=80371&amp;lsd=79cdd733-1588-4471-862e-f5a97a05ce55&amp;t=MV83OTlhMDA2NzMyNDE2MDdmMTEyZWRkN2YxODAyM2Q5NF8w&amp;winW=1920&amp;winH=974" charset="UTF-8" async=""></script>
+    <script async="" src="//sfgate.placester.net/api/widgets/"></script>
+    <script type="text/javascript" src="http://odb.outbrain.com/utils/get?url=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F&amp;settings=true&amp;recs=true&amp;widgetJSId=AR_5&amp;key=NANOWDGT01&amp;idx=0&amp;version=248244&amp;ref=&amp;apv=false&amp;sig=VSZGNB8U&amp;format=html&amp;rand=5940&amp;lsd=79cdd733-1588-4471-862e-f5a97a05ce55&amp;winW=1920&amp;winH=974" charset="UTF-8" async=""></script>
+    <script src="http://t01.proximic.com/c.js?m=1&amp;s=hearst_js&amp;url=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F"></script>
+    <script src="//static.chartbeat.com/js/chartbeat.js"></script>
+    <script src="//native.sharethrough.com/assets/tag.js"></script>
+    <script src="http://a.postrelease.com/serve/load.js?async=true"></script>
+    <script type="text/javascript" async="" src="//m.burt.io/s/sfgate-com.js"></script>
+    <script type="text/javascript" async="" src="http://s.moatads.com/sfgate883iFkm77/moatcontent.js"></script>
+    <script src="//tru.am/scripts/ta-pagesocial-sdk.js"></script>
+    <script type="text/javascript" async="" src="http://c4.ic-live.COM/pixel-js/c4-pixel.js"></script>
+    <script type="text/javascript" async="" src="http://stats.g.doubleclick.net/dc.js"></script>
+    <script src="http://nexus.ensighten.com/hearst/news/code/ecab0722633089a634d4b7b851a9e66d.js?conditionId0=318651"></script>
+    <script src="http://nexus.ensighten.com/hearst/news/code/99610952aba0b868d6321e192a9e0e8b.js?conditionId0=304054"></script>
+    <script src="http://nexus.ensighten.com/hearst/news/code/b9eca02bcd22723f07d36a655f71c115.js?conditionId0=324930"></script>
+    <script src="http://nexus.ensighten.com/hearst/news/code/618a1f51d36b70ff8ff2a0364ead6da8.js?conditionId0=318893"></script>
+    <script type="text/javascript" async="" src="http://nexus.ensighten.com/hearst/news/code/ebdb7a11ab840ea107b16733e694cf32.js?conditionId0=353340"></script>
+    <script type="text/javascript" async="" src="//cdn.viafoura.net/vf.js"></script>
+    <script type="text/javascript" async="" id="_nw2e-js" src="http://launch.newsinc.com/js/embed.js"></script>
+    <script type="text/javascript" async="" id="_nw2e-js" src="http://launch.newsinc.com/js/embed.js"></script>
+    <script src="http://nexus.ensighten.com/hearst/news/serverComponent.php?r=448.55555168648&amp;ClientID=109&amp;PageID=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F"></script>
+    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible" />
+    <meta charset="UTF-8" />
+    <iframe style="position: absolute; top: -10000px; left: -1000px;"></iframe>
+    <script type="text/javascript" async="" src="http://ad.crwdcntrl.net/5/c=1859/pe=y/callback=_nw2e.closures.c0"></script>
+    <script type="text/javascript">
+    window.NREUM || (NREUM = {}), __nr_require = function(e, n, t) {
+        function r(t) {
+            if (!n[t]) {
+                var o = n[t] = {
+                    exports: {}
+                };
+                e[t][0].call(o.exports, function(n) {
+                    var o = e[t][1][n];
+                    return r(o ? o : n)
+                }, o, o.exports)
+            }
+            return n[t].exports
+        }
+        if ("function" == typeof __nr_require) return __nr_require;
+        for (var o = 0; o & lt; t.length; o++) r(t[o]);
+        return r
+    }({
+        QJf3ax: [function(e, n) {
+            function t(e) {
+                function n(n, t, a) {
+                    e & amp; & amp;
+                    e(n, t, a), a || (a = {});
+                    for (var u = c(n), f = u.length, s = i(a, o, r), p = 0; f & gt; p; p++) u[p].apply(s, t);
+                    return s
+                }
+
+                function a(e, n) {
+                    f[e] = c(e).concat(n)
+                }
+
+                function c(e) {
+                    return f[e] || []
+                }
+
+                function u() {
+                    return t(n)
+                }
+                var f = {};
+                return {
+                    on: a,
+                    emit: n,
+                    create: u,
+                    listeners: c,
+                    _events: f
+                }
+            }
+
+            function r() {
+                return {}
+            }
+            var o = "nr@context",
+                i = e("gos");
+            n.exports = t()
+        }, {
+            gos: "7eSDFh"
+        }],
+        ee: [function(e, n) {
+            n.exports = e("QJf3ax")
+        }, {}],
+        3: [function(e, n) {
+            function t(e) {
+                return function() {
+                    r(e, [(new Date).getTime()].concat(i(arguments)))
+                }
+            }
+            var r = e("handle"),
+                o = e(1),
+                i = e(2);
+            "undefined" == typeof window.newrelic & amp; & amp;
+            (newrelic = window.NREUM);
+            var a = ["setPageViewName", "addPageAction", "setCustomAttribute", "finished", "addToTrace", "inlineHit", "noticeError"];
+            o(a, function(e, n) {
+                window.NREUM[n] = t("api-" + n)
+            }), n.exports = window.NREUM
+        }, {
+            1: 12,
+            2: 13,
+            handle: "D5DuLP"
+        }],
+        "7eSDFh": [function(e, n) {
+            function t(e, n, t) {
+                if (r.call(e, n)) return e[n];
+                var o = t();
+                if (Object.defineProperty & amp; & amp; Object.keys) try {
+                    return Object.defineProperty(e, n, {
+                        value: o,
+                        writable: !0,
+                        enumerable: !1
+                    }), o
+                } catch (i) {}
+                return e[n] = o, o
+            }
+            var r = Object.prototype.hasOwnProperty;
+            n.exports = t
+        }, {}],
+        gos: [function(e, n) {
+            n.exports = e("7eSDFh")
+        }, {}],
+        handle: [function(e, n) {
+            n.exports = e("D5DuLP")
+        }, {}],
+        D5DuLP: [function(e, n) {
+            function t(e, n, t) {
+                return r.listeners(e).length ? r.emit(e, n, t) : (o[e] || (o[e] = []), void o[e].push(n))
+            }
+            var r = e("ee").create(),
+                o = {};
+            n.exports = t, t.ee = r, r.q = o
+        }, {
+            ee: "QJf3ax"
+        }],
+        id: [function(e, n) {
+            n.exports = e("XL7HBI")
+        }, {}],
+        XL7HBI: [function(e, n) {
+            function t(e) {
+                var n = typeof e;
+                return !e || "object" !== n & amp; & amp;
+                "function" !== n ? -1 : e === window ? 0 : i(e, o, function() {
+                    return r++
+                })
+            }
+            var r = 1,
+                o = "nr@id",
+                i = e("gos");
+            n.exports = t
+        }, {
+            gos: "7eSDFh"
+        }],
+        G9z0Bl: [function(e, n) {
+            function t() {
+                var e = d.info = NREUM.info,
+                    n = f.getElementsByTagName("script")[0];
+                if (e & amp; & amp; e.licenseKey & amp; & amp; e.applicationID & amp; & amp; n) {
+                    c(p, function(n, t) {
+                        n in e || (e[n] = t)
+                    });
+                    var t = "https" === s.split(":")[0] || e.sslForHttp;
+                    d.proto = t ? "https://" : "http://", a("mark", ["onload", i()]);
+                    var r = f.createElement("script");
+                    r.src = d.proto + e.agent, n.parentNode.insertBefore(r, n)
+                }
+            }
+
+            function r() {
+                "complete" === f.readyState & amp; & amp;
+                o()
+            }
+
+            function o() {
+                a("mark", ["domContent", i()])
+            }
+
+            function i() {
+                return (new Date).getTime()
+            }
+            var a = e("handle"),
+                c = e(1),
+                u = (e(2), window),
+                f = u.document,
+                s = ("" + location).split("?")[0],
+                p = {
+                    beacon: "bam.nr-data.net",
+                    errorBeacon: "bam.nr-data.net",
+                    agent: "js-agent.newrelic.com/nr-632.min.js"
+                },
+                d = n.exports = {
+                    offset: i(),
+                    origin: s,
+                    features: {}
+                };
+            f.addEventListener ? (f.addEventListener("DOMContentLoaded", o, !1), u.addEventListener("load", t, !1)) : (f.attachEvent("onreadystatechange", r), u.attachEvent("onload", t)), a("mark", ["firstbyte", i()])
+        }, {
+            1: 12,
+            2: 3,
+            handle: "D5DuLP"
+        }],
+        loader: [function(e, n) {
+            n.exports = e("G9z0Bl")
+        }, {}],
+        12: [function(e, n) {
+            function t(e, n) {
+                var t = [],
+                    o = "",
+                    i = 0;
+                for (o in e) r.call(e, o) & amp; & amp;
+                (t[i] = n(o, e[o]), i += 1);
+                return t
+            }
+            var r = Object.prototype.hasOwnProperty;
+            n.exports = t
+        }, {}],
+        13: [function(e, n) {
+            function t(e, n, t) {
+                n || (n = 0), "undefined" == typeof t & amp; & amp;
+                (t = e ? e.length : 0);
+                for (var r = -1, o = t - n || 0, i = Array(0 & gt; o ? 0 : o); ++r & lt; o;) i[r] = e[n + r];
+                return i
+            }
+            n.exports = t
+        }, {}]
+    }, {}, ["G9z0Bl"]);
+    </script>
+    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0" name="viewport" id="owp" />
+    <title>
+        Nob Hill one-bedroom sells for $2.3 million - On The Block </title>
+    <!-- wroteOmniVars:  -->
+    <script type="text/javascript">
+    // Set some JS variables
+    omni_blogname = "On The Block";
+    omni_blogposttitle = "Nob Hill one-bedroom sells for $2.3 million";
+    omni_blogID = '2283';
+    omni_blogusage = 'blog';
+    omni_blogauthortype = 'staff';
+    omni_blogcategory = 'classifieds';
+    omni_blogcategory2 = 'realestate';
+
+
+    omni_blognetwork = 'blog.sfgate.com';
+    omni_blogpath = '/ontheblock/';
+    omni_blogpagetype = 'post';
+    omni_blogpageID = '9755'
+
+
+    omni_blogauthor = 'Emily Landes';
+    </script>
+    <script>
+    try {
+        var args = document.location.search.substring(1).split('&amp;');
+        argsParsed = {};
+        for (var i = 0; i & lt; args.length; i++) {
+            var arg = decodeURIComponent(args[i]);
+            if (arg.indexOf('=') == -1) {
+                argsParsed[arg.trim()] = true;
+            } else {
+                var kvp = arg.split('=');
+                argsParsed[kvp[0].trim()] = kvp[1].trim();
+            }
+        }
+        var aps = {};
+        if (argsParsed.hasOwnProperty("s")) {
+            aps.key = 'keyword';
+            aps.values = argsParsed["s"].split('+');
+        } else if (argsParsed.hasOwnProperty("tsp")) {
+            aps.key = 'keyword';
+            aps.values = ['top_story_page'];
+        }
+
+
+    } catch (err) {}
+    </script>
+    <script src="/wp-content/mu-plugins/is-mobile/set-web.js" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/mu-plugins/is-mobile/is-mobile.js" type="text/javascript"></script>
+    <script type="text/javascript">
+    document.write('&lt;scr' + 'ipt type="text/javascript" src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/chrome.js.php?h=' + (is_mobile ? "f4b4002267098f050571fc904fd8c008" : "db6578420d83622f4501e30d88f41645") + (is_mobile ? '&amp;amp;view=mobile' : '') + '"&gt;&lt;/scr' + 'ipt&gt;');
+    window.responsive_base = window.responsive_base || {};
+    window.responsive_base.nav_json = "";
+    </script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/chrome.js.php?h=db6578420d83622f4501e30d88f41645" type="text/javascript"></script>
+    <!-- ux/sfgate hearst/home/header_main.tpl -->
+    <meta charset="utf-8" />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+    <script type="text/javascript">
+    (window.NREUM || (NREUM = {})).loader_config = {
+        xpid: "UAcHUF9ACQcHVVRV"
+    };
+    window.NREUM || (NREUM = {}), __nr_require = function(t, e, n) {
+        function r(n) {
+            if (!e[n]) {
+                var o = e[n] = {
+                    exports: {}
+                };
+                t[n][0].call(o.exports, function(e) {
+                    var o = t[n][1][e];
+                    return r(o ? o : e)
+                }, o, o.exports)
+            }
+            return e[n].exports
+        }
+        if ("function" == typeof __nr_require) return __nr_require;
+        for (var o = 0; o & lt; n.length; o++) r(n[o]);
+        return r
+    }({
+        QJf3ax: [function(t, e) {
+            function n(t) {
+                function e(e, n, a) {
+                    t & amp; & amp;
+                    t(e, n, a), a || (a = {});
+                    for (var c = s(e), f = c.length, u = i(a, o, r), d = 0; f & gt; d; d++) c[d].apply(u, n);
+                    return u
+                }
+
+                function a(t, e) {
+                    f[t] = s(t).concat(e)
+                }
+
+                function s(t) {
+                    return f[t] || []
+                }
+
+                function c() {
+                    return n(e)
+                }
+                var f = {};
+                return {
+                    on: a,
+                    emit: e,
+                    create: c,
+                    listeners: s,
+                    _events: f
+                }
+            }
+
+            function r() {
+                return {}
+            }
+            var o = "nr@context",
+                i = t("gos");
+            e.exports = n()
+        }, {
+            gos: "7eSDFh"
+        }],
+        ee: [function(t, e) {
+            e.exports = t("QJf3ax")
+        }, {}],
+        3: [function(t) {
+            function e(t) {
+                try {
+                    i.console & amp; & amp;
+                    console.log(t)
+                } catch (e) {}
+            }
+            var n, r = t("ee"),
+                o = t(1),
+                i = {};
+            try {
+                n = localStorage.getItem("__nr_flags").split(","), console & amp; & amp;
+                "function" == typeof console.log & amp; & amp;
+                (i.console = !0, -1 !== n.indexOf("dev") & amp; & amp;
+                    (i.dev = !0), -1 !== n.indexOf("nr_dev") & amp; & amp;
+                    (i.nrDev = !0))
+            } catch (a) {}
+            i.nrDev & amp; & amp;
+            r.on("internal-error", function(t) {
+                e(t.stack)
+            }), i.dev & amp; & amp;
+            r.on("fn-err", function(t, n, r) {
+                e(r.stack)
+            }), i.dev & amp; & amp;
+            (e("NR AGENT IN DEVELOPMENT MODE"), e("flags: " + o(i, function(t) {
+                return t
+            }).join(", ")))
+        }, {
+            1: 22,
+            ee: "QJf3ax"
+        }],
+        4: [function(t) {
+            function e(t, e, n, i, s) {
+                try {
+                    c ? c -= 1 : r("err", [s || new UncaughtException(t, e, n)])
+                } catch (f) {
+                    try {
+                        r("ierr", [f, (new Date).getTime(), !0])
+                    } catch (u) {}
+                }
+                return "function" == typeof a ? a.apply(this, o(arguments)) : !1
+            }
+
+            function UncaughtException(t, e, n) {
+                this.message = t || "Uncaught error with no additional information", this.sourceURL = e, this.line = n
+            }
+
+            function n(t) {
+                r("err", [t, (new Date).getTime()])
+            }
+            var r = t("handle"),
+                o = t(6),
+                i = t("ee"),
+                a = window.onerror,
+                s = !1,
+                c = 0;
+            t("loader").features.err = !0, t(5), window.onerror = e;
+            try {
+                throw new Error
+            } catch (f) {
+                "stack" in f & amp; & amp;
+                (t(1), t(2), "addEventListener" in window & amp; & amp; t(3), window.XMLHttpRequest & amp; & amp; XMLHttpRequest.prototype & amp; & amp; XMLHttpRequest.prototype.addEventListener & amp; & amp; window.XMLHttpRequest & amp; & amp; XMLHttpRequest.prototype & amp; & amp; XMLHttpRequest.prototype.addEventListener & amp; & amp; !/CriOS/.test(navigator.userAgent) & amp; & amp; t(4), s = !0)
+            }
+            i.on("fn-start", function() {
+                s & amp; & amp;
+                (c += 1)
+            }), i.on("fn-err", function(t, e, r) {
+                s & amp; & amp;
+                (this.thrown = !0, n(r))
+            }), i.on("fn-end", function() {
+                s & amp; & amp;
+                !this.thrown & amp; & amp;
+                c & gt;
+                0 & amp; & amp;
+                (c -= 1)
+            }), i.on("internal-error", function(t) {
+                r("ierr", [t, (new Date).getTime(), !0])
+            })
+        }, {
+            1: 9,
+            2: 8,
+            3: 6,
+            4: 10,
+            5: 3,
+            6: 23,
+            ee: "QJf3ax",
+            handle: "D5DuLP",
+            loader: "G9z0Bl"
+        }],
+        5: [function(t) {
+            function e() {}
+            if (window.performance & amp; & amp; window.performance.timing & amp; & amp; window.performance.getEntriesByType) {
+                var n = t("ee"),
+                    r = t("handle"),
+                    o = t(1),
+                    i = t(2);
+                t("loader").features.stn = !0, t(3), n.on("fn-start", function(t) {
+                    var e = t[0];
+                    e instanceof Event & amp; & amp;
+                    (this.bstStart = Date.now())
+                }), n.on("fn-end", function(t, e) {
+                    var n = t[0];
+                    n instanceof Event & amp; & amp;
+                    r("bst", [n, e, this.bstStart, Date.now()])
+                }), o.on("fn-start", function(t, e, n) {
+                    this.bstStart = Date.now(), this.bstType = n
+                }), o.on("fn-end", function(t, e) {
+                    r("bstTimer", [e, this.bstStart, Date.now(), this.bstType])
+                }), i.on("fn-start", function() {
+                    this.bstStart = Date.now()
+                }), i.on("fn-end", function(t, e) {
+                    r("bstTimer", [e, this.bstStart, Date.now(), "requestAnimationFrame"])
+                }), n.on("pushState-start", function() {
+                    this.time = Date.now(), this.startPath = location.pathname + location.hash
+                }), n.on("pushState-end", function() {
+                    r("bstHist", [location.pathname + location.hash, this.startPath, this.time])
+                }), "addEventListener" in window.performance & amp; & amp;
+                (window.performance.addEventListener("webkitresourcetimingbufferfull", function() {
+                    r("bstResource", [window.performance.getEntriesByType("resource")]), window.performance.webkitClearResourceTimings()
+                }, !1), window.performance.addEventListener("resourcetimingbufferfull", function() {
+                    r("bstResource", [window.performance.getEntriesByType("resource")]), window.performance.clearResourceTimings()
+                }, !1)), document.addEventListener("scroll", e, !1), document.addEventListener("keypress", e, !1), document.addEventListener("click", e, !1)
+            }
+        }, {
+            1: 9,
+            2: 8,
+            3: 7,
+            ee: "QJf3ax",
+            handle: "D5DuLP",
+            loader: "G9z0Bl"
+        }],
+        6: [function(t, e) {
+            function n(t) {
+                i.inPlace(t, ["addEventListener", "removeEventListener"], "-", r)
+            }
+
+            function r(t) {
+                return t[1]
+            }
+            var o = (t(1), t("ee").create()),
+                i = t(2)(o),
+                a = t("gos");
+            if (e.exports = o, n(window), "getPrototypeOf" in Object) {
+                for (var s = document; s & amp; & amp; !s.hasOwnProperty("addEventListener");) s = Object.getPrototypeOf(s);
+                s & amp; & amp;
+                n(s);
+                for (var c = XMLHttpRequest.prototype; c & amp; & amp; !c.hasOwnProperty("addEventListener");) c = Object.getPrototypeOf(c);
+                c & amp; & amp;
+                n(c)
+            } else XMLHttpRequest.prototype.hasOwnProperty("addEventListener") & amp; & amp;
+            n(XMLHttpRequest.prototype);
+            o.on("addEventListener-start", function(t) {
+                if (t[1]) {
+                    var e = t[1];
+                    "function" == typeof e ? this.wrapped = t[1] = a(e, "nr@wrapped", function() {
+                        return i(e, "fn-", null, e.name || "anonymous")
+                    }) : "function" == typeof e.handleEvent & amp; & amp;
+                    i.inPlace(e, ["handleEvent"], "fn-")
+                }
+            }), o.on("removeEventListener-start", function(t) {
+                var e = this.wrapped;
+                e & amp; & amp;
+                (t[1] = e)
+            })
+        }, {
+            1: 23,
+            2: 24,
+            ee: "QJf3ax",
+            gos: "7eSDFh"
+        }],
+        7: [function(t, e) {
+            var n = (t(2), t("ee").create()),
+                r = t(1)(n);
+            e.exports = n, r.inPlace(window.history, ["pushState"], "-")
+        }, {
+            1: 24,
+            2: 23,
+            ee: "QJf3ax"
+        }],
+        8: [function(t, e) {
+            var n = (t(2), t("ee").create()),
+                r = t(1)(n);
+            e.exports = n, r.inPlace(window, ["requestAnimationFrame", "mozRequestAnimationFrame", "webkitRequestAnimationFrame", "msRequestAnimationFrame"], "raf-"), n.on("raf-start", function(t) {
+                t[0] = r(t[0], "fn-")
+            })
+        }, {
+            1: 24,
+            2: 23,
+            ee: "QJf3ax"
+        }],
+        9: [function(t, e) {
+            function n(t, e, n) {
+                t[0] = o(t[0], "fn-", null, n)
+            }
+            var r = (t(2), t("ee").create()),
+                o = t(1)(r);
+            e.exports = r, o.inPlace(window, ["setTimeout", "setInterval", "setImmediate"], "setTimer-"), r.on("setTimer-start", n)
+        }, {
+            1: 24,
+            2: 23,
+            ee: "QJf3ax"
+        }],
+        10: [function(t, e) {
+            function n() {
+                f.inPlace(this, p, "fn-")
+            }
+
+            function r(t, e) {
+                f.inPlace(e, ["onreadystatechange"], "fn-")
+            }
+
+            function o(t, e) {
+                return e
+            }
+
+            function i(t, e) {
+                for (var n in t) e[n] = t[n];
+                return e
+            }
+            var a = t("ee").create(),
+                s = t(1),
+                c = t(2),
+                f = c(a),
+                u = c(s),
+                d = window.XMLHttpRequest,
+                p = ["onload", "onerror", "onabort", "onloadstart", "onloadend", "onprogress", "ontimeout"];
+            e.exports = a, window.XMLHttpRequest = function(t) {
+                var e = new d(t);
+                try {
+                    a.emit("new-xhr", [], e), u.inPlace(e, ["addEventListener", "removeEventListener"], "-", o), e.addEventListener("readystatechange", n, !1)
+                } catch (r) {
+                    try {
+                        a.emit("internal-error", [r])
+                    } catch (i) {}
+                }
+                return e
+            }, i(d, XMLHttpRequest), XMLHttpRequest.prototype = d.prototype, f.inPlace(XMLHttpRequest.prototype, ["open", "send"], "-xhr-", o), a.on("send-xhr-start", r), a.on("open-xhr-start", r)
+        }, {
+            1: 6,
+            2: 24,
+            ee: "QJf3ax"
+        }],
+        11: [function(t) {
+            function e(t) {
+                var e = this.params,
+                    r = this.metrics;
+                if (!this.ended) {
+                    this.ended = !0;
+                    for (var i = 0; c & gt; i; i++) t.removeEventListener(s[i], this.listener, !1);
+                    if (!e.aborted) {
+                        if (r.duration = (new Date).getTime() - this.startTime, 4 === t.readyState) {
+                            e.status = t.status;
+                            var a = t.responseType,
+                                f = "arraybuffer" === a || "blob" === a || "json" === a ? t.response : t.responseText,
+                                u = n(f);
+                            if (u & amp; & amp;
+                                (r.rxSize = u), this.sameOrigin) {
+                                var d = t.getResponseHeader("X-NewRelic-App-Data");
+                                d & amp; & amp;
+                                (e.cat = d.split(", ").pop())
+                            }
+                        } else e.status = 0;
+                        r.cbTime = this.cbTime, o("xhr", [e, r, this.startTime])
+                    }
+                }
+            }
+
+            function n(t) {
+                if ("string" == typeof t & amp; & amp; t.length) return t.length;
+                if ("object" != typeof t) return void 0;
+                if ("undefined" != typeof ArrayBuffer & amp; & amp; t instanceof ArrayBuffer & amp; & amp; t.byteLength) return t.byteLength;
+                if ("undefined" != typeof Blob & amp; & amp; t instanceof Blob & amp; & amp; t.size) return t.size;
+                if ("undefined" != typeof FormData & amp; & amp; t instanceof FormData) return void 0;
+                try {
+                    return JSON.stringify(t).length
+                } catch (e) {
+                    return void 0
+                }
+            }
+
+            function r(t, e) {
+                var n = i(e),
+                    r = t.params;
+                r.host = n.hostname + ":" + n.port, r.pathname = n.pathname, t.sameOrigin = n.sameOrigin
+            }
+            if (window.XMLHttpRequest & amp; & amp; XMLHttpRequest.prototype & amp; & amp; XMLHttpRequest.prototype.addEventListener & amp; & amp; !/CriOS/.test(navigator.userAgent)) {
+                t("loader").features.xhr = !0;
+                var o = t("handle"),
+                    i = t(2),
+                    a = t("ee"),
+                    s = ["load", "error", "abort", "timeout"],
+                    c = s.length,
+                    f = t(1);
+                t(4), t(3), a.on("new-xhr", function() {
+                    this.totalCbs = 0, this.called = 0, this.cbTime = 0, this.end = e, this.ended = !1, this.xhrGuids = {}
+                }), a.on("open-xhr-start", function(t) {
+                    this.params = {
+                        method: t[0]
+                    }, r(this, t[1]), this.metrics = {}
+                }), a.on("open-xhr-end", function(t, e) {
+                    "loader_config" in NREUM & amp; & amp;
+                    "xpid" in NREUM.loader_config & amp; & amp;
+                    this.sameOrigin & amp; & amp;
+                    e.setRequestHeader("X-NewRelic-ID", NREUM.loader_config.xpid)
+                }), a.on("send-xhr-start", function(t, e) {
+                    var r = this.metrics,
+                        o = t[0],
+                        i = this;
+                    if (r & amp; & amp; o) {
+                        var f = n(o);
+                        f & amp; & amp;
+                        (r.txSize = f)
+                    }
+                    this.startTime = (new Date).getTime(), this.listener = function(t) {
+                        try {
+                            "abort" === t.type & amp; & amp;
+                            (i.params.aborted = !0), ("load" !== t.type || i.called === i.totalCbs & amp; & amp;
+                                (i.onloadCalled || "function" != typeof e.onload)) & amp; & amp;
+                            i.end(e)
+                        } catch (n) {
+                            try {
+                                a.emit("internal-error", [n])
+                            } catch (r) {}
+                        }
+                    };
+                    for (var u = 0; c & gt; u; u++) e.addEventListener(s[u], this.listener, !1)
+                }), a.on("xhr-cb-time", function(t, e, n) {
+                    this.cbTime += t, e ? this.onloadCalled = !0 : this.called += 1, this.called !== this.totalCbs || !this.onloadCalled & amp; & amp;
+                    "function" == typeof n.onload || this.end(n)
+                }), a.on("xhr-load-added", function(t, e) {
+                    var n = "" + f(t) + !!e;
+                    this.xhrGuids & amp; & amp;
+                    !this.xhrGuids[n] & amp; & amp;
+                    (this.xhrGuids[n] = !0, this.totalCbs += 1)
+                }), a.on("xhr-load-removed", function(t, e) {
+                    var n = "" + f(t) + !!e;
+                    this.xhrGuids & amp; & amp;
+                    this.xhrGuids[n] & amp; & amp;
+                    (delete this.xhrGuids[n], this.totalCbs -= 1)
+                }), a.on("addEventListener-end", function(t, e) {
+                    e instanceof XMLHttpRequest & amp; & amp;
+                    "load" === t[0] & amp; & amp;
+                    a.emit("xhr-load-added", [t[1], t[2]], e)
+                }), a.on("removeEventListener-end", function(t, e) {
+                    e instanceof XMLHttpRequest & amp; & amp;
+                    "load" === t[0] & amp; & amp;
+                    a.emit("xhr-load-removed", [t[1], t[2]], e)
+                }), a.on("fn-start", function(t, e, n) {
+                    e instanceof XMLHttpRequest & amp; & amp;
+                    ("onload" === n & amp; & amp;
+                        (this.onload = !0), ("load" === (t[0] & amp; & amp; t[0].type) || this.onload) & amp; & amp;
+                        (this.xhrCbStart = (new Date).getTime()))
+                }), a.on("fn-end", function(t, e) {
+                    this.xhrCbStart & amp; & amp;
+                    a.emit("xhr-cb-time", [(new Date).getTime() - this.xhrCbStart, this.onload, e], e)
+                })
+            }
+        }, {
+            1: "XL7HBI",
+            2: 12,
+            3: 10,
+            4: 6,
+            ee: "QJf3ax",
+            handle: "D5DuLP",
+            loader: "G9z0Bl"
+        }],
+        12: [function(t, e) {
+            e.exports = function(t) {
+                var e = document.createElement("a"),
+                    n = window.location,
+                    r = {};
+                e.href = t, r.port = e.port;
+                var o = e.href.split("://");
+                return !r.port & amp; & amp;
+                o[1] & amp; & amp;
+                (r.port = o[1].split("/")[0].split("@").pop().split(":")[1]), r.port & amp; & amp;
+                "0" !== r.port || (r.port = "https" === o[0] ? "443" : "80"), r.hostname = e.hostname || n.hostname, r.pathname = e.pathname, r.protocol = o[0], "/" !== r.pathname.charAt(0) & amp; & amp;
+                (r.pathname = "/" + r.pathname), r.sameOrigin = !e.hostname || e.hostname === document.domain & amp; & amp;
+                e.port === n.port & amp; & amp;
+                e.protocol === n.protocol, r
+            }
+        }, {}],
+        13: [function(t, e) {
+            function n(t) {
+                return function() {
+                    r(t, [(new Date).getTime()].concat(i(arguments)))
+                }
+            }
+            var r = t("handle"),
+                o = t(1),
+                i = t(2);
+            "undefined" == typeof window.newrelic & amp; & amp;
+            (newrelic = window.NREUM);
+            var a = ["setPageViewName", "addPageAction", "setCustomAttribute", "finished", "addToTrace", "inlineHit", "noticeError"];
+            o(a, function(t, e) {
+                window.NREUM[e] = n("api-" + e)
+            }), e.exports = window.NREUM
+        }, {
+            1: 22,
+            2: 23,
+            handle: "D5DuLP"
+        }],
+        "7eSDFh": [function(t, e) {
+            function n(t, e, n) {
+                if (r.call(t, e)) return t[e];
+                var o = n();
+                if (Object.defineProperty & amp; & amp; Object.keys) try {
+                    return Object.defineProperty(t, e, {
+                        value: o,
+                        writable: !0,
+                        enumerable: !1
+                    }), o
+                } catch (i) {}
+                return t[e] = o, o
+            }
+            var r = Object.prototype.hasOwnProperty;
+            e.exports = n
+        }, {}],
+        gos: [function(t, e) {
+            e.exports = t("7eSDFh")
+        }, {}],
+        handle: [function(t, e) {
+            e.exports = t("D5DuLP")
+        }, {}],
+        D5DuLP: [function(t, e) {
+            function n(t, e, n) {
+                return r.listeners(t).length ? r.emit(t, e, n) : (o[t] || (o[t] = []), void o[t].push(e))
+            }
+            var r = t("ee").create(),
+                o = {};
+            e.exports = n, n.ee = r, r.q = o
+        }, {
+            ee: "QJf3ax"
+        }],
+        id: [function(t, e) {
+            e.exports = t("XL7HBI")
+        }, {}],
+        XL7HBI: [function(t, e) {
+            function n(t) {
+                var e = typeof t;
+                return !t || "object" !== e & amp; & amp;
+                "function" !== e ? -1 : t === window ? 0 : i(t, o, function() {
+                    return r++
+                })
+            }
+            var r = 1,
+                o = "nr@id",
+                i = t("gos");
+            e.exports = n
+        }, {
+            gos: "7eSDFh"
+        }],
+        G9z0Bl: [function(t, e) {
+            function n() {
+                var t = p.info = NREUM.info,
+                    e = f.getElementsByTagName("script")[0];
+                if (t & amp; & amp; t.licenseKey & amp; & amp; t.applicationID & amp; & amp; e) {
+                    s(d, function(e, n) {
+                        e in t || (t[e] = n)
+                    });
+                    var n = "https" === u.split(":")[0] || t.sslForHttp;
+                    p.proto = n ? "https://" : "http://", a("mark", ["onload", i()]);
+                    var r = f.createElement("script");
+                    r.src = p.proto + t.agent, e.parentNode.insertBefore(r, e)
+                }
+            }
+
+            function r() {
+                "complete" === f.readyState & amp; & amp;
+                o()
+            }
+
+            function o() {
+                a("mark", ["domContent", i()])
+            }
+
+            function i() {
+                return (new Date).getTime()
+            }
+            var a = t("handle"),
+                s = t(1),
+                c = (t(2), window),
+                f = c.document,
+                u = ("" + location).split("?")[0],
+                d = {
+                    beacon: "bam.nr-data.net",
+                    errorBeacon: "bam.nr-data.net",
+                    agent: "js-agent.newrelic.com/nr-632.min.js"
+                },
+                p = e.exports = {
+                    offset: i(),
+                    origin: u,
+                    features: {}
+                };
+            f.addEventListener ? (f.addEventListener("DOMContentLoaded", o, !1), c.addEventListener("load", n, !1)) : (f.attachEvent("onreadystatechange", r), c.attachEvent("onload", n)), a("mark", ["firstbyte", i()])
+        }, {
+            1: 22,
+            2: 13,
+            handle: "D5DuLP"
+        }],
+        loader: [function(t, e) {
+            e.exports = t("G9z0Bl")
+        }, {}],
+        22: [function(t, e) {
+            function n(t, e) {
+                var n = [],
+                    o = "",
+                    i = 0;
+                for (o in t) r.call(t, o) & amp; & amp;
+                (n[i] = e(o, t[o]), i += 1);
+                return n
+            }
+            var r = Object.prototype.hasOwnProperty;
+            e.exports = n
+        }, {}],
+        23: [function(t, e) {
+            function n(t, e, n) {
+                e || (e = 0), "undefined" == typeof n & amp; & amp;
+                (n = t ? t.length : 0);
+                for (var r = -1, o = n - e || 0, i = Array(0 & gt; o ? 0 : o); ++r & lt; o;) i[r] = t[e + r];
+                return i
+            }
+            e.exports = n
+        }, {}],
+        24: [function(t, e) {
+            function n(t) {
+                return !(t & amp; & amp;
+                    "function" == typeof t & amp; & amp; t.apply & amp; & amp; !t[i])
+            }
+            var r = t("ee"),
+                o = t(1),
+                i = "nr@wrapper",
+                a = Object.prototype.hasOwnProperty;
+            e.exports = function(t) {
+                function e(t, e, r, a) {
+                    function nrWrapper() {
+                        var n, i, s, f;
+                        try {
+                            i = this, n = o(arguments), s = r & amp; & amp;
+                            r(n, i) || {}
+                        } catch (d) {
+                            u([d, "", [n, i, a], s])
+                        }
+                        c(e + "start", [n, i, a], s);
+                        try {
+                            return f = t.apply(i, n)
+                        } catch (p) {
+                            throw c(e + "err", [n, i, p], s), p
+                        } finally {
+                            c(e + "end", [n, i, f], s)
+                        }
+                    }
+                    return n(t) ? t : (e || (e = ""), nrWrapper[i] = !0, f(t, nrWrapper), nrWrapper)
+                }
+
+                function s(t, r, o, i) {
+                    o || (o = "");
+                    var a, s, c, f = "-" === o.charAt(0);
+                    for (c = 0; c & lt; r.length; c++) s = r[c], a = t[s], n(a) || (t[s] = e(a, f ? s + o : o, i, s))
+                }
+
+                function c(e, n, r) {
+                    try {
+                        t.emit(e, n, r)
+                    } catch (o) {
+                        u([o, e, n, r])
+                    }
+                }
+
+                function f(t, e) {
+                    if (Object.defineProperty & amp; & amp; Object.keys) try {
+                        var n = Object.keys(t);
+                        return n.forEach(function(n) {
+                            Object.defineProperty(e, n, {
+                                get: function() {
+                                    return t[n]
+                                },
+                                set: function(e) {
+                                    return t[n] = e, e
+                                }
+                            })
+                        }), e
+                    } catch (r) {
+                        u([r])
+                    }
+                    for (var o in t) a.call(t, o) & amp; & amp;
+                    (e[o] = t[o]);
+                    return e
+                }
+
+                function u(e) {
+                    try {
+                        t.emit("internal-error", e)
+                    } catch (n) {}
+                }
+                return t || (t = r), e.inPlace = s, e.flag = i, e
+            }
+        }, {
+            1: 23,
+            ee: "QJf3ax"
+        }]
+    }, {}, ["G9z0Bl", 4, 11, 5]);
+    </script>
+    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport" id="ovp" />
+    <meta content="telephone=no" name="format-detection" />
+    <!-- Hotfix Top freeform -->
+    <!-- hearst/item/standalone.tpl -->
+    <!-- mid:freeform.38661 -->
+    <!-- CFREE-7548 | Do not remove -->
+    <script type="text/javascript">
+    function RProfiler() {}(function() {
+        var restUrl = "g.3gl.net/jp/v2/M";
+        var cfgUrl = "g.3gl.net/jp/147/v2/C";
+        var gsTime = (new Date()).getTime();
+        var RP = window.RProfiler;
+        if (!RP || RP.d) {
+            return;
+        }
+        RP.a = {};
+        RP.addInfo = function(iType, key, value) {
+            if (iType === undefined || iType === null) {
+                return;
+            }
+            if (value === undefined || value === null) {
+                RP.a[iType] = key;
+            } else {
+                if (key === undefined || key === null) {
+                    return;
+                }
+                if (!RP.a[iType]) {
+                    RP.a[iType] = {};
+                }
+                RP.a[iType][key] = value;
+            }
+        };
+        if (!document.getElementById || !(window.attachEvent || window.addEventListener)) {
+            return;
+        }
+        RP.d = {
+            s: gsTime,
+            lT: -1,
+            jsC: undefined,
+            jsE: undefined,
+            Lf: -1
+        };
+        var $E = RP.$E = (function() {
+            var sc = {};
+
+            function add(type, el, fn) {
+                if (!sc[type]) {
+                    sc[type] = [];
+                }
+                sc[type].push([el, type, fn]);
+            }
+            var atEv = (window.attachEvent) ? true : false;
+            return {
+                add: function(type, el, fn) {
+                    add(type, el, fn);
+                    if (atEv) {
+                        el.attachEvent('on' + type, fn);
+                    } else {
+                        el.addEventListener(type, fn, false);
+                    }
+                },
+                clearAll: function() {
+                    for (var type in sc) {
+                        var e, evs = sc[type];
+                        if ((evs) & amp; & amp;
+                            (evs.length & gt; 0)) {
+                            for (var i = 0; i & lt; evs.length; i++) {
+                                e = evs[i];
+                                if (atEv) {
+                                    e[0].detachEvent(e[1], e[2]);
+                                } else {
+                                    e[0].removeEventListener(e[1], e[2], false);
+                                }
+                            }
+                        }
+                    }
+                    sc = {};
+                }
+            };
+        })();
+
+        function regPL() {
+            RP.d.lT = (new Date()).getTime();
+            RP.d.Lf = 1;
+        }
+        $E.add('load', window, regPL);
+
+        function addErrorToList(m, u, l) {
+            RP.d.jsC++;
+            var k = [m, u, l].join(':'),
+                bFound = false;
+            var e = RP.d.jsE;
+            for (var i = 0; i & lt; e.length; i++) {
+                if (e[i][0] === k) {
+                    e[i][4]++;
+                    bFound = true;
+                    break;
+                }
+            }
+            if (!bFound) {
+                e.push([k, m, u, l, 1]);
+            }
+        }
+        if (!!window.opera) {
+            function regJsError(e) {
+                var ev = (e.target) ? e.target : e.srcElement;
+                if (ev.nodeType == 3) {
+                    ev = ev.parentNode;
+                }
+                addErrorToList('N/A', ev.src || ev.URL, 'N/A');
+                return false;
+            }
+            RP.d.jsC = 0;
+            RP.d.jsE = [];
+            $E.add('error', document, regJsError);
+        } else if ("onerror" in window) {
+            RP.d.jsC = 0;
+            RP.d.jsE = [];
+            var orgOnErr = window.onerror;
+            window.onerror = function(m, u, l) {
+                addErrorToList(m, u, l);
+                var r = false;
+                if (!!orgOnErr) {
+                    r = orgOnErr(m, u, l);
+                }
+                return r;
+            };
+        }
+        if (!!window.__cpCdnPath) {
+            restUrl = __cpCdnPath.trim();
+        }
+        var r = document.createElement("iframe");
+        var s = r.style;
+        s.position = "absolute";
+        s.top = "-10000px";
+        s.left = "-1000px";
+        var at = document.getElementsByTagName('script')[0];
+        at.parentNode.insertBefore(r, at);
+        var i = r.contentWindow.document.open('text/html', 'replace');
+        var pr = window.location.protocol + '//';
+        i.write("&lt;body onload='function f(u){ var d=document, s = d.createElement(\x22script\x22); s.type=\x22text/javascript\x22; s.src=u; d.body.appendChild(s); } f(\x22" + pr + cfgUrl + "\x22); f(\x22" + pr + restUrl + "\x22);'&gt;&lt;/body&gt;");
+        i.close();
+    })();
+    </script>
+    <!-- e CFREE-7548 -->
+    <script>
+    var HDN = HDN || {};
+    HDN.t_firstbyte = Number(new Date());
+    </script>
+    <!-- generated at 2015-05-06 07:40:21 on prodWCM6 running vr6.12.0.21 -->
+    <meta content="sfc" name="adwiz-site" />
+    <meta content="SKYPE_TOOLBAR_PARSER_COMPATIBLE" name="SKYPE_TOOLBAR" />
+    <script src="http://c.amazon-adsystem.com/aax2/amzn_ads.js" type="text/javascript"></script>
+    <script type="text/javascript">
+    try {
+        amznads.getAds('3070');
+    } catch (e) { /*ignore*/ }
+    </script>
+    <script src="http://aax.amazon-adsystem.com/e/dtb/bid?src=3070&amp;u=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F&amp;cb=5131702" type="text/javascript"></script>
+    <script type="text/javascript">
+    // &lt;![CDATA[
+    bizobject_identifier = "";
+    var requestTime = new Date(1430916021 * 1000);
+
+
+
+    // ]]&gt;
+    </script>
+    <script src="http://admin.brightcove.com/js/BrightcoveExperiences.js" type="text/javascript" language="JavaScript"></script>
+    <script id="_nw2e-js" src="http://launch.newsinc.com/js/embed.js" async="" type="text/javascript"></script>
+    <script src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"></script>
+    <title>CmfThirdPartyHeader - SFGate</title>
+    <link href="http://www.sfgate.com/favicon.ico" rel="SHORTCUT ICON" />
+    <link href="http://www.sfgate.com/apple-touch-icon.png" sizes="60x60" rel="apple-touch-icon" />
+    <link href="http://www.sfgate.com/apple-touch-icon-76x76.png" sizes="76x76" rel="apple-touch-icon" />
+    <link href="http://www.sfgate.com/apple-touch-icon-120x120.png" sizes="120x120" rel="apple-touch-icon" />
+    <link href="http://www.sfgate.com/apple-touch-icon-152x152.png" sizes="152x152" rel="apple-touch-icon" />
+    <link href="http://www.sfgate.com/apple-touch-icon-128x128.png" sizes="128x128" rel="apple-touch-icon-precomposed" />
+    <script src="http://www.sfgate.com/js/hdn/utils/modernizr-2.6.2.min.js?r6.12.0.21" type="text/javascript"></script>
+    <link media="all" href="http://www.sfgate.com/external/css/global.sharedmain.r6.12.0.21.css" type="text/css" rel="stylesheet" />
+    <link media="all" href="http://www.sfgate.com/external/css/global.sharedmodules.r6.12.0.21.css" type="text/css" rel="stylesheet" />
+    <link media="all" href="http://www.sfgate.com/external/css/global.legacyPages.r6.12.0.21.css" type="text/css" rel="stylesheet" />
+    <link media="all" href="http://www.sfgate.com/external/css/global.allPages.r6.12.0.21.css" type="text/css" rel="stylesheet" />
+    <!--[if lte IE 9]><link rel="stylesheet" type="text/css" href="http://www.sfgate.com/external/css/global.iePages.r6.12.0.21.css" media="all" /><![endif]-->
+    <script src="http://www.sfgate.com/external/js/global.allPages.r6.12.0.21.js" type="text/javascript"></script>
+    <!-- /business/templates/hearst/home/header_fbpage.tpl-->
+    <!-- e /business/templates/hearst/home/header_fbpage.tpl-->
+    <!-- CSS/JS Hotfix freeform -->
+    <!-- noGen: item_thirdParty_hotfix -->
+    <!-- Bing Webmaster Tools verification -->
+    <meta content="9451CA04ABC9D1D5C6419C73B4C4F7B7" name="msvalidate.01" />
+    <script type="text/javascript">
+    (function(e) {
+        var h = window.location.host;
+        var s = h.search(/qa|dev|preprod/);
+        var t = "";
+        if (s & gt; - 1 || document.cookie.indexOf("nsghtn=dev") & gt; - 1) {
+            console.log("Ensighten DEV");
+            t = e.location.protocol + "//nexus.ensighten.com/hearst/news-dev/Bootstrap.js";
+        } else {
+            console.log("Ensighten Prod");
+            t = e.location.protocol + "//nexus.ensighten.com/hearst/news/Bootstrap.js";
+        }
+        document.write("&lt;scr" + "ipt src='" + t + "'&gt;&lt;/scr" + "ipt&gt;");
+    })(document);
+    </script>
+    <script src="http://nexus.ensighten.com/hearst/news/Bootstrap.js"></script>
+    <script type="text/javascript">
+    function hdnIsTopStoryPage() {
+        var ref = document.referrer;
+        var refRE = /^http:\/\/[a-z.]*sfgate\.com(\/|\/index.s?html)?$/;
+        if (!ref.match(refRE)) {
+            return false;
+        }
+        var qs = window.location.search.substring(1, window.location.search.length);
+        if (qs.length & gt; 1) {
+            var qarray = qs.split("&amp;");
+            var re = /^tsp=/;
+            for (var i = 0; i & lt; qarray.length; i++) {
+                if (qarray[i].match(re)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    if (hdnIsTopStoryPage()) {
+        var aps = {};
+        aps.keyword = ["Top Story Page"];
+    }
+    </script>
+    <script type="text/javascript">
+    (function() {
+
+
+
+        window.juiceHasLoaded = false;
+
+        var prevDefinedEndDefineTagsFunction = window.onJuiceEvent_endDefineTags;
+        window.onJuiceEvent_endDefineTags = function() {
+            window.juiceHasLoaded = true;
+            prevDefinedEndDefineTagsFunction & amp; & amp;
+            prevDefinedEndDefineTagsFunction();
+        }
+    })();
+    </script>
+    <style type="text/css">
+    /* Fix for WP-936 3/4/15 */
+
+    .hst-resgallery-container .carousel {
+        height: auto !important;
+    }
+    /* Fix for update to WCM 3/3/15, removed after next WP Push to prod */
+
+    .ui-panel-animate.ui-panel-content-fixed-toolbar-position-right.ui-panel-content-fixed-toolbar-open.ui-panel-content-fixed-toolbar-display-reveal,
+    .ui-panel-animate.ui-panel-content-fixed-toolbar-position-right.ui-panel-content-fixed-toolbar-open.ui-panel-content-fixed-toolbar-display-push,
+    .ui-panel-animate.ui-panel-content-wrap-position-right.ui-panel-content-wrap-open.ui-panel-content-wrap-display-reveal,
+    .ui-panel-animate.ui-panel-content-wrap-position-right.ui-panel-content-wrap-open.ui-panel-content-wrap-display-push {
+        -webkit-transform: translate(-22em, 0);
+        -moz-transform: translate(-22em, 0);
+        transform: translate(-22em, 0);
+    }
+    /* WP-920 - fix for gallery overlay under nav EAR 2/20/15 fixed in following sprint */
+
+    .gallery-overlay-outter {
+        z-index: 5000 !important;
+    }
+    /* Fix for gallery appearing on top of A300 on mobile issue reported Jan 23rd */
+
+    .caption {
+        position: relative !important;
+    }
+    /* 3rd party Header bug fix */
+
+    .single-post #outer-wrap #content-wrap,
+    #outer-wrap #content-wrap {
+        margin-top: 50px;
+    }
+    /* WP-813 - Remove this once this ticket is in production */
+    /*.hdn-comments .viafoura .vf-comment-box .vf-comment-textarea .vf-content {
+color: #222 !important;
+font-family: "Georgia", sans-serif;
+font-size: 16px;
+font-weight: normal;
+line-height: 22px;
+}*/
+    </style>
+    <script language="javascript">
+    jQuery(document).ready(function() {
+        jQuery("a[href='/cgi-bin/sso/action/login']").attr('href', 'http://www.sfgate.com/cgi-bin/sso/action/login');
+        jQuery("a[href='/cgi-bin/webreg/user/reg_cnt']").attr('href', 'http://www.sfgate.com//cgi-bin/webreg/user/reg_cnt');
+    });
+    </script>
+    <style>
+    .page-template-nativo-page-php #A728 {
+        display: none;
+    }
+
+    .body-mobile #A300_ad_container iframe,
+    .body-mobile #B300_ad_container iframe,
+    .body-mobile #S300_ad_container iframe {
+        height: inherit !important;
+    }
+    /*Fix for Rm 23281*/
+
+    .body-mobile iframe,
+    .body-mobile img,
+    .body-mobile embed,
+    .body-mobile object {
+        height: auto !important;
+    }
+
+    .widget-ad-position-RM.widget-container.header-full-width-ad.ad_position {
+        padding-top: 0;
+    }
+
+    .hdn-comments .viafoura .vf-load-more-con a.vf-load-more {
+        background-image: none !important;
+    }
+    /*A951 fix*/
+
+    .body-desktop .hdn-ad-position.ad-A951 {
+        margin-left: auto !important;
+    }
+    /* fix for sponsor banner*/
+
+    .body-desktop .hst-siteheader .sponsor {
+        float: left;
+        height: 27px !important;
+        margin: 0;
+        padding: 0;
+        width: 86px !important;
+    }
+    /* Styling fix for gallery captions */
+
+    .galleria-info-description {
+        font-family: 'Helvetica Neue Regular', Helvetica, sans-serif !important;
+    }
+    /* Font fix for SFGate blogs */
+
+    .body-desktop #pagecontent {
+        font-family: inherit !important;
+    }
+
+    .body-desktop #pagecontent .blogtitle,
+    .body-desktop #pagecontent .blogtitle a {
+        font-family: inherit !important;
+        font-weight: bold !important;
+    }
+
+    .body-desktop #pagecontent .post-author,
+    .body-desktop #pagecontent .post-author a {
+        font-family: inherit !important;
+        font-weight: bold !important;
+    }
+
+    .body-desktop #pagecontent .post-date {
+        font-family: inherit !important;
+        font-style: italic !important;
+    }
+
+    .body-desktop #pagecontent #main &gt;
+    .post .entry,
+    .body-desktop #pagecontent #main .post .blogentrytext {
+        font-family: Georgia, 'Times New Roman', serif !important;
+        font-size: 16px;
+        line-height: 22px;
+    }
+    /* end font fix code in the head */
+
+    .galleria-gallery-title {
+        color: #000 !important;
+    }
+
+    .galleria-info-title {
+        display: none !important;
+    }
+
+    var premiumSlideshowAction=premiumSlideshowAction || function(param) {
+        console.log("Premium slideshow action called with param " + param);
+    }
+
+    .juice-ad-position-A300,
+    .juice-ad-position-a300 {
+        height: auto !important;
+    }
+
+    .body-mobile .widget_twitter_timeline {
+        display: none;
+        !important;
+    }
+
+    .hdn-comments .viafoura .vf-load-more {
+        background-image: url('http://www.sfgate.com/img/icons/SFGate_LoadMore_icon.png') !important;
+    }
+
+    .galleria-play {
+        display: none !important;
+    }
+
+    .pagecontent {
+        margin: 0 !important;
+    }
+
+    .weather__internal-wrapper {
+        background-image: none !important;
+    }
+    /* TSN Styles */
+
+    .mobile_sports_widget {
+        font-family: 'Helvetica Neue', Helvetica, arial, sans-serif;
+        font-weight: bold;
+    }
+
+    .mobile_sports_widget_wrapper {
+        background-color: #fff;
+        padding-bottom: 8px;
+        width: 100%;
+    }
+
+    .mobile_sports_widget_header {
+        font-size: 16px;
+        line-height: 1em;
+        color: #000;
+        font-family: 'Helvetica Neue', Helvetica, arial, sans-serif;
+        font-weight: bold;
+        padding-bottom: 10px;
+        margin: 0;
+    }
+
+    .mobile_sports_widget_header span {
+        color: #000;
+    }
+
+    .mobile_sports_widget table {
+        min-width: 300px;
+    }
+
+    .mobile_sports_widget th {
+        background: #9B0000;
+        color: #fff;
+        font-size: 12px;
+        font-weight: bold;
+        line-height: 1em;
+        padding: 8px 0;
+        vertical-align: middle;
+    }
+
+    .mobile_sports_widget th:first-child {
+        padding-left: 6px;
+    }
+
+    .mobile_sports_widget td {
+        font-size: 10px;
+        font-weight: bold;
+        line-height: 1em;
+        padding: 6px 0;
+        vertical-align: middle;
+    }
+
+    .mobile_sports_widget td:first-child {
+        padding-left: 6px;
+    }
+
+    td.TSN1d,
+    td.TSN6 {
+        background: #9B0000;
+        color: #fff;
+        font-size: 13px;
+        line-height: 1em;
+        text-transform: uppercase;
+        padding: 8px;
+        border: 0;
+        vertical-align: middle;
+        text-align: center;
+    }
+
+    .TSN2 {
+        background: #999;
+    }
+
+    .TSN5 {
+        background: #fff;
+    }
+
+    .TSN1 {
+        background: #ddd;
+    }
+    /* Scoreboard */
+
+    .tsn_scoreboard table {
+        min-width: 300px;
+        text-transform: uppercase;
+        font-size: 11px;
+    }
+
+    .tsn_scoreboard table tr {
+        border-bottom: 1px solid #999;
+    }
+
+    .tsn_scoreboard table tr:first-child,
+    .tsn_scoreboard table tr:last-child {
+        border-bottom: 0;
+    }
+    /* Standings */
+
+    .tsn_standings table td {
+        padding: 4px 0;
+    }
+
+    .tsn_standings table td:first-child {
+        padding: 4px 0 4px 4px;
+    }
+
+    .tsn_standings table td table td {
+        padding: 4px 0;
+        font-size: 10px;
+    }
+
+    .tsn_standings table td table {
+        margin-top: -4px;
+        margin-left: -4px;
+    }
+
+    .tsn_standings table td table td.TSN2 {
+        padding: 4px 0;
+    }
+
+    .tsn_standings table td table td:first-child {
+        padding-left: 4px;
+    }
+
+    .tsn_standings table td[colspan="11"] {
+        height: 20px;
+    }
+
+    .tsn_standings .TSN1d,
+    .tsn_standings .TSN6 {
+        height: 48px;
+    }
+    /* Draft */
+
+    .tsn_draft table {
+        background: transparent;
+    }
+
+    .tsn_draft .TSN1 {
+        background: transparent;
+    }
+
+    .tsn_draft td:first-child {
+        color: #9B0000;
+    }
+
+    .tsn_draft tr {
+        border-bottom: 1px solid #999;
+    }
+
+    .tsn_draft tr:first-child {
+        border-bottom: 0;
+    }
+
+    .tsn_draft td.TSNDRAFT2:first-child {
+        color: #000;
+    }
+
+    .tsn_draft td.TSNDRAFT1:first-child {
+        color: #fff;
+    }
+
+    .mobile_sports_widget .TSNDRAFT1 {
+        height: 36px;
+        background: #9B0000;
+        color: #fff;
+        font-size: 13px;
+        line-height: 1em;
+        text-transform: uppercase;
+        vertical-align: middle;
+        text-align: center;
+    }
+
+    .mobile_sports_widget .TSNDRAFT2 {
+        font-size: 13px;
+        line-height: 1em;
+        text-transform: uppercase;
+        vertical-align: middle;
+        height: 36px;
+    }
+
+    .mobile_sports_widget .TSNDRAFT4 {
+        text-align: center;
+        text-transform: uppercase;
+        vertical-align: middle;
+        height: 36px;
+    }
+    /* Player */
+
+    table.BIOTABLE {
+        border-top: 2px solid #000;
+    }
+
+    .tsn_player td {
+        border-bottom: 1px solid #999;
+    }
+
+    .tsn_player tr:first-child {
+        border-bottom: 0;
+    }
+
+    .tsn_player tr:nth-child(odd) {
+        background: #ddd;
+    }
+
+    .tsn_player tr:nth-child(even) {
+        background: #fff;
+    }
+
+    .BIOCAT,
+    .tsn_player .BIOCAT {
+        background: #9B0000;
+        color: #fff;
+        font-size: 13px;
+        border-bottom: 0;
+    }
+
+    table.BIOTABLE tr,
+    table.BIOTABLE tr:nth-child(odd) {
+        background: #fff;
+    }
+
+    td.BIONAME {
+        text-align: center;
+        font-size: 17px;
+    }
+
+    td.BIONAME a {
+        line-height: 1.25em;
+    }
+
+    span.BIOINFO {
+        font-size: 11px;
+    }
+    /* END TSN Styles */
+    </style>
+    <!-- Bing Webmaster Tools validation code -->
+    <meta content="9451CA04ABC9D1D5C6419C73B4C4F7B7" name="msvalidate.01" />
+    <!-- wroteOmniVars: 1 -->
+    <script type="text/javascript">
+    jQuery(document).ready(function() {
+        checkJuiceLoaded = function() {
+            if (window.juiceHasLoaded)
+                jQuery(document).trigger('JuiceFinishedLoadingEvent');
+            else
+                setTimeout(checkJuiceLoaded, 100);
+        }
+
+        checkJuiceLoaded();
+    });
+    </script>
+    <link href="http://blog.sfgate.com/ontheblock/feed/" title="On The Block » Feed" type="application/rss+xml" rel="alternate" />
+    <link href="http://blog.sfgate.com/ontheblock/comments/feed/" title="On The Block » Comments Feed" type="application/rss+xml" rel="alternate" />
+    <link href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/feed/" title="On The Block » Nob Hill one-bedroom sells for $2.3 million Comments Feed" type="application/rss+xml" rel="alternate" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/css/base.css?ver=7917d9b1cfae81efd22c1bc919287dad" id="responsive_base-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-sfgate/css/sitewide.css?ver=270eecd79ef2bdb9499c621cb3dfccb3" id="responsive_sfgate_sitewide-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-sfgate/css/base.css?ver=092bbc8a1e2be62cb87709d20b788bd1" id="responsive_sfgate_base-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-sfgate/css/responsive.css?ver=da3d861ef623e90c83f78bfcf4ff5c6c" id="responsive_sfgate-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://www.sfgate.com/css/hdn/modules/viafoura_comments.css?ver=3.8.3" id="wcm_viafoura-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://www.sfgate.com/css/modules/viafoura_comments.css?ver=3.8.3" id="wcm_sfgate_viafoura-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/author-social-info/author-social-info.css?ver=bd9a5aeca2f0cae5d6f48979a8be62d6" id="author-social-info-css-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-connect/css/hdnconnect-style.css?ver=20121015;4df43a7a6c8a7e27b028de3b9992dbec" id="hdnConnect-style-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-the-sports-network/css/tsnstyle.css?ver=d1b774c668562ac2473cf98a0cdf53c8" id="hdn-tsn-short-code-gen-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-wp-galleries/themes/hdn_responsive/galleria.hdn_responsive.css?ver=746f6293196a5425a0120857bea5fb86" id="hdn_wpg_gallery_style-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/wp-polls/polls-css.css?ver=2.63;e619fed4db9cedec2065f006d5b63713" id="wp-polls-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/wp-pagenavi/pagenavi-css.css?ver=2.70;73d29ecb3ae4eb2b78712fab3a46d32d" id="wp-pagenavi-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-sfgate/css/wcm-sections/realestate.css?ver=5264c5e9ca2927e809209e40c89b7cf7" id="wcm-section-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/ad_position_widget/css/named.css?ver=ff9fd6544112cdc13082904ae835a2fa" id="ad_position_widget_named-css" rel="stylesheet" />
+    <link media="all" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/jetpack/modules/sharedaddy/sharing.css?ver=2.9.3;b99e72ab39e0c6e50f15faacaa32e753" id="sharedaddy-css" rel="stylesheet" />
+    <script src="http://blog.sfgate.com/ontheblock/wp-includes/js/comment-reply.min.js?ver=1b1e9d1d12fcc51a151e7e0688bc695f" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-includes/js/jquery/jquery.js?ver=1.10.2;92c9ccfa9216499d48ecc11e6d9887d5" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.2.1;512b871a2830e44259bc3ce3343afcd0" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/jquery-conditional.js?ver=1.10.2;54e3f1603c986c336537d624142b5364" type="text/javascript"></script>
+    <script src="/wp-content/themes/responsive-base/js/jquery-migrate.js" type="text/javascript"></script>
+    <script src="/wp-content/themes/responsive-base/js/jquery.hoverIntent.minified.js" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/hdn_ndn_video.js?ver=18742b6103e85cdf274ebf41a017059c" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/hdn_ndn_video_resizer.js?ver=e6e5a57451e5cac7c9caeb663b56fbf3" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-ndn-video/includes/hdn_ndn.js?ver=e25a4070306ada2f81edbc48f2416c07" type="text/javascript"></script>
+    <script type="text/javascript">
+    /* &lt;![CDATA[ */
+    var hdn_perfect_market = {
+        "is_home": "",
+        "is_single": "1",
+        "blog_wide_setting": "",
+        "network_wide_setting": "&lt;script src=\"http:\/\/widget.perfectmarket.com\/wwwsfgate\/load.js\"&gt;&lt;\/script&gt;",
+        "blog_wide_post_only_setting": "",
+        "network_wide_post_only_setting": "1"
+    };
+    /* ]]&gt; */
+    </script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-perfect-market/perfect-market.js?ver=98dccb741aa4e16c63c48b822a0e922e" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-wp-galleries/galleria-1.3.3.js?ver=9060b658462310d7256c5cc53f2ab5d2" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-wp-galleries/themes/hdn_responsive/galleria.hdn_responsive.min.js?ver=a5165856f5656740c576aa8830c68e19" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-wp-galleries/plugins/history/galleria.history.js?ver=62b0b254aa89eeee615e09a3eb618695" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-sfgate/js/mostPopular.js?ver=1;9959698fc709f5483b9b287072f0f13d" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/scripts.js?ver=99fea1342fdeb56773e3c9ed27b8b26d" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/jquery.ba-resize.min.js?ver=9e80c546032c71de01a5c4bf4527995f" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/responsive.js?ver=3a8199bf8200fcc0eaefb5a9fa3983fc" type="text/javascript"></script>
+    <script type="text/javascript">
+    /* &lt;![CDATA[ */
+    var ad_position_widget = {
+        "ysm_source_url": "http:\/\/images.chron.com\/CDC\/elf\/js\/ysmwrapper.js",
+        "ysm_override_url": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/plugins\/ad_position_widget\/js\/ysm_adfix.js",
+        "style_override_url": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/plugins\/ad_position_widget\/css\/ysm.css",
+        "page_url_tweaks": {
+            "host": {
+                "prepend": "m."
+            }
+        }
+    };
+    /* ]]&gt; */
+    </script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/ad_position_widget/js/ad_position_widget.js?ver=828180daba5d727ad8781b68c2ee646b" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/in_post_widgets.js?ver=10ad2e9bee090fc092c2996d6cd12605" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/js/css_browser_selector.js?ver=6c90e8b1a59df8f373e37995c4c27fb0" type="text/javascript"></script>
+    <script src="http://aps.hearstnp.com/scripts/loadAdsParam.js?ver=2.0" type="text/javascript"></script>
+    <script src="http://aps.hearstnp.com/Scripts/loadAdsMainParam.js" type="text/javascript" id="loadAdsMain"></script>
+    <script src="http://aps.hearstnp.com/SRO/GetJSP?url=blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million" type="text/javascript" id="AdsConfigJavaScript"></script>
+    <script src="http://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async="" type="text/javascript" src="http://www.googletagservices.com/tag/js/check_359604.js"></script>
+    <iframe src="http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html" style="visibility: hidden; display: none;"></iframe>
+    <script src="http://aps.hearstnp.com/Scripts/initDefineAds.js"></script>
+    <script type="text/javascript" async="" src="http://rtax.criteo.com/delivery/rta/rta.js?netId=2333&amp;cookieName=crtg_hearst&amp;rnd=8415873979&amp;varName=crtg_content"></script>
+    <script src="http://partner.googleadservices.com/gpt/pubads_impl_60.js" type="text/javascript"></script>
+    <script src="http://aps.hearstnp.com/Scripts/parameterOverride.js" type="text/javascript" id="AdsJavaScriptOverride"></script>
+    <link href="http://blog.sfgate.com/ontheblock/2015/05/04/bernal-heights-tenant-moves-out-but-continues-to-dispute-400-percent-rent-increase/" title="Bernal Heights tenant moves out, but continues to dispute 400 percent rent increase" rel="prev" />
+    <link href="http://blog.sfgate.com/ontheblock/?p=9755" rel="shortlink" />
+    <link rel="stylesheet" href="https://cdn.viafoura.net/095e45d/viafoura.css" />
+    <script type="text/javascript" src="//tru.am/page_views?clientID=495&amp;version=13&amp;canonical=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F&amp;ogURL=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F&amp;published=2015-05-05T11%3A00%3A19%2B00%3A00&amp;title=Nob+Hill+one-bedroom+sells+for+%242.3+million&amp;image=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2Ffiles%2F2015%2F04%2FOne-Bedroom.jpg&amp;callback=reqwest_1430917071901" async=""></script>
+    <script type="text/javascript" src="http://adserve.postrelease.com/serve/trigger/1430917072084.js?prx_url=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F"></script>
+    <style type="text/css">
+    .ob-tcolor {
+        color: rgb(34, 34, 34)
+    }
+
+    .ob-lcolor {
+        color: rgb(155, 0, 0)
+    }
+
+    .ob-bgtcolor {
+        background-color: rgb(34, 34, 34)
+    }
+
+    .item-link-container:hover .ob-tcolor {
+        border-color: rgb(34, 34, 34)
+    }
+    </style>
+    <script type="text/javascript" charset="utf-8" async="" src="https://cdn.viafoura.net/095e45d/f0b3c21b28b83ff15b63.vf.js"></script>
+    <script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="models/Ndn/Widget" src="http://launch.newsinc.com/75/js/models/Ndn/Widget.js"></script>
+    <link href="http://launch.newsinc.com/75/css/NdnEmbed.css" type="text/css" rel="stylesheet" class="_nw2eStyles" />
+    <link href="http://launch.newsinc.com/75/css/NdnEmbed2.css" type="text/css" rel="stylesheet" class="_nw2eStyles" />
+    <script type="text/javascript" src="http://rs2.adledge.com/alestetkr.js"></script>
+    <script type="text/javascript" src="http://rs2.adledge.com/aleaskw.js"></script>
+</head>
+
+<body class="single single-post postid-9755 single-format-standard ui-mobile-viewport ui-overlay-c body-responsive realestate" location="realestate" id="page-body">
+    <div style="display:none;" id="BF_WIDGET_WP">
+        <script type="text/javascript" src="http://ct.buzzfeed.com/wd/UserWidget?u=sfgate.com&amp;to=1&amp;or=vb&amp;wid=1&amp;cb=1430917071015"></script>
+    </div>
+    <script type="text/javascript">
+    (function() {
+        BF_WIDGET_JS = document.createElement("script");
+        BF_WIDGET_JS.type = "text/javascript";
+        BF_WIDGET_SRC = "http://ct.buzzfeed.com/wd/UserWidget?u=sfgate.com&amp;to=1&amp;or=vb&amp;wid=1&amp;cb=" + (new Date()).getTime();
+        setTimeout(function() {
+            document.getElementById("BF_WIDGET_WP").appendChild(BF_WIDGET_JS);
+            BF_WIDGET_JS.src = BF_WIDGET_SRC
+        }, 1);
+    })();
+    </script>
+    <style type="text/css">
+    .wp-polls .pollbar {
+        margin: 1px;
+        font-size: 6px;
+        line-height: 8px;
+        height: 8px;
+        background-image: url('http://blog.sfgate.com/ontheblock/wp-content/plugins/wp-polls/images/default/pollbg.gif');
+        border: 1px solid #c8c8c8;
+    }
+    </style>
+    <meta content="1.7.5" name="NextGEN" />
+    <link href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" rel="canonical" />
+    <meta content="Nob Hill one-bedroom sells for $2.3 million" name="title" />
+    <meta content="" name="description" />
+    <meta content="wp_sfgate_blog_sfgate_com_ontheblock_2283_blogEntryId9755" property="vf:unique_id" />
+    <script type="text/javascript">
+    //&lt;![CDATA[
+    // define common vars elements (known by functions) where returned data goes (must be done after divs are built but before call to function
+    var HDN = HDN || {
+        site: "sfgate",
+        cookieDomain: "sfgate.com",
+        domain: "sfgate.com"
+    };
+
+    try {
+        if (document.domain != HDN.domain)
+            document.domain = HDN.domain;
+    } catch (e) {
+        console.log(e);
+    }
+
+    var HDNViafoura = new Object();
+    HDNViafoura.all_entries = {
+        'rows': new Object(),
+        'ok': new Array()
+    };
+    HDNViafoura.entry_id = '9755';
+    HDNViafoura.file = 'wp_sfgate_blog_sfgate_com_ontheblock_2283_blogEntryId9755';
+    HDNViafoura.full_filepath = 'http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/';
+    HDNViafoura.details_page = HDNViafoura.full_filepath;
+    HDNViafoura.success_page = 'http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/';
+    HDNViafoura.isActive = true;
+    HDNViafoura.addlink = '&lt;a href="' + HDNViafoura.success_page + '"&gt;Add Your Comment&lt;/a&gt;';
+    HDNViafoura.viewlink = '&lt;a href="' + HDNViafoura.success_page + '"&gt;View Comments &amp;raquo;&lt;/a&gt;';
+    HDNViafoura.categories = new Array(); // Currently we only store one category for blogs: the blogid.
+    HDNViafoura.categories[0] = 'ontheblock';
+    HDNViafoura.categories[1] = 'emilylandes';
+    HDNViafoura.article_thumbs = new Array();
+    //]]&gt;
+    </script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-viafoura-comments/js/commentcount.js" type="text/javascript"></script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-viafoura-comments/js/viafouracomments.js" type="text/javascript"></script>
+    <!-- Jetpack Open Graph Tags -->
+    <meta content="article" property="og:type" />
+    <meta content="Nob Hill one-bedroom sells for $2.3 million" property="og:title" />
+    <meta content="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" property="og:url" />
+    <meta content="In early March, we told you about a one-bedroom in the prestigious Comstock in Nob Hill, which came to market at $2.495 million, making it the most expensive one-bedroom on the market at the time. ..." property="og:description" />
+    <meta content="2015-05-05T11:00:19+00:00" property="article:published_time" />
+    <meta content="2015-05-04T17:44:18+00:00" property="article:modified_time" />
+    <meta content="http://blog.sfgate.com/ontheblock/author/elandes/" property="article:author" />
+    <meta content="On The Block" property="og:site_name" />
+    <meta content="http://blog.sfgate.com/ontheblock/files/2015/04/One-Bedroom.jpg" property="og:image" />
+    <!-- START - HDN Facebook Open Graph Tags -->
+    <meta content="en_US" property="og:locale" />
+    <meta content="On The Block" property="og:site_name" />
+    <meta content="Nob Hill one-bedroom sells for $2.3 million" property="og:title" />
+    <meta content="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" property="og:url" />
+    <meta content="http://blog.sfgate.com/ontheblock/files/2015/04/One-Bedroom.jpg" property="og:image" />
+    <meta content="article" property="og:type" />
+    <meta content="In early March, we told you about a one-bedroom in the prestigious Comstock in Nob Hill, which came to market at $2.495 million, making it the most expensive one-bedroom on the market at the time. The northwest facing unit—with amazing panoramic views of Twin Peaks, the Golden Gate Bridge, the" property="og:description" />
+    <!-- END -  HDN Facebook Open Graph Tags -->
+    <style type="text/css">
+    .fullscreen .gallery-overlay-title-container .homeLink .icon {
+        background: url("/wp-content/plugins/hdn-wp-galleries-redesigned/images/network_logos.svg") repeat 0 0px;
+    }
+    </style>
+    <!--[if IE 9]>
+        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <![endif]-->
+    <!--[if IE 8]>
+     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <![endif]-->
+    <meta content="Emily Landes" name="sailthru.author" />
+    <meta content="2015-05-05 4:00:00 -0700" name="sailthru.date" />
+    <meta content="In early March, we told you about a one-bedroom in the prestigious Comstock in Nob Hill, which came to market at $2.495 million, making it the most expensive one-bedroom on the market at the time. The northwest facing unit—with amazing panoramic views of Twin Peaks, the Golden Gate Bridge, the North Bay, Alcatraz and Coit" name="sailthru.description" />
+    <meta content="http://blog.sfgate.com/ontheblock/files/2015/04/One-Bedroom-350x250.jpg" name="sailthru.image.thumb" />
+    <meta content="Nob Hill one-bedroom sells for $2.3 million" name="sailthru.title" />
+    <meta content="$2.3 million one-bedroom, New Nob Hill listing, Nob Hill one-bedroom" name="sailthru.tags" />
+    <script>
+    (function(w) {
+
+        if (_browser == "desktop") {
+            console.log("On desktop, NOT enabling viewport resize");
+            return;
+        } else {
+            console.log("On device, enabling viewport resize");
+        }
+
+        var m = w.document.getElementById('owp');
+        var l, c;
+        var d = "width=1024, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no";
+        var p = "width=1024, initial-scale=0.75, minimum-scale=0.75, maximum-scale=1";
+
+        //remove any additional contentView meta tags - possibly from third-party headers
+        var metaList = w.document.getElementsByTagName("meta");
+
+        for (var i = 0; i & lt; metaList.length; i++) {
+            // Our contentView meta vieport has an id set to "ovp"
+            if ((metaList[i].getAttribute("id") != "owp") & amp; & amp;
+                (metaList[i].getAttribute("name") == "viewport")) {
+                metaList[i].parentNode.removeChild(metaList[i]);
+            }
+        }
+
+        // Get device orientation -- mobile devices only
+        function readDeviceOrientation() {
+
+            var orientation = w.orientation; // this is undefined on desktop
+
+            if (orientation === undefined) {
+                return 0; // For desktop assume portrait
+            } else if (Math.abs(orientation) === 90) {
+                return 90; // Landscape
+            } else {
+                return 0; // Portrait
+            }
+
+        }
+
+
+        function updateViewPort(landscape, portrait) {
+            console.log("update view port called .....");
+            if ((w.innerWidth & gt; 767) & amp; & amp;
+                (w.innerWidth & lt; 1025)) {
+                if (readDeviceOrientation() === 90) {
+                    m.setAttribute('content', landscape);
+                    console.log("set to landscape....");
+                } else {
+                    m.setAttribute('content', portrait);
+                    console.log("set to portrait....");
+                }
+            }
+        }
+
+
+        previousWidth = w.innerWidth;
+
+        // DISABLED TEMPORARILY : PER JIM
+
+        w.onresize = function() {
+            var currentWidth = w.innerWidth;
+
+            if (currentWidth !== previousWidth) {
+                setTimeout(function() {
+                    updateViewPort(d, p);
+                    console.log('on resize executed....');
+                }, 500);
+
+                previousWidth = currentWidth;
+            }
+
+
+        }
+
+        updateViewPort(d, p);
+
+
+
+
+    })(window);
+    </script>
+    <script type="text/javascript">
+    responsive_base.include.do_snippet('header');
+    </script>
+    <!-- Tutorial freeform -->
+    <!-- noGen: item_tutorial_overlay -->
+    <!-- business/templates/hearst/home/HNavigation.tpl -->
+    <!-- hearst/home/navigation.tpl -->
+    <!-- ux hearst/home/navigation_main.tpl -->
+    <header>
+        <div class="hst-leaderboard">
+            <div class="ad_deferrable" id="A728">
+                <script type="text/javascript">
+                /*&lt;![CDATA[*/
+                hearstPlaceAd("A728"); /*]]&gt;*/
+                </script>
+                <iframe width="1920" height="250" id="A728-ju1c3-TWFobmEgTWFobmE=-1fr4m3-0" name="A728-ju1c3-TWFobmEgTWFobmE=-1fr4m3-0" style="width: 728px; height: 90px; border: medium none; background-color: transparent; vertical-align: bottom;" scrolling="no" src="http://juice-files.sfgate.com/html/juiceframe?generationID=0x8D02BCA19C4A6A4CA4BE819B7EFEE027A26BD40D&amp;dm=sfgate.com&amp;slt=A728"></iframe>
+            </div>
+        </div>
+        <div class="subHead" id="subHead">
+            <div class="innerWrap">
+                <div class="weatherWrapper">
+                    <div class="weather__current-forecast">
+                        <a href="http://www.sfgate.com/weather/">
+                            <div class="condition"><span class="icon"></span></div><span class="temp"></span></a>
+                        <span class="city"></span>
+                        <p id="weatherChange">
+                            <ul class="citySelect">
+                                <li><a class="close" onclick="selectBoxToggle();" href="javascript:void(0)"><span class="icon"></span></a></li>
+                                <li><a onclick="manualLocation(0); selectBoxToggle();" href="javascript:void(0)">antioch</a></li>
+                                <li><a onclick="manualLocation(1); selectBoxToggle();" href="javascript:void(0)">concord</a></li>
+                                <li><a onclick="manualLocation(2); selectBoxToggle();" href="javascript:void(0)">fairfield</a></li>
+                                <li><a onclick="manualLocation(3); selectBoxToggle();" href="javascript:void(0)">hayward</a></li>
+                                <li><a onclick="manualLocation(4); selectBoxToggle();" href="javascript:void(0)">livermore</a></li>
+                                <li><a onclick="manualLocation(5); selectBoxToggle();" href="javascript:void(0)">mill valley</a></li>
+                                <li><a onclick="manualLocation(6); selectBoxToggle();" href="javascript:void(0)">mountain view</a></li>
+                                <li><a onclick="manualLocation(7); selectBoxToggle();" href="javascript:void(0)">napa</a></li>
+                                <li><a onclick="manualLocation(8); selectBoxToggle();" href="javascript:void(0)">oakland</a></li>
+                                <li><a onclick="manualLocation(9); selectBoxToggle();" href="javascript:void(0)">palo alto</a></li>
+                                <li><a onclick="manualLocation(10); selectBoxToggle();" href="javascript:void(0)">richmond</a></li>
+                                <li><a onclick="manualLocation(11); selectBoxToggle();" href="javascript:void(0)">san carlos</a></li>
+                                <li><a onclick="manualLocation(12); selectBoxToggle();" href="javascript:void(0)">san francisco</a></li>
+                                <li><a onclick="manualLocation(13); selectBoxToggle();" href="javascript:void(0)">san jose</a></li>
+                                <li><a onclick="manualLocation(14); selectBoxToggle();" href="javascript:void(0)">santa rosa</a></li>
+                            </ul>
+                        </p>
+                    </div>
+                    <div class="weatherChange"><span class="icon"></span></div>
+                </div>
+                <form target="_top" method="get" action="http://www.sfgate.com/search/?" id="search_form" class="searchWrapper">
+                    <input type="hidden" value="search" name="action" />
+                    <input type="hidden" value="1" name="firstRequest" />
+                    <input type="hidden" value="gsa" name="searchindex" />
+                    <input type="text" class="textInputNote" value="Search" id="search_query" name="query" autocomplete="off" />
+                    <input type="submit" disabled="disabled" class="submit" value="Submit" />
+                </form>
+                <div class="socialWrapper">
+                    <ul>
+                        <li class="socialIcon facebook"><a target="_blank" href="https://www.facebook.com/SFGate/"><span class="icon"></span></a></li>
+                        <li class="socialIcon twitter"><a target="_blank" href="https://twitter.com/sfgate/"><span class="icon"></span></a></li>
+                        <li class="socialIcon google"><a target="_blank" href="https://plus.google.com/118071641239908367285/posts/"><span class="icon"></span></a></li>
+                        <li class="socialIcon pinterest"><a target="_blank" href="http://www.pinterest.com/sfgate/"><span class="icon"></span></a></li>
+                        <li class="socialIcon rss"><a href="http://www.sfgate.com/rss/"><span class="icon"></span></a></li>
+                        <li id="reg_member" class="text user_tools"><a href="http://www.sfgate.com/cgi-bin/sso/action/login">Sign In</a><a href="http://www.sfgate.com/cgi-bin/webreg/user/reg_cnt">Register</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <nav class="site-nav menu-slide" id="siteNav">
+            <div class="innerWrap">
+                <!-- hearst/sitemenu/dynamic_r1.tpl -->
+                <!-- ux hearst/sitemenu/menuSiteNav_r1.tpl -->
+                <ul class="topnav">
+                    <!-- navMenu foreach -->
+                    <!-- navloop foreach -->
+                    <li location="home" class="subMenuContainer homeLink"><a class="subMenuLink homeLink hdn-analytics" href="http://www.sfgate.com/" target="_top"><span class="hdn-analytics-data">visit|Home|navigation-www|1</span><span class="icon"></span><span class="logo"></span><span class="label">SFGate</span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics hasSubmenu" href="http://www.sfgate.com/chronicle-contacts/" target="_top">Contact SFGate<span class="hdn-analytics-data">visit|Home-Contact SFGate|navigation-www|1</span> <span class="icon"></span></a>
+                                        <div class="submenu">
+                                            <ul class="submenuUlList">
+                                                <li class="desktop"><a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/chronicle-contacts/" target="_top">Contact SFGate<span class="hdn-analytics-data">visit|Home-Contact SFGate|navigation-www|1</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/feedback/" target="_top">Customer Support<span class="hdn-analytics-data">visit|Home-Contact SFGate-Customer Support|navigation-www|2</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/submissions/" target="_top">Submissions &amp; Tips<span class="hdn-analytics-data">visit|Home-Contact SFGate-Submissions &amp; Tips|navigation-www|3</span></a></li>
+                                            </ul>
+                                        </div>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics hasSubmenu" href="http://www.sfgate.com/aboutsfgate/" target="_top">About SFGate<span class="hdn-analytics-data">visit|Home-About SFGate|navigation-www|2</span> <span class="icon"></span></a>
+                                        <div class="submenu">
+                                            <ul class="submenuUlList">
+                                                <li class="desktop"><a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/aboutsfgate/" target="_top">About SFGate<span class="hdn-analytics-data">visit|Home-About SFGate|navigation-www|2</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/faq/" target="_top">FAQ<span class="hdn-analytics-data">visit|Home-About SFGate-FAQ|navigation-www|2</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/cgi-bin/webreg/user/reg_cnt" target="_top">Register on SFGate<span class="hdn-analytics-data">visit|Home-About SFGate-Register on SFGate|navigation-www|3</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/cgi-bin/newsletter/services/main" target="_top">SFGate Newsletters<span class="hdn-analytics-data">visit|Home-About SFGate-SFGate Newsletters|navigation-www|4</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/staff/" target="_top">SFGate Staff<span class="hdn-analytics-data">visit|Home-About SFGate-SFGate Staff|navigation-www|5</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/chronicle/hr/" target="_top">Careers<span class="hdn-analytics-data">visit|Home-About SFGate-Careers|navigation-www|6</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.hearst.com/" target="_top">Hearst<span class="hdn-analytics-data">visit|Home-About SFGate-Hearst|navigation-www|7</span></a></li>
+                                            </ul>
+                                        </div>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics hasSubmenu" href="http://www.hearst.com/newspapers/san-francisco-chronicle" target="_top">About SF Chronicle<span class="hdn-analytics-data">visit|Home-About SF Chronicle|navigation-www|3</span> <span class="icon"></span></a>
+                                        <div class="submenu">
+                                            <ul class="submenuUlList">
+                                                <li class="desktop"><a class="subMenuItemLink hdn-analytics" href="http://www.hearst.com/newspapers/san-francisco-chronicle" target="_top">About SF Chronicle<span class="hdn-analytics-data">visit|Home-About SF Chronicle|navigation-www|3</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfchronicle.com/newsroom_contacts/" target="_top">SF Chronicle Staff<span class="hdn-analytics-data">visit|Home-About SF Chronicle-SF Chronicle Staff|navigation-www|2</span></a></li>
+                                                <li><a class="hdn-analytics" href="https://myaccount.sfchronicle.com/dsssubscribe.aspx?pid=90" target="_top">Become a Subscriber<span class="hdn-analytics-data">visit|Home-About SF Chronicle-Become a Subscriber|navigation-www|3</span></a></li>
+                                                <li><a class="hdn-analytics" href="https://myaccount.sfchronicle.com/" target="_top">Manage Your Subscription<span class="hdn-analytics-data">visit|Home-About SF Chronicle-Manage Your Subscription|navigation-www|4</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfchronicle.com/customer_service/" target="_top">SF Chronicle Delivery<span class="hdn-analytics-data">visit|Home-About SF Chronicle-SF Chronicle Delivery|navigation-www|5</span></a></li>
+                                                <li><a class="hdn-analytics" href="https://myaccount.sfchronicle.com/Login.aspx" target="_top">E-Edition<span class="hdn-analytics-data">visit|Home-About SF Chronicle-E-Edition|navigation-www|6</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/faq/#faq10" target="_top">Back Copies<span class="hdn-analytics-data">visit|Home-About SF Chronicle-Back Copies|navigation-www|7</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://nieonline.com/sfchronicle" target="_top">Chron in Education<span class="hdn-analytics-data">visit|Home-About SF Chronicle-Chron in Education|navigation-www|8</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/corrections/" target="_top">Corrections<span class="hdn-analytics-data">visit|Home-About SF Chronicle-Corrections|navigation-www|9</span></a></li>
+                                            </ul>
+                                        </div>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics hasSubmenu" href="http://extras.sfgate.com/chronicle/new/pages/home.php" target="_top">Advertise with us<span class="hdn-analytics-data">visit|Home-Advertise with us|navigation-www|4</span> <span class="icon"></span></a>
+                                        <div class="submenu">
+                                            <ul class="submenuUlList">
+                                                <li class="desktop"><a class="subMenuItemLink hdn-analytics" href="http://extras.sfgate.com/chronicle/new/pages/home.php" target="_top">Advertise with us<span class="hdn-analytics-data">visit|Home-Advertise with us|navigation-www|4</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://extras.sfgate.com/chronicle/new/pages/home.php" target="_top">Media Kit<span class="hdn-analytics-data">visit|Home-Advertise with us-Media Kit|navigation-www|2</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://sfgate.kaango.com//" target="_top">Place a Classified Ad<span class="hdn-analytics-data">visit|Home-Advertise with us-Place a Classified Ad|navigation-www|3</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.sfgate.com/privacy-policy/" target="_top">About Our Ads<span class="hdn-analytics-data">visit|Home-Advertise with us-About Our Ads|navigation-www|4</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.legalnotice.org/pl/SFGate/landing1.aspx" target="_top">Public Notices<span class="hdn-analytics-data">visit|Home-Advertise with us-Public Notices|navigation-www|5</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://local.sfgate.com/" target="_top">Local Business Directory<span class="hdn-analytics-data">visit|Home-Advertise with us-Local Business Directory|navigation-www|6</span></a></li>
+                                            </ul>
+                                        </div>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/chronicle/hr/" target="_top">Careers<span class="hdn-analytics-data">visit|Home-Careers|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics" href="http://sfchronicle.myshopify.com/" target="_top">Store<span class="hdn-analytics-data">visit|Home-Store|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics hasSubmenu" href="http://www.sfgate.com/privacy-policy/" target="_top">Privacy policy<span class="hdn-analytics-data">visit|Home-Privacy policy|navigation-www|7</span> <span class="icon"></span></a>
+                                        <div class="submenu">
+                                            <ul class="submenuUlList">
+                                                <li class="desktop"><a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/privacy-policy/" target="_top">Privacy policy<span class="hdn-analytics-data">visit|Home-Privacy policy|navigation-www|7</span></a></li>
+                                                <li><a class="hdn-analytics" href="http://www.aboutads.info/choices/" target="_top">Ad Choices<span class="hdn-analytics-data">visit|Home-Privacy policy-Ad Choices|navigation-www|2</span></a></li>
+                                            </ul>
+                                        </div>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/privacy-policy/#caprivacyrights" target="_top">Your CA Privacy Rights<span class="hdn-analytics-data">visit|Home-Your CA Privacy Rights|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/termsandconditions/" target="_top">Terms of Use<span class="hdn-analytics-data">visit|Home-Terms of Use|navigation-www|9</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/index/" target="_top">Site Index<span class="hdn-analytics-data">visit|Home-Site Index|navigation-www|10</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/cgi-bin/newsletter/services/main" target="_top">Newsletters<span class="hdn-analytics-data">visit|Home-Newsletters|navigation-www|11</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics" href="http://www.sfgate.com/getus/" target="_top">Get news alerts<span class="hdn-analytics-data">visit|Home-Get news alerts|navigation-www|12</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics" href="http://local.sfgate.com/" target="_top">Gate List<span class="hdn-analytics-data">visit|Home-Gate List|navigation-www|13</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/feedbackredesign/" target="_top">
+                                            <img alt="SFGate Customer support - Photo" src="http://ww1.hdnux.com/photos/34/12/05/7381320/3/landscape_32.jpg" />
+                                            <h4 class="headline">SFGate Customer support</h4>
+                                            <span class="hdn-analytics-data">visit|channel-11753|Home-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="https://myaccount.sfchronicle.com/dsssubscribe.aspx?pid=1249&amp;z=00000" target="_top">
+                                            <img alt="Get VIP access with SF Chronicle Membership - Photo" src="http://ww2.hdnux.com/photos/31/52/13/6726389/4/landscape_32.jpg" />
+                                            <h4 class="headline">Get VIP access with SF Chronicle Membership</h4>
+                                            <span class="hdn-analytics-data">visit|link-28248|Home-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/newsletters" target="_top">
+                                            <img alt="Get SFGate newsletters for the latest from the Bay - Photo" src="http://ww1.hdnux.com/photos/31/61/66/6757800/5/landscape_32.jpg" />
+                                            <h4 class="headline">Get SFGate newsletters for the latest from the Bay</h4>
+                                            <span class="hdn-analytics-data">visit|link-28249|Home-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/food/top100/2014/" target="_top">
+                                            <img alt="Check out the Top 100 Bay Area restaurants - Photo" src="http://ww2.hdnux.com/photos/31/62/41/6760529/7/landscape_32.jpg" />
+                                            <h4 class="headline">Check out the Top 100 Bay Area restaurants</h4>
+                                            <span class="hdn-analytics-data">visit|link-28250|Home-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="news" class="subMenuContainer news"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/news/" target="_top">News<span class="hdn-analytics-data">visit|News|navigation-www|2</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/bayarea/" target="_top">Bay Area &amp; State<span class="hdn-analytics-data">visit|News-Bay Area &amp; State|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/traffic" target="_top">Traffic<span class="hdn-analytics-data">visit|News-Traffic|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/nation/" target="_top">Nation<span class="hdn-analytics-data">visit|News-Nation|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/world/" target="_top">World<span class="hdn-analytics-data">visit|News-World|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/politics/" target="_top">Politics<span class="hdn-analytics-data">visit|News-Politics|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/crime/" target="_top">Crime<span class="hdn-analytics-data">visit|News-Crime|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/technology/" target="_top">Tech<span class="hdn-analytics-data">visit|News-Tech|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.legacy.com/obituaries/sfgate/" target="_top">Obituaries<span class="hdn-analytics-data">visit|News-Obituaries|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/opinion/" target="_top">Opinion<span class="hdn-analytics-data">visit|News-Opinion|navigation-www|9</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/you/" target="_top">You<span class="hdn-analytics-data">visit|News-You|navigation-www|10</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/health/" target="_top">Health<span class="hdn-analytics-data">visit|News-Health|navigation-www|11</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/education/" target="_top">Education<span class="hdn-analytics-data">visit|News-Education|navigation-www|12</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://video.sfgate.com/" target="_top">Video<span class="hdn-analytics-data">visit|News-Video|navigation-www|13</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/news/blogs/" target="_top">News Blogs<span class="hdn-analytics-data">visit|News-News Blogs|navigation-www|14</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics news" href="http://www.sfgate.com/news/education/lifelonglearning/" target="_top">Lifelong Learning<span class="hdn-analytics-data">visit|News-Lifelong Learning|navigation-www|15</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/news/article/Condo-protesters-block-Oakland-City-Council-6244926.php" target="_top">
+                                            <img alt="Condo protesters keep Oakland City Council from meeting - Photo" src="http://ww2.hdnux.com/photos/36/20/61/7933005/9/landscape_32.jpg" />
+                                            <h4 class="headline">Condo protesters keep Oakland City Council from meeting</h4>
+                                            <span class="hdn-analytics-data">visit|article-6244926|News-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/crime/article/Friends-and-family-rail-at-Livermore-DUI-suspect-6243924.php" target="_top">
+                                            <img alt="Protesters confront DUI suspect in crash that killed 2 - Photo" src="http://ww4.hdnux.com/photos/36/16/30/7923227/5/landscape_32.jpg" />
+                                            <h4 class="headline">Protesters confront DUI suspect in crash that killed 2</h4>
+                                            <span class="hdn-analytics-data">visit|article-6243924|News-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/bayarea/article/Ominous-signs-of-problems-with-new-Bay-Bridge-s-6244776.php" target="_top">
+                                            <img alt="Ominous signs of problems with new Bay Bridge foundation - Photo" src="http://ww4.hdnux.com/photos/34/64/16/7553931/11/landscape_32.jpg" />
+                                            <h4 class="headline">Ominous signs of problems with new Bay Bridge foundation</h4>
+                                            <span class="hdn-analytics-data">visit|article-6244776|News-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/news/article/California-still-failing-to-conserve-water-as-big-6244363.php" target="_top">
+                                            <img alt="California needs to turn down the tap, state OKs historic cuts - Photo" src="http://ww1.hdnux.com/photos/36/20/27/7931344/3/landscape_32.jpg" />
+                                            <h4 class="headline">California needs to turn down the tap, state OKs historic cuts</h4>
+                                            <span class="hdn-analytics-data">visit|article-6244363|News-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="sports" class="subMenuContainer sports"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/sports/" target="_top">Sports<span class="hdn-analytics-data">visit|Sports|navigation-www|3</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://blog.sfgate.com/49ers/" target="_top">49ers<span class="hdn-analytics-data">visit|Sports-49ers|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/raiders/" target="_top">Raiders<span class="hdn-analytics-data">visit|Sports-Raiders|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/giants/" target="_top">Giants<span class="hdn-analytics-data">visit|Sports-Giants|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/sports/giantsfandom/" target="_top">Giants Fandom<span class="hdn-analytics-data">visit|Sports-Giants Fandom|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/athletics/" target="_top">A's<span class="hdn-analytics-data">visit|Sports-A's|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/warriors/" target="_top">Warriors<span class="hdn-analytics-data">visit|Sports-Warriors|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/quakes/" target="_top">Quakes<span class="hdn-analytics-data">visit|Sports-Quakes|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/sports/blogs/" target="_top">Sports Blogs<span class="hdn-analytics-data">visit|Sports-Sports Blogs|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/sports/tv/" target="_top">Sports Calendar<span class="hdn-analytics-data">visit|Sports-Sports Calendar|navigation-www|9</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://sports.sfgate.com/merge/tsnform.aspx?c=sfgate&amp;page=mlb/indexpic.htm" target="_top">MLB<span class="hdn-analytics-data">visit|Sports-MLB|navigation-www|10</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://sports.sfgate.com/merge/tsnform.aspx?c=sfgate&amp;page=nba/indexpic.htm" target="_top">NBA<span class="hdn-analytics-data">visit|Sports-NBA|navigation-www|11</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/collegesports/" target="_top">College<span class="hdn-analytics-data">visit|Sports-College|navigation-www|12</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/preps/" target="_top">Preps<span class="hdn-analytics-data">visit|Sports-Preps|navigation-www|13</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://sports.sfgate.com/merge/tsnform.aspx?c=sfgate&amp;page=golf-m/indexpic.htm" target="_top">Golf<span class="hdn-analytics-data">visit|Sports-Golf|navigation-www|14</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sports" href="http://www.sfgate.com/outdoors/" target="_top">Outdoors<span class="hdn-analytics-data">visit|Sports-Outdoors|navigation-www|15</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/warriors/article/Roar-from-crowd-for-Curry-as-MVP-brings-down-the-6244992.php" target="_top">
+                                            <img alt="Roar from crowd for Curry as MVP brings down the house - Photo" src="http://ww3.hdnux.com/photos/36/20/64/7933202/13/landscape_32.jpg" />
+                                            <h4 class="headline">Roar from crowd for Curry as MVP brings down the house</h4>
+                                            <span class="hdn-analytics-data">visit|article-6244992|Sports-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/sports/ostler/article/Wake-up-call-ends-Warriors-dreams-of-sweeps-6245019.php" target="_top">
+                                            <img alt="Wake-up call ends Warriorsâ€™ dreams of sweeps - Photo" src="http://ww3.hdnux.com/photos/36/20/63/7933158/21/landscape_32.jpg" />
+                                            <h4 class="headline">Wake-up call ends Warriorsâ€™ dreams of sweeps</h4>
+                                            <span class="hdn-analytics-data">visit|article-6245019|Sports-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/giants/jenkins/article/Like-an-old-friend-Giants-look-familiar-6244513.php" target="_top">
+                                            <img alt="Like an old friend, Giants look familiar - Photo" src="http://ww3.hdnux.com/photos/36/10/55/7899986/7/landscape_32.jpg" />
+                                            <h4 class="headline">Like an old friend, Giants look familiar</h4>
+                                            <span class="hdn-analytics-data">visit|article-6244513|Sports-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/warriors/article/Series-outlook-changes-with-Conley-s-return-6245015.php" target="_top">
+                                            <img alt="Series outlook changes with Conleyâ€™s return - Photo" src="http://ww2.hdnux.com/photos/36/20/70/7933453/11/landscape_32.jpg" />
+                                            <h4 class="headline">Series outlook changes with Conleyâ€™s return</h4>
+                                            <span class="hdn-analytics-data">visit|article-6245015|Sports-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="business" class="subMenuContainer business"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/business/" target="_top">Business<span class="hdn-analytics-data">visit|Business|navigation-www|4</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://www.sfgate.com/technology/" target="_top">Technology<span class="hdn-analytics-data">visit|Business-Technology|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://finance.sfgate.com" target="_top">Finance<span class="hdn-analytics-data">visit|Business-Finance|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://www.sfgate.com/technology/innovation/" target="_top">Innovation<span class="hdn-analytics-data">visit|Business-Innovation|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://www.sfgate.com/mortgagerates/" target="_top">Mortgage Rates<span class="hdn-analytics-data">visit|Business-Mortgage Rates|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://homeguides.sfgate.com/" target="_top">Home Guides<span class="hdn-analytics-data">visit|Business-Home Guides|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://www.legalnotice.org/pl/SFGate/landing1.aspx" target="_top">Public Notices<span class="hdn-analytics-data">visit|Business-Public Notices|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://www.sfgate.com/sponsoredarticles/business/" target="_top">Sponsored Content<span class="hdn-analytics-data">visit|Business-Sponsored Content|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://www.sfgate.com/officespace/" target="_top">Office Space<span class="hdn-analytics-data">visit|Business-Office Space|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://blog.sfgate.com/techchron/" target="_top">The Tech Chronicles<span class="hdn-analytics-data">visit|Business-The Tech Chronicles|navigation-www|9</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://blog.sfgate.com/pender/" target="_top">Net Worth<span class="hdn-analytics-data">visit|Business-Net Worth|navigation-www|10</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://blog.sfgate.com/energy/" target="_top">Fossils &amp; Photons<span class="hdn-analytics-data">visit|Business-Fossils &amp; Photons|navigation-www|11</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics business" href="http://blog.sfgate.com/mindyourbusiness/" target="_top">Mind Your Business<span class="hdn-analytics-data">visit|Business-Mind Your Business|navigation-www|12</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/business/article/California-gas-prices-jump-31-cents-in-1-week-on-6241905.php" target="_top">
+                                            <img alt="California gas prices jump 31 cents in 1 week on refinery woes - Photo" src="http://ww2.hdnux.com/photos/34/64/02/7553153/7/landscape_32.jpg" />
+                                            <h4 class="headline">California gas prices jump 31 cents in 1 week on refinery woes</h4>
+                                            <span class="hdn-analytics-data">visit|article-6241905|Business-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/business/article/Twitter-declares-Periscope-won-the-6241802.php" target="_top">
+                                            <img alt="Twitter declares Periscope won the Pacquiao-Mayweather fight - Photo" src="http://ww4.hdnux.com/photos/36/16/66/7925175/6/landscape_32.jpg" />
+                                            <h4 class="headline">Twitter declares Periscope won the Pacquiao-Mayweather fight</h4>
+                                            <span class="hdn-analytics-data">visit|article-6241802|Business-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/business/article/Daily-Briefing-May-5-6241579.php" target="_top">
+                                            <img alt="Daily Briefing, May 5 - Photo" src="http://ww3.hdnux.com/photos/36/16/62/7924906/3/landscape_32.jpg" />
+                                            <h4 class="headline">Daily Briefing, May 5</h4>
+                                            <span class="hdn-analytics-data">visit|article-6241579|Business-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/business/article/Comcast-Internet-customers-surpass-cable-6241771.php" target="_top">
+                                            <img alt="Comcast Internet customers surpass cable subscribers - Photo" src="http://ww2.hdnux.com/photos/36/16/62/7924901/3/landscape_32.jpg" />
+                                            <h4 class="headline">Comcast Internet customers surpass cable subscribers</h4>
+                                            <span class="hdn-analytics-data">visit|article-6241771|Business-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="ae" class="subMenuContainer ae"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/entertainment/" target="_top">A&amp;E<span class="hdn-analytics-data">visit|A&amp;E|navigation-www|5</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://blog.sfgate.com/dailydish/" target="_top">The Daily Dish<span class="hdn-analytics-data">visit|A&amp;E-The Daily Dish|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/movies/" target="_top">Movies<span class="hdn-analytics-data">visit|A&amp;E-Movies|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/music/" target="_top">Music &amp; Nightlife<span class="hdn-analytics-data">visit|A&amp;E-Music &amp; Nightlife|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/performance/" target="_top">Performance<span class="hdn-analytics-data">visit|A&amp;E-Performance|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/art/" target="_top">Art<span class="hdn-analytics-data">visit|A&amp;E-Art|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/entertainment/blogs/" target="_top">Blogs<span class="hdn-analytics-data">visit|A&amp;E-Blogs|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/entertainment/video/" target="_top">Videos<span class="hdn-analytics-data">visit|A&amp;E-Videos|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/events/" target="_top">Events<span class="hdn-analytics-data">visit|A&amp;E-Events|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/books/" target="_top">Books<span class="hdn-analytics-data">visit|A&amp;E-Books|navigation-www|9</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/tv/" target="_top">TV<span class="hdn-analytics-data">visit|A&amp;E-TV|navigation-www|10</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/horoscope/" target="_top">Horoscope<span class="hdn-analytics-data">visit|A&amp;E-Horoscope|navigation-www|11</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/comics/" target="_top">Comics<span class="hdn-analytics-data">visit|A&amp;E-Comics|navigation-www|12</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/games/" target="_top">Games<span class="hdn-analytics-data">visit|A&amp;E-Games|navigation-www|13</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics ae" href="http://www.sfgate.com/thingstodo/" target="_top">Things To Do<span class="hdn-analytics-data">visit|A&amp;E-Things To Do|navigation-www|14</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/music/article/Tei-Shi-a-musician-without-a-genre-makes-her-6237948.php" target="_top">
+                                            <img alt="Tei Shi, a musician without a genre, makes her West Coast debut - Photo" src="http://ww4.hdnux.com/photos/36/17/21/7926859/3/landscape_32.jpg" />
+                                            <h4 class="headline">Tei Shi, a musician without a genre, makes her West Coast debut</h4>
+                                            <span class="hdn-analytics-data">visit|article-6237948|A&amp;E-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/movies/article/Reflecting-on-the-career-and-life-Orson-Welles-at-6240710.php" target="_top">
+                                            <img alt="Reflecting on the career and life Orson Welles at 100 - Photo" src="http://ww4.hdnux.com/photos/36/16/23/7922927/7/landscape_32.jpg" />
+                                            <h4 class="headline">Reflecting on the career and life Orson Welles at 100</h4>
+                                            <span class="hdn-analytics-data">visit|article-6240710|A&amp;E-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/music/article/Sleater-Kinney-s-statement-rock-6239294.php" target="_top">
+                                            <img alt="Sleater-Kinneyâ€™s statement rock still enthralls - Photo" src="http://ww1.hdnux.com/photos/36/15/16/7918524/15/landscape_32.jpg" />
+                                            <h4 class="headline">Sleater-Kinneyâ€™s statement rock still enthralls</h4>
+                                            <span class="hdn-analytics-data">visit|article-6239294|A&amp;E-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/music/article/Esa-Pekka-Salonen-a-conductor-in-the-catbird-seat-6236507.php" target="_top">
+                                            <img alt="Esa-Pekka Salonen: a conductor in the catbird seat - Photo" src="http://ww3.hdnux.com/photos/36/11/60/7904318/13/landscape_32.jpg" />
+                                            <h4 class="headline">Esa-Pekka Salonen: a conductor in the catbird seat</h4>
+                                            <span class="hdn-analytics-data">visit|article-6236507|A&amp;E-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="food" class="subMenuContainer food"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/food/" target="_top">Food<span class="hdn-analytics-data">visit|Food|navigation-www|6</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://www.sfgate.com/restaurants/" target="_top">Restaurants<span class="hdn-analytics-data">visit|Food-Restaurants|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://www.sfgate.com/recipes/" target="_top">Recipes<span class="hdn-analytics-data">visit|Food-Recipes|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://www.sfgate.com/wine/" target="_top">Wine<span class="hdn-analytics-data">visit|Food-Wine|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://www.sfgate.com/food/top100/2014/" target="_top">Top 100 Restaurants<span class="hdn-analytics-data">visit|Food-Top 100 Restaurants|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://www.sfgate.com/wine/article/Top-100-Wines-The-Best-of-the-West-Coast-in-2014-5935710.php" target="_top">Top 100 Wines<span class="hdn-analytics-data">visit|Food-Top 100 Wines|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://www.sfgate.com/bargainbites" target="_top">Bargain Bites<span class="hdn-analytics-data">visit|Food-Bargain Bites|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://www.opentable.com/start.aspx?m=4&amp;ref=7801" target="_top">Reservations<span class="hdn-analytics-data">visit|Food-Reservations|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://insidescoopsf.sfgate.com/" target="_top">Inside Scoop SF<span class="hdn-analytics-data">visit|Food-Inside Scoop SF|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics food" href="http://healthyeating.sfgate.com/" target="_top">Healthy Eating<span class="hdn-analytics-data">visit|Food-Healthy Eating|navigation-www|9</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://insidescoopsf.sfgate.com/blog/2015/05/05/max-snyder-named-chef-at-bernal-heights-forthcoming-old-bus-tavern/" target="_top">
+                                            <img alt="Max Snyder named chef at Bernal Heights’ forthcoming Old Bus Tavern - Photo" src="http://ww4.hdnux.com/photos/36/17/67/7929287/5/landscape_32.jpg" />
+                                            <h4 class="headline">Max Snyder named chef at Bernal Heights’ forthcoming Old</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1685147|Food-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://insidescoopsf.sfgate.com/blog/2015/05/05/making-food-casa-de-tamales-reinvents-tradition/" target="_top">
+                                            <img alt="Making Food: Casa de Tamales reinvents tradition - Photo" src="http://ww3.hdnux.com/photos/36/17/70/7929354/3/landscape_32.jpg" />
+                                            <h4 class="headline">Making Food: Casa de Tamales reinvents tradition</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1685163|Food-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://insidescoopsf.sfgate.com/blog/2015/05/04/james-beard-award-winners-2015-a16-and-jessica-largey-of-manresa-among-winners/" target="_top">
+                                            <img alt="James Beard Award winners 2015: A16 and Jessica Largey of Manresa among winners - Photo" src="http://ww4.hdnux.com/photos/36/17/23/7927011/3/landscape_32.jpg" />
+                                            <h4 class="headline">James Beard Award winners 2015: A16 and Jessica Largey of Manresa</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1684503|Food-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://insidescoopsf.sfgate.com/blog/2015/05/04/blue-bottle-coffee-says-goodbye-to-ferry-plaza-market/" target="_top">
+                                            <img alt="Blue Bottle Coffee says goodbye to Ferry Plaza Farmers’ Market - Photo" src="http://ww3.hdnux.com/photos/36/16/75/7925586/5/landscape_32.jpg" />
+                                            <h4 class="headline">Blue Bottle Coffee says goodbye to Ferry Plaza Farmers’</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1684358|Food-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="living" class="subMenuContainer living"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/living/" target="_top">Living<span class="hdn-analytics-data">visit|Living|navigation-www|7</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/homeandgarden/" target="_top">Home &amp; Garden<span class="hdn-analytics-data">visit|Living-Home &amp; Garden|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/style/" target="_top">Style<span class="hdn-analytics-data">visit|Living-Style|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/sfsocial/" target="_top">Parties<span class="hdn-analytics-data">visit|Living-Parties|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/philanthropy/" target="_top">Philanthropy<span class="hdn-analytics-data">visit|Living-Philanthropy|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/lust/" target="_top">Lust<span class="hdn-analytics-data">visit|Living-Lust|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/weekendwarrior/" target="_top">Weekend Warrior<span class="hdn-analytics-data">visit|Living-Weekend Warrior|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/skiing/" target="_top">Ski<span class="hdn-analytics-data">visit|Living-Ski|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/lgbt/" target="_top">LGBT<span class="hdn-analytics-data">visit|Living-LGBT|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://remodeling.sfgate.com/" target="_top">Houzz<span class="hdn-analytics-data">visit|Living-Houzz|navigation-www|9</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/outdoors/" target="_top">Outdoors<span class="hdn-analytics-data">visit|Living-Outdoors|navigation-www|10</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/living/blogs/" target="_top">Blogs<span class="hdn-analytics-data">visit|Living-Blogs|navigation-www|11</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/sponsoredarticles/lifestyle/" target="_top">Sponsored<span class="hdn-analytics-data">visit|Living-Sponsored|navigation-www|12</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics living" href="http://www.sfgate.com/campguide/" target="_top">Schools, Camps &amp; Activities<span class="hdn-analytics-data">visit|Living-Schools, Camps &amp; Activities|navigation-www|13</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/sfmoms/2015/05/04/like-mother-like-daughter-share-your-photos/" target="_top">
+                                            <img alt="Like mother, like daughter: Share your photos - Photo" src="http://ww2.hdnux.com/photos/36/16/14/7922449/3/landscape_32.jpg" />
+                                            <h4 class="headline">Like mother, like daughter: Share your photos</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1683713|Living-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/style/slideshow/Best-and-worst-dressed-from-the-2015-Met-Gala-109080.php" target="_top">
+                                            <img alt="Best and worst looks at the 2015 Met Gala - Photo" src="http://ww1.hdnux.com/photos/36/17/00/7925804/11/landscape_32.jpg" />
+                                            <h4 class="headline">Best and worst looks at the 2015 Met Gala</h4>
+                                            <span class="hdn-analytics-data">visit|slideshow-109080|Living-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/living/article/Why-the-Marina-is-a-great-neighborhood-6231820.php" target="_top">
+                                            <img alt="Why the Marina is amazing â€” despite what youâ€™ve heard - Photo" src="http://ww1.hdnux.com/photos/36/11/54/7904056/4/landscape_32.jpg" />
+                                            <h4 class="headline">Why the Marina is amazing â€” despite what youâ€™ve heard</h4>
+                                            <span class="hdn-analytics-data">visit|article-6231820|Living-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/living/slideshow/A-photo-history-of-royal-babies-66157.php" target="_top">
+                                            <img alt="A photo history of royal babies - Photo" src="http://ww3.hdnux.com/photos/22/55/13/4903650/3/landscape_32.jpg" />
+                                            <h4 class="headline">A photo history of royal babies</h4>
+                                            <span class="hdn-analytics-data">visit|slideshow-66157|Living-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="travel" class="subMenuContainer travel"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/travel/" target="_top">Travel<span class="hdn-analytics-data">visit|Travel|navigation-www|8</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/getaways/" target="_top">Weekend Getaways<span class="hdn-analytics-data">visit|Travel-Weekend Getaways|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/neighborhoods/" target="_top">Neighborhoods<span class="hdn-analytics-data">visit|Travel-Neighborhoods|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/winecountry/" target="_top">Wine Country<span class="hdn-analytics-data">visit|Travel-Wine Country|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/monterey-carmel/" target="_top">Monterey-Carmel<span class="hdn-analytics-data">visit|Travel-Monterey-Carmel|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/renotahoe/" target="_top">Tahoe<span class="hdn-analytics-data">visit|Travel-Tahoe|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/hawaii/" target="_top">Hawaii<span class="hdn-analytics-data">visit|Travel-Hawaii|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/mexico/" target="_top">Mexico<span class="hdn-analytics-data">visit|Travel-Mexico|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/vegas/" target="_top">Vegas<span class="hdn-analytics-data">visit|Travel-Vegas|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics travel" href="http://www.sfgate.com/living/blogs/" target="_top">Blogs<span class="hdn-analytics-data">visit|Travel-Blogs|navigation-www|9</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/travel/article/The-top-tiny-hotels-around-the-world-6236503.php" target="_top">
+                                            <img alt="The top tiny hotels around the world - Photo" src="http://ww2.hdnux.com/photos/36/13/13/7910133/6/landscape_32.jpg" />
+                                            <h4 class="headline">The top tiny hotels around the world</h4>
+                                            <span class="hdn-analytics-data">visit|article-6236503|Travel-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/getlost/2015/05/04/two-tourists-allegedly-break-ancient-statue-in-italy-while-taking-a-selfie/" target="_top">
+                                            <img alt="Two tourists allegedly break ancient statue while taking a selfie - Photo" src="http://ww4.hdnux.com/photos/36/16/40/7923763/13/landscape_32.png" />
+                                            <h4 class="headline">Two tourists allegedly break ancient statue while taking a selfie</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1683988|Travel-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/travel/article/Waterways-offer-deeper-insights-into-New-York-City-6234970.php" target="_top">
+                                            <img alt="Waterways offer deeper insights into New York City - Photo" src="http://ww2.hdnux.com/photos/36/06/37/7890913/7/landscape_32.jpg" />
+                                            <h4 class="headline">Waterways offer deeper insights into New York City</h4>
+                                            <span class="hdn-analytics-data">visit|article-6234970|Travel-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/getlost/2015/04/30/top-10-global-destinations-tips-for-north-americans/" target="_top">
+                                            <img alt="Top 10 global destinations, tips for North Americans - Photo" src="http://ww1.hdnux.com/photos/36/10/63/7900372/3/landscape_32.jpg" />
+                                            <h4 class="headline">Top 10 global destinations, tips for North Americans</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1680593|Travel-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="realestate" class="subMenuContainer realestate"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/realestate/" target="_top">Real Estate<span class="hdn-analytics-data">visit|Real Estate|navigation-www|9</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://www.sfgate.com/newhomes/" target="_top">New Homes<span class="hdn-analytics-data">visit|Real Estate-New Homes|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://www.sfgate.com/openhomes/" target="_top">Open Homes<span class="hdn-analytics-data">visit|Real Estate-Open Homes|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://www.sfgate.com/luxuryhomes/" target="_top">Luxury<span class="hdn-analytics-data">visit|Real Estate-Luxury|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://www.sfgate.com/rentals/" target="_top">Rentals<span class="hdn-analytics-data">visit|Real Estate-Rentals|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://www.sfgate.com/mortgagerates/" target="_top">Mortgage Rates<span class="hdn-analytics-data">visit|Real Estate-Mortgage Rates|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://www.loopnet.com/looplink/sfgate/searchpage.aspx" target="_top">Commercial<span class="hdn-analytics-data">visit|Real Estate-Commercial|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://www.sfgate.com/realestate/advertise/" target="_top">Place an ad<span class="hdn-analytics-data">visit|Real Estate-Place an ad|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://homeguides.sfgate.com/" target="_top">Home Guides<span class="hdn-analytics-data">visit|Real Estate-Home Guides|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://www.sfgate.com/webdb/homesales" target="_top">Homesales<span class="hdn-analytics-data">visit|Real Estate-Homesales|navigation-www|9</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics realestate" href="http://blog.sfgate.com/ontheblock" target="_top">On the Block Blog<span class="hdn-analytics-data">visit|Real Estate-On the Block Blog|navigation-www|10</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" target="_top">
+                                            <img alt="Nob Hill one-bedroom sells for $2.3 million - Photo" src="http://ww1.hdnux.com/photos/36/17/52/7928484/3/landscape_32.jpg" />
+                                            <h4 class="headline">Nob Hill one-bedroom sells for $2.3 million</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1684669|Real Estate-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/ontheblock/2015/05/04/bernal-heights-tenant-moves-out-but-continues-to-dispute-400-percent-rent-increase/" target="_top">
+                                            <img alt="Bernal Heights tenant moves out, but continues to dispute 400 percent rent increase - Photo" src="http://ww4.hdnux.com/photos/36/16/67/7925247/3/landscape_32.png" />
+                                            <h4 class="headline">Bernal Heights tenant moves out, but continues to dispute 400</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1684321|Real Estate-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/ontheblock/2015/05/04/joe-montanas-latest-score-a-2275000-marina-condo/" target="_top">
+                                            <img alt="Joe Montana’s latest score: A $2,275,000 Marina condo - Photo" src="http://ww3.hdnux.com/photos/36/16/03/7921898/5/landscape_32.jpg" />
+                                            <h4 class="headline">Joe Montana’s latest score: A $2,275,000 Marina condo</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1683479|Real Estate-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/realestate/article/Hot-Property-Contemporary-living-in-classical-6237331.php" target="_top">
+                                            <img alt="Hot Property: Contemporary living in classical style in the Inner Richmond - Photo" src="http://ww4.hdnux.com/photos/36/11/67/7904743/3/landscape_32.jpg" />
+                                            <h4 class="headline">Hot Property: Contemporary living in classical style in the Inner</h4>
+                                            <span class="hdn-analytics-data">visit|article-6237331|Real Estate-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- end navMenu foreach -->
+                    <!-- navMenu foreach -->
+                    <!-- navloop foreach -->
+                    <li location="cars" class="subMenuContainer more cars"><a class="subMenuLink hdn-analytics" href="http://cars.sfgate.com" target="_top">Cars<span class="hdn-analytics-data">visit|Cars|navigation-www|1</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics cars" href="http://cars.sfgate.com/Dealers?zipCode=94103&amp;make=&amp;maxDistance=100&amp;sortBy=1" target="_top">Dealers<span class="hdn-analytics-data">visit|Cars-Dealers|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics cars" href="http://www.sfgate.com/columns/clickandclack/" target="_top">Click and Clack<span class="hdn-analytics-data">visit|Cars-Click and Clack|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics cars" href="http://blog.sfgate.com/topdown/" target="_top">Car Blog<span class="hdn-analytics-data">visit|Cars-Car Blog|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics cars" href="http://www.sfgate.com/columns/myride/" target="_top">My Ride<span class="hdn-analytics-data">visit|Cars-My Ride|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics cars" href="http://www.sfgate.com/cars/sellyourcar/" target="_top">Sell Your Car<span class="hdn-analytics-data">visit|Cars-Sell Your Car|navigation-www|5</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/cars/myride/article/T-bird-evokes-special-memories-6233783.php" target="_top">
+                                            <img alt="T-bird evokes special memories - Photo" src="http://ww2.hdnux.com/photos/36/10/16/7898041/3/landscape_32.jpg" />
+                                            <h4 class="headline">T-bird evokes special memories</h4>
+                                            <span class="hdn-analytics-data">visit|article-6233783|Cars-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/cars/myride/article/Rebuilt-Buick-runs-like-it-did-in-1936-6204208.php" target="_top">
+                                            <img alt="Rebuilt Buick runs like it did in 1936 - Photo" src="http://ww4.hdnux.com/photos/35/66/44/7825687/5/landscape_32.jpg" />
+                                            <h4 class="headline">Rebuilt Buick runs like it did in 1936</h4>
+                                            <span class="hdn-analytics-data">visit|article-6204208|Cars-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/cars/clickandclack/article/Luxury-cars-come-with-higher-repair-costs-6204180.php" target="_top">
+                                            <img alt="Luxury cars come with higher repair costs - Photo" src="http://ww3.hdnux.com/photos/33/32/57/7187406/55/landscape_32.jpg" />
+                                            <h4 class="headline">Luxury cars come with higher repair costs</h4>
+                                            <span class="hdn-analytics-data">visit|article-6204180|Cars-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfgate.com/cars/article/Bay-Area-s-best-and-worst-Zip-codes-for-car-6171217.php" target="_top">
+                                            <img alt="Bay Area's best, and worst, Zip codes for car insurance - Photo" src="http://ww1.hdnux.com/photos/24/27/42/5339272/7/landscape_32.jpg" />
+                                            <h4 class="headline">Bay Area's best, and worst, Zip codes for car insurance</h4>
+                                            <span class="hdn-analytics-data">visit|article-6171217|Cars-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="jobs" class="subMenuContainer more jobs"><a class="subMenuLink hdn-analytics" href="http://www.sfgate.com/jobs/" target="_top">Jobs<span class="hdn-analytics-data">visit|Jobs|navigation-www|2</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics jobs" href="http://events.sfgate.com/search?acat=&amp;new=n&amp;sort=0&amp;srad=50&amp;srss=10&amp;ssrss=5&amp;st=event&amp;svt=text&amp;swhat=&amp;swhen=&amp;swhere=San+Francisco%2CCA&amp;trim=1&amp;cat=1111" target="_top">Job Events<span class="hdn-analytics-data">visit|Jobs-Job Events|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics jobs" href="http://hiring.local-jobs.monster.com/recruitment/Standard-Postings.aspx?ch=sanfranchron" target="_top">Advertise<span class="hdn-analytics-data">visit|Jobs-Advertise|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics jobs" href="http://bayarea.salary.com/SalaryWizard/LayoutScripts/Swzl_NewSearch.aspx" target="_top">Salary Wizard<span class="hdn-analytics-data">visit|Jobs-Salary Wizard|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics jobs" href="http://blog.sfgate.com/gettowork/" target="_top">Get To Work<span class="hdn-analytics-data">visit|Jobs-Get To Work|navigation-www|4</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/gettowork/2015/05/05/recent-college-grads-can-benefit-from-having-business-card-to-exchange/" target="_top">
+                                            <img alt="Recent college grads can benefit from having business card to exchange - Photo" src="http://ww3.hdnux.com/photos/36/17/64/7929102/3/landscape_32.jpg" />
+                                            <h4 class="headline">Recent college grads can benefit from having business card to</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1685055|Jobs-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/gettowork/2015/05/05/where-workers-are-gaining-weight/" target="_top">
+                                            <img alt="Which jobs make you gain weight? - Photo" src="http://ww1.hdnux.com/photos/36/17/52/7928468/3/landscape_32.jpg" />
+                                            <h4 class="headline">Which jobs make you gain weight?</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1684667|Jobs-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/gettowork/2015/05/04/job-fair-just-for-startups-is-coming-to-s-f/" target="_top">
+                                            <img alt="Job fair just for startups is coming to S.F. - Photo" src="http://ww4.hdnux.com/photos/36/16/77/7925743/5/landscape_32.jpg" />
+                                            <h4 class="headline">Job fair just for startups is coming to S.F.</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1684366|Jobs-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://blog.sfgate.com/gettowork/2015/04/30/what-to-do-when-your-company-gets-acquired/" target="_top">
+                                            <img alt="What to do when your company gets acquired - Photo" src="http://ww1.hdnux.com/photos/36/11/11/7901784/3/landscape_32.jpg" />
+                                            <h4 class="headline">What to do when your company gets acquired</h4>
+                                            <span class="hdn-analytics-data">visit|blogPost-1681067|Jobs-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="sfchronicle" class="subMenuContainer more sfchronicle"><a class="subMenuLink hdn-analytics" href="http://www.sfchronicle.com/" target="_top">SFChronicle<span class="hdn-analytics-data">visit|SFChronicle|navigation-www|3</span><span class="icon"></span></a>
+                        <ul class="subnav">
+                            <div class="shadow"></div>
+                            <div class="subnavLeft">
+                                <ul class="subnavlinks">
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/local/columnists" target="_top">Latest columns<span class="hdn-analytics-data">visit|SFChronicle-Latest columns|navigation-www|1</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/michael-bauer" target="_top">Michael Bauer<span class="hdn-analytics-data">visit|SFChronicle-Michael Bauer|navigation-www|2</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/jon-carroll/" target="_top">Jon Carroll<span class="hdn-analytics-data">visit|SFChronicle-Jon Carroll|navigation-www|3</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/leah-garchik/" target="_top">Leah Garchik<span class="hdn-analytics-data">visit|SFChronicle-Leah Garchik|navigation-www|4</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfgate.com/columnists/jenkins" target="_top">Bruce Jenkins<span class="hdn-analytics-data">visit|SFChronicle-Bruce Jenkins|navigation-www|5</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/chip-johnson" target="_top">Chip Johnson<span class="hdn-analytics-data">visit|SFChronicle-Chip Johnson|navigation-www|6</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfgate.com/columnists/killion/" target="_top">Ann Killion<span class="hdn-analytics-data">visit|SFChronicle-Ann Killion|navigation-www|7</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/thomas-lee/" target="_top">Thomas Lee<span class="hdn-analytics-data">visit|SFChronicle-Thomas Lee|navigation-www|8</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/matier-ross/" target="_top">Matier &amp; Ross<span class="hdn-analytics-data">visit|SFChronicle-Matier &amp; Ross|navigation-www|9</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/c-w-nevius/" target="_top">C.W Nevius<span class="hdn-analytics-data">visit|SFChronicle-C.W Nevius|navigation-www|10</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/kathleen-pender/" target="_top">Kathleen Pender<span class="hdn-analytics-data">visit|SFChronicle-Kathleen Pender|navigation-www|11</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfgate.com/columnists/ostler/" target="_top">Scott Ostler<span class="hdn-analytics-data">visit|SFChronicle-Scott Ostler|navigation-www|12</span></a>
+                                    </li>
+                                    <li class="subMenuItem">
+                                        <a class="subMenuItemLink hdn-analytics sfchronicle" href="http://www.sfchronicle.com/author/debra-saunders/" target="_top">Debra J Saunders<span class="hdn-analytics-data">visit|SFChronicle-Debra J Saunders|navigation-www|13</span></a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="subnavRight">
+                                <!-- widgetdataprovider -->
+                                <!-- e widgetdataprovider -->
+                                <div class="subnavPreview">
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfchronicle.com/oursf/" target="_top">
+                                            <img alt="Our San Francisco: Exploring The Archives - Photo" src="http://ww3.hdnux.com/photos/35/34/64/7720226/3/landscape_32.jpg" />
+                                            <h4 class="headline">Our San Francisco: Exploring The Archives</h4>
+                                            <span class="hdn-analytics-data">visit|link-30168|SFChronicle-nav-hcat|1</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfchronicle.com/top-100-restaurants/" target="_top">
+                                            <img alt="Top 100 Restaurants - Photo" src="http://ww4.hdnux.com/photos/27/71/60/6265875/6/landscape_32.jpg" />
+                                            <h4 class="headline">Top 100 Restaurants</h4>
+                                            <span class="hdn-analytics-data">visit|link-30882|SFChronicle-nav-hcat|2</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfchronicle.com/the-mission/" target="_top">
+                                            <img alt="The Mission Project - Photo" src="http://ww3.hdnux.com/photos/27/50/64/6196506/5/landscape_32.jpg" />
+                                            <h4 class="headline">The Mission Project</h4>
+                                            <span class="hdn-analytics-data">visit|link-30211|SFChronicle-nav-hcat|3</span>
+                                        </a>
+                                    </div>
+                                    <div class="nav-hcat">
+                                        <a class="hdn-analytics" href="http://www.sfchronicle.com/drought/" target="_top">
+                                            <img alt="California Drought: Running Dry - Photo" src="http://ww3.hdnux.com/photos/33/42/47/7219682/9/landscape_32.jpg" />
+                                            <h4 class="headline">California Drought: Running Dry</h4>
+                                            <span class="hdn-analytics-data">visit|link-30881|SFChronicle-nav-hcat|4</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </ul>
+                    </li>
+                    <!-- end navloop foreach -->
+                    <!-- navloop foreach -->
+                    <li location="findsave" class="subMenuContainer more findsave"><a class="subMenuLink hdn-analytics" href="http://findnsave.sfgate.com/" target="_top">Find&amp;Save<span class="hdn-analytics-data">visit|Find&amp;Save|navigation-www|4</span></a></li>
+                    <!-- end navloop foreach -->
+                    <!-- end navMenu foreach -->
+                </ul>
+                <!-- /ux hearst/sitemenu/menuSiteNav_r1.tpl -->
+                <!-- e hearst/sitemenu/dynamic_r1.tpl -->
+            </div>
+        </nav>
+        <div class="menu-bar">
+            <a class="homeLink" href="http://www.sfgate.com/"><span class="icon"></span></a><a class="nav-btn" id="menu-open"><span class="icon">Menu</span><span class="label">Sections</span></a>
+            <div class="title"><span class="icon"></span></div>
+        </div>
+    </header>
+    <div id="content">
+        <!-- e ux hearst/home/navigation_main.tpl -->
+        <!-- e hearst/home/navigation.tpl -->
+        <!-- e business/templates/hearst/home/HNavigation.tpl -->
+        <script type="text/javascript">
+        jQuery(function($) {
+            $(".hst-siteheader a, .topnav a, .sitenav a, .subnav li a").attr("target", "_top");
+        });
+        </script>
+        <script type="text/javascript">
+        window.NREUM || (NREUM = {});
+        NREUM.info = {
+            "beacon": "bam.nr-data.net",
+            "licenseKey": "3fd06eaac1",
+            "applicationID": "147157",
+            "transactionName": "MwQBZ0RXV0NTVhBdDgpONkFfGVBeVlAcGhEMEQ==",
+            "queueTime": 0,
+            "applicationTime": 7,
+            "ttGuid": "",
+            "agentToken": "",
+            "userAttributes": "",
+            "errorBeacon": "bam.nr-data.net",
+            "agent": "js-agent.newrelic.com/nr-632.min.js"
+        }
+        </script>
+    </div>
+    <script type="text/javascript">
+    document.getElementById('page-body').className += ' body-responsive';
+
+    $('.home').removeClass('home');
+    $('body').addClass('realestate');
+    </script>
+    <!--[if lt IE 9]>
+    <script type="text/javascript">
+    document.getElementById('page-body').className += ' old-ie';
+    </script>
+    <![endif]-->
+    <div class="group" id="page-wrap">
+        <script type="text/javascript">
+        //&lt;![CDATA[
+        var amc = amc || {};
+        if (!amc.on) {
+            amc.on = amc.call = function() {}
+        };
+        document.write("&lt;scr" + "ipt type=\"text/javascript\" src=\"//www.adobetag.com/d1/v2/ZDEtaGVhcnN0LTMwNzctMzY0Ni0=/amc.js\"&gt;&lt;/sc" + "ript&gt;");
+        //]]&gt;
+        </script>
+        <script src="//www.adobetag.com/d1/v2/ZDEtaGVhcnN0LTMwNzctMzY0Ni0=/amc.js" type="text/javascript"></script>
+        <div id="index-blog-above-header-image-area">
+            <div class="widget-ad-position-A951 widget-container header-full-width-ad ad_position" id="hdn_ad_position-17">
+                <div class="hdn-ad-position ad-A951 hdn-ap-visible-mobile hdn-ap-visible-desktop">
+                    <div class="juice-ad-position juice-ad-position-A951" id="A951" style="display: none;">
+                        <script id="A951-0-72020400-1430916267" type="text/javascript">
+                        window.ad_position_widget.place_named_ad('A951', 'A951-0-72020400-1430916267');
+                        </script>
+                        <script src="http://pubads.g.doubleclick.net/gampad/ads?gdfp_req=1&amp;correlator=451533144857127&amp;output=json_html&amp;callback=googletag.impl.pubads.setAdContentsBySlotForSync&amp;impl=s&amp;eid=108809030%2C108809046&amp;sc=0&amp;sfv=1-0-2&amp;iu=%2F36117602%2Fhnp-sfgate.com%2FReal_Estate&amp;sz=970x415%7C970x250&amp;scp=custom%3Don_the_block%26page_type%3Dblog%26position%3DATF%26page_type2%3Dundefined%26DIV_ID%3DA951%26page_type3%3DA951_undefined&amp;cust_params=referrer%3D%26PageUrl%3Dblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million&amp;cookie=ID%3D852c9ccda72616fa%3AT%3D1430916346%3AS%3DALNI_MbwxT7dVlSWJ3uPaeoKvFiGTZiKgQ&amp;lmt=1430917071&amp;dt=1430917071444&amp;cc=100&amp;frm=20&amp;biw=1920&amp;bih=974&amp;oid=3&amp;adx=960&amp;ady=168&amp;adk=1992995004&amp;gut=v2&amp;ifi=1&amp;u_tz=120&amp;u_his=3&amp;u_java=true&amp;u_h=1080&amp;u_w=1920&amp;u_ah=1053&amp;u_aw=1920&amp;u_cd=24&amp;u_nplug=7&amp;u_nmime=28&amp;u_sd=1&amp;flash=17.0.0&amp;url=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F&amp;vrg=60&amp;vrp=60&amp;ga_vid=915408869.1430916345&amp;ga_sid=1430916345&amp;ga_hid=1690637165&amp;ga_fc=true" type="text/javascript"></script>
+                    </div>
+                </div>
+            </div>
+            <div class="widget-ad-position-RM widget-container header-full-width-ad ad_position" id="hdn_ad_position-18">
+                <div class="hdn-ad-position ad-RM hdn-ap-visible-mobile hdn-ap-visible-desktop">
+                    <div class="juice-ad-position juice-ad-position-RM" id="RM" style="display: none;">
+                        <script id="RM-0-72060500-1430916267" type="text/javascript">
+                        window.ad_position_widget.place_named_ad('RM', 'RM-0-72060500-1430916267');
+                        </script>
+                        <script src="http://pubads.g.doubleclick.net/gampad/ads?gdfp_req=1&amp;correlator=451533144857127&amp;output=json_html&amp;callback=googletag.impl.pubads.setAdContentsBySlotForSync&amp;impl=s&amp;eid=108809030%2C108809046&amp;sc=0&amp;sfv=1-0-2&amp;iu=%2F36117602%2Fhnp-sfgate.com%2FReal_Estate&amp;sz=1x1&amp;scp=custom%3Don_the_block%26page_type%3Dblog%26position%3DATF%26page_type2%3DBlogs%26DIV_ID%3DRM%26page_type3%3DRM_Blogs&amp;cust_params=referrer%3D%26PageUrl%3Dblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million&amp;cookie=ID%3D852c9ccda72616fa%3AT%3D1430916346%3AS%3DALNI_MbwxT7dVlSWJ3uPaeoKvFiGTZiKgQ&amp;lmt=1430917071&amp;dt=1430917071850&amp;cc=100&amp;frm=20&amp;biw=1920&amp;bih=974&amp;oid=3&amp;adx=0&amp;ady=0&amp;adk=3596092527&amp;gut=v2&amp;ifi=2&amp;u_tz=120&amp;u_his=3&amp;u_java=true&amp;u_h=1080&amp;u_w=1920&amp;u_ah=1053&amp;u_aw=1920&amp;u_cd=24&amp;u_nplug=7&amp;u_nmime=28&amp;u_sd=1&amp;flash=17.0.0&amp;url=http%3A%2F%2Fblog.sfgate.com%2Fontheblock%2F2015%2F05%2F05%2Fnob-hill-one-bedroom-sells-for-2-3-million%2F&amp;vrg=60&amp;vrp=60&amp;ga_vid=915408869.1430916345&amp;ga_sid=1430916345&amp;ga_hid=1690637165&amp;ga_fc=true" type="text/javascript"></script>
+                    </div>
+                </div>
+            </div>
+            <div class="widget-ad-position-PAGEWIDE widget-container header-full-width-ad ad_position" id="hdn_ad_position-19">
+                <div class="hdn-ad-position ad-PAGEWIDE hdn-ap-visible-mobile hdn-ap-visible-desktop">
+                    <div class="juice-ad-position juice-ad-position-PAGEWIDE" id="PAGEWIDE">
+                        <script id="PAGEWIDE-0-72102000-1430916267" type="text/javascript">
+                        window.ad_position_widget.place_named_ad('PAGEWIDE', 'PAGEWIDE-0-72102000-1430916267');
+                        </script>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div data-role="content" class="pagecontent" id="pagecontent">
+            <div class="" id="nav-border"></div>
+            <div id="outer-wrap">
+                <div class="left" id="content-wrap">
+                    <!-- branding standard default -->
+                    <div class="branding-standard-default" id="branding">
+                        <div class="header-text">
+                            <h2 class="blogname "><a style="color:#2c2f2a;" href="http://blog.sfgate.com/ontheblock">
+        On The Block</a></h2>
+                        </div>
+                    </div>
+                    <script>
+                    (function(w) {
+
+                        if (jQuery) {
+                            //alert(jQuery);
+                        }
+
+                        //alert(w);
+
+                        var menuList = new Array();
+                        var subNav = 'div.niche-subnav-header li.menu-item';
+
+                        jQuery('#subnav_display_control_more').click(function(e) {
+                            e.preventDefault();
+
+
+                            if (menuList.length & gt; 0) {
+                                jQuery('.niche-subnav-header ul').css('margin-left', '-400px');
+                                /**
+                                  for (var i = menuList.length -1; i &gt;= 0; i--){
+                                          jQuery('#'+menuList[i]+'').css('display','');
+                                      }
+                                **/
+
+                                jQuery('#subnav_display_control_more').hide();
+                                jQuery('#subnav_display_control_less').show();
+
+                            }
+
+                            this.hide();
+
+
+                        });
+
+                        jQuery('#subnav_display_control_less').click(function(e) {
+                            e.preventDefault();
+                            //alert('less clicked ...');
+
+                            // Maximum visible item
+                            var maxItems = 0;
+                            maxItems +=
+                                if (menuList.length & gt; 0) {
+
+                                    jQuery('.niche-subnav-header ul').css('margin-left', '10px');
+
+                                    // safety check
+                                    /**
+         if (maxItems &gt; menuList.length) {
+             maxItems = 2;
+         }
+
+        for (var i = menuList.length -1; i &gt;= maxItems; i--){
+                jQuery('#'+menuList[i]+'').css('display','none');
+            }
+        **/
+
+                                    jQuery('#subnav_display_control_less').hide();
+                                    jQuery('#subnav_display_control_more').show();
+
+                                }
+
+
+
+                            return false;
+                        });
+
+                        // Global
+                        var oldTopMargin = 0;
+
+                        jQuery('#subnav-open-close-button').click(function() {
+                            //alert('mobile open/close');
+                            var nicheList = jQuery('.niche-subnav-header ul');
+                            var nicheContainer = jQuery('.niche-subnav-header');
+
+                            if (nicheList.is(':visible')) {
+                                nicheList.hide();
+                                nicheContainer.hide();
+                            } else {
+                                nicheList.show();
+                                nicheContainer.show();
+                                jQuery('#subnav-open-close-button').hide();
+                            }
+
+
+                            /**
+                            var navHeight = nicheList.height();
+                            var navTopMargin = parseInt(nicheList.css('margin-top'));
+
+
+
+                            if (navTopMargin &gt; 0){
+                                 oldTopMargin = navTopMargin;
+                                 //alert('old margin '+ oldTopMargin + " height = "+ navHeight);
+                                 nicheList.css('margin-top','-'+(navHeight + navTopMargin) +'px');
+                            }
+                            else{
+                               //alert("margin = "+ oldTopMargin);
+                               nicheList.css('margin-top',''+ oldTopMargin +'px');
+                            }
+
+                            **/
+
+                        });
+
+
+
+                        initMenuList(subNav);
+
+                        //alert(initMenuList);
+
+                        function initMenuList(nav) {
+                            //alert(" array size  "+menuList.length);
+                            if (nav) {
+                                jQuery(nav).each(function() {
+                                    //alert(this.id);
+                                    menuList.push(this.id);
+                                });
+                            }
+
+                            //alert(" array size  "+menuList.length);
+                        }
+
+
+                    })(window);
+
+
+
+                    window.addEventListener("resize", pageDidResize);
+
+                    //jQuery(window).resize(function() {
+                    function pageDidResize() {
+                        console.log('resizing..... ******************************');
+                        //console.log('resizing....' +  jQuery(window).width() );
+                        var windowSize = jQuery(window).width();
+
+                        if (windowSize & gt; 767) {
+                            jQuery('.niche-subnav-header').show();
+                            jQuery('.niche-subnav-header ul').show();
+                            jQuery('#subnav-open-close-button').hide();
+                        } else {
+                            jQuery('.niche-subnav-header ul').hide();
+                            jQuery('.niche-subnav-header').hide();
+                            jQuery('#subnav-open-close-button').show();
+                        }
+
+                        // if (jQuery(window).width() &gt;= 768){
+                        //   jQuery('.niche-subnav-header ul').css('margin-top','0px');
+                        // }
+                    }
+
+                    //});
+                    </script>
+                    <div class="left main-singular" id="main">
+                        <div id="blogarticle">
+                            <div id="article-section">
+                                <div data-post-id="9755" id="post-9755" class="post-9755 post type-post status-publish format-standard hentry category-design category-high-high-end category-home-sales category-luxury-homes category-nob-hill category-san-francisco tag-2-3-million-one-bedroom tag-new-nob-hill-listing tag-nob-hill-one-bedroom">
+                                    <h1 class="blogtitle">Nob Hill one-bedroom sells for $2.3 million</h1>
+                                    <div class="meta "> <span class="post-author">By <a rel="author" title="Posts by Emily Landes" href="http://blog.sfgate.com/ontheblock/author/elandes/">Emily Landes</a> </span>
+                                        <span class="post-date">on May 5, 2015 4:00 AM</span>
+                                        <!--
+        <span class="post-on"> | </span>
+        -->
+                                    </div>
+                                    <script>
+                                    hdnShareButtonsDisableCollapse = true;
+                                    </script>
+                                    <div class="sharedaddy sd-sharing-enabled">
+                                        <div class="robots-nocontent sd-block sd-social sd-social-hdnicon sd-sharing" style="display: block;">
+                                            <div class="sd-content">
+                                                <ul>
+                                                    <li class="share-email share-service-visible"><a title="Click to email this to a friend" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?share=email&amp;nb=1" class="share-email sd-button hdn-share-icon no-text" rel="nofollow"><span></span></a></li>
+                                                    <li class="share-facebook"><a id="sharing-facebook-9755" title="Share on Facebook" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?share=facebook&amp;nb=1" class="share-facebook sd-button hdn-share-icon no-text" rel="nofollow"><span></span></a></li>
+                                                    <li class="share-twitter"><a id="sharing-twitter-9755" title="Click to share on Twitter" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?share=twitter&amp;nb=1" class="share-twitter sd-button hdn-share-icon no-text" rel="nofollow"><span></span></a></li>
+                                                    <li class="share-pinterest"><a title="Click to share on Pinterest" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?share=pinterest&amp;nb=1" class="share-pinterest sd-button hdn-share-icon no-text" rel="nofollow"><span></span></a></li>
+                                                    <li class="share-reddit"><a title="Click to share on Reddit" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?share=reddit&amp;nb=1" class="share-reddit sd-button hdn-share-icon no-text" rel="nofollow"><span></span></a></li>
+                                                    <li class="share-google-plus-1"><a id="sharing-google-9755" title="Click to share on Google+" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?share=google-plus-1&amp;nb=1" class="share-google-plus-1 sd-button hdn-share-icon no-text" rel="nofollow"><span></span></a></li>
+                                                    <li class="share-hdn-comment"><a title="Click to comment" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/#comments" class="share-hdn-comment sd-button hdn-share-icon no-text" rel="nofollow"><span></span><span data-path="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" data-widget="counter" class="vf-counter vf-widget" data-widget-id="1">52</span></a></li>
+                                                    <li class="share-print"><a title="Click to print" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/#print" class="share-print sd-button hdn-share-icon no-text" rel="nofollow"><span></span><span class="print-text">Print</span></a></li>
+                                                    <li class="share-end"></li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="hdn_pm_post_below_post_title"></div>
+                                    <div class="entry">
+                                        <p>
+                                            <link rel="stylesheet" type="text/css" href="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-wp-galleries-redesigned/themes/hdn_responsive-redesigned/gallery.css" data-redesigned="redesigned" media="all" />
+                                        </p>
+                                        <div class="gallery clearfix">
+                                            <!-- <div class="gallery_outer_overlay_dynamic" style="background-color:rgba(255,0,0,0.7);"></div> -->
+                                            <script type="text/javascript">
+                                            var OUTER_OVERLAY_ON = false;
+                                            var SCREEN_HEIGHT = 320;
+                                            var SCREEN_WIDTH = 320;
+                                            var MOBILE_PHONE_DEVICE = false;
+                                            var IPAD_DEVICE = false;
+                                            var DISABLE_INLINE_ADJUSTMENT = false;
+
+                                            $(function() {
+                                                MOBILE_PHONE_DEVICE = isMobilePhoneDevice();
+                                                IPAD_DEVICE = isiPadDevice();
+                                                updateScreenHeight();
+                                                updateGalleryWidth();
+
+                                                $(window).resize(function() {
+                                                    if (!DISABLE_INLINE_ADJUSTMENT) {
+                                                        console.log("INLINE ADJUSTMENT ENABLED.....===========");
+                                                        updateGalleryWidth();
+                                                    }
+
+                                                    resizeOuterOverlay();
+                                                    resizeInnerOverlay();
+
+
+                                                });
+
+                                            });
+
+
+                                            function isiPadDevice() {
+                                                var uagent = window.navigator.userAgent;
+
+                                                if ((uagent.toLowerCase().indexOf('ipad')) & gt; - 1) {
+
+                                                    return true;
+                                                } else {
+                                                    return false;
+                                                }
+                                            }
+
+                                            function isMobilePhoneDevice() {
+                                                var uagent = window.navigator.userAgent.toLowerCase();
+
+                                                if ((uagent.indexOf('iphone') & gt; - 1) || (uagent.indexOf('android') & gt; - 1) || (uagent.indexOf('windows phone os') & gt; - 1)) {
+
+                                                    return true;
+                                                } else {
+                                                    return false;
+                                                }
+                                            }
+
+                                            function getScreenHeight() {
+                                                return $(window).height();
+                                            }
+
+                                            function getScreenWidth() {
+                                                return $(window).width();
+                                            }
+
+
+
+                                            function updateScreenHeight() {
+                                                SCREEN_HEIGHT = $(window).height();
+                                            }
+
+
+                                            function updateScreenWidth() {
+                                                SCREEN_WIDTH = $(window).width();
+                                            }
+
+                                            function updateGalleryWidth() {
+                                                updateScreenWidth();
+                                                //console.log("++++++++++++++ Screen w = "+ SCREEN_WIDTH +" OUTER " + $(body).outerWidth() );
+
+                                                //console.log("OUTER OVERLAY FALSE ...");
+                                                /**
+                                                if (SCREEN_WIDTH &lt; 480){
+                                                    $(".hst-resgallery-container").css("marginLeft","-10px");
+                                                    $(".hst-resgallery-container").css("width",""+SCREEN_WIDTH+"px");
+                                                }
+                                                else if (SCREEN_WIDTH &lt; 768) { // phone landscape
+                                                     $(".hst-resgallery-container").css("marginLeft","10%");
+                                                     $(".hst-resgallery-container").css("width","384px");
+                                                }
+                                                else {
+                                                     $(".hst-resgallery-container").css("marginLeft","0px");
+                                                     $(".hst-resgallery-container").css("width","100%");
+                                                }
+                                                **/
+
+                                            }
+
+                                            function doInlineGalleryAdjustment() {
+                                                console.log("DO-INLINE-GALLERY-ADJUSTMENT CALLED ");
+                                                DISABLE_INLINE_ADJUSTMENT = false;
+                                                updateGalleryWidth();
+                                            }
+
+                                            function undoInlineGalleryAdjustment() {
+                                                console.log("UN-DO-INLINE-GALLERY-ADJUSTMENT CALLED ");
+                                                DISABLE_INLINE_ADJUSTMENT = true;
+
+                                                if (SCREEN_WIDTH & lt; 480) {
+                                                    $(".hst-resgallery-container").css("marginLeft", "0px");
+                                                    $(".hst-resgallery-container").css("width", "100%");
+                                                } else if (SCREEN_WIDTH & lt; 768) { // phone landscape
+                                                    $(".hst-resgallery-container").css("marginLeft", "0px");
+                                                    $(".hst-resgallery-container").css("width", "384px");
+                                                }
+                                            }
+
+
+
+                                            function resizeInnerOverlay() {
+                                                updateScreenHeight();
+                                                console.log("RESIZE_INNER_OVERLAY  screen height " + $(window).height());
+                                                // Inner overlay sizing
+                                                $(".fullscreen div.gallery-overlay-inner").css("height", "" + SCREEN_HEIGHT + "px");
+                                                // $(".fullscreen .hst-resgallery-container").css("height","100%");
+
+                                                $(".fullscreen .hst-resgallery-container").css("height", "" + (SCREEN_HEIGHT + 200) + "px");
+
+                                                console.log("+++++++   CONTAINER RESIZED TO " + SCREEN_HEIGHT + "px +++++++++++++++++");
+
+                                            }
+
+                                            function undoResizeInnerOverlay() {
+                                                $(".hst-resgallery-container").css("height", "inherit");
+                                                console.log("************ UNDO RESIZE_INNER_OVERLAY (Container) ****************** ");
+
+                                            }
+
+
+                                            function resizeOuterOverlay() {
+                                                updateScreenHeight();
+
+                                                if (IPAD_DEVICE & amp; & amp;
+                                                    (OUTER_OVERLAY_ON === true)) {
+                                                    lockBodyElement();
+                                                    doTabletOverlayAdjustment();
+                                                }
+
+                                                if (!MOBILE_PHONE_DEVICE) {
+                                                    return;
+                                                }
+
+                                                if (OUTER_OVERLAY_ON === true) {
+                                                    //console.log("screen height "+ $(window).height() );
+                                                    //console.log("Resizing content view ... 997799 document height = "+ $(document).height()  + ", body outerheight " + $(document.body).outerHeight() );
+                                                    $(".gallery_outer_overlay_dynamic").css("height", "" + $(document).height() + "px");
+                                                    $(".gallery_outer_overlay_dynamic").css("width", "" + $(document).width() + "px");
+
+                                                    // Inner overlay sizing
+                                                    // $(".fullscreen div.gallery-overlay-inner").css("height",""+SCREEN_HEIGHT+"px");
+                                                    // $(".fullscreen div.gallery-overlay-inner").css("background-color","red");
+
+                                                    // gallery container
+                                                    //$(".fullscreen div.hst-resgallery-container").css("height",""+SCREEN_HEIGHT+"px");
+
+                                                } else {
+                                                    //console.log("Overlay off...");
+                                                }
+                                            }
+
+
+                                            function lockBodyElement() {
+                                                $(document.body).css("overflow", "hidden");
+                                                $(document.body).css("position", "fixed");
+                                                $(document.body).css("width", "100%");
+                                            }
+
+                                            function unlockBodyElement() {
+                                                $(document.body).css("overflow", "auto");
+                                                $(document.body).css("position", "static");
+                                                $(document.body).css("width", "auto");
+                                            }
+
+                                            function doTabletOverlayAdjustment() {
+                                                // gallery outer overlay
+                                                $(".gallery-overlay-outter.fullscreen").css("top", "0px");
+                                                // Inner overlay sizing
+                                                $(".fullscreen div.gallery-overlay-inner").css("height", "" + SCREEN_HEIGHT + "px");
+
+                                            }
+
+
+
+                                            function removeOuterOverlay() {
+
+                                                if (IPAD_DEVICE || MOBILE_PHONE_DEVICE) {
+                                                    unlockBodyElement();
+                                                }
+
+                                                if (MOBILE_PHONE_DEVICE) {
+                                                    // control panel
+                                                    $("div.hst-resgallery-container .control-panel").css("position", "relative");
+                                                    $("div.hst-resgallery-container .control-panel").css("float", "left");
+
+                                                    // gallery container
+                                                    $("div.hst-resgallery-container").css("position", "relative");
+                                                    $("div.hst-resgallery-container").css("height", "");
+
+
+
+                                                }
+
+                                                if ($(".gallery_outer_overlay_dynamic")) {
+                                                    $(".gallery_outer_overlay_dynamic").remove();
+                                                }
+
+                                                OUTER_OVERLAY_ON = false;
+                                            }
+
+                                            function createOuterOverlay() {
+                                                if (IPAD_DEVICE) {
+                                                    lockBodyElement();
+                                                    doTabletOverlayAdjustment();
+                                                    OUTER_OVERLAY_ON = true;
+                                                }
+
+                                                if (!MOBILE_PHONE_DEVICE) {
+                                                    OUTER_OVERLAY_ON = true;
+                                                    return;
+                                                }
+
+                                                // Body
+                                                lockBodyElement();
+
+                                                // gallery outer overlay
+                                                $(".gallery-overlay-outter.fullscreen").css("top", "0px");
+                                                //$(".gallery-overlay-outter.fullscreen").css("overflowY","auto");
+
+                                                // Inner overlay sizing
+                                                $(".fullscreen div.gallery-overlay-inner").css("height", "" + SCREEN_HEIGHT + "px");
+                                                $(".fullscreen div.gallery-overlay-inner").css("overflowY", "auto");
+
+                                                // gallery container
+
+                                                //$(".fullscreen div.hst-resgallery-container").css("position","static");
+
+                                                $(".fullscreen div.hst-resgallery-container").css("height", "" + SCREEN_HEIGHT + "px");
+
+                                                // control panel
+
+                                                $(".fullscreen div.hst-resgallery-container .control-panel").css("position", "static");
+                                                $(".fullscreen div.hst-resgallery-container .control-panel").css("float", "none");
+
+                                                // Wedge
+                                                $(".fullscreen div.hst-resgallery-container .hst-resgallery-wedge").css("float", "none");
+
+
+
+
+                                                $(document.body).append("&lt;div class=\"gallery_outer_overlay_dynamic\"&gt;&lt;/div&gt;");
+                                                $(".gallery_outer_overlay_dynamic").css("position", "absolute");
+                                                $(".gallery_outer_overlay_dynamic").css("z-index", "500");
+                                                $(".gallery_outer_overlay_dynamic").css("top", "0");
+                                                $(".gallery_outer_overlay_dynamic").css("left", "0");
+                                                $(".gallery_outer_overlay_dynamic").css("height", "" + $(document).height() + "px");
+                                                $(".gallery_outer_overlay_dynamic").css("width", "" + $(document).width() + "px");
+                                                $(".gallery_outer_overlay_dynamic").css("backgroundColor", "rgba(0,0,0,1)");
+                                                $(".gallery_outer_overlay_dynamic").css("overflow", "hidden");
+                                                OUTER_OVERLAY_ON = true;
+                                            }
+                                            </script>
+                                            <div class="galleria asset_gallery" id="galleria_31011101">
+                                                <script type="text/javascript">
+                                                // Gallery data array of image objects - mostly for whoever needs it - app-wrapper etc...   - with unique gallery ID
+                                                var nggallery_data_31011 = new Array();
+
+
+                                                nggallery_data_31011[0] = {
+                                                    "title": "430235_1",
+                                                    "description": "The one-bedroom just came to market at $2.495 million",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[1] = {
+                                                    "title": "315735_2_2",
+                                                    "description": "Before the massive renovation, the living area still had great views, but was dated.",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/315735_2_2.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[2] = {
+                                                    "title": "430235_2_1",
+                                                    "description": "Beautiful views from the floor-to-ceiling windows.",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_2_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[3] = {
+                                                    "title": "430235_3_1",
+                                                    "description": "The open concept living room",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_3_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[4] = {
+                                                    "title": "430235_5_1",
+                                                    "description": "The dining area",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_5_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[5] = {
+                                                    "title": "430235_6_1",
+                                                    "description": "The open entertaining space",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_6_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[6] = {
+                                                    "title": "315735_3_2",
+                                                    "description": "The dining area before",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/315735_3_2.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[7] = {
+                                                    "title": "430235_7_1",
+                                                    "description": "The den",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_7_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[8] = {
+                                                    "title": "430235_9_1",
+                                                    "description": "Another view of the den",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_9_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[9] = {
+                                                    "title": "430235_10_1",
+                                                    "description": "The kitchen",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_10_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[10] = {
+                                                    "title": "430235_11_1",
+                                                    "description": "The kitchen",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_11_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[11] = {
+                                                    "title": "430235_13_1",
+                                                    "description": "Custom cabinets and granite counters",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_13_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[12] = {
+                                                    "title": "430235_14_1",
+                                                    "description": "Another shot of the kitchen",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_14_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[13] = {
+                                                    "title": "315735_9_2",
+                                                    "description": "The old, enclosed kitchen",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/315735_9_2.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[14] = {
+                                                    "title": "430235_15_1",
+                                                    "description": "Views from the kitchen",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_15_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[15] = {
+                                                    "title": "430235_16_1",
+                                                    "description": "Built-in office nook",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_16_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[16] = {
+                                                    "title": "430235_17_1",
+                                                    "description": "The only bedroom also takes advantage of the views. ",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_17_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[17] = {
+                                                    "title": "430235_19_1",
+                                                    "description": "Another shot of the bedroom",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_19_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[18] = {
+                                                    "title": "315735_4_2",
+                                                    "description": "The bedroom before",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/315735_4_2.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[19] = {
+                                                    "title": "430235_20_1",
+                                                    "description": "Master closet",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_20_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[20] = {
+                                                    "title": "430235_21_1",
+                                                    "description": "Master bath",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_21_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[21] = {
+                                                    "title": "430235_23_1",
+                                                    "description": "Another shot of the master bath",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_23_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[22] = {
+                                                    "title": "430235_24_1",
+                                                    "description": "Soaking tub",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_24_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[23] = {
+                                                    "title": "430235_25_1",
+                                                    "description": "Entry",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_25_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[24] = {
+                                                    "title": "430235_27_1",
+                                                    "description": "Standing on the balcony",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_27_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[25] = {
+                                                    "title": "430235_29_1",
+                                                    "description": "Views from the northwest facing condo",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_29_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[26] = {
+                                                    "title": "430235_32_1",
+                                                    "description": "More views",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_32_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[27] = {
+                                                    "title": "430235_35_1",
+                                                    "description": "Golden Gate Bridge views",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_35_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[28] = {
+                                                    "title": "430235_39_1",
+                                                    "description": "From inside the condo",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_39_1.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[29] = {
+                                                    "title": "315735_7_2",
+                                                    "description": "This corner window before",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/315735_7_2.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[30] = {
+                                                    "title": "430235_46_0",
+                                                    "description": "The Comstock",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_46_0.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[31] = {
+                                                    "title": "430235_48_0",
+                                                    "description": "The lobby",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_48_0.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+                                                nggallery_data_31011[32] = {
+                                                    "title": "430235_49_0",
+                                                    "description": "Another view of the lobby",
+                                                    "image": "http:\/\/blog.sfgate.com\/ontheblock\/wp-content\/blogs.dir\/2283\/files\/1333-jones-st-806\/430235_49_0.jpg",
+                                                    "byline": "MLS",
+                                                    "credit": ""
+                                                }
+
+
+                                                //alert(nggallery_data_31011.length);
+
+                                                //alert(HDN.site);
+                                                </script>
+                                                <div id="hst-resgallery-31011101" class="hst-resgallery-container clearfix">
+                                                    <span gallery_title="1333 Jones St. #806" gallery_id="31011" class="gallery-metadata"></span>
+                                                    <div class="hst-resgallery-wedge">
+                                                        <ul class="hst-resgallery clearfix">
+                                                            <li item_id="photo-602852" class="hst-resgalleryitem  ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The one-bedroom just came to market at $2.495 million" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-629000" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Before the massive renovation, the living area still had great views, but was dated." load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_2_2.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602869" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Beautiful views from the floor-to-ceiling windows." load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_2_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602873" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The open concept living room" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_3_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602877" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The dining area" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_5_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602878" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The open entertaining space" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_6_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-629001" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The dining area before" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_3_2.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602879" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The den" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_7_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602880" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Another view of the den" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_9_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602853" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The kitchen" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_10_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602854" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The kitchen" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_11_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602855" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Custom cabinets and granite counters" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_13_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602856" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Another shot of the kitchen" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_14_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-629004" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The old, enclosed kitchen" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_9_2.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602857" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Views from the kitchen" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_15_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602858" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Built-in office nook" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_16_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602859" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The only bedroom also takes advantage of the views. " load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_17_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602860" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Another shot of the bedroom" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_19_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-629002" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The bedroom before" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_4_2.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602862" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Master closet" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_20_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602863" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Master bath" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_21_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602864" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Another shot of the master bath" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_23_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602865" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Soaking tub" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_24_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602866" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Entry" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_25_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602867" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Standing on the balcony" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_27_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602868" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Views from the northwest facing condo" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_29_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602870" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="More views" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_32_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602871" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Golden Gate Bridge views" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_35_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602872" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="From inside the condo" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_39_1.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-629003" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="This corner window before" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_7_2.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602874" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The Comstock" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_46_0.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602875" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="The lobby" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_48_0.jpg" /></div>
+                                                            </li>
+                                                            <li item_id="photo-602876" class="hst-resgalleryitem hidden ">
+                                                                <div class="img-wrap landscape  hst-resgallery-31011101-img-wrap  ">
+                                                                    <div class="nav left clearfix stopped">
+                                                                        <a alt="previous" href="#prev" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_prev_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div>
+                                                                    <div class="nav right clearfix stopped">
+                                                                        <a alt="next" href="#next" class="hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">photo_next_inline|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </a>
+                                                                    </div><img class="portrait" lazy-state="queue" alt="Another view of the lobby" load-src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_49_0.jpg" /></div>
+                                                            </li>
+                                                        </ul>
+                                                        <!-- SOCIAL Start  -->
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602852|on_the_block-2283-post-9755-g31011-602852|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602852','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602852|on_the_block-2283-post-9755-g31011-602852|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602852|on_the_block-2283-post-9755-g31011-602852|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602852|on_the_block-2283-post-9755-g31011-602852|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602852|on_the_block-2283-post-9755-g31011-602852|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602852|on_the_block-2283-post-9755-g31011-602852|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_2_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-629000|on_the_block-2283-post-9755-g31011-629000|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=629000','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-629000|on_the_block-2283-post-9755-g31011-629000|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_2_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-629000|on_the_block-2283-post-9755-g31011-629000|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_2_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-629000|on_the_block-2283-post-9755-g31011-629000|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_2_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-629000|on_the_block-2283-post-9755-g31011-629000|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_2_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-629000|on_the_block-2283-post-9755-g31011-629000|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_2_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602869|on_the_block-2283-post-9755-g31011-602869|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602869','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602869|on_the_block-2283-post-9755-g31011-602869|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_2_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602869|on_the_block-2283-post-9755-g31011-602869|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_2_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602869|on_the_block-2283-post-9755-g31011-602869|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_2_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602869|on_the_block-2283-post-9755-g31011-602869|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_2_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602869|on_the_block-2283-post-9755-g31011-602869|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_3_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602873|on_the_block-2283-post-9755-g31011-602873|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602873','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602873|on_the_block-2283-post-9755-g31011-602873|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_3_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602873|on_the_block-2283-post-9755-g31011-602873|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_3_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602873|on_the_block-2283-post-9755-g31011-602873|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_3_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602873|on_the_block-2283-post-9755-g31011-602873|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_3_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602873|on_the_block-2283-post-9755-g31011-602873|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_5_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602877|on_the_block-2283-post-9755-g31011-602877|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602877','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602877|on_the_block-2283-post-9755-g31011-602877|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_5_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602877|on_the_block-2283-post-9755-g31011-602877|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_5_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602877|on_the_block-2283-post-9755-g31011-602877|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_5_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602877|on_the_block-2283-post-9755-g31011-602877|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_5_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602877|on_the_block-2283-post-9755-g31011-602877|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_6_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602878|on_the_block-2283-post-9755-g31011-602878|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602878','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602878|on_the_block-2283-post-9755-g31011-602878|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_6_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602878|on_the_block-2283-post-9755-g31011-602878|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_6_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602878|on_the_block-2283-post-9755-g31011-602878|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_6_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602878|on_the_block-2283-post-9755-g31011-602878|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_6_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602878|on_the_block-2283-post-9755-g31011-602878|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_3_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-629001|on_the_block-2283-post-9755-g31011-629001|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=629001','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-629001|on_the_block-2283-post-9755-g31011-629001|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_3_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-629001|on_the_block-2283-post-9755-g31011-629001|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_3_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-629001|on_the_block-2283-post-9755-g31011-629001|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_3_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-629001|on_the_block-2283-post-9755-g31011-629001|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_3_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-629001|on_the_block-2283-post-9755-g31011-629001|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_7_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602879|on_the_block-2283-post-9755-g31011-602879|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602879','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602879|on_the_block-2283-post-9755-g31011-602879|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_7_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602879|on_the_block-2283-post-9755-g31011-602879|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_7_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602879|on_the_block-2283-post-9755-g31011-602879|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_7_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602879|on_the_block-2283-post-9755-g31011-602879|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_7_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602879|on_the_block-2283-post-9755-g31011-602879|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_9_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602880|on_the_block-2283-post-9755-g31011-602880|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602880','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602880|on_the_block-2283-post-9755-g31011-602880|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_9_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602880|on_the_block-2283-post-9755-g31011-602880|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_9_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602880|on_the_block-2283-post-9755-g31011-602880|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_9_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602880|on_the_block-2283-post-9755-g31011-602880|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_9_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602880|on_the_block-2283-post-9755-g31011-602880|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_10_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602853|on_the_block-2283-post-9755-g31011-602853|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602853','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602853|on_the_block-2283-post-9755-g31011-602853|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_10_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602853|on_the_block-2283-post-9755-g31011-602853|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_10_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602853|on_the_block-2283-post-9755-g31011-602853|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_10_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602853|on_the_block-2283-post-9755-g31011-602853|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_10_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602853|on_the_block-2283-post-9755-g31011-602853|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_11_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602854|on_the_block-2283-post-9755-g31011-602854|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602854','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602854|on_the_block-2283-post-9755-g31011-602854|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_11_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602854|on_the_block-2283-post-9755-g31011-602854|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_11_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602854|on_the_block-2283-post-9755-g31011-602854|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_11_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602854|on_the_block-2283-post-9755-g31011-602854|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_11_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602854|on_the_block-2283-post-9755-g31011-602854|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_13_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602855|on_the_block-2283-post-9755-g31011-602855|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602855','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602855|on_the_block-2283-post-9755-g31011-602855|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_13_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602855|on_the_block-2283-post-9755-g31011-602855|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_13_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602855|on_the_block-2283-post-9755-g31011-602855|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_13_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602855|on_the_block-2283-post-9755-g31011-602855|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_13_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602855|on_the_block-2283-post-9755-g31011-602855|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_14_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602856|on_the_block-2283-post-9755-g31011-602856|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602856','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602856|on_the_block-2283-post-9755-g31011-602856|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_14_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602856|on_the_block-2283-post-9755-g31011-602856|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_14_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602856|on_the_block-2283-post-9755-g31011-602856|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_14_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602856|on_the_block-2283-post-9755-g31011-602856|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_14_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602856|on_the_block-2283-post-9755-g31011-602856|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_9_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-629004|on_the_block-2283-post-9755-g31011-629004|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=629004','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-629004|on_the_block-2283-post-9755-g31011-629004|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_9_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-629004|on_the_block-2283-post-9755-g31011-629004|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_9_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-629004|on_the_block-2283-post-9755-g31011-629004|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_9_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-629004|on_the_block-2283-post-9755-g31011-629004|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_9_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-629004|on_the_block-2283-post-9755-g31011-629004|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_15_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602857|on_the_block-2283-post-9755-g31011-602857|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602857','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602857|on_the_block-2283-post-9755-g31011-602857|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_15_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602857|on_the_block-2283-post-9755-g31011-602857|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_15_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602857|on_the_block-2283-post-9755-g31011-602857|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_15_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602857|on_the_block-2283-post-9755-g31011-602857|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_15_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602857|on_the_block-2283-post-9755-g31011-602857|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_16_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602858|on_the_block-2283-post-9755-g31011-602858|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602858','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602858|on_the_block-2283-post-9755-g31011-602858|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_16_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602858|on_the_block-2283-post-9755-g31011-602858|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_16_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602858|on_the_block-2283-post-9755-g31011-602858|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_16_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602858|on_the_block-2283-post-9755-g31011-602858|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_16_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602858|on_the_block-2283-post-9755-g31011-602858|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_17_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602859|on_the_block-2283-post-9755-g31011-602859|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602859','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602859|on_the_block-2283-post-9755-g31011-602859|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_17_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602859|on_the_block-2283-post-9755-g31011-602859|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_17_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602859|on_the_block-2283-post-9755-g31011-602859|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_17_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602859|on_the_block-2283-post-9755-g31011-602859|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_17_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602859|on_the_block-2283-post-9755-g31011-602859|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_19_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602860|on_the_block-2283-post-9755-g31011-602860|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602860','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602860|on_the_block-2283-post-9755-g31011-602860|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_19_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602860|on_the_block-2283-post-9755-g31011-602860|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_19_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602860|on_the_block-2283-post-9755-g31011-602860|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_19_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602860|on_the_block-2283-post-9755-g31011-602860|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_19_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602860|on_the_block-2283-post-9755-g31011-602860|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_4_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-629002|on_the_block-2283-post-9755-g31011-629002|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=629002','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-629002|on_the_block-2283-post-9755-g31011-629002|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_4_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-629002|on_the_block-2283-post-9755-g31011-629002|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_4_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-629002|on_the_block-2283-post-9755-g31011-629002|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_4_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-629002|on_the_block-2283-post-9755-g31011-629002|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_4_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-629002|on_the_block-2283-post-9755-g31011-629002|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_20_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602862|on_the_block-2283-post-9755-g31011-602862|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602862','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602862|on_the_block-2283-post-9755-g31011-602862|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_20_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602862|on_the_block-2283-post-9755-g31011-602862|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_20_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602862|on_the_block-2283-post-9755-g31011-602862|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_20_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602862|on_the_block-2283-post-9755-g31011-602862|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_20_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602862|on_the_block-2283-post-9755-g31011-602862|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_21_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602863|on_the_block-2283-post-9755-g31011-602863|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602863','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602863|on_the_block-2283-post-9755-g31011-602863|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_21_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602863|on_the_block-2283-post-9755-g31011-602863|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_21_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602863|on_the_block-2283-post-9755-g31011-602863|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_21_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602863|on_the_block-2283-post-9755-g31011-602863|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_21_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602863|on_the_block-2283-post-9755-g31011-602863|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_23_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602864|on_the_block-2283-post-9755-g31011-602864|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602864','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602864|on_the_block-2283-post-9755-g31011-602864|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_23_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602864|on_the_block-2283-post-9755-g31011-602864|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_23_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602864|on_the_block-2283-post-9755-g31011-602864|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_23_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602864|on_the_block-2283-post-9755-g31011-602864|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_23_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602864|on_the_block-2283-post-9755-g31011-602864|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_24_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602865|on_the_block-2283-post-9755-g31011-602865|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602865','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602865|on_the_block-2283-post-9755-g31011-602865|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_24_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602865|on_the_block-2283-post-9755-g31011-602865|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_24_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602865|on_the_block-2283-post-9755-g31011-602865|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_24_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602865|on_the_block-2283-post-9755-g31011-602865|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_24_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602865|on_the_block-2283-post-9755-g31011-602865|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_25_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602866|on_the_block-2283-post-9755-g31011-602866|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602866','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602866|on_the_block-2283-post-9755-g31011-602866|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_25_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602866|on_the_block-2283-post-9755-g31011-602866|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_25_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602866|on_the_block-2283-post-9755-g31011-602866|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_25_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602866|on_the_block-2283-post-9755-g31011-602866|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_25_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602866|on_the_block-2283-post-9755-g31011-602866|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_27_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602867|on_the_block-2283-post-9755-g31011-602867|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602867','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602867|on_the_block-2283-post-9755-g31011-602867|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_27_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602867|on_the_block-2283-post-9755-g31011-602867|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_27_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602867|on_the_block-2283-post-9755-g31011-602867|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_27_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602867|on_the_block-2283-post-9755-g31011-602867|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_27_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602867|on_the_block-2283-post-9755-g31011-602867|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_29_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602868|on_the_block-2283-post-9755-g31011-602868|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602868','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602868|on_the_block-2283-post-9755-g31011-602868|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_29_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602868|on_the_block-2283-post-9755-g31011-602868|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_29_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602868|on_the_block-2283-post-9755-g31011-602868|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_29_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602868|on_the_block-2283-post-9755-g31011-602868|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_29_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602868|on_the_block-2283-post-9755-g31011-602868|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_32_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602870|on_the_block-2283-post-9755-g31011-602870|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602870','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602870|on_the_block-2283-post-9755-g31011-602870|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_32_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602870|on_the_block-2283-post-9755-g31011-602870|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_32_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602870|on_the_block-2283-post-9755-g31011-602870|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_32_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602870|on_the_block-2283-post-9755-g31011-602870|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_32_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602870|on_the_block-2283-post-9755-g31011-602870|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_35_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602871|on_the_block-2283-post-9755-g31011-602871|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602871','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602871|on_the_block-2283-post-9755-g31011-602871|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_35_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602871|on_the_block-2283-post-9755-g31011-602871|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_35_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602871|on_the_block-2283-post-9755-g31011-602871|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_35_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602871|on_the_block-2283-post-9755-g31011-602871|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_35_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602871|on_the_block-2283-post-9755-g31011-602871|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_39_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602872|on_the_block-2283-post-9755-g31011-602872|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602872','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602872|on_the_block-2283-post-9755-g31011-602872|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_39_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602872|on_the_block-2283-post-9755-g31011-602872|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_39_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602872|on_the_block-2283-post-9755-g31011-602872|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_39_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602872|on_the_block-2283-post-9755-g31011-602872|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_39_1.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602872|on_the_block-2283-post-9755-g31011-602872|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_7_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-629003|on_the_block-2283-post-9755-g31011-629003|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=629003','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-629003|on_the_block-2283-post-9755-g31011-629003|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_7_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-629003|on_the_block-2283-post-9755-g31011-629003|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_7_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-629003|on_the_block-2283-post-9755-g31011-629003|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_7_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-629003|on_the_block-2283-post-9755-g31011-629003|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/315735_7_2.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-629003|on_the_block-2283-post-9755-g31011-629003|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_46_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602874|on_the_block-2283-post-9755-g31011-602874|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602874','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602874|on_the_block-2283-post-9755-g31011-602874|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_46_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602874|on_the_block-2283-post-9755-g31011-602874|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_46_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602874|on_the_block-2283-post-9755-g31011-602874|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_46_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602874|on_the_block-2283-post-9755-g31011-602874|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_46_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602874|on_the_block-2283-post-9755-g31011-602874|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_48_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602875|on_the_block-2283-post-9755-g31011-602875|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602875','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602875|on_the_block-2283-post-9755-g31011-602875|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_48_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602875|on_the_block-2283-post-9755-g31011-602875|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_48_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602875|on_the_block-2283-post-9755-g31011-602875|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_48_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602875|on_the_block-2283-post-9755-g31011-602875|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_48_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602875|on_the_block-2283-post-9755-g31011-602875|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <div class="gallery-sharing hidden">
+                                                            <ul class="left">
+                                                                <li class="gallery-share-icon email">
+                                                                    <a href="javascript:wpshareit('email','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_49_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">email_share_inline|on_the_block-2283-post-9755-g31011-602876|on_the_block-2283-post-9755-g31011-602876|1</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon facebook">
+                                                                    <a href="javascript:wpshareit('facebook','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/?photo=602876','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">facebook_share_inline|on_the_block-2283-post-9755-g31011-602876|on_the_block-2283-post-9755-g31011-602876|2</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon twitter">
+                                                                    <a href="javascript:wpshareit('twitter','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_49_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">twitter_share_inline|on_the_block-2283-post-9755-g31011-602876|on_the_block-2283-post-9755-g31011-602876|3</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon pinterest">
+                                                                    <a href="javascript:wpshareit('pinterest','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_49_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">pinterest_share_inline|on_the_block-2283-post-9755-g31011-602876|on_the_block-2283-post-9755-g31011-602876|4</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon reddit">
+                                                                    <a href="javascript:wpshareit('reddit','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_49_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">reddit_share_inline|on_the_block-2283-post-9755-g31011-602876|on_the_block-2283-post-9755-g31011-602876|5</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                                <li class="gallery-share-icon google">
+                                                                    <a href="javascript:wpshareit('googleplus','http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/430235_49_0.jpg','Nob Hill one-bedroom sells for $2.3 million','http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/');" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">google_share_inline|on_the_block-2283-post-9755-g31011-602876|on_the_block-2283-post-9755-g31011-602876|6</span>
+                                                                        <span class="icon"></span>
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                        <!-- SOCIAL END  -->
+                                                    </div>
+                                                    <!-- JS UTILS FOR GALLERY -->
+                                                    <script type="text/javascript">
+                                                    function deviceWidthCheck() {
+                                                        return $(window).width();
+                                                    }
+
+                                                    function deviceHeightCheck() {
+                                                        return $(window).height();
+                                                    }
+
+                                                    function go300Wrapper() {
+                                                        if (deviceWidthCheck() & gt; 568) {
+                                                            // console.log("will  place go300 wrapper 1122");
+                                                            hearstPlaceAd("GO300");
+                                                        } else {
+                                                            // console.log("will  not place go300 wrapper 1122");
+                                                        }
+                                                    }
+                                                    </script>
+                                                    <!-- HST-RESGALLERYNAV START  -->
+                                                    <div class="hst-resgallerynav small clearfix">
+                                                        <div class="carousel">
+                                                            <ul class="clearfix">
+                                                                <li class="thumb selected">
+                                                                    <a href="#photo-602852" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|1</span>
+                                                                        <img alt="430235_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-629000" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|2</span>
+                                                                        <img alt="315735_2_2" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_315735_2_2.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602869" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|3</span>
+                                                                        <img alt="430235_2_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_2_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602873" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|4</span>
+                                                                        <img alt="430235_3_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_3_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602877" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|5</span>
+                                                                        <img alt="430235_5_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_5_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602878" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|6</span>
+                                                                        <img alt="430235_6_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_6_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-629001" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|7</span>
+                                                                        <img alt="315735_3_2" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_315735_3_2.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602879" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|8</span>
+                                                                        <img alt="430235_7_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_7_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602880" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|9</span>
+                                                                        <img alt="430235_9_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_9_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602853" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|10</span>
+                                                                        <img alt="430235_10_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_10_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602854" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|11</span>
+                                                                        <img alt="430235_11_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_11_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602855" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|12</span>
+                                                                        <img alt="430235_13_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_13_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602856" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|13</span>
+                                                                        <img alt="430235_14_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_14_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-629004" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|14</span>
+                                                                        <img alt="315735_9_2" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_315735_9_2.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602857" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|15</span>
+                                                                        <img alt="430235_15_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_15_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602858" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|16</span>
+                                                                        <img alt="430235_16_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_16_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602859" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|17</span>
+                                                                        <img alt="430235_17_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_17_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602860" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|18</span>
+                                                                        <img alt="430235_19_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_19_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-629002" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|19</span>
+                                                                        <img alt="315735_4_2" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_315735_4_2.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602862" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|20</span>
+                                                                        <img alt="430235_20_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_20_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602863" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|21</span>
+                                                                        <img alt="430235_21_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_21_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602864" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|22</span>
+                                                                        <img alt="430235_23_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_23_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602865" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|23</span>
+                                                                        <img alt="430235_24_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_24_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602866" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|24</span>
+                                                                        <img alt="430235_25_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_25_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602867" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|25</span>
+                                                                        <img alt="430235_27_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_27_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602868" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|26</span>
+                                                                        <img alt="430235_29_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_29_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602870" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|27</span>
+                                                                        <img alt="430235_32_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_32_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602871" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|28</span>
+                                                                        <img alt="430235_35_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_35_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602872" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|29</span>
+                                                                        <img alt="430235_39_1" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_39_1.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-629003" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|30</span>
+                                                                        <img alt="315735_7_2" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_315735_7_2.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602874" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|31</span>
+                                                                        <img alt="430235_46_0" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_46_0.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602875" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|32</span>
+                                                                        <img alt="430235_48_0" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_48_0.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                                <li class="thumb ">
+                                                                    <a href="#photo-602876" class="hdn-analytics">
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_photo|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|33</span>
+                                                                        <img alt="430235_49_0" src="http://blog.sfgate.com/ontheblock/wp-content/blogs.dir/2283/files/1333-jones-st-806/thumbs/thumbs_430235_49_0.jpg" />
+                                                                    </a>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                    </div>
+                                                    <!-- HST-RESGALLERYNAV END  -->
+                                                    <!-- CONTROL PANEL START  -->
+                                                    <div class="control-panel">
+                                                        <span data="" id="gallerySection"></span>
+                                                        <div class="control-panel-inner">
+                                                            <div class="control-bar-480">
+                                                                <ul class="control-bar-480-items">
+                                                                    <li class="control-bar-480-item-a-list">
+                                                                        <div class="control-bar-480-item-a">MLS </div>
+                                                                    </li>
+                                                                    <li class="control-bar-480-item-b-list">
+                                                                        <div class="control-bar-480-item-b">
+                                                                            <!-- <span class="icon"></span> -->
+                                                                            <div class="thumblink-480 hdn-analytics">
+                                                                                <span class="icon"></span>
+                                                                                <span class="hdn-analytics-data">&gt;gallery_thumbnails_show|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                            </div>
+                                                                        </div>
+                                                                    </li>
+                                                                </ul>
+                                                            </div>
+                                                            <div class="control-bar">
+                                                                <div class="sidebar-overlay-title">
+                                                                    <span>1333 Jones St. #806</span>
+                                                                </div>
+                                                                <div class="control-bar-left">
+                                                                    <div class="control-bar-credit"><span>MLS  </span></div>
+                                                                </div>
+                                                                <div class="control-bar-right">
+                                                                    <div class="slide-count">
+                                                                        <div class="nav-stats">Image <span class="item-count-current">1</span><span> of </span><span class="item-count-total">33</span></div>
+                                                                    </div>
+                                                                    <div class="play"><span class="icon"></span></div>
+                                                                    <div class="thumblink hdn-analytics">
+                                                                        <span class="icon"></span>
+                                                                        <span class="hdn-analytics-data">gallery_thumbnails_show|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                    </div>
+                                                                    <div class="overlaylink expanded"><span class="icon"></span></div>
+                                                                    <div class="overlaylink fullscreen hdn-analytics">
+                                                                        <span class="icon"></span>
+                                                                        <span class="hdn-analytics-data">gallery_overlay_open|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                    </div>
+                                                                    <div class="overlaylink thumbs hdn-analytics">
+                                                                        <span class="icon"></span>
+                                                                        <span class="hdn-analytics-data">gallery_overlay_open_thumbs|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                    </div>
+                                                                    <div class="share-toggle"><span class="icon"></span></div>
+                                                                </div>
+                                                            </div>
+                                                            <div class="caption ">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">1</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The one-bedroom just came to market at $2.495 million</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>1</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The one-bedroom just came to market at $2.495 million </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The one-bedroom just came to market at $2.495 million</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">2</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Before the massive renovation, the living area still had great views, but was dated.</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>2</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Before the massive renovation, the living area still had great views, but was dated. </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Before the massive renovation, the living area still had great views,...but was dated.</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">3</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Beautiful views from the floor-to-ceiling windows.</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>3</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Beautiful views from the floor-to-ceiling windows. </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Beautiful views from the floor-to-ceiling windows.</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">4</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The open concept living room</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>4</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The open concept living room </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The open concept living room</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">5</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The dining area</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>5</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The dining area </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The dining area</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">6</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The open entertaining space</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>6</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The open entertaining space </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The open entertaining space</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">7</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The dining area before</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>7</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The dining area before </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The dining area before</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">8</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The den</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>8</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The den </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The den</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">9</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Another view of the den</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>9</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Another view of the den </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Another view of the den</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">10</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The kitchen</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>10</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The kitchen </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The kitchen</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">11</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The kitchen</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>11</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The kitchen </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The kitchen</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">12</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Custom cabinets and granite counters</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>12</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Custom cabinets and granite counters </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Custom cabinets and granite counters</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">13</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Another shot of the kitchen</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>13</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Another shot of the kitchen </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Another shot of the kitchen</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">14</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The old, enclosed kitchen</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>14</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The old, enclosed kitchen </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The old, enclosed kitchen</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">15</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Views from the kitchen</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>15</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Views from the kitchen </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Views from the kitchen</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">16</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Built-in office nook</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>16</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Built-in office nook </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Built-in office nook</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">17</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The only bedroom also takes advantage of the views. </p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>17</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The only bedroom also takes advantage of the views. </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The only bedroom also takes advantage of the views. </p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">18</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Another shot of the bedroom</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>18</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Another shot of the bedroom </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Another shot of the bedroom</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">19</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The bedroom before</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>19</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The bedroom before </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The bedroom before</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">20</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Master closet</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>20</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Master closet </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Master closet</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">21</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Master bath</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>21</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Master bath </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Master bath</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">22</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Another shot of the master bath</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>22</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Another shot of the master bath </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Another shot of the master bath</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">23</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Soaking tub</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>23</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Soaking tub </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Soaking tub</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">24</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Entry</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>24</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Entry </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Entry</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">25</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Standing on the balcony</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>25</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Standing on the balcony </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Standing on the balcony</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">26</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Views from the northwest facing condo</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>26</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Views from the northwest facing condo </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Views from the northwest facing condo</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">27</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">More views</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>27</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        More views </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">More views</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">28</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Golden Gate Bridge views</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>28</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Golden Gate Bridge views </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Golden Gate Bridge views</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">29</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">From inside the condo</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>29</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        From inside the condo </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">From inside the condo</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">30</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">This corner window before</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>30</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        This corner window before </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">This corner window before</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">31</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The Comstock</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>31</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The Comstock </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The Comstock</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">32</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">The lobby</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>32</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        The lobby </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">The lobby</p>
+                                                            </div>
+                                                            <div class="caption staged" style="">
+                                                                <div class="slide-count">
+                                                                    <div class="nav-stats">
+                                                                        <span class="label">Image </span>
+                                                                        <span class="item-count-current">33</span>
+                                                                        <span> of </span><span class="item-count-total">33</span>
+                                                                        <span class="gallery-title-divider">|</span><span class="main-gallery-title">1333 Jones St. #806</span>
+                                                                    </div>
+                                                                </div>
+                                                                <span class="credit">MLS  </span>
+                                                                <p class="MsoNormal">Another view of the lobby</p>
+                                                                <!-- This is only displayed for breakpoints lower than 768 -->
+                                                                <div class="caption_480">
+                                                                    <p class="caption_480_header_line">Image <span>33</span> of <span> 33 - 1333 Jones St. #806 </span> </p>
+                                                                    <p>
+                                                                        Another view of the lobby </p>
+                                                                </div>
+                                                            </div>
+                                                            <div style="display:none;" class="caption-truncated">
+                                                                <p class="MsoNormal">Another view of the lobby</p>
+                                                            </div>
+                                                            <div class="caption-wedge" style=""></div>
+                                                        </div>
+                                                        <!-- Ad Space start  -->
+                                                        <div class="hst-mediumrectangle clearfix" id="hst-mediumrectangle4">
+                                                            <div class="galleryAd" id="GO300">
+                                                                <script type="text/javascript">
+                                                                /*&lt;![CDATA[*/
+                                                                go300Wrapper(); /*]]&amp;gt;*/
+                                                                </script>
+                                                            </div>
+                                                        </div>
+                                                        <!-- Ad Space end  -->
+                                                    </div>
+                                                    <!-- CONTROL PANEL END  -->
+                                                    <!-- GALLERY OVERLAY OUTTER START   -->
+                                                    <div class="gallery-overlay-outter hidden">
+                                                        <div class="gallery-overlay-inner">
+                                                            <ul class="gallery-overlay-title-container">
+                                                                <li class="homeLink">
+                                                                    <span class="icon"></span>
+                                                                </li>
+                                                                <!-- 320 thumb close -->
+                                                                <li class="thumbs-close-overlay-320 hdn-analytics">
+                                                                    <span class="icon"></span>
+                                                                    <span class="hdn-analytics-data">gallery_thumbs_close|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                </li>
+                                                                <!-- thumb close 320 -->
+                                                                <li class="gallery-overlay-title">
+                                                                    Nob Hill one-bedroom sells for $2.3 million </li>
+                                                                <li style="float:right;">
+                                                                    <ul>
+                                                                        <li class="gallery-overlay-thumbs-close2 hdn-analytics hidden">
+                                                                            <div class="thumbs-close-overlay-label">
+                                                                                <span class="icon"></span>Back to Gallery
+                                                                            </div>
+                                                                            <span class="hdn-analytics-data">gallery_thumbs_close|loaded-2432-post-2857-g24417|loaded-2432-post-2857-g24417|0</span>
+                                                                        </li>
+                                                                        <li class="gallery-close-overlay hdn-analytics">
+                                                                            <span class="icon"></span>
+                                                                            <span class="hdn-analytics-data">gallery_overlay_close|ontheblock-2283-post-9755-g31011|ontheblock-2283-post-9755-g31011|0</span>
+                                                                        </li>
+                                                                    </ul>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                    </div>
+                                                    <!-- GALLERY OVERLAY OUTTER END   -->
+                                                </div>
+                                                <!-- END OF GALL  -->
+                                                <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-wp-galleries-redesigned/responsivegallery.js" type="text/javascript"></script>
+                                                <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-wp-galleries-redesigned/wpg_analytics.js" type="text/javascript"></script>
+                                                <script type="text/javascript">
+                                                function wpshareit(social_type, photo_url, photo_title, article) {
+                                                    var current_url = encodeURIComponent(window.location.href);
+                                                    switch (social_type) {
+                                                        case 'facebook':
+                                                            window.open('http://www.facebook.com/sharer.php?u=' + encodeURIComponent(photo_url) + '&amp;t=' + encodeURIComponent(photo_title), 'sharer', 'toolbar=0,status=0,width=626,height=436');
+                                                            break;
+                                                        case 'twitter':
+                                                            window.open("https://twitter.com/intent/tweet?text=Currently+reading%20:%20" + photo_title + "&amp;url=" + photo_url + "", 'tsharer', 'toolbar=0,status=0,width=626,height=436');
+                                                            break;
+                                                        case 'reddit':
+                                                            window.open("http://reddit.com/submit?url=" + photo_url + "&amp;title=" + photo_title + "", 'rdsharer', 'toolbar=0,status=0,width=823,height=436');
+                                                            break;
+                                                        case 'pinterest':
+                                                            window.open("http://pinterest.com/pin/create/button/?url=" + current_url + "&amp;media=" + photo_url + "&amp;description=" + photo_title + "", 'pnsharer', 'toolbar=0,status=0,width=750,height=436');
+                                                            break;
+                                                        case 'googleplus':
+                                                            window.open('https://plus.google.com/share?url=' + current_url, 'gpsharer', 'toolbar=0,status=0,width=626,height=436');
+                                                            break;
+                                                        case 'email':
+                                                            var subject = 'Check out this image';
+                                                            var address = '';
+                                                            var body = 'I thought you would be interested in this : ' + current_url;
+                                                            window.location.href = "mailto:" + address + "?subject=" + subject + "&amp;body=" + body + "";
+                                                            break;
+
+                                                    }
+
+
+                                                }
+
+                                                $(function() {
+                                                    var browser_ie11 = window.navigator.userAgent.indexOf('Trident/7.0');
+                                                    var browser_ie10 = window.navigator.userAgent.indexOf('MSIE 10');
+                                                    var browser_ie9 = window.navigator.userAgent.indexOf('MSIE 9');
+                                                    var browser_ie8 = window.navigator.userAgent.indexOf('MSIE 8');
+
+
+                                                    if (browser_ie11 != -1) {
+                                                        $("body").addClass("ie11");
+                                                    }
+
+                                                    if (browser_ie10 != -1) {
+                                                        $("body").addClass("ie10");
+                                                    }
+
+                                                    if (browser_ie9 != -1) {
+                                                        $("body").addClass("ie9");
+                                                    }
+
+                                                    if (browser_ie8 != -1) {
+                                                        $("body").addClass("ie8");
+                                                    }
+
+
+
+                                                });
+
+
+
+                                                // Init gallery
+
+                                                $(function() {
+
+                                                    var gallery_container = $('#hst-resgallery-31011101');
+
+                                                    //alert(" "+  gallery_container +  "ok "+ nggallery_data_31011);
+
+                                                    new ResponsiveGallery(gallery_container,
+                                                        gallery_container.find('.hst-resgallery'), gallery_container.find('.hst-resgallerynav'),
+                                                        gallery_container.find('.control-bar'), gallery_container.find('.nav'), nggallery_data_31011);
+
+                                                });
+                                                </script>
+                                            </div>
+                                        </div>
+                                        <p></p>
+                                        <div class="widget ad_position clearfix widget-ad-position-A300 widget-fake" style="display: none;">
+                                            <div class="hdn-ad-position ad-A300 hdn-ap-visible-mobile">
+                                                <div class="juice-ad-position juice-ad-position-A300">
+                                                    <div id="A300-0-73556800-1430916267"></div>
+                                                    <script type="text/javascript">
+                                                    jQuery(document).on('JuiceFinishedLoadingEvent', function(e) {
+                                                        window.ad_position_widget.place_named_ad_dynamic('A300', 'A300-0-73556800-1430916267');
+                                                    });
+                                                    </script>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <p>In early March, we told you about <a href="http://blog.sfgate.com/ontheblock/2015/03/05/2-495-million-for-s-f-s-most-expensive-one-bedroom/">a one-bedroom in the prestigious Comstock </a>in Nob Hill, which came to market at $2.495 million, making it the most expensive one-bedroom on the market at the time. The northwest facing unit—with amazing panoramic views of Twin Peaks, the Golden Gate Bridge, the North Bay, Alcatraz and Coit Tower in almost every room—has now sold for $2.3 million, or 8% under the asking price.</p>
+                                        <p>At just over 1,800 square feet, the sale works out to about $1,250 a square foot for the completely gutted and remodeled unit. That price is also about $700K higher than when the unit last sold at the end of 2006. Of course, it was also in a very different state at the time, with old carpeting; a closed-off, very outdated kitchen; and two bedrooms. (<strong>Before and afters are in the gallery above.</strong>)</p>
+                                        <p>Almost all the walls came down during the remodel and the carpeting was changed out for hardwoods, not to mention the addition of a completely new open concept kitchen and modern bathrooms. Also, the second bedroom was changed into a den/office with a glass wall separating it from the rest of the large entertaining space. Even the windows were updated to take better advantage of the unbelievable views.</p>
+                                        <p>By the way, if you’re looking for the same great views with a (slightly) smaller price tag, <a href="http://www.comstock1402.com">a 1,200-square-foot one-bedroom</a> just came to market in the same building. You’ll get less indoor space but what appears to be a larger balcony to take in those incredible San Francisco sights, all for the bargain price of $1.75 million.</p>
+                                        <p><em>Emily Landes is a writer and editor who is obsessed with all things real estate.</em></p>
+                                        <p> </p>
+                                    </div>
+                                    <div class="catsandtags">
+                                        <div class="catHolder">Categories: <a rel="category tag" title="View all posts in Design" href="http://blog.sfgate.com/ontheblock/category/design/?cmpid=wp-cat-frompost">Design</a><span class="tag-separator">,</span> <a rel="category tag" title="View all posts in High High-End" href="http://blog.sfgate.com/ontheblock/category/high-high-end/?cmpid=wp-cat-frompost">High High-End</a><span class="tag-separator">,</span> <a rel="category tag" title="View all posts in Home Sales" href="http://blog.sfgate.com/ontheblock/category/home-sales/?cmpid=wp-cat-frompost">Home Sales</a><span class="tag-separator">,</span> <a rel="category tag" title="View all posts in Luxury homes" href="http://blog.sfgate.com/ontheblock/category/luxury-homes/?cmpid=wp-cat-frompost">Luxury homes</a><span class="tag-separator">,</span> <a rel="category tag" title="View all posts in Nob Hill" href="http://blog.sfgate.com/ontheblock/category/nob-hill/?cmpid=wp-cat-frompost">Nob Hill</a><span class="tag-separator">,</span> <a rel="category tag" title="View all posts in San Francisco" href="http://blog.sfgate.com/ontheblock/category/san-francisco/?cmpid=wp-cat-frompost">San Francisco</a> </div>
+                                        <div class="tagHolder">Tags: <a rel="tag" href="http://blog.sfgate.com/ontheblock/tag/2-3-million-one-bedroom/">$2.3 million one-bedroom</a> <span class="tag-separator">|</span> <a rel="tag" href="http://blog.sfgate.com/ontheblock/tag/new-nob-hill-listing/">New Nob Hill listing</a> <span class="tag-separator">|</span> <a rel="tag" href="http://blog.sfgate.com/ontheblock/tag/nob-hill-one-bedroom/">Nob Hill one-bedroom</a> </div>
+                                    </div>
+                                    <script type="text/javascript">
+                                    jQuery(document).ready(function($) {
+                                        (function(be) {
+                                            if (!be || !window.is_mobile) return;
+                                            be = $($(be).prevAll('p, ul').get(5));
+                                            var sml = $('&lt;a name="show-more" class="show-more-link"&gt;&lt;div class="show-more-link-default"&gt;&lt;span&gt;Show More&lt;/span&gt;&lt;/div&gt;&lt;/a&gt;');
+                                            sml.click(function() {
+                                                sml.fadeOut();
+                                                be.nextAll('.gallery').css({
+                                                    'opacity': '',
+                                                    'height': '',
+                                                    'margin': '',
+                                                    'overflow': ''
+                                                });
+                                                be.nextAll(':not(.show-more-link)').slideDown();
+                                                $(document).trigger('show-more-single-after-show');
+                                                $(be.nextAll().prev().get(0)).after('&lt;div class="widget ad_position clearfix widget-ad-position-S300 widget-fake"&gt;' + "&lt;div id=\"S300\" class=\"S300 ad_deferrable hdn-ad-position\"&gt;&lt;script type=\"text\/javascript\"&gt; \/*&lt;![CDATA[*\/ hearstPlaceAd(\"S300\"); \/*]]&gt;*\/ &lt;\/script&gt;&lt;\/div&gt;" + '&lt;/div&gt;');
+
+                                                try {
+                                                    hearstRefreshInterstitialAds(['S300']);
+                                                } catch (e) {}
+                                            });
+                                            be.nextAll('.gallery').css({
+                                                'opacity': '0',
+                                                'height': '1',
+                                                'margin': '0',
+                                                'overflow': 'hidden'
+                                            });
+                                            be.nextAll().not('.gallery').hide().last().after(sml);
+                                        })($('.post .entry').children('p, ul').get(12));
+                                    });
+                                    </script>
+                                    <div class="only-desktop"></div>
+                                    <div class="only-mobile">
+                                        <div id="blogauthor">
+                                            <div class="blogauthor-meta">
+                                                <span class="blogauthor-meta-name">Emily Landes</span> </div>
+                                            <div class="blogauthor-social sharedaddy sd-sharing-enabled sd-fake">
+                                                <div style="display: block;" class="robots-nocontent sd-block sd-social sd-social-hdnicon sd-sharing">
+                                                    <div class="sd-content">
+                                                        <ul>
+                                                            <li class="share-email share-service-visible">
+                                                                <a title="Click to email Emily Landes" href="mailto:landesemily@gmail.com" class="share-email sd-button hdn-share-icon no-text" rel="nofollow">
+                                                                    <span></span>
+                                                                </a>
+                                                            </li>
+                                                            <li class="share-rss share-service-visible">
+                                                                <a title="Click to email Emily Landes" href="http://blog.sfgate.com/ontheblock/author/elandes//feed/" class="share-rss sd-button hdn-share-icon no-text" rel="nofollow">
+                                                                    <span></span>
+                                                                </a>
+                                                            </li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div style="clear:both;"> </div>
+                                </div>
+                                <div class="hdn_pm_post_below_1st_post_ad"></div>
+                            </div>
+                            <span id="blog-extras-anchor-large"></span>
+                            <div id="blog-extras">
+                                <div class="blogpost-outbrain clearfix">
+                                    <script type="text/javascript">
+                                    if (window.is_mobile)
+                                        document.write("&lt;div class=\"OUTBRAIN\" data-src=\"http:\/\/blog.sfgate.com\/ontheblock\/2015\/05\/05\/nob-hill-one-bedroom-sells-for-2-3-million\/\" data-widget-id=\"AR_5\" data-ob-template=\"sfgate\" &gt;&lt;\/div&gt;\r\n&lt;script type=\"text\/javascript\" src=\"http:\/\/widgets.outbrain.com\/outbrain.js\"&gt;&lt;\/script&gt;\r\n\r\n&lt;div class=\"OUTBRAIN\" data-src=\"http:\/\/blog.sfgate.com\/ontheblock\/2015\/05\/05\/nob-hill-one-bedroom-sells-for-2-3-million\/\" data-widget-id=\"AR_3\" data-ob-template=\"sfgate\" &gt;&lt;\/div&gt;\r\n&lt;script type=\"text\/javascript\" src=\"http:\/\/widgets.outbrain.com\/outbrain.js\"&gt;&lt;\/script&gt;");
+                                    else
+                                        document.write("&lt;div class=\"OUTBRAIN\" data-src=\"http:\/\/blog.sfgate.com\/ontheblock\/2015\/05\/05\/nob-hill-one-bedroom-sells-for-2-3-million\/\" data-widget-id=\"AR_5\" data-ob-template=\"sfgate\" &gt;&lt;\/div&gt;\r\n&lt;script type=\"text\/javascript\" src=\"http:\/\/widgets.outbrain.com\/outbrain.js\"&gt;&lt;\/script&gt;\r\n\r\n&lt;div class=\"OUTBRAIN\" data-src=\"http:\/\/blog.sfgate.com\/ontheblock\/2015\/05\/05\/nob-hill-one-bedroom-sells-for-2-3-million\/\" data-widget-id=\"AR_3\" data-ob-template=\"sfgate\" &gt;&lt;\/div&gt;\r\n&lt;script type=\"text\/javascript\" src=\"http:\/\/widgets.outbrain.com\/outbrain.js\"&gt;&lt;\/script&gt;");
+                                    </script>
+                                    <div id="ob_holder" style="display: none;">
+                                        <iframe id="ob_iframe" style="display: none; width: 1px; height: 1px;" src="http://widgets.outbrain.com/nanoWidget/3rd/comScore/comScore.htm"></iframe>
+                                        <script type="text/javascript" src="http://log.outbrain.com/loggerServices/widgetGlobalEvent?tm=2603&amp;pid=787&amp;sid=2104226&amp;wId=125&amp;wRV=248244&amp;rId=799a00673241607f112edd7f18023d94&amp;eT=0&amp;idx=0&amp;eIdx=&amp;pvId=799a00673241607f112edd7f18023d94&amp;org=0&amp;pad=4&amp;ab=false" charset="UTF-8" async=""></script>
+                                        <script type="text/javascript" src="http://log.outbrain.com/loggerServices/widgetGlobalEvent?tm=4055&amp;pid=787&amp;sid=2104226&amp;wId=110&amp;wRV=248244&amp;rId=b9b21be712ff37c82b6e3c0e53434c7b&amp;eT=0&amp;idx=1&amp;eIdx=&amp;pvId=799a00673241607f112edd7f18023d94&amp;org=7&amp;pad=7&amp;ab=false" charset="UTF-8" async=""></script>
+                                        <script type="text/javascript" src="http://log.outbrain.com/loggerServices/widgetGlobalEvent?tm=4912&amp;pid=787&amp;sid=2104226&amp;wId=103&amp;wRV=248244&amp;rId=c60f10eae13a779981e81eed2d1ac426&amp;eT=0&amp;idx=2&amp;eIdx=&amp;pvId=799a00673241607f112edd7f18023d94&amp;org=0&amp;pad=4&amp;ab=false" charset="UTF-8" async=""></script>
+                                        <script type="text/javascript" src="http://log.outbrain.com/loggerServices/widgetGlobalEvent?tm=5008&amp;pid=787&amp;sid=2104226&amp;wId=103&amp;wRV=248244&amp;rId=c60f10eae13a779981e81eed2d1ac426&amp;eT=3&amp;idx=2&amp;eIdx=0&amp;pvId=799a00673241607f112edd7f18023d94&amp;org=0&amp;pad=4&amp;ab=false" charset="UTF-8" async=""></script>
+                                    </div>
+                                    <div data-ob-template="sfgate" data-widget-id="AR_5" data-src="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" class="OUTBRAIN" data-ob-mark="true" data-browser="firefox" data-os="macintel" data-dynload="" id="outbrain_widget_0">
+                                        <div class="ob_strip_container AR_5">
+                                            <span class="ob_empty"><wbr /></span>
+                                            <style type="text/css">
+                                            .voterDiv .ob_bctrl {
+                                                display: none;
+                                            }
+
+                                            .ob_pdesc IMG {
+                                                border: none;
+                                            }
+
+                                            .AR_5 .ob_what {
+                                                direction: ltr;
+                                                text-align: right;
+                                                clear: both;
+                                                padding: 5px 10px 0px;
+                                            }
+
+                                            .AR_5 .ob_what a {
+                                                color: #999;
+                                                font-size: 10px;
+                                                font-family: arial;
+                                                text-decoration: none;
+                                            }
+
+                                            .AR_5 .ob_what.ob-hover:hover a {
+                                                text-decoration: underline;
+                                            }
+
+                                            .AR_5 .ob_clear {
+                                                clear: both;
+                                            }
+
+                                            .AR_5 .ob_amelia,
+                                            .AR_5 .ob_logo,
+                                            .AR_5 .ob_text_logo {
+                                                display: inline-block;
+                                                vertical-align: text-bottom;
+                                                padding: 0px 5px;
+                                                box-sizing: content-box;
+                                                -moz-box-sizing: content-box;
+                                                -webkit-box-sizing: content-box;
+                                            }
+
+                                            .AR_5 .ob_amelia {
+                                                background: url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_16x16.png') no-repeat center top;
+                                                width: 16px;
+                                                height: 16px;
+                                                margin-bottom: -2px;
+                                            }
+
+                                            .AR_5 .ob_logo {
+                                                background: url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_67x12.png') no-repeat center top;
+                                                width: 67px;
+                                                height: 12px;
+                                            }
+
+                                            .AR_5 .ob_text_logo {
+                                                background: url('http://widgets.outbrain.com/images/widgetIcons/ob_text_logo_66x23.png') no-repeat center top;
+                                                width: 66px;
+                                                height: 23px;
+                                            }
+
+                                            .AR_5:hover .ob_amelia,
+                                            .AR_5:hover .ob_logo,
+                                            .AR_5:hover .ob_text_logo {
+                                                background-position: center bottom;
+                                            }
+
+                                            .AR_5 .ob_container {
+                                                width: 100%;
+                                                position: relative;
+                                                overflow: hidden;
+                                            }
+
+                                            .AR_5 .strip-img {
+                                                width: 142px;
+                                                height: 115px;
+                                                border: none !important;
+                                                margin: 0px !important;
+                                                display: block;
+                                                padding: 0px !important;
+                                            }
+
+                                            .AR_5 .item-link-container {
+                                                text-decoration: none;
+                                            }
+
+                                            .AR_5 .strip-rec-link-title {
+                                                font-size: 13px;
+                                                font-weight: normal;
+                                                line-height: 16px;
+                                            }
+
+                                            .AR_5 .strip-rec-link-source {
+                                                font-size: 12px;
+                                                line-height: 16px
+                                            }
+
+                                            .AR_5 .strip-like {
+                                                padding-bottom: 4px;
+                                                font-size: 14px;
+                                                line-height: 16px;
+                                                height: 20px;
+                                                font-weight: bold;
+                                            }
+
+                                            .AR_5 .item-container a,
+                                            .AR_5 .item-container a:hover,
+                                            .AR_5 .item-container a:visited {
+                                                border: medium none;
+                                                text-decoration: none;
+                                            }
+
+                                            .AR_5 .ob_video {
+                                                border: medium none;
+                                                position: absolute;
+                                                top: 5px;
+                                                left: 5px
+                                            }
+
+                                            .AR_5 .ob-rec-link-img {
+                                                position: relative;
+                                            }
+
+                                            .AR_5 .wbr:before {
+                                                content: \"\200B\"}
+ .AR_5 .ob_container_recs {
+                                                    width: 100%;
+                                                    position: absolute;
+                                                }
+                                                .AR_5 .ob_container_recs A {
+                                                    display: inline;
+                                                    direction: ltr;
+                                                    text-align: left;
+                                                }
+                                                .AR_5 .ob-text-content A {
+                                                    width: 100%;
+                                                    padding: 0px 0px;
+                                                }
+                                                .AR_5 .ob-text-content {
+                                                    padding-top: 6px;
+                                                }
+                                                .AR_5 .item-container A.ob-text-content {
+                                                    display: block;
+                                                }
+                                                .AR_5 .ob_container_recs .item-container {
+                                                    float: left;
+                                                    direction: ltr;
+                                                    width: 144px;
+                                                    margin-bottom: 300px;
+                                                    padding-right: 12px;
+                                                }
+                                                .AR_5 .ob_container_recs .ob-last {
+                                                    padding-right: 0px;
+                                                }
+                                                .AR_5 .ob_container_shadow_outer {
+                                                    position: static;
+                                                    width: 100%;
+                                                }
+                                                .AR_5 .ob_container_shadow .item-container-shadow {
+                                                    position: static;
+                                                    overflow-x: hidden;
+                                                    width: 0px;
+                                                    float: left;
+                                                    direction: ltr;
+                                                }
+                                                .AR_5 .ob_container_shadow .item-container {
+                                                    width: 144px;
+                                                    visibility: hidden;
+                                                    float: left
+                                                }
+                                            </style>
+                                            <style class="ob-custom-css" type="text/css">
+                                            .OUTBRAIN .AR_5 .ob_org_header {
+                                                font-size: 16px;
+                                                color: #222;
+                                            }
+
+                                            @media screen and (min-width: 1280px) {
+                                                .OUTBRAIN .AR_5 .ob_container_recs .item-container {
+                                                    width: 207px;
+                                                }
+                                            }
+
+                                            .OUTBRAIN .AR_5 .strip-rec-link-title {
+                                                font-family: 'Sofia Pro Bold', 'Arial', sans-serif;
+                                                font-size: 16px;
+                                                line-height: 18px;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_org_header {
+                                                font-family: 'Euclid Bold', Arial, sans-serif;
+                                                text-transform: uppercase;
+                                                font-size: 20px !important;
+                                                font-family: 'Euclid Bold', Arial, sans-serif;
+                                                text-transform: uppercase;
+                                                height: 40px;
+                                                line-height: 40px;
+                                                color: white !important;
+                                                background-color: black;
+                                                border-bottom: none !important;
+                                                padding-left: 10px;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_text_content {
+                                                font-size: 12px;
+                                                line-height: 18px;
+                                                max-height: 4.5em;
+                                                font-weight: 700;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_source {
+                                                font-family: 'Sofia Pro Bold', 'Arial', sans-serif;
+                                                font-size: 16px;
+                                                line-height: 18px;
+                                                max-height: 4.5em;
+                                                font-weight: 700;
+                                            }
+                                            /* Smartphones (portrait) ----------- */
+
+                                            @media only screen and (max-width: 680px) {
+                                                /* Styles */
+
+                                                body .OUTBRAIN .AR_5 .ob_container_recs .item-container {
+                                                    width: 46%;
+                                                    padding: 0;
+                                                    margin: 3% 4% 0 0;
+                                                }
+                                                .OUTBRAIN .AR_5 .ob-text-content {
+                                                    height: 70px;
+                                                }
+                                                body .OUTBRAIN .AR_5 .strip-img {
+                                                    width: 100%;
+                                                    height: auto;
+                                                }
+                                            }
+
+                                            .OUTBRAIN a {
+                                                display: block;
+                                            }
+
+                                            .ob_container_recs {
+                                                padding: 15px;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .strip-rec-link-title:hover {
+                                                text-decoration: underline;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .strip-rec-link-title:visited {
+                                                color: #777 !important;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_source {
+                                                color: #000000;
+                                                font-family: 'Arial', sans-serif;
+                                                font-size: 12px;
+                                                line-height: 18px;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_container_recs {
+                                                padding: 0;
+                                                position: relative;
+                                            }
+
+                                            .ob_strip_container {
+                                                padding-bottom: 10px;
+                                                border-bottom: 2px solid #ccc;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_container {
+                                                height: auto;
+                                            }
+
+                                            .ob_empty {
+                                                display: none;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_container_recs {
+                                                position: relative;
+                                            }
+
+                                            .ob_what a {
+                                                color: #999999;
+                                                font-family: 'Arial', sans-serif;
+                                                font-size: 10px;
+                                                line-height: 18px;
+                                                text-decoration: none;
+                                                text-transform: uppercase;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .strip-rec-link-title {
+                                                color: #000000 !important;
+                                                font-family: 'Arial', sans-serif;
+                                                font-size: 12px;
+                                                line-height: 18px;
+                                                max-height: 4.5em;
+                                                overflow: hidden;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .strip-img {
+                                                border: medium none !important;
+                                                display: block;
+                                                height: 115px;
+                                                margin: 0 !important;
+                                                padding: 0 !important;
+                                                width: 147px;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_container_recs .item-container {
+                                                width: 147px;
+                                                height: initial;
+                                                margin-bottom: 0px;
+                                                margin-left: 20px;
+                                                padding-right: 0;
+                                                padding-top: 15px;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_container_recs .item-container.ob-recIdx-0 {
+                                                margin-left: 0px;
+                                                padding-right: 0;
+                                            }
+
+                                            .ob_strip_container.OUTBRAIN .AR_5 {
+                                                height: auto !important;
+                                                padding: 0;
+                                            }
+
+                                            .OUTBRAIN {
+                                                border-top: 0px;
+                                                padding: 0px !important;
+                                            }
+
+                                            .ob_what {
+                                                padding-top: 0px !important;
+                                            }
+
+                                            @media screen and (min-width: 1280px) {
+                                                .OUTBRAIN .AR_5 .strip-img {
+                                                    height: auto;
+                                                    width: 207px;
+                                                }
+                                                .OUTBRAIN .AR_5 .ob_container_recs .item-container {
+                                                    width: 207px;
+                                                }
+                                            }
+
+                                            @media screen and (max-width: 767px) {
+                                                .blogpost-outbrain {
+                                                    margin: 0px;
+                                                    width: 100%;
+                                                }
+                                                .OUTBRAIN .AR_5 .ob_org_header {
+                                                    margin-bottom: 20px;
+                                                }
+                                                #outbrain_widget_0,
+                                                .OUTBRAIN {
+                                                    width: 100% !important;
+                                                }
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_container_recs {
+                                                width: 100%;
+                                                position: relative;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_container {
+                                                width: 100%;
+                                                position: relative;
+                                                overflow: hidden;
+                                                height: auto;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .strip-rec-link-title {
+                                                font-size: 12px;
+                                                line-height: 16px;
+                                                font-weight: bold;
+                                            }
+
+                                            .ob_strip_container.OUTBRAIN .AR_5 {
+                                                height: 265px;
+                                                padding: 0 2%;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_org_header {
+                                                font-weight: bold;
+                                                font-size: 16px;
+                                                color: black;
+                                                display: block;
+                                            }
+
+                                            .OUTBRAIN .AR_5 .ob_what a {
+                                                color: #999;
+                                                font-size: 10px;
+                                                font-family: arial;
+                                                text-decoration: none;
+                                                display: none!important;
+                                            }
+                                            </style>
+                                            <span class="ob_org_header">
+You Might Also Like
+</span>
+                                            <div class="ob_container">
+                                                <div class="ob_container_recs">
+                                                    <a rel="nofollow" target="_blank" onmousedown="outbrain.recClicked(event,this);" onclick="" data-redirect="http://paid.outbrain.com/network/redir?p=90N8bjj49SCv1L-G90ak61KwNtN5noXsupVtzQMSqk5laK5KO8dgwVJPhHFWroDAnRyP6N2QPyhmdr0cq4otYPGlw6WhQZOh5moHnxhTAtoNzVi_kR6ahTHeU2INhhMZhHoMUi8xdhs9yXx5rUz05CbNDM5y2-mHhWNgPS_P3jhrY_Hb7TkUWOf0S4KrA_ClJw1bwrfOpgZugdF5thWM3w-e--KAuC6_UqZ7fM2Jn7XX9bkaJJFlDsmR6KdbAIBS6p9aKJlz8mrbc-EVhh-jjF-AnL3dv2In8Orymto_NAJgd8Qz6lwMZ_HRzVoZ24V1FSUFcKIDK0JAi28dqNvet1pAyIok5574a2ybdcyVrCdrF-Qlh_zpT2DmAZb93qKS9CZ5R01bDmOsC6Mwalqz70_fVGIh4nOS2HTv0JrEvcFskGGW1jEzHJSGPcAFudlJjWmpi7YldkHwsXiv99dcyaijwZ7hGqFjXUzTpgdjHSsGwI0A5_hJ-BI987BzNx1dxQBkVSKJWU3RNrgnXT9v5hHG7kjombbdN9o2jx3g5PAA8t2DMafnTBEWonmfEdU4&amp;c=ecbd0aac&amp;v=3" href="http://seotwist.com/digital-marketing/upping-your-digital-marketing-strategy-with-personalized-content/?outbrain" class="item-link-container ob-odd">
+                                                        <div class="item-container ob-recIdx-0  item-container-ad ">
+                                                            <div class="ob-rec-link-img ob-tcolor">
+                                                                <img width="142" height="115" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/Ls0q/n/155r5n/abc/10dMIl/155r5n-ayB-142x115.jpg" alt="Upping your Digital Marketing Strategy with Personalized Content |" class="strip-img" title="Upping your Digital Marketing Strategy with Personalized Content |" onload="this.style.visibility=''" style="" />
+                                                            </div>
+                                                            <div class="ob-text-content">
+                                                                <div class="strip-rec-link-title ob-tcolor">Upping your Digital Marketing Strategy with…</div>
+                                                                <div class="strip-rec-link-source ob-lcolor">
+                                                                    <span class="ob_source">(SEO TWIST - Expert SEO Services Ottawa)</span> </div>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a rel="nofollow" target="_blank" onmousedown="outbrain.recClicked(event,this);" onclick="" data-redirect="http://paid.outbrain.com/network/redir?p=JqHUrOOQb885WgcE7quTRKuOEyLQLbl1WrbD1TT7iTNODGPvzP8X9VuSOFUa-Uwk2f3fbuQ8iHT6mfv02SLFp0vfoHF2J7icu05BilfyCAG-3OIj96zaLkZhKsm6PDh-Y611brNKHQ3zPFep-BdRaqvmUpyknM7hAbdmJ0GlruOOKh34flN3NO8ywmmg6EG-aS17UPHDWvvRNATRWlDTSnESq_QqgB7xJ1wAmeWOFhvOtraZNhEnq4cio9FoC2lMMIssncL423xcuqYwUw5bj5IBxAdasAER3FwdwZ4zYKDP6LfQFFKf2lmnHpkw4nAibb7-Ef_ohbrqfHdQP6ddwCqBf6Gq6lEqyiewbzkjNL4JsTZWVpOWBhR3BfRf3Os8YBPS1SSu56BRCngLkq6H628nWd4j4KEosX1erYMDhcdR2Lnv-9BFXMi-8kBdH91KBtWGZpwa1RlWKLarWzNOnwHCgTY-JFkyLtsyAWU48YC6TpAhYaDKbIovaTK6SseLwqxh2Z4iR0KtD_GSLgiKxhhhQEhtQxM-tqfGfzBDuYs&amp;c=283aa8db&amp;v=3" href="http://www.ozy.com/fast-forward/cheating-but-not-leaving/38322?utm_source=Outbrain&amp;utm_medium=CPC&amp;utm_campaign=INTL%20-%20All%20Clicks%20ALL%20Devices" class="item-link-container ob-even">
+                                                        <div class="item-container ob-recIdx-1  item-container-ad ">
+                                                            <div class="ob-rec-link-img ob-tcolor">
+                                                                <img width="142" height="115" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/L8LH/n/ztShX/abc/10exgq/ztShX-ayB-142x115.jpg" alt="Cheating, But Not Leaving" class="strip-img" title="Cheating, But Not Leaving" onload="this.style.visibility=''" style="" />
+                                                            </div>
+                                                            <div class="ob-text-content">
+                                                                <div class="strip-rec-link-title ob-tcolor">Cheating, But Not Leaving</div>
+                                                                <div class="strip-rec-link-source ob-lcolor">
+                                                                    <span class="ob_source">(OZY)</span> </div>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a rel="nofollow" target="_blank" onmousedown="outbrain.recClicked(event,this);" onclick="" data-redirect="http://paid.outbrain.com/network/redir?p=eWdWdCt2Tnc_VtIs3IqBLobVmSsvR_7eRBivgH3OVZbanBbc2BGFxXNZSWvRq62LGApMy3TnUZx1lRX5vXoVfROLbEvH0YI03BVJZZWDo2_cPztzHyOjm-xN28oHK17p7lHcK-oln_86OGDUwsXFIGFQO-EhxQauXBTMMNtSh-K3QMbSY2z60vSx_fBuFvW2gZjOuGrquT-PKyHR-MNzRUpZbqY4FuU2iEL22Z1dZtgNEVUzFYZqdN6pFBd9i6q5IHL3Cvde0YZb8DzpP8VbDbPLngKKvlQExG6s9v263YcC-M5LJi8DHNoTWEJCn20POaeHnf7kwHESUYAY5BXMTRpIzsJiucHgnW1MBUFnTpHg6pppPwPCdUY1yeFs3OFzLzL9rwQn4bxY6kuzq8bMe72jxBMYS9BUSBmLA5ntwY_uyU5FnSXY3jpI1ZtpMC4YtRUFcOHnvKquJYQWuz4KmUl_MjEhTUnwl3RmqBNdWJlE_7iFB_dGvjiP-G3MkfyXePlb49sHhvmntYE7Ya0i5FI7nlXTX_cGhvQCLWWImRTIQWZVkMeOVbAnXNK5-qlQ&amp;c=7a5f70fe&amp;v=3" href="http://travelversed.com/travel-spots/15-most-beautiful-beaches-youll-find-anywhere/?utm_source=outbrain&amp;utm_medium=cpc&amp;utm_content=wp%7Ehttps%3A%2F%2Ftravelversed.com%2Fwp-content%2Fuploads%2F2015%2F02%2FRabbit-Beach-Italy.jpg&amp;utm_campaign=ob-Beautiful%20Beaches-USA-desktop" class="item-link-container ob-odd">
+                                                        <div class="item-container ob-recIdx-2  item-container-ad ">
+                                                            <div class="ob-rec-link-img ob-tcolor">
+                                                                <img width="142" height="115" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/MeWm/a/11qmBf/2Ro7Z/1eZF/11qmBf-ayB-142x115.jpg" alt="Top 20 Most Beautiful Beaches You’ll Find Anywhere" class="strip-img" title="Top 20 Most Beautiful Beaches You’ll Find Anywhere" onload="this.style.visibility=''" style="" />
+                                                            </div>
+                                                            <div class="ob-text-content">
+                                                                <div class="strip-rec-link-title ob-tcolor">Top 20 Most Beautiful Beaches You’ll Find Anywhere</div>
+                                                                <div class="strip-rec-link-source ob-lcolor">
+                                                                    <span class="ob_source">(Travel Versed)</span> </div>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a rel="nofollow" target="_blank" onmousedown="outbrain.recClicked(event,this);" onclick="" data-redirect="http://paid.outbrain.com/network/redir?p=oQ3UWlsAHkgPN3wsHVH2ShBxJQEGakvgb4C8Dju6ndNlwHVq7vAn8Yk8_E6fdIhBHTGTiTltsYxIUdTNHev7vZ-YaQFCZ6CKHouf_FZaX130BIpWfBK9jEdpT0RAhN8G0zNN12-qXChAm-DL8suzIRjfi0bA1pUTPOPdxLL2mMf9p7boS8fpfQ9sfO1xJ2ihoIkD0gkeixwSNTOFoe3PYGbrO29Kv4c8JxhzL1nbISjQcIuV9rmDSafZTHJ8YS5HJVbRmm5FjZg4EFIWK8YMYpqdyQRnDFwQp8hSBzEteJjqPIRCTnd9t3PjdQ1Lesh2T1bzY8QUdUBCkHiOKMuQaC_prcuwrAcAFVL_bsQk5zlSVM99tM9OGLoCCRQbwvvi3n1QvlUyvgoaoBnVqZOWBfM48jPhZ6YsJ7LyVn3xLvmD8ae3Dgcggk_IAPC-ybaoZ2Xh6ccfZKARlTvc_0RwWFyO5H88N7fDvL_sAETBo8P-DDGn9MOojyMJQkNrIy0uOtSLMwE8Y9EF18mrWbDF4j7pWcdjOvprHKq5jV9r-yY&amp;c=ba48bea9&amp;v=3" href="http://www.revolvy.com/main/index.php?pagetype=quiz&amp;id=79" class="item-link-container ob-even">
+                                                        <div class="item-container ob-recIdx-3  item-container-ad  ob-last ">
+                                                            <div class="ob-rec-link-img ob-tcolor">
+                                                                <img width="142" height="115" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/MYUg/a/132ceE/2PDJi/1UUA/132ceE-ayB-142x115.jpg" alt="Beatles Songs: Who Sang Lead? Quiz #3" class="strip-img" title="Beatles Songs: Who Sang Lead? Quiz #3" onload="this.style.visibility=''" style="" />
+                                                            </div>
+                                                            <div class="ob-text-content">
+                                                                <div class="strip-rec-link-title ob-tcolor">Beatles Songs: Who Sang Lead? Quiz #3</div>
+                                                                <div class="strip-rec-link-source ob-lcolor">
+                                                                    <span class="ob_source">(Revolvy Nowhere)</span> </div>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                </div>
+                                                <div class="ob_container_shadow_outer">
+                                                    <div class="ob_container_shadow">
+                                                        <div class="item-container-shadow ob-recIdx-0   ob-odd">
+                                                            <div class="item-container ob-recIdx-0  item-container-ad ">
+                                                                <div class="ob-rec-link-img ob-tcolor">
+                                                                    <img width="142" height="115" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/Ls0q/n/155r5n/abc/10dMIl/155r5n-ayB-142x115.jpg" alt="Upping your Digital Marketing Strategy with Personalized Content |" class="strip-img" title="Upping your Digital Marketing Strategy with Personalized Content |" onload="this.style.visibility=''" style="" />
+                                                                </div>
+                                                                <div class="ob-text-content">
+                                                                    <div class="strip-rec-link-title ob-tcolor">Upping your Digital Marketing Strategy with…</div>
+                                                                    <div class="strip-rec-link-source ob-lcolor">
+                                                                        <span class="ob_source">(SEO TWIST - Expert SEO Services Ottawa)</span> </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="item-container-shadow ob-recIdx-1  ob-even">
+                                                            <div class="item-container ob-recIdx-1  item-container-ad ">
+                                                                <div class="ob-rec-link-img ob-tcolor">
+                                                                    <img width="142" height="115" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/L8LH/n/ztShX/abc/10exgq/ztShX-ayB-142x115.jpg" alt="Cheating, But Not Leaving" class="strip-img" title="Cheating, But Not Leaving" onload="this.style.visibility=''" style="" />
+                                                                </div>
+                                                                <div class="ob-text-content">
+                                                                    <div class="strip-rec-link-title ob-tcolor">Cheating, But Not Leaving</div>
+                                                                    <div class="strip-rec-link-source ob-lcolor">
+                                                                        <span class="ob_source">(OZY)</span> </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="item-container-shadow ob-recIdx-2   ob-odd">
+                                                            <div class="item-container ob-recIdx-2  item-container-ad ">
+                                                                <div class="ob-rec-link-img ob-tcolor">
+                                                                    <img width="142" height="115" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/MeWm/a/11qmBf/2Ro7Z/1eZF/11qmBf-ayB-142x115.jpg" alt="Top 20 Most Beautiful Beaches You’ll Find Anywhere" class="strip-img" title="Top 20 Most Beautiful Beaches You’ll Find Anywhere" onload="this.style.visibility=''" style="" />
+                                                                </div>
+                                                                <div class="ob-text-content">
+                                                                    <div class="strip-rec-link-title ob-tcolor">Top 20 Most Beautiful Beaches You’ll Find Anywhere</div>
+                                                                    <div class="strip-rec-link-source ob-lcolor">
+                                                                        <span class="ob_source">(Travel Versed)</span> </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="item-container-shadow ob-recIdx-3  ob-even">
+                                                            <div class="item-container ob-recIdx-3  item-container-ad  ob-last ">
+                                                                <div class="ob-rec-link-img ob-tcolor">
+                                                                    <img width="142" height="115" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/MYUg/a/132ceE/2PDJi/1UUA/132ceE-ayB-142x115.jpg" alt="Beatles Songs: Who Sang Lead? Quiz #3" class="strip-img" title="Beatles Songs: Who Sang Lead? Quiz #3" onload="this.style.visibility=''" style="" />
+                                                                </div>
+                                                                <div class="ob-text-content">
+                                                                    <div class="strip-rec-link-title ob-tcolor">Beatles Songs: Who Sang Lead? Quiz #3</div>
+                                                                    <div class="strip-rec-link-source ob-lcolor">
+                                                                        <span class="ob_source">(Revolvy Nowhere)</span> </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="ob_what">
+                                                <a onclick="OBR.extern.callWhatIs('http://www.outbrain.com/what-is/default/en','',-1,-1,true ,null);return false" onmousedown="" href="#">
+        Recommended by<span title="Outbrain" class="ob_amelia"></span>
+    </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <script src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"></script>
+                                    <div data-ob-template="sfgate" data-widget-id="AR_3" data-src="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" class="OUTBRAIN" data-ob-mark="true" data-browser="firefox" data-os="macintel" data-dynload="" id="outbrain_widget_1">
+                                        <div class="ob_dual_container AR_3">
+                                            <span class="ob_empty"><wbr /></span>
+                                            <style type="text/css">
+                                            .voterDiv .ob_bctrl {
+                                                display: none;
+                                            }
+
+                                            .ob_pdesc IMG {
+                                                border: none;
+                                            }
+
+                                            .AR_3 .ob_what {
+                                                direction: ltr;
+                                                text-align: right;
+                                                clear: both;
+                                                padding: 5px 10px 0px;
+                                            }
+
+                                            .AR_3 .ob_what a {
+                                                color: #999;
+                                                font-size: 10px;
+                                                font-family: arial;
+                                                text-decoration: none;
+                                            }
+
+                                            .AR_3 .ob_what.ob-hover:hover a {
+                                                text-decoration: underline;
+                                            }
+
+                                            .AR_3 .ob_clear {
+                                                clear: both;
+                                            }
+
+                                            .AR_3 .ob_amelia,
+                                            .AR_3 .ob_logo,
+                                            .AR_3 .ob_text_logo {
+                                                display: inline-block;
+                                                vertical-align: text-bottom;
+                                                padding: 0px 5px;
+                                                box-sizing: content-box;
+                                                -moz-box-sizing: content-box;
+                                                -webkit-box-sizing: content-box;
+                                            }
+
+                                            .AR_3 .ob_amelia {
+                                                background: url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_16x16.png') no-repeat center top;
+                                                width: 16px;
+                                                height: 16px;
+                                                margin-bottom: -2px;
+                                            }
+
+                                            .AR_3 .ob_logo {
+                                                background: url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_67x12.png') no-repeat center top;
+                                                width: 67px;
+                                                height: 12px;
+                                            }
+
+                                            .AR_3 .ob_text_logo {
+                                                background: url('http://widgets.outbrain.com/images/widgetIcons/ob_text_logo_66x23.png') no-repeat center top;
+                                                width: 66px;
+                                                height: 23px;
+                                            }
+
+                                            .AR_3:hover .ob_amelia,
+                                            .AR_3:hover .ob_logo,
+                                            .AR_3:hover .ob_text_logo {
+                                                background-position: center bottom;
+                                            }
+
+                                            .AR_3 .ob_dual_container {
+                                                clear: both;
+                                            }
+
+                                            .AR_3 .ob_dual_left,
+                                            .AR_3 .ob_dual_right {
+                                                float: left;
+                                                width: 46%;
+                                                padding: 0 2%;
+                                            }
+
+                                            .AR_3 .ob_empty {
+                                                display: none;
+                                            }
+                                            </style>
+                                            <style class="ob-custom-css" type="text/css">
+                                            .OUTBRAIN .AR_3 .odb_li {
+                                                list-style-type: none !important;
+                                                margin-left: 0 !important;
+                                            }
+
+                                            .OUTBRAIN .AR_3 .obpd_header,
+                                            .OUTBRAIN .AR_3 .ob_org_header {
+                                                font-family: 'Euclid Bold', Arial, sans-serif;
+                                                text-transform: uppercase;
+                                                font-size: 20px !important;
+                                                height: 40px;
+                                                line-height: 40px;
+                                                color: white !important;
+                                                display: block;
+                                                background-color: black;
+                                                border-bottom: none !important;
+                                                padding-left: 10px;
+                                            }
+
+                                            .OUTBRAIN .AR_3 .ob_dual_left,
+                                            .OUTBRAIN .AR_3 .ob_dual_right {
+                                                width: 47%;
+                                                padding: 0;
+                                                margin: 0;
+                                            }
+
+                                            .OUTBRAIN .AR_3 .ob_dual_right {
+                                                padding-left: 5%;
+                                            }
+
+                                            .OUTBRAIN .AR_3 .rec-link,
+                                            .OUTBRAIN .AR_3 .rec-src-link {
+                                                color: #222 !important;
+                                                font-size: 16px;
+                                                line-height: 18px;
+                                                font-family: 'Sofia Pro Bold', 'Arial', sans-serif;
+                                            }
+
+                                            .OUTBRAIN .AR_3 .ob-text-content {
+                                                padding-top: 20px;
+                                            }
+
+                                            .OUTBRAIN .AR_3 .obpd_header {
+                                                margin: 0;
+                                                display: block;
+                                                padding-bottom: 0px;
+                                            }
+
+                                            .ob_what {
+                                                padding-top: 0px !important;
+                                            }
+
+                                            .OUTBRAIN .AR_3 .rec-link,
+                                            .OUTBRAIN .AR_3 .rec-src-link {
+                                                color: #222;
+                                                font-family: 'Sofia Pro Bold', 'Arial', sans-serif;
+                                                font-size: 16px;
+                                                line-height: 18px;
+                                            }
+
+                                            @media only screen and (min-device-width: 540px) and (max-device-width: 960px) and (orientation: portrait) {
+                                                .OUTBRAIN .AR_3 .ob_dual_left,
+                                                .OUTBRAIN .AR_3 .ob_dual_right {
+                                                    width: 100%;
+                                                    padding: 0;
+                                                    margin: 0;
+                                                    margin-top: 10px;
+                                                }
+                                            }
+
+                                            @media only screen and (min-device-width: 320px) and (max-device-width: 568px) and (orientation: portrait) {
+                                                .OUTBRAIN .AR_3 .ob_dual_left,
+                                                .OUTBRAIN .AR_3 .ob_dual_right {
+                                                    width: 100%;
+                                                    padding: 0;
+                                                    margin: 0;
+                                                    margin-top: 10px;
+                                                }
+                                            }
+
+                                            @media only screen and (min-device-width: 320px) and (max-device-width: 480px) {
+                                                .OUTBRAIN .AR_3 .ob_dual_left,
+                                                .OUTBRAIN .AR_3 .ob_dual_right {
+                                                    width: 100%;
+                                                    padding: 0;
+                                                    margin: 0;
+                                                    margin-top: 10px;
+                                                }
+                                            }
+                                            </style>
+                                            <div class="ob_dual_left">
+                                                <span class="obpd_header">From Around the Web</span>
+                                                <ul>
+                                                    <li class="odb_li ob-recIdx-0  ob-odd">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="nofollow" onmousedown="this.href='http://paid.outbrain.com/network/redir?p=zMAQF4GTMta9S9L_6l6wmoS9hS5YXQZFFbwTriSWpIh5xY9m3_FVaS1_4BDitmVqChIC9qwZRgb6cPwLb9qxC40u0PJ_OOxPFrW5fts3ttnjzMBb63NlFvQGOooozBE5b6dtNafx1XaJM9Q-6deZE3FKN_cDRKLhpJ3zYSLyKHhPVKheOp04Z5w0DXUu3v_i5_zRN891J1gxwREmeDXG8fLiWxUlBiLN1D0mbPq0CM4-V-SfK5170f6Dur_I6tOcCSzhQ63bUHvXJ9LaQV2c9El_GZqQRPkhZA6vMt5Cj2xj9eKAqJOxoMiiARCXb0OLD7MK4gNzpCNGDbOK45O6v9qYvbUo20Ufwb41u5VNQ2ggAipZbRW7YabJhOCy18APaY8Bs0SgR_s3Dzb_iy8Z8HwtpoNxlQEJQTC-HEx4hs4yk2LtVmLvuGvS5vVTasItNMFfVz-SRURbDAiczQ1rJ1G7XAt71kVjbuVYd-3dykImqmMU1-2gMrnS_Q20tyZqgcp2liDQUqkBmfCCKQHrxa3Lf9XPNp-RNNu9lBxLKSY&amp;c=af4f1444&amp;v=3';" href="http://www.willpowered.co/learn/daily-willpower-habits?utm_source=Outbrain&amp;utm_medium=CPC&amp;utm_campaign=Willpower%20Habits" onclick="" target="_blank">10 Daily Habits That Will Give You Incredible Willpower</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(Willpowered)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-1  ob-even">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="nofollow" onmousedown="this.href='http://paid.outbrain.com/network/redir?p=yx6cJNiLcsaMJKqW0SI8NIZOQZN7YhTBx_UdAXUjegbGGroVWKbsFuUUVBsCH7N4I_eC5t0Bdx-joEHijbs1PcpmGBGM0d-bYsHtRxLaTzb7Zl3g1k6Qeur6dIfNDE9lZ6aWAZCqUZFzEY1e8s96kBdlIFD2zVgnGiQYSPaBOsn-DkrIJwWEscOWt6n_vrKhqw-FomXw8_GvIFHVnGoA3AhS11hd-uNg6v9dvOeariHIYGH9jpY4dZ3N6zTPJ7T-B994zdQz4blcJnFVjbDlYrcHIvvbbkhu18eBj22ZgfWqu3THyW6c35ussAZXcy4YIKnta6ij21nYge6Rdm0bFNJ08y-U5KgzPF7b2ERYBKbPzX7yGmf0LZoFy3PsJUYxRV7Id45QmIY43ZvYVe6Wq5TCqgszRi1JrPYrtYxoi7fXtohlbbr5t5V2wHlwtgg5CMYogNQGQxCt-03PYAmSLw2gqpCaqarv9BTu3ozLL-xecqEddQx9Ibq6STkYRgjktC7xK50EqLxJ47ht8SQDXpVcLvNy1RaaXSCRnKrolrQ&amp;c=6a7967ac&amp;v=3';" href="https://overviewmarketingsolutions.com/what-metrics-should-you-be-tracking/?utm_source=Outbrain&amp;utm_medium=cpc&amp;utm_campaign=Subscribe%20" onclick="" target="_blank">What Website Metrics Should You Be Tracking?</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(OverView Marketing)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-2  ob-odd">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="nofollow" onmousedown="this.href='http://paid.outbrain.com/network/redir?p=3Q2tEiE2rt5Whh6grByS1GG_Y-u9o8sh1SBSi8DjGKYtO5aCFvdy-mR_cRW3Mq1dlSxEWz1T9Rl7ZkyHYGqcWaTrTs1Lmr31FrCSFE_s105Z0p42xdGsyX1HFWvQAfSceuzbdFVEGZEDrtC2k89RyNZIzmXO89AiWxuaZ6yO79SZkQ55__wu8LJlzlT1KfYBhSgCnMb_1myAN9L_EfaLf1BXK96tPLQZ7SKbIL-Pq6ESmw7JO2IFY_0CABe-HBMbpfKd9OSG6nhMTZXfTpE0sJHWaNXw0qOXoWpnrHv4buCP_lVCTwk8mIr54En-bjrTRlhqALG5F5uEzmzm2LztreJhRlqh2DQlAH6hNdpN_V15TwzbCEjtK4jZ8_SM_0ngl9Pyfc6a-S6x1gFSx1qBFM_dii7hrK2zBfJUbVkaVck8olrR0ICl1skQEzphWW_2Iw8_MGJ3i08j92ux0kkKi5VSg2bhvMkKQhw5-vfH_nIk6R5hIFnZ6lPNfhExp6eRfJygL4iEb6H0QXKVvh-s9hDMaMwFshl3C50GGPn1MBc&amp;c=79ccb35&amp;v=3';" href="https://milaap.org/stories/marilyn" onclick="" target="_blank">Help Marilyn Get Back Home To Her Daughters Again</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(Milaap.org)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-3  ob-even">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="nofollow" onmousedown="this.href='http://paid.outbrain.com/network/redir?p=cKymJdUSZTx3rZrrFFRjHd5pJleLnvjBPJdLqFUgfPTEcDh_hddRo3rLCXYh0Edc0L9Nf2GWmouS4S5fK65PPp40flMR4ikrqAQMot3SCen7IFdfIXsxYRLzaTWdP7uInNtw1UR0zZvkPwKboBC1oOaH86r25bNbjRUbdCYWogWnT514BrGVGynWg2H6L7PuGoPRFDOCAZoJzhRN1PJwza1uVrKEJzpk9G_xdFq00O3nxFV9AEO69F1taB3llt6fs-XW4kZ-0SNbyUkULxNHT68AoNyuq5Mgbj80Rx-3XZrgK7B2rBJtcA8JfhPN1CNcNKLGX5JVqHtfLI30FwI1OzzMjbIF_snpH2w4Jmgfna9v3TemH8oQBkVuMQcTBA0rQgIehX-uUghqTL02I1o6TrLAyj1bfugHyc5kSGWOGlbpvxgLC8-dwVUeXp54Zm9bUQ-yAU-sjEX4OiJrg-noFY-MQAczqcD9Lf79nQW4vZ14izO2xhQdHOc446ZyvTIXM-q9dkp8XcGaNgWFAt2FoRmsPXpXSR_9n4UwMNcA4Vs&amp;c=3c8560da&amp;v=3';" href="http://artsbeat.blogs.nytimes.com/2015/04/30/at-moma-dream-designs-on-instagram-the-reality/?WT.mc_id=2015-MAY-OTB-INTL_AUD_DEV-0503-0531&amp;WT.mc_ev=click&amp;ad-keywords=IntlAudDev" onclick="" target="_blank">At MoMA, Dream Designs. On Instagram, the Reality.</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(New York Times)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-4  ob-odd">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="nofollow" onmousedown="this.href='http://paid.outbrain.com/network/redir?p=rmCUH3gHSngpG6OvHnDQk5qLpH_PkYSJYMWNiBpLiA03Z8v_ecENw3MVG56C8Xb5NaQaaibz0vC3PS_OPraJFwazGNu7LckvE6HY2mAZnseiyJLq4LvSPVGdNiDvpQEIzY3uptK4apkVDlVIC-MUNNhcB5z1vLksWDij-BdQLdZ5DI5aV2HxuzecvYPjtrUBbsfHAxGZwQBFohwF7IokmY5zEEY18mqaBU76KvPbDo7bkW-XvE3WiAvjL7lJ2ANWbw4cAXB8Ii8ldgB1FtYNsDwjNzG90Fl9nP_HegrYNplXQ3NWAMZtIaSUDug8d9rz7E-jRomEJuZG5Da5zxh1BupmsVLcpbRvVsKwP2HBP-3ZrqBZ8dCRqGpODGyqo6NEJFGvBxDUMdwOsCkUufuvewCK8qoxlHpOlXdHqYBFVAlQGRzbBk9VmbKM0vshk60UomEvdSGb6XRiGeXouYrUbXx6vdvpQ6EXKkU3m--HpjrAwCW2XZMpQNeLDGDmxEQbjghnkC2hhCX33WG2as5v4qZWALrxu8pQ-YD_rr5JW8w&amp;c=4ed8ef76&amp;v=3';" href="http://asia.nikkei.com/Business/Deals/Future-group-Bharti-Retail-merge-retail-operations" onclick="" target="_blank">Indian retailers consolidate- Future group, Bharti Retail merge retail operations</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(Nikkei Asian Review)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-5  ob-even">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="nofollow" onmousedown="this.href='http://paid.outbrain.com/network/redir?p=YAiK6sr1C1hp6ptgc7qWOz0Ii930oN5MattR9dl9RtfsxwqCEpRWuXbLlI8pEX9VFF4EdpAbVFpFLf2gm-uZpXAhy-kOg3Io_bPMYbWIkdJ6A6bTiIJjCNLzFS1tnsIULnt6gGxiF_K6-EmnGMU4DUKGh5m1eDITd8yF-BLiK1Sv8g-MOelhTN_vppqvuC6pA9pjAT0-HkeQfpXr3jjnE_z5_Qy3XJnyOvlUaB15aIMEjTbYj9fEUAFelPiY0Xo_CzUpxDv3Wjb-hqqxxq_ufye1cvSIXAEcgD1I1T3BkVu2AQIholMJdRbQHB_Qn7RG8Cn_3N4iTwF14oyymMnHusgEVEljc4dr8gOQTmxnPbn5AVyKpptcsWAf7SQLT09etyiAJs34z-8vn8CZv7PQq09PjkNdBDpbsDFF5qId_jP8q4LDEmQyTQ2UjyAaMbOEG9pdRMgXIyETguy503pVu7G90C7Pt6zKfPP33GPJ-ZPlqpFht8T5JzOoma30y_2u39VOtSY4uRakqANWVsYRw1q0s6lEIRpLuq3CzAg3WNg&amp;c=22666ff1&amp;v=3';" href="http://www.talkmarkets.com/content/us-markets/uncle-buck-updated-april-30-2015?post=63990&amp;utm_source=outbrain&amp;utm_medium=referral" onclick="" target="_blank">Uncle Buck Updated - April 30, 2015</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(TalkMarkets)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-6  ob-odd">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="nofollow" onmousedown="this.href='http://paid.outbrain.com/network/redir?p=rMdmcAK5JwpzAQOspcY2hwljppLz5JFWTxshj3150lRZa-jacjAYoQPlYEUK64-Td8P1CWYlTJ5-4d7fPkCDIY6ukJII4FpE6kZwGsyXT1URDZBf524oN-Iuk7FRmZdBJyxkhlj0XLOdqhmszIHm0gdyBqjiOmv0BaMiQVayCQ4WzXRSD3yNMtfo2ctWp-obiIKZiXh3uQi5P1moWqhVBJerP9sQ9twaa9-lXil3FH9AdjgRvhaHuIB1ik4SP_N5K9d_fDwVTkhuwXT0mJUuhyDKnQnrDEXOM55-54t8sI7csHPZLzWaV5bQyJY3nTQgYtmmm0ggPIcFBI57AEvOHRXfRGdpFlhSJM33SCN2-xviLapLgiwWEPX9iPk9Yl78TNhyZP4baCXOuNozPtB12fKjqyDu-PaHyRfslnnnouvZuk-IY3Q2_3rqRONm2OJjg-_gVuA17Oco--aqCArX3rxbEtd-X9dURhmKI_XWKCTV0eWGr_AwoxEvOkVWHWQeXcRb426jRXAsosgpK8GTznh1SIVUtowdqbSHT-OqMxc&amp;c=b762163e&amp;v=3';" href="http://www.ozy.com/fast-forward/the-indian-version-of-uber-and-others/38025?utm_source=Outbrain&amp;utm_medium=CPC&amp;utm_campaign=INTL%20-%20All%20Clicks%20ALL%20Devices" onclick="" target="_blank">The Indian Version of Uber (and Others)</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(OZY)</span></span>
+                                                        </div>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="ob_dual_right">
+                                                <span class="ob_org_header">We Recommend</span>
+                                                <ul>
+                                                    <li class="odb_li ob-recIdx-0  ob-odd">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="" onmousedown="this.href='http://traffic.outbrain.com/network/redir?p=2l9r4xcRi-fqTth9fbNfXW0RYpu42L8UcQNAu7ZvI_Bz9PXTu3oNyMuTEm-EAEjCdND03OCfuqCoJbPgcx19R2JgjdFKY6Ay9ck-JfAignKNakuL3qyjJJWb94LXBjFK8qMOHrGLjB_I0BnzpUsWQ6dCydFRfIXK6Et6onCpb35bfCz-SiNARU4LI1-d5ijDZQKedM4fgGGgP6BQ_UBFLO05BA50MhyuTFco38ATKMAiV352mYwICYLvYHVeg_JMJvgnO1G43VPXSJRZgf6uVre3qrk36-19l2RFq3_IyB8L3KSCVMcVwd-ACgL03rr3m9WhiR-eI9xcejGg1n687u9gcPosJHsmJkfw4_SBNB0US7P6iLlBxqz_vTmvwolSHd2sZAWBxNk8xynldgHTyhKMV1ZBnqSdSSnPMeUVHEeXvwqHhj4Fp7bfuYPAH16xQ5puH-QyX7vPsGprahzrSg67R65F2kqC1O5o0WVxMTE&amp;c=9cfc878d&amp;v=3';" href="http://www.sfgate.com/bayarea/article/Mapping-the-drought-How-much-water-must-your-6240882.php" onclick="" target="_self">Mapping the drought: How much water must your community save?</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(SFGate)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-1  ob-even">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="" onmousedown="this.href='http://traffic.outbrain.com/network/redir?p=kN8Z1R0s99HgluZxEjim1c98nJlqPsWw4S1sznjQFc0zP1mv68qzHWRfvN_ANApBfHcjZbekFi6zQN_yzWG7lYL2J3c5_Q2aC5xbRXLvKUgYXB2Vw3b9Hvpmu900ziCKAk2zWJeVNQwuNNWKVG_iuZTOzWjijVmopjLIZMonGxScxiUkBeN7AIr2j7DJwwsxJowTHucEJ54MmontPa3nso4QOSqlctyPaGK_yDRJFdJNOwHe_ReavZI2DUCRk6mJWAjZX5nyac2hByjng43vMzJoVZZnff4iftgHsW_5l8Gifaqf3MLPZsyX6rawBR6o22gNEIEObKmXciaTwB3aGxZLk9Clhz_VNTE7I8JeiqHRQmm63eZXAvWCqUdadj-e_ePTBYmy4o2RmTdzMRyKhu6YPsGNnojiEd7wJjV0iIiyil9TfpkqLUZRLjCakT85iZyTz0I56HknVueRECVVEZatzC8ZKGyPhrKt7t44vxc&amp;c=1ab77a92&amp;v=3';" href="http://www.sfgate.com/sports/article/Raiders-say-Marv-Hubbard-has-died-6242236.php" onclick="" target="_self">Ex-Raiders fullback Marv Hubbard dies at 68</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(Sports)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-2  ob-odd">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="" onmousedown="this.href='http://traffic.outbrain.com/network/redir?p=OghISVW99_mpAkkHUuVMU0ALoEEh42QqnKECFpPIj-5pYQhUua-hnTdw1DoYyJYWoZb3CuzdfX7-zAsSQSP6jLtHxt9LGsiwID9IEtro9cGyNnBIwHF_2a4a32WHWItlu-qpHML5mHudvkJ_K6quADbn1ZkzYa6kJz20CwQg78YnkEPFwrBANhC0byFMSK_39aSwaOgd9VC0mFqp7bkk3DV5ELtZfFaciDoTkkYUJ_iJA2so3rW8Xz5MPAKybmHq_MFWR8dgo0mGc-WXUNAhamYkk3aAparR4LKRdpSin7q3isVydnCOkeel4EgV1qc4NpYUX9W4_C3RZuxvKAWes8Gngs00NosCn5m3B3AeK0Clten3PkfjrFH4SS5PeFq3OfxsyTauN65g-sPzN38Ep3KvwPwLWjdJxJis3P2dJIWk4rI4PCcn8DUHHVxXmEHwA-FwFT8fKcRsCxCG4xw7vyG_8rLHl54V1uLRBS-LnZY&amp;c=6ec68983&amp;v=3';" href="http://www.sfgate.com/news/article/Vonn-says-relationship-with-Woods-is-over-6239432.php" onclick="" target="_self">Vonn says relationship with Woods is over</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(News)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-3  ob-even">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="" onmousedown="this.href='http://traffic.outbrain.com/network/redir?p=Z1AVUvYqi-IB_TMMuYNmKe_BuViTpQQi6g-R0-6v10pr4Bc0WLdjyR_1yQ7d8vkV5-ab57GoQcsslRDUuw1fXMm3ltuIiV8U_C8yGOkTGrqs_K2p5iDqco7ukg2Zsf1LKOjKtbmicpBSFVo_dqiBjzGjNEqnCpeksL-HHn8ocUS2hMrc-XLURENAmE_IFAke2AaceRn7NCY4haTs2qFmSGhUtcfavnAO2oJWOAbYySZsrdmWX9mNp0RAAOZYdZMKs9HZfIMHfzk3Ykkupe2YA1tUycNt_iDRf_E6aK9SJdN0UVxqwHIcAWsbmvRF-IrrmcY-eKJE4vIoXCHC8eDBEL0T8iFD3L6yibqWsUBvFYWebax014NLpzw7QY3SgbLo7UJmnkxLgJW0r-DV9MFAOLK6tjYiEDRw917_mByedF6xkIWnpar4nol0_GGiZ8vwdbEJsjNDGTKOwaA3XRDetmKLk_-FkfLEdkP8rRC3WJc&amp;c=12a18666&amp;v=3';" href="http://www.sfgate.com/crime/article/Judge-sentences-gang-member-questions-agents-6237036.php" onclick="" target="_self">Judge sentences gang member, questions agents’ tactics in arrest</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(SFGate)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-4  ob-odd">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="" onmousedown="this.href='http://traffic.outbrain.com/network/redir?p=YRdPpYy8ivOhnOzsVXr-86CvWhxOZsZUyu3G90IHo-69Lb9YU-fRogNXt-P5DWpmV948e7Tv_P_5J7eN3lo26A07zwBVJGw4eNvPcLV75qm--7PeEBO4HudPUDGkeTGnRMsXNz14pt9IyMGie_MTzsNfcSdffCOiK71DmspbPLMrollDC-vys35x1kqZmqtCWbOTpitmgI0YHpvLAmWivfmopnhaHfIAf-7OlT26NlnqfFLYv_0KE7CyuT63W-4yRAnKwJFCHRmZF1V_t-VxKRaQbHffCBaMTFoSUQp8JQTOWrXGMXZrzF5XYq402I9XJB1fB289ibUJT1VIrLY4aTKGfBb19f8hP1hpOTShwJdujS4RyTvyVJgtPByW-GpNJhUfnT2wJStF_q4XEchwBY6IiMsab8-LI6_M_fum43iPIUfmHiiAtVZ1p-5xMVyW6KbxXXGZj3OoB4kvLGsVDQ6ibZUnF9zCEFB_u4tF1Mw&amp;c=e2fc3aad&amp;v=3';" href="http://www.sfgate.com/news/medical/article/Family-Teens-still-critical-6-weeks-after-resort-6240883.php" onclick="" target="_self">Family: Teens still critical 6 weeks after resort poisoning</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(News)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-5  ob-even">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="" onmousedown="this.href='http://traffic.outbrain.com/network/redir?p=uWRrN73jll_kHGoDGkgvqxg2xyhngz9HffXKVX6v_C9q5BWkj29ck19B--92Abl0hpGMCgjqbmwwy10G3UzGO404P_nm52Yw3itXt-ZnkJczNrf0wFS1XmlKERapsB_jLJ4eYIDZ4e4XngWEZisyH3VolA7Z-uwuSD3SirSujOoNp2414DgHRE8M_SauL-H4a7sGfTm-wDPHliHxH1v_WNBH3cMrz9J9_ulkvz1PcB3R-Az3ymnlXj4v-U8gAw4QUTG5lKuEsaFH8dCUU2Wk7y6vQ77_n_xDRDZt9c5aXcWrci2DwYZSumLvQL7E4dlYN2QtRcQz7Wg0rqk_AnWG50cg0WgxUoNqbL7mX6DtQk4TiBmtAVeYrFDmnBkd8NOwQirk0Dqnf5gTtUd_34OxUo6xV-_L01JSF0GUbiUud5bShu8-ASC2gUKCmpTBFJlwmi3eb5CS1w7L4GKG7EzyrQ2JGxw1Z_OM1ehZInhndd0&amp;c=df89f907&amp;v=3';" href="http://www.sfgate.com/news/article/Mini-Cooper-apparently-empty-goes-over-Treasure-6243240.php" onclick="" target="_self">Mini Cooper, apparently empty, goes over Yerba Buena Island cliff</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(News)</span></span>
+                                                        </div>
+                                                    </li>
+                                                    <li class="odb_li ob-recIdx-6  ob-odd">
+                                                        <div class="ob-text-content">
+                                                            <a class="rec-link" rel="" onmousedown="this.href='http://traffic.outbrain.com/network/redir?p=zCWKTuS5lIWevqZbsR4tT8jU08BIIme1mfZxq_Nf61fBjzKCuv-SmsEPdWRQu4StAErzc9snGY50YtT4DDkrfk5mAbNYPcxX1IaJBtdsj4fLS0gH-JkjRlMIJ8eu2nn8fgrOD3KvNDNkyCtCiy9mmAB9KteVSB4ETCU0GTzSzvUHDbW86L1elLjUnD8Cz1BS0hDnQoyk7Qqof72LhpCuX1yYp4CyDmPHxBZqRCeqt7_YAHQg7-KsM6JTDhdU6uUtIC6rUg3txEF2ZFGnaB4tINysIzOQUdiOKqJapMHGi5pbbGEvkuu_LJ5IJYTxBSkFcMEWoCme-F-TyER04Ck_waTBSp4hGOfTlGUrppwrcYeCY3jx0343AEuS_wqvFGUPEF8XjlmjCsW8_xhthLzrNo_BBgwEQJrCX33oVBx4asPij66TABA2Gu21ukrVURUlGwBNZ_fdWaQp29SfBVaa0YP-D3KQxdXyozGwzo_NQFo&amp;c=d2ccd334&amp;v=3';" href="http://www.sfgate.com/news/article/Man-allegedly-performed-webcam-sex-acts-as-6232935.php" onclick="" target="_self">Man allegedly performed webcam sex acts as children watched</a>
+                                                            <span class="ob_source"> <span class="rec-src-link">(News)</span></span>
+                                                        </div>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="ob_what">
+                                                <a onclick="OBR.extern.callWhatIs('http://www.outbrain.com/what-is/default/en','',-1,-1,true ,null);return false" onmousedown="" href="#">
+        Recommended by<span title="Outbrain" class="ob_amelia"></span>
+    </a>
+                                            </div>
+                                            <div class="ob_clear"></div>
+                                        </div>
+                                    </div>
+                                    <script src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"></script>
+                                </div>
+                                <div class="hdn_pm_post_mainwell_featured"></div>
+                            </div>
+                            <div class="widget ad_position clearfix widget-ad-position-B728 widget-fake">
+                                <div class="hdn-ad-position ad-B728 hdn-ap-visible-desktop">
+                                    <div class="juice-ad-position juice-ad-position-B728" id="B728">
+                                        <script id="B728-0-80429500-1430916267" type="text/javascript">
+                                        window.ad_position_widget.place_named_ad('B728', 'B728-0-80429500-1430916267');
+                                        </script>
+                                        <iframe width="1920" height="250" id="B728-ju1c3-TWFobmEgTWFobmE=-1fr4m3-1" name="B728-ju1c3-TWFobmEgTWFobmE=-1fr4m3-1" style="width: 728px; height: 90px; border: medium none; background-color: transparent; vertical-align: bottom;" scrolling="no" src="http://juice-files.sfgate.com/html/juiceframe?generationID=0x8D02BCA19C4A6A4CA4BE819B7EFEE027A26BD40D&amp;dm=sfgate.com&amp;slt=B728"></iframe>
+                                    </div>
+                                </div>
+                            </div>
+                            <span id="comments-anchor-large"></span>
+                            <div id="comments-section">
+                                <a id="comments"></a>
+                                <!-- /wp-content/plugins/hdn-viafoura-comments/comments_tmpl.php -->
+                                <a name="comments"></a>
+                                <div class="hdn-comments">
+                                    <div class="signin" id="modal_signin_div">
+                                        <div style="display:none;" id="modal_signin_error_div"></div>
+                                        <form method="post" action="http://www.sfgate.com/cgi-bin/sso/action/mobile_login" id="modal_signin_form" data-ajax="false">
+                                            <input type="text" placeholder="USERNAME" data-mini="true" value="" autocapitalize="off" selected="" maxlength="15" name="user" id="modal_signin_user" />
+                                            <input type="password" placeholder="PASSWORD" data-mini="true" value="" autocapitalize="off" selected="" maxlength="15" name="password" id="modal_signin_password" />
+                                            <input type="checkbox" class="custom-check" value="1" name="rememberme" id="modal_signin_rememberme" />
+                                            <label data-corners="false" for="modal_signin_rememberme">Remember Me</label>
+                                            <input type="hidden" value="Update" name="Submit" />
+                                            <p>
+                                                <input type="submit" class="submit-btn" data-corners="false" data-mini="true" value="Sign-in" />
+                                            </p>
+                                            <a class="hdn-comments form-link" href="http://www.sfgate.com/cgi-bin/webreg/user/reset_init">Forgot your password?</a>
+                                        </form>
+                                    </div>
+                                    <div id="hdn-vf-comments">
+                                        <div class="viafoura" name="comments">
+                                            <div data-widget="comments" class="vf-comments vf-widget" data-widget-id="2">
+                                                <div class="vf-commenting">
+                                                    <div data-view="page_settings" class="view vf-page-settings"></div>
+                                                    <ul class="vf-comments-meta vf-clearfix">
+                                                        <li class="vf-left"><b>
+    <b class="vf-total-comments">52</b> Comments
+                                                            </b>
+                                                        </li>
+                                                        <li class="vf-right"><a target="_blank" href="http://viafoura.com" class="vf-branding"><b>powered by:</b><span title="Viafoura" class="vf-logo"></span></a></li>
+                                                    </ul>
+                                                    <div class="vf-comment-box">
+                                                        <div data-id="0" class="vf-comment-user">
+                                                            <div class="vf-avatar-container">
+                                                                <img alt="Guest" src="https://cdn.viafoura.net/095e45d/img/defaultavatar.png" class="vf-avatar" onerror="this.src='https://cdn.viafoura.net/095e45d/img/defaultavatar.png'" />
+                                                            </div>
+                                                        </div>
+                                                        <form class="vf-comment-form">
+                                                            <div class="vf-textarea-container">
+                                                                <div class="vf-comment-textarea">
+                                                                    <textarea placeholder="Write your comment here" class="vf-content" name="vf_content"></textarea>
+                                                                </div>
+                                                            </div>
+                                                            <ul class="vf-comment-controls vf-clearfix">
+                                                                <li class="vf-left vf-upload-item"><a class="vf-record-video">Record video</a></li>
+                                                                <li class="vf-left vf-upload-item"><a class="vf-upload-video">Upload video</a>
+                                                                    <input type="file" class="vf-video-file" name="video" size="1" style="display: none;" />
+                                                                </li>
+                                                                <li class="vf-left vf-upload-item"><a class="vf-upload-image">Upload image</a>
+                                                                    <input type="file" class="vf-image-file" name="image" size="1" style="display: none;" />
+                                                                </li>
+                                                                <li class="vf-left">
+                                                                    <div style="display: none;" class="vf-progress-bar">
+                                                                        <div class="vf-progress"><span class="vf-progress-filename">–</span><a class="vf-progress-cancel" href="#">cancel</a></div>
+                                                                    </div>
+                                                                </li>
+                                                                <li class="vf-right"><span class="vf-char-count"></span>
+                                                                    <div class="vf-comment-submit-wrap">
+                                                                        <button type="submit" class="vf-comment-submit">Submit</button>
+                                                                        <div class="vf-tipsy-mask" style="display: none;"></div>
+                                                                    </div>
+                                                                </li>
+                                                            </ul>
+                                                            <span class="vf-error-box"></span>
+                                                        </form>
+                                                    </div>
+                                                    <div>
+                                                        <div class="vf-comments-setting vf-clearfix">
+                                                            <a data-title="subscribe-page" class="vf-btn vf-subscribe vf-tip" href="#" data-id="1619300001529">Follow</a>
+                                                            <div class="vf-comments-sort-block">
+                                                                <select class="vf-comments-sort">
+                                                                    <option value="newest">Newest</option>
+                                                                    <option value="oldest">Oldest</option>
+                                                                    <option value="likes">Most Liked</option>
+                                                                    <option value="editor-picks">Editor's Pick</option>
+                                                                    <option value="activity">Most Active</option>
+                                                                    <option value="replies">Most Replies</option>
+                                                                </select>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="vf-show-all-con" style="display: none;">
+                                                        <a class="vf-show-all vf-button" href="#">← Show all comments</a>
+                                                    </div>
+                                                    <div class="vf-horizontal-list"></div>
+                                                    <div class="vf-load-more-con" style="display: none;">
+                                                        <a class="vf-load-more" href="#">Show More</a>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- e /wp-content/plugins/hdn-viafoura-comments/comments_tmpl.php -->
+                                <!--after comments ad-->
+                                <!--after comments ad-->
+                            </div>
+                        </div>
+                    </div>
+                    <div class="left" id="sidebar">
+                        <div class="widget-ad-position-A300 widget ad_position" id="hdn_ad_position-0">
+                            <div class="hdn-ad-position ad-A300 hdn-ap-visible-mobile hdn-ap-visible-desktop">
+                                <div class="juice-ad-position juice-ad-position-A300" id="A300">
+                                    <script id="A300-0-80968800-1430916267" type="text/javascript">
+                                    window.ad_position_widget.place_named_ad('A300', 'A300-0-80968800-1430916267');
+                                    </script>
+                                    <iframe width="1920" height="250" id="A300-ju1c3-TWFobmEgTWFobmE=-1fr4m3-2" name="A300-ju1c3-TWFobmEgTWFobmE=-1fr4m3-2" style="width: 300px; height: 250px; border: medium none; background-color: transparent; vertical-align: bottom;" scrolling="no" src="http://juice-files.sfgate.com/html/juiceframe?generationID=0x8D02BCA19C4A6A4CA4BE819B7EFEE027A26BD40D&amp;dm=sfgate.com&amp;slt=A300"></iframe>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="widget widget_text" id="text-7">
+                            <div class="textwidget">
+                                <div data-ob-template="sfgate" data-widget-id="SB_2" data-src="$permalink" class="OUTBRAIN" data-ob-mark="true" data-browser="firefox" data-os="macintel" data-dynload="" id="outbrain_widget_2">
+                                    <div class="ob_strip_container SB_2">
+                                        <span class="ob_empty"><wbr /></span>
+                                        <style type="text/css">
+                                        .voterDiv .ob_bctrl {
+                                            display: none;
+                                        }
+
+                                        .ob_pdesc IMG {
+                                            border: none;
+                                        }
+
+                                        .SB_2 .ob_what {
+                                            direction: ltr;
+                                            text-align: right;
+                                            clear: both;
+                                            padding: 5px 10px 0px;
+                                        }
+
+                                        .SB_2 .ob_what a {
+                                            color: #999;
+                                            font-size: 10px;
+                                            font-family: arial;
+                                            text-decoration: none;
+                                        }
+
+                                        .SB_2 .ob_what.ob-hover:hover a {
+                                            text-decoration: underline;
+                                        }
+
+                                        .SB_2 .ob_clear {
+                                            clear: both;
+                                        }
+
+                                        .SB_2 .ob_amelia,
+                                        .SB_2 .ob_logo,
+                                        .SB_2 .ob_text_logo {
+                                            display: inline-block;
+                                            vertical-align: text-bottom;
+                                            padding: 0px 5px;
+                                            box-sizing: content-box;
+                                            -moz-box-sizing: content-box;
+                                            -webkit-box-sizing: content-box;
+                                        }
+
+                                        .SB_2 .ob_amelia {
+                                            background: url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_16x16.png') no-repeat center top;
+                                            width: 16px;
+                                            height: 16px;
+                                            margin-bottom: -2px;
+                                        }
+
+                                        .SB_2 .ob_logo {
+                                            background: url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_67x12.png') no-repeat center top;
+                                            width: 67px;
+                                            height: 12px;
+                                        }
+
+                                        .SB_2 .ob_text_logo {
+                                            background: url('http://widgets.outbrain.com/images/widgetIcons/ob_text_logo_66x23.png') no-repeat center top;
+                                            width: 66px;
+                                            height: 23px;
+                                        }
+
+                                        .SB_2:hover .ob_amelia,
+                                        .SB_2:hover .ob_logo,
+                                        .SB_2:hover .ob_text_logo {
+                                            background-position: center bottom;
+                                        }
+
+                                        .SB_2 .ob_container {
+                                            width: 100%;
+                                            position: relative;
+                                            overflow: hidden;
+                                        }
+
+                                        .SB_2 .strip-img {
+                                            width: 109px;
+                                            height: 70px;
+                                            border: none !important;
+                                            margin: 0px !important;
+                                            display: block;
+                                            padding: 0px !important;
+                                        }
+
+                                        .SB_2 .item-link-container {
+                                            text-decoration: none;
+                                        }
+
+                                        .SB_2 .strip-rec-link-title {
+                                            font-size: 13px;
+                                            font-weight: normal;
+                                            line-height: 16px;
+                                        }
+
+                                        .SB_2 .strip-rec-link-source {
+                                            font-size: 12px;
+                                            line-height: 16px
+                                        }
+
+                                        .SB_2 .strip-like {
+                                            padding-bottom: 4px;
+                                            font-size: 14px;
+                                            line-height: 16px;
+                                            height: 20px;
+                                            font-weight: bold;
+                                        }
+
+                                        .SB_2 .item-container a,
+                                        .SB_2 .item-container a:hover,
+                                        .SB_2 .item-container a:visited {
+                                            border: medium none;
+                                            text-decoration: none;
+                                        }
+
+                                        .SB_2 .ob_video {
+                                            border: medium none;
+                                            position: absolute;
+                                            top: 5px;
+                                            left: 5px
+                                        }
+
+                                        .SB_2 .ob-rec-link-img {
+                                            position: relative;
+                                        }
+
+                                        .SB_2 .wbr:before {
+                                            content: \"\200B\"}
+ .SB_2 .ob-rec-link-img {
+                                                float: left;
+                                            }
+                                            .SB_2 .ob-text-content {
+                                                text-align: left;
+                                                padding-left: 114px;
+                                            }
+                                            .SB_2 .item-container {
+                                                position: relative;
+                                                height: 72px;
+                                                padding-bottom: 9px;
+                                                width: 100%;
+                                                clear: both;
+                                            }
+                                            .SB_2 .item-container A {
+                                                display: inline;
+                                            }
+                                            .SB_2 .item-container A.ob-text-content {
+                                                display: block;
+                                            }
+                                            .SB_2 .ob_container_shadow_outer {
+                                                display: none;
+                                            }
+                                            .SB_2 .item-container-obpd .obpd {
+                                                text-decoration: none;
+                                                border-color: #eee;
+                                                border-style: solid;
+                                                border-width: 2px 2px 0 0;
+                                                color: #fff;
+                                                font-family: verdana, arial, sans-serif;
+                                                font-size: 9px;
+                                                font-size-adjust: none;
+                                                font-stretch: normal;
+                                                font-style: normal;
+                                                font-variant: normal;
+                                                font-weight: normal;
+                                                line-height: normal;
+                                                padding: 2px 4px;
+                                                position: absolute;
+                                                left: 0;
+                                                top: 52px;
+                                                z-index: 10;
+                                            }
+                                        </style>
+                                        <style class="ob-custom-css" type="text/css">
+                                        .OUTBRAIN .SB_2 .ob_org_header {
+                                            display: block;
+                                            font-family: 'Euclid Bold', Arial, sans-serif;
+                                            font-size: 20px;
+                                            line-height: 45px;
+                                            font-style: normal;
+                                            text-transform: uppercase;
+                                            background-color: #000;
+                                            height: 45px;
+                                            color: #FFF;
+                                            padding: 0px 0px 0px 0px;
+                                            margin: 0;
+                                            text-align: center;
+                                            overflow: hidden;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .strip-img {
+                                            width: 120px !important;
+                                            height: 80px !important;
+                                        }
+
+                                        .OUTBRAIN a {
+                                            display: block;
+                                        }
+
+                                        .ob_org_header {
+                                            display: block
+                                        }
+
+                                        .ob_container_recs {
+                                            padding: 15px;
+                                        }
+
+                                        .ob_strip_container .OUTBRAIN .SB_2 .ob_what {
+                                            height: 28px;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .ob_amelia {
+                                            margin-bottom: 5px;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .item-container {
+                                            padding-top: 0px !important;
+                                            padding-bottom: 15px;
+                                            height: auto;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .ob-text-content {
+                                            padding-left: 15px;
+                                            float: left;
+                                            width: 131px;
+                                            color: #000000 !important;
+                                            font-family: 'Arial', sans-serif;
+                                            font-size: 12px;
+                                            line-height: 18px;
+                                            max-height: 4.5em;
+                                            font-weight: bold;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .item-container:after {
+                                            visibility: hidden;
+                                            display: block;
+                                            font-size: 0;
+                                            content: '';
+                                            clear: both;
+                                            height: 0;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .strip-rec-link-title {
+                                            max-height: 4.5em;
+                                            font-weight: bold;
+                                            overflow: hidden;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .strip-rec-link-title:hover {
+                                            text-decoration: underline;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .strip-rec-link-title:visited {
+                                            color: #777 !important;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .ob_source,
+                                        {
+                                            color: #000000;
+                                            font-family: 'Sofia Pro Bold', 'Arial', sans-serif;
+                                            font-size: 16px;
+                                            line-height: 18px;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .ob_what {
+                                            margin-top: -33px;
+                                            padding: 0 5px 0 !important;
+                                        }
+
+                                        .ob_strip_container {
+                                            padding-bottom: 10px;
+                                            border-bottom: 2px solid #ccc;
+                                        }
+
+                                        .ob_empty {
+                                            display: none;
+                                        }
+
+                                        .ob_what a {
+                                            color: #999999;
+                                            font-family: 'Arial', sans-serif;
+                                            font-size: 10px;
+                                            line-height: 18px;
+                                            text-decoration: none;
+                                            text-transform: uppercase;
+                                        }
+
+                                        .OUTBRAIN {
+                                            border-top: 0px;
+                                            padding: 0px !important;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .strip-rec-link-title {
+                                            font-family: 'Sofia Pro Bold', 'Arial', sans-serif;
+                                            font-size: 16px;
+                                            line-height: 18px;
+                                        }
+                                        /* Merge these with the selectors in your css, don't just put them at the end. */
+
+                                        .ob_strip_container {
+                                            border-bottom: none !important;
+                                            /*should be able to remove !important once css is merged in*/
+                                        }
+
+                                        .OUTBRAIN .SB_2 .item-container,
+                                        .OUTBRAIN .MB_1 .ob_title_custom {
+                                            display: table;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .item-link-container:last-child .item-container {
+                                            padding-bottom: 0px !important;
+                                            /* MAY be able to remove !important once css is merged in*/
+                                        }
+
+                                        .OUTBRAIN .SB_2 .ob-text-content,
+                                        .MB_1 .ob-text-content {
+                                            display: table-cell;
+                                            vertical-align: middle;
+                                            float: none !important;
+                                            /*should be able to remove !important once css is merged in*/
+
+                                            width: initial !important;
+                                            /*should be able to remove !important once css is merged in*/
+                                        }
+
+                                        .SB_2 .ob-rec-link-img,
+                                        .MB_1 .ob-rec-link-img {
+                                            display: table-cell;
+                                            vertical-align: middle;
+                                            float: none !important;
+                                            /*should be able to remove !important once css is merged in*/
+
+                                            width: 120px;
+                                            height: 80px;
+                                            margin: 0 !important;
+                                            /* MAY be able to remove !important once css is merged in*/
+
+                                            padding: 0;
+                                        }
+
+                                        .OUTBRAIN .SB_2 .ob_what {
+                                            margin-top: -23px !important;
+                                            /*should be able to remove !important once css is merged in*/
+
+                                            margin-bottom: -10px;
+                                        }
+
+                                        .OUTBRAIN .AR_5 .ob_container_recs .item-container {
+                                            padding-top: 20px !important;
+                                            /*should be able to remove !important once css is merged in*/
+                                        }
+
+                                        .OUTBRAIN .AR_3 .odb_li:first-child .ob-text-content {
+                                            padding-top: 15px;
+                                        }
+
+                                        .AR_3 .ob_what a {
+                                            text-transform: lowercase;
+                                        }
+
+                                        .SB_2 .ob-lcolor {
+                                            color: #000;
+                                        }
+
+                                        .OUTBRAIN div.MB_1 {
+                                            background: none !important;
+                                        }
+
+                                        .OUTBRAIN .MB_1 .ob_dual_left,
+                                        .OUTBRAIN .MB_1 .ob_dual_right {
+                                            background: #fff;
+                                            float: none;
+                                            width: 100%;
+                                            padding: 0;
+                                        }
+
+                                        .MB_1 .ob_org_header,
+                                        body .MB_1 .obpd_header {
+                                            margin: 0 !important;
+                                            /*should be able to remove !important once css is merged in*/
+
+                                            padding: 0 !important;
+                                            /*should be able to remove !important once css is merged in*/
+                                        }
+
+                                        .OUTBRAIN .MB_1 .odb_div {
+                                            height: auto !important;
+                                            /*should be able to remove !important once css is merged in*/
+
+                                            padding: 20px 15px 0px 15px !important;
+                                            /*should be able to remove !important once css is merged in*/
+                                        }
+
+                                        .OUTBRAIN .MB_1 .ob_dual_left .odb_div:last-child {
+                                            padding-bottom: 20px !important;
+                                            /* MAY be able to remove !important once css is merged in*/
+                                        }
+
+                                        .OUTBRAIN .MB_1 .ob-text-content {
+                                            padding: 0;
+                                        }
+
+                                        .OUTBRAIN .MB_1 .strip-img {
+                                            width: 120px;
+                                            height: auto;
+                                        }
+
+                                        .OUTBRAIN .MB_1 .odb_div .ob-rec-link-img a {
+                                            width: 120px;
+                                            height: 80px;
+                                            max-height: 80px;
+                                            margin-right: 15px;
+                                        }
+
+                                        .MB_1 .ob_video {
+                                            top: 46% !important;
+                                            /*should be able to remove !important once css is merged in*/
+
+                                            left: 58px !important;
+                                            /*should be able to remove !important once css is merged in*/
+                                        }
+
+                                        body .MB_1 .ob_what a {
+                                            text-transform: lowercase;
+                                        }
+
+                                        .MB_1 .ob_what {
+                                            margin-top: -6px;
+                                        }
+
+                                        @media screen and (max-width: 767px) {
+                                            .OUTBRAIN .SB_2 .item-container {
+                                                padding-bottom: 20px !important;
+                                                /* MAY be able to remove !important once css is merged in*/
+                                            }
+                                            .OUTBRAIN .SB_2 .ob_what {
+                                                margin-top: -19px !important;
+                                                /*should be able to remove !important once css is merged in*/
+                                            }
+                                        }
+                                        </style>
+                                        <span class="ob_org_header">
+You Might Also Like
+</span>
+                                        <div class="ob_container">
+                                            <div class="ob_container_recs">
+                                                <a rel="nofollow" target="_blank" onmousedown="outbrain.recClicked(event,this);" onclick="" data-redirect="http://paid.outbrain.com/network/redir?p=ujB1DB7FUX_9yW4vGUcentHs8QWicbH5BvSaScOeP4iSJMnTnODjo0WdNLiywSaZs2u4z6SX8sbi5Cwh7kfu1_yt0XYnoPV4HM0qmV-ZTRqYD9h0T_ONwzU9NGrwj4kexoB68e02geGuJ78eHpMOi292iy3mKz62idH4WK3OYKW3BmyvaQ6Fs7SAgyozHloUXM0dbtrXUlmTfo3vEwxStsZ_p5XUOGgCqSBpWOEuX0v9wVwjk18xUWW-O3r_q1HML1gTjPlKQpDMXRtReiHMN81qgb0L_GuYfc9vujd3xyzjs_oAgzydqRiRgWDaK1prwxF0SAvKRepJ8VjFFjEpa7cn2az7fS8PFzYdrr91_eq2rLLIKlAMv0LYhdZWuXlY8aYBY_p0BMrqE6aE7_QjdZepdNHJpHkPmBJBsNUKAIGrv5OjvzBE4BV-gNGt21twgPh2N5HdjSARHj3g6HxixpRWdUYGZoTs20-T51noJr5HGcZIbGVQ50eYDI9x2YJTcmELSM-jnNGG4tb8r6UvTsPDBjOlKqJSlyRe-5_jno0&amp;c=4e5b89f7&amp;v=3" href="http://www.talkmarkets.com/content/macro-analytics-learning-to-innovate--with-charles-hugh-smith?post=64151&amp;utm_source=outbrain&amp;utm_medium=referral" class="item-link-container ob-odd">
+                                                    <div class="item-container ob-recIdx-0  item-container-obpd ">
+                                                        <div class="ob-rec-link-img ob-tcolor">
+                                                            <img width="109" height="70" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/Kz6e/n/15HsiH/abc/10puYW/15HsiH-SNC-109x70.jpg" alt="Macro Analytics - Learning To Innovate, With Charles Hugh Smith" class="strip-img" title="Macro Analytics - Learning To Innovate, With Charles Hugh Smith" onload="this.style.visibility=''" style="" />
+                                                        </div>
+                                                        <div class="ob-text-content">
+                                                            <div class="strip-rec-link-title ob-tcolor">Macro Analytics - Learning To Innovate, With…</div>
+                                                            <div class="strip-rec-link-source ob-lcolor">
+                                                                <span class="ob_source">(TalkMarkets)</span> </div>
+                                                        </div>
+                                                    </div>
+                                                </a>
+                                                <a rel="nofollow" target="_blank" onmousedown="outbrain.recClicked(event,this);" onclick="" data-redirect="http://paid.outbrain.com/network/redir?p=plAYUyFcbQrJO_G34NOZZNpVALueoQMWhZpyQ7rhVXkGPfyYfvWo2oONj6XVXQJbcnUPIpFQW0Q3vVHurj8icHHPKPqmyNlLy1RvIWUfn9DKP-Nr9rd6sDa_ZP_yJ5aTwsT-BxGM8Ky0UKg_J3bVZ33kxazmWlzaYTsJ3TR4IVMXxnyF8hzSQOq5WWct4cps7aBlmVO1qqq-X3LdYFnqoBnKl2gEyfsUw6-3w5KXp_yNICUJpz-QcFU0PRW0X2VVXYDdLPbYdKNVGpwoGyhubGFqsKlq4nHef4SZ__siVNxZCZNmRw9twcGk2v6OLtZu7g35tPbzw6ky2YZzxz1CMYaOBDdNwLJ16Q6dvc0YrDLUXVlnxBybFDgK-omcZnbhlOt_7qcDuTa2rsskxLwZ_LNBReVyEniaB2c3SGODGVlIAitU1qifAgtPSrBmcd3A5hKac0h_PkdqV30bVCxL9JlTdV7RuV-zVHMAfleglfE6pX6xXp4czLC9q_QFiIbKE_AsSD0JA0JIC6Lylzr_bLJtXtbX2IvcywsQChYiNNI&amp;c=e9a5f104&amp;v=3" href="http://www.ozy.com/fast-forward/the-new-new-thing-the-internet-of-things/32714?utm_source=Outbrain&amp;utm_medium=CPC&amp;utm_campaign=INTL%20-%20All%20Clicks%20ALL%20Devices" class="item-link-container ob-even">
+                                                    <div class="item-container ob-recIdx-1  item-container-obpd ">
+                                                        <div class="ob-rec-link-img ob-tcolor">
+                                                            <img width="109" height="70" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/L8LH/n/z3jLT/abc/10exhg/z3jLT-SNC-109x70.jpg" alt="The New New Thing: The Internet of Things" class="strip-img" title="The New New Thing: The Internet of Things" onload="this.style.visibility=''" style="visibility:hidden;" />
+                                                        </div>
+                                                        <div class="ob-text-content">
+                                                            <div class="strip-rec-link-title ob-tcolor">The New New Thing: The Internet of Things</div>
+                                                            <div class="strip-rec-link-source ob-lcolor">
+                                                                <span class="ob_source">(OZY)</span> </div>
+                                                        </div>
+                                                    </div>
+                                                </a>
+                                                <a rel="nofollow" target="_blank" onmousedown="outbrain.recClicked(event,this);" onclick="" data-redirect="http://paid.outbrain.com/network/redir?p=qOOvCIMDydaEFpClJA3x_4eSB7xbgTdTgz79Le5a0YUzR8cXi3bGkvnD114MMWVPbRl2qEooIjkerSZ-XpRk_WHchzyFVNKhd9k_-82bKJ9fIyAXiCdKftH08bh5lRKlf1fy_cdsBZShDTY1mFBX-9dcd6R-y_68WvnmwmgTiLyuF1vxVaMsTeHlgfJ3V1xUKmryfqoBWBwx2apUfi1aOkZDT8ZO2iq8RFGXOBYf69kXxsRou4UZHlgEe-EqpCNQIzKEqmZBhVvelcEByjXDkK13HQoKrrrZ5ym-WhxnFf7OkC75HtcjG-qu14jrSwGjA06dx8NLDF_bnkKVTAr1FqwJ1kGde2WEu2h9jzEBcPkEhv4Ojl90Ph3yd_oh7jbCp8v-iaSGWOr2im6fi0GDVGnGTgNlzyRGf0wq_u-uY33NdBLy072p21HuQI350Mm1TUTn8JnvQ2qQSljCh4CA6GOhul22UQliPnXfESIkVT4TeTShkt9sgR9l8_RaJGzQGWFAkoq94YNLZxepyYWQVYZyMea_FfmIxBxmlp8OqaQ&amp;c=2085d95b&amp;v=3" href="http://asia.nikkei.com/Politics-Economy/International-Relations/Foreigners-go-before-firing-squad-despite-international-appeals" class="item-link-container ob-odd">
+                                                    <div class="item-container ob-recIdx-2  item-container-obpd ">
+                                                        <div class="ob-rec-link-img ob-tcolor">
+                                                            <img width="109" height="70" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/Ln8d/a/14ymuL/2WTme/0/14ymuL-SNC-109x70.jpg" alt="Indonesia executions - Foreigners go before firing squad despite international appeals" class="strip-img" title="Indonesia executions - Foreigners go before firing squad despite international appeals" onload="this.style.visibility=''" style="" />
+                                                        </div>
+                                                        <div class="ob-text-content">
+                                                            <div class="strip-rec-link-title ob-tcolor">Indonesia executions - Foreigners go before…</div>
+                                                            <div class="strip-rec-link-source ob-lcolor">
+                                                                <span class="ob_source">(Nikkei Asian Review)</span> </div>
+                                                        </div>
+                                                    </div>
+                                                </a>
+                                                <a rel="nofollow" target="_blank" onmousedown="outbrain.recClicked(event,this);" onclick="" data-redirect="http://paid.outbrain.com/network/redir?p=qM27jVDLRGcMV34PuFKfl8Xw5J6a5mXK3c0jvX4meWW_Ue2CZ1zoINlAmeNAoYKErGrmxT4mwHt_KctZ2lbkozm5LOSKsyR-pB-PJyXx9Bsgt23H3cZP6b71r9Rx5NJ9eGZrnbuSCHCpxr77hsahrL_OqpobqzTDUs399PLowSwMhoPvpuT1aGDmOS4D9kI9JL_P2WKkUAAv8E9BMNyhGv_ioqC4NeEoKy1fd99hb0DeiUCJKBPai2Nhx4zYsJtGx_2BZHhMvr4aM1x0FOFQ12Gl-Q9gL-ZsuvZPLjQT5wvPBlm5xL-unBVT2x8_v9XXhA8_V_GCN_S0KQY5qT3IxBVkaMKSollRVo65b5Cxn6N3nMmYalreM6dJZNPkTwDvAf5NppSDkPmff0mslp4O_BF-7WPNOdMkatJOi7Mp7euiruF1QAcHxEy_qmB34n4YcPZ6U9g28dToYNNYK6OO5ZHmThS0mj7hLtzV4HtTQBfWT1Es1qJt_delYczy5uDaHWgsR6WQSJ4AGgzUioD_iX7feJr0tJXjAx4czyMxpTS-U1xBVCrhUreGf9O7LSmz&amp;c=c90bdbb7&amp;v=3" href="http://blog.quarkexpeditions.com/photo-fun-how-to-take-polar-jumping-selfies" class="item-link-container ob-even">
+                                                    <div class="item-container ob-recIdx-3  item-container-obpd  ob-last ">
+                                                        <div class="ob-rec-link-img ob-tcolor">
+                                                            <img width="109" height="70" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/MWqX/a/155IZz/2XEfM/0/155IZz-SNC-109x70.jpg" alt="Photo Fun: How to Take Polar Jumping Selfies" class="strip-img" title="Photo Fun: How to Take Polar Jumping Selfies" onload="this.style.visibility=''" style="" />
+                                                        </div>
+                                                        <div class="ob-text-content">
+                                                            <div class="strip-rec-link-title ob-tcolor">Photo Fun: How to Take Polar Jumping Selfies</div>
+                                                            <div class="strip-rec-link-source ob-lcolor">
+                                                                <span class="ob_source">(Quark Expeditions® Blog)</span> </div>
+                                                        </div>
+                                                    </div>
+                                                </a>
+                                            </div>
+                                            <div class="ob_container_shadow_outer">
+                                                <div class="ob_container_shadow">
+                                                    <div class="item-container-shadow ob-recIdx-0   ob-odd">
+                                                        <div class="item-container ob-recIdx-0  item-container-obpd ">
+                                                            <div class="ob-rec-link-img ob-tcolor">
+                                                                <img width="109" height="70" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/Kz6e/n/15HsiH/abc/10puYW/15HsiH-SNC-109x70.jpg" alt="Macro Analytics - Learning To Innovate, With Charles Hugh Smith" class="strip-img" title="Macro Analytics - Learning To Innovate, With Charles Hugh Smith" onload="this.style.visibility=''" style="" />
+                                                            </div>
+                                                            <div class="ob-text-content">
+                                                                <div class="strip-rec-link-title ob-tcolor">Macro Analytics - Learning To Innovate, With…</div>
+                                                                <div class="strip-rec-link-source ob-lcolor">
+                                                                    <span class="ob_source">(TalkMarkets)</span> </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="item-container-shadow ob-recIdx-1  ob-even">
+                                                        <div class="item-container ob-recIdx-1  item-container-obpd ">
+                                                            <div class="ob-rec-link-img ob-tcolor">
+                                                                <img width="109" height="70" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/L8LH/n/z3jLT/abc/10exhg/z3jLT-SNC-109x70.jpg" alt="The New New Thing: The Internet of Things" class="strip-img" title="The New New Thing: The Internet of Things" onload="this.style.visibility=''" style="visibility:hidden;" />
+                                                            </div>
+                                                            <div class="ob-text-content">
+                                                                <div class="strip-rec-link-title ob-tcolor">The New New Thing: The Internet of Things</div>
+                                                                <div class="strip-rec-link-source ob-lcolor">
+                                                                    <span class="ob_source">(OZY)</span> </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="item-container-shadow ob-recIdx-2   ob-odd">
+                                                        <div class="item-container ob-recIdx-2  item-container-obpd ">
+                                                            <div class="ob-rec-link-img ob-tcolor">
+                                                                <img width="109" height="70" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/Ln8d/a/14ymuL/2WTme/0/14ymuL-SNC-109x70.jpg" alt="Indonesia executions - Foreigners go before firing squad despite international appeals" class="strip-img" title="Indonesia executions - Foreigners go before firing squad despite international appeals" onload="this.style.visibility=''" style="" />
+                                                            </div>
+                                                            <div class="ob-text-content">
+                                                                <div class="strip-rec-link-title ob-tcolor">Indonesia executions - Foreigners go before…</div>
+                                                                <div class="strip-rec-link-source ob-lcolor">
+                                                                    <span class="ob_source">(Nikkei Asian Review)</span> </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="item-container-shadow ob-recIdx-3  ob-even">
+                                                        <div class="item-container ob-recIdx-3  item-container-obpd  ob-last ">
+                                                            <div class="ob-rec-link-img ob-tcolor">
+                                                                <img width="109" height="70" onerror="outbrain.imageError(this)" src="http://images.outbrain.com/imageserver/v2/s/MWqX/a/155IZz/2XEfM/0/155IZz-SNC-109x70.jpg" alt="Photo Fun: How to Take Polar Jumping Selfies" class="strip-img" title="Photo Fun: How to Take Polar Jumping Selfies" onload="this.style.visibility=''" style="" />
+                                                            </div>
+                                                            <div class="ob-text-content">
+                                                                <div class="strip-rec-link-title ob-tcolor">Photo Fun: How to Take Polar Jumping Selfies</div>
+                                                                <div class="strip-rec-link-source ob-lcolor">
+                                                                    <span class="ob_source">(Quark Expeditions® Blog)</span> </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="ob_what">
+                                            <a onclick="OBR.extern.callWhatIs('http://www.outbrain.com/what-is/default/en','',-1,-1,true ,null);return false" onmousedown="" href="#">
+                                                <span title="Outbrain" class="ob_amelia"></span>
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <script src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"></script>
+                            </div>
+                        </div>
+                        <div class="widget widget_text" id="text-12">
+                            <div class="textwidget">
+                                <div id="SearchWithPhotos"></div>
+                                <p>
+                                    <script type="text/javascript">
+                                    plsWidgets.push(['ListingSearch', {
+                                        "domId": "SearchWithPhotos",
+                                        "title": "SEARCH LOCAL LISTINGS",
+                                        "use_search_form": "1",
+                                        "use_links": "",
+                                        "use_listings": "1",
+                                        "use_for_sale": "1",
+                                        "use_rentals": "1",
+                                        "use_open_house": "1",
+                                        "for_sale_url": "http://realestate.sfgate.com/listing-search/?sort_field=featured_weight&amp;sort_direction=desc&amp;search_num_results=10&amp;purchase_types=buy&amp;curr_page=1&amp;view=gallery\t\t\t",
+                                        "rentals_url": "http://realestate.sfgate.com/for-rent/?sort_field=featured_weight&amp;sort_direction=desc&amp;search_num_results=10&amp;purchase_types=rental&amp;curr_page=1&amp;view=gallery",
+                                        "open_house_url": "http://realestate.sfgate.com/open-houses/?sort_field=featured_weight&amp;sort_direction=desc&amp;search_num_results=10&amp;open_house_filter_start_utc=1430118000&amp;open_house_filter_end_utc=1461826799&amp;purchase_types=buy&amp;curr_page=1&amp;view=gallery",
+                                        "placeholder": "Enter City, Zip, Amenity...",
+                                        "col_0_title": "",
+                                        "col_0_link_0_text": "",
+                                        "col_0_link_0_url": "",
+                                        "col_0_link_1_text": "",
+                                        "col_0_link_1_url": "",
+                                        "col_0_link_2_text": "",
+                                        "col_0_link_2_url": "",
+                                        "col_0_link_3_text": "",
+                                        "col_0_link_3_url": "",
+                                        "col_0_link_4_text": "",
+                                        "col_0_link_4_url": "",
+                                        "listings_title": "",
+                                        "searchParams": {
+                                            "text_search": "",
+                                            "search_num_results": "3",
+                                            "min_beds": "",
+                                            "min_baths": "",
+                                            "min_price": "",
+                                            "max_price": "",
+                                            "locality": "",
+                                            "neighborhood": "",
+                                            "zip": "",
+                                            "region": "",
+                                            "min_sqft": "",
+                                            "max_sqft": ""
+                                        }
+                                    }]);
+                                    </script>
+                                </p>
+                            </div>
+                        </div>
+                        <div class="widget widget_text" id="text-11">
+                            <div class="textwidget">
+                                <iframe width="320" height="240" frameborder="0" scrolling="no" src="http://ads.placester.net/ad?placement_id=eh_2&amp;siteid=sfgate&amp;cid=sfgatefrontpage&amp;amp" style="width: 300px; height: 330px; overflow: hidden; border: none;"></iframe>
+                            </div>
+                        </div>
+                        <div class="widget widget_text" id="text-14">
+                            <div class="textwidget">
+                                <div class="ff-margin-fix">
+                                    <iframe width="320" height="240" frameborder="0" scrolling="no" src="http://ads.placester.net/ad?placement_id=eh_1&amp;w=300&amp;h=182&amp;siteid=sfgate&amp;cid=sfgatefrontpage&amp;amp" style="width: 300px; height: 240px; overflow: hidden; border: none;"></iframe>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="widget">
+                            <div class="HDNAuthorSocialMedia clearfix">
+                                <h2>Follow Emily</h2>
+                                <div class="asi_pic"><img src="https://media.licdn.com/mpr/mpr/shrink_200_200/p/7/005/03d/3db/353042c.jpg" /></div>
+                                <div class="asi_details">
+                                    <div class="asi_name">Emily Landes</div>
+                                    <div class="asi_title">Real Estate blogger</div>
+                                    <div class="asi_icons">
+                                        <a title="Click to email the author" href="mailto:landesemily@gmail.com" class="asi_icon asi_email no-text" rel="nofollow"><span></span></a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="widget widget_hdn_ndn_video" id="hdn-ndn-video-wrapper">
+                            <h2>
+
+    <span class="title">Top <span class="widget-title-remainder">Videos</span></span>
+    </h2>
+                            <div class="ndn-holder"><img src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-ndn-video/images/ndn_video_blank.png" class="ndn-image" />
+                                <div class="ndn-content">
+                                    <div data-config-site-section="sfgate2slider_hom_non_fro" data-config-tracking-group="45981" data-config-type="VideoLauncher/Slider300x250" data-config-widget-id="10991" class="ndn_embed ndn_embedContainer ndn-widget-embed-1 ndn_widget_VideoPlayer-PTR ndn_widget_VideoLauncher-Slider ndn_embedded" id="ndn-widget-embed-1">
+                                        <div class="ndn_responsiveContainer ndn_sliderTopContainer" style="height: 250px;">
+                                            <div class="ndn_sliderContainer">
+                                                <div class="ndn_videoPlayerWrapper ndn_videoPlayerWrapper_loading">
+                                                    <div class="ndn_playerContainer ndn_videoPlayer ndn_videoPlayer_view1198 ndn_videoPlayer_view1022 ndn_videoPlayer_view999 ndn_videoPlayer_view849 ndn_videoPlayer_view784 ndn_videoPlayer_view766 ndn_videoPlayer_view702 ndn_videoPlayer_view639 ndn_videoPlayer_view574 ndn_videoPlayer_view499 ndn_videoPlayer_smallView akamai-flash akamai-player akamai-desktop akamai-ready" id="ndn-widget-embed-1-player" data-version="AMP Premier - NDN v1.16.0.0005">
+                                                        <div class="ndn_infoOverlayContainer ndn_playerOverlay" style="display: block;">
+                                                            <div class="ndn_videoInfo">
+                                                                <img src="http://assets.newsinc.com/eonline.png?t=1430873880" class="ndn_videoProviderLogo" />
+                                                                <div class="ndn_videoTitle">"Bachelor" Chris Soules' Emotional "DWTS" Moment</div>
+                                                                <div class="ndn_videoInfoDescription">Bachelor alum holds back tears</div>
+                                                                <div class="ndn_videoProviderName">E! Online</div>
+                                                                <div title="More Info" class="ndn_toggleInfoDescription ndn_icon_info-circled"></div>
+                                                                <div title="Share" class="ndn_toggleShare ndn_icon_share"></div>
+                                                                <div class="ndn_infoPanelOverlay"></div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="ndn_endslateOverlay ndn_playerOverlay" style="display: none;"></div>
+                                                        <div class="ndn_startOverlayContainer ndn_playerOverlay" style="display: none;">
+                                                            <div class="ndn_pauseVideoInfo">
+                                                                <img src="" class="ndn_pauseVideoLogo" />
+                                                                <div class="ndn_videoTitle"></div>
+                                                                <div class="ndn_videoDescription"></div>
+                                                                <div class="ndn_videoProviderName"></div>
+                                                                <div title="More Info" class="ndn_toggleDescription ndn_icon_info-circled"></div>
+                                                                <div class="ndn_infoPanelOverlay"></div>
+                                                            </div>
+                                                            <div class="ndn_startOverlay">
+                                                                <div class="ndn_startPlay ndn_fastClick_touchandclickevent"></div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="ndn_shareOverlay ndn_playerOverlay" style="display: none;">
+                                                            <div class="ndn_shareContainer ndn_shareTabs">
+                                                                <div class="ndn_closeShare ndn_icon_cancel"></div>
+                                                                <div class="ndn_shareBox">
+                                                                    <div class="ndn_shareButtons">
+                                                                        <div class="ndn_shareButtonList">
+                                                                            <ul class="ndn_shareButtonsList">
+                                                                                <li class="ndn_mainShareButtons ndn_shareFacebook">
+                                                                                    <a href="http://api.addthis.com/oexchange/0.8/forward/facebook/offer?url=http%3A%2F%2Fsocial.newsinc.com%2Fmedia%2Fjson%2F69017%2F29024634%2FsingleVideoOG.html%3Ftype%3DVideoPlayer%2F16x9%26trackingGroup%3D69017%26videoId%3D29024634&amp;pubid=ra-518bbde23f7ed2a9&amp;ct=1" target="_blank" class="ndn_a_shareFacebook ndn_icon_facebook"></a>
+                                                                                </li>
+                                                                                <li class="ndn_mainShareButtons ndn_shareTwitter">
+                                                                                    <a href="http://api.addthis.com/oexchange/0.8/forward/twitter/offer?url=https%3A%2F%2Fsocial.newsinc.com%2Fmedia%2Fjson%2F69017%2F29024634%2FsingleVideoOG.html%3Ftype%3DVideoPlayer%2FDefault%26widgetId%3D2%26trackingGroup%3D69017%26videoId%3D29024634&amp;title=%22Bachelor%22%20Chris%20Soules%27%20Emotional%20%22DWTS%22%20Moment&amp;description=Bachelor%20alum%20holds%20back%20tears&amp;pubid=ra-518bbde23f7ed2a9&amp;ct=1" target="_blank" class="ndn_a_shareTwitter ndn_icon_twitter"></a>
+                                                                                </li>
+                                                                                <li class="ndn_mainShareButtons ndn_shareEmail">
+                                                                                    <a href="mailto:?subject=%22Bachelor%22%20Chris%20Soules%27%20Emotional%20%22DWTS%22%20Moment&amp;body=Check%20out%20this%20video:%0A%0A%22Bachelor%22%20Chris%20Soules%27%20Emotional%20%22DWTS%22%20Moment%0Ahttps%3A%2F%2Fsocial.newsinc.com%2Fmedia%2Fjson%2F69017%2F29024634%2FsingleVideoOG.html%3FvideoId%3D29024634%26type%3DVideoPlayer%2F16x9%26widgetId%3D2%26trackingGroup%3D69017" class="ndn_icon_mail-alt"></a>
+                                                                                </li>
+                                                                                <li class="ndn_mainShareButtons ndn_shareEmbed"><span class="ndn_icon_code"></span></li>
+                                                                            </ul>
+                                                                            <textarea class="ndn_shareCopyVideoLinkText" readonly="readonly">http://www.sfgate.com/ndnvideos/?ndn.trackingGroup=45981&amp;ndn.siteSection=sfgate2slider_hom_non_fro&amp;ndn.videoId=29024634&amp;freewheel=45981&amp;sitesection=sfgate2slider_hom_non_fro&amp;vid=29024634</textarea>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="ndn_embedBox">
+                                                                    <div class="ndn_backToShare ndn_icon_left-big">BACK</div>
+                                                                    <div class="ndn_embedLink">
+                                                                        <span class="ndn_shareCopyEmbedCode ndn_linkEmbed">
+            <label for="ndn_shareCopyEmbedCodeText">Embed</label>
+        </span>
+                                                                        <textarea class="ndn_shareCopyEmbedCodeText" readonly="readonly">&lt;iframe width="590" height="332" src="http://launch.newsinc.com/?type=VideoPlayer/Single&amp;widgetId=1&amp;trackingGroup=69016&amp;siteSection=sfgate2slider_hom_non_fro&amp;videoId=29024634&amp;playlistId=507" frameborder="no" scrolling="no" noresize marginwidth="0" marginheight="0"&gt;&lt;/iframe&gt;</textarea>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="ndn_sharePrivacyPolicy">
+                                                                    <a target="_blank" href="http://www.newsinc.com/privacy-policy">Privacy Policy</a>   |   <a target="_blank" href="http://www.newsinc.com/player-terms">Terms of Use</a>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="ndn_enforceVisibilityOverlay ndn_playerOverlay" style="display: none;">
+                                                            <span class="ndn_errorMessage">This video player must be at least 300x168 pixels in order to operate.</span>
+                                                        </div>
+                                                        <div class="akamai-video akamai-layer">
+                                                            <object width="100%" height="100%" type="application/x-shockwave-flash" id="flashObject1430917077061" name="flashObject1430917077061" data="http://launch.newsinc.com/75/js/lib/amp.premier/AkamaiPremierPlayer-static.swf" style="visibility: visible;" class="video">
+                                                                <param name="allowFullScreen" value="true" />
+                                                                <param name="allowScriptAccess" value="always" />
+                                                                <param name="wmode" value="transparent" />
+                                                                <param name="bgColor" value="#000000" />
+                                                                <param name="flashvars" value="auto_play=false&amp;hinting_rules=%7B%22flashTablets%22%3A%7B%22label%22%3A%22Android%202%20%26%203%20or%20Kindle%20Fire%201%22%2C%22regexp%22%3A%22Android%20%5B23%5D%7CSilk/1%22%7D%2C%22html5Phones%22%3A%7B%22label%22%3A%22iPhone%22%2C%22regexp%22%3A%22iPhone%22%7D%2C%22html5Tablets%22%3A%7B%22label%22%3A%22HTML5%20Tablets%22%2C%22regexp%22%3A%22iPad%7CAndroid%204%7CSilk/2%22%7D%2C%22desktop%22%3A%7B%22label%22%3A%22Desktop%22%2C%22regexp%22%3A%22%5E%28%28%3F%21iPad%7CiPhone%7CAndroid%7CBlackBerry%7CPlayBook%7CSilk%29.%29*%24%22%7D%2C%22android_4_gets_m3u8%22%3A%7B%22regexp%22%3A%22Android%204%22%7D%7D&amp;volume=1&amp;external_target=_top&amp;domain=newsinc.com&amp;embed_domain=newsinc.com&amp;auto_replay=false&amp;fullscreen_enabled=true&amp;params=%7B%22auditude_userDataString%22%3A%22%22%2C%22distributorName%22%3A%22%22%2C%22producerCategory%22%3A%22%22%2C%22producerAuditudeId%22%3A%22%22%2C%22windowLocation%22%3A%22http%3A//blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/%22%2C%22tracking_group%22%3A9999%2C%22sitesection%22%3A%22ndn%22%2C%22sec%22%3A%22oth%22%2C%22sub%22%3A%22non%22%2C%22plt%22%3A%2211%22%2C%22wgt%22%3A1%2C%22fp%22%3A0%2C%22aud_zone_id%22%3A50974%2C%22aud_default_asset%22%3A%22default_ndn%22%2C%22partner_type%22%3A%22conventional%22%2C%22autoplay%22%3A1%2C%22continuous_play%22%3A1%2C%22sound%22%3A1%2C%22ad_server%22%3A%22none%22%2C%22trans_time%22%3A0%2C%22size%22%3A%2210x10%22%2C%22player_type%22%3A11%2C%22launcher_type%22%3A0%2C%22ads_enabled%22%3A0%2C%22wid%22%3A0%2C%22share%22%3A1%2C%22email%22%3A0%2C%22device_mode%22%3A1%2C%22external_url%22%3A%22http%3A//newsinc.com%22%2C%22override_playlist%22%3A0%2C%22user_token%22%3A%22ZZZZZZZ%22%2C%22embed_type%22%3A0%2C%22ndn_session_id%22%3A%22%22%2C%22rmm%22%3A0%2C%22wid_type%22%3A0%2C%22desc_url_type%22%3A%22http%3A//newsinc.com%22%7D&amp;context_menu_label=AMP Premier - NDN v1.16.0.0005&amp;show_play_button_overlay=false&amp;auto_play_list=false&amp;next_video_timer=-1&amp;context_menu_mode=short&amp;share_mode=2&amp;core_ads_enabled=true&amp;ad_server_timeout=30&amp;ad_media_server_timeout=30&amp;display_scene_markers=false&amp;overlay_ad_delay=3&amp;share_enabled=true&amp;auto_play_override=true&amp;externalTarget=_top&amp;embedDomain=newsinc.com&amp;settings_xml=%3Capplication%3E%3Cplayer%20ad_control_enabled%3D%22true%22%20ad_server_timeout%3D%2220%22%20auto_replay%3D%22false%22%20branding_preload%3D%22none%22%20core_player_name%3D%22ndn-player%22%20dvr_enabled%3D%220%22%20fullscreen_enabled%3D%22true%22%20hds_live_low_latency%3D%22true%22%20mbr_start_index%3D%222%22%20netsession_install_prompt_frequency_secs%3D%22-1%22%20show_feature_bar%3D%22false%22%20use_last_known_bitrate%3D%22false%22%20use_netsession_client%3D%22false%22%20volume%3D%2275%22%3E%3C/player%3E%3Cplugins%3E%3Cplugin%20absolute%3D%22true%22%20host%3D%22osmf%22%20id%3D%22AkamaiAdvancedStreamingPlugin%22%20type%3D%22static%22%3Ecom.akamai.osmf.AkamaiAdvancedStreamingPluginInfo%3C/plugin%3E%3C%21--%20%3Cplugin%20host%3D%27osmf%27%20type%3D%27static%27%20id%3D%27OSMFCSMALoader%27%3Ecom.akamai.playeranalytics.osmf.OSMFCSMALoaderInfo%3C/plugin%3E%20--%3E%3C%21--%20%3Cplugin%20host%3D%27osmf%27%20type%3D%27dynamic%27%20id%3D%27CaptioningPlugin%27%3Ehttp%3A%26%23x2F%3B%26%23x2F%3Blaunch.newsinc.com%26%23x2F%3B75%26%23x2F%3Bresources/plugins/CaptioningPlugin.swf%3C/plugin%3E%20--%3E%3C/plugins%3E%3Cview%20skin%3D%22http%3A//launch.newsinc.com/75/js/lib/amp.premier/ndn.assets.swf%22%3E%3Celement%20id%3D%22captionDisplay%22%20style%3D%22bottom%3A%200px%3B%20opacity%3A1%3B%22/%3E%3Celement%20id%3D%22controls%22%20scrubPosition%3D%22top%22%20backgroundAlpha%3D%22.8%22%20height%3D%2251%22%20autoHideDelay%3D%221%22%20transitionTime%3D%220.50%22%3E%3Celement%20id%3D%22playPauseBtn%22/%3E%3Celement%20id%3D%22scrubBar%22%20collapsedHeight%3D%225%22%20style%3D%22background%3A%20linear-gradient%2890deg%2C%20%23232323%20%23232323%29%3B%20height%3A%209px%3B%22/%3E%3Celement%20id%3D%22progressBar%22%20style%3D%22background%3A%20linear-gradient%2890deg%2C%20%230099CC%20%230099CC%29%3B%22/%3E%3Celement%20id%3D%22loadedBar%22%20style%3D%22background%3A%20linear-gradient%2890deg%2C%20%23666666%20%23666666%29%3B%22/%3E%3Celement%20id%3D%22streamTimeIndicator%22%20position%3D%22left%22%3E%3Celement%20id%3D%22streamTime%22/%3E%3Celement%20id%3D%22streamDuration%22%20color%3D%22%23666666%22/%3E%3C/element%3E%3Celement%20id%3D%22shareBtn%22/%3E%3Celement%20id%3D%22facebookBtn%22/%3E%3Celement%20id%3D%22twitterBtn%22/%3E%3Celement%20id%3D%22volumeBar%22%20backgroundColor%3D%22%23111111%22%20trackColor%3D%22%23C1C1C3%22%20color%3D%22%230099CC%22%20position%3D%22relative%22%20width%3D%2225%22/%3E%3Celement%20id%3D%22volumeBtn%22/%3E%3Celement%20id%3D%22fullscreenBtn%22/%3E%3Celement%20id%3D%22posterBackground%22%20color%3D%22%23000000%22%20alpha%3D%221%22/%3E%3C/element%3E%3Celement%20id%3D%22loadingView%22%20radius%3D%220%22/%3E%3Celement%20id%3D%22adOptions%22%3E%3Celement%20id%3D%22adChoices%22%20target%3D%22http%3A//assets.newsinc.com/info/adchoices.html%22/%3E%3Celement%20id%3D%22adCountdown%22/%3E%3C/element%3E%3C/view%3E%3Clocales%3E%3Clocale%20id%3D%22en%22%3E%3Cproperty%20key%3D%22MSG_NEXT_VIDEO%22%3EStarts%20in%20%3C/property%3E%3Cproperty%20key%3D%22MSG_SECONDS%22%3Eseconds%3C/property%3E%3C/locale%3E%3C/locales%3E%3Cmetrics%3E%3Cvendor%20id%3D%22comscore%22%3E%3Cproperty%20key%3D%22adStart%22%3E%3Cproperty%20key%3D%22COMSCORE_CSURL%22%3Ehttp%3A//b.scorecardresearch.com/b%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC1%22%3E1%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC2%22%3E11112732%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC3%22%3E%23%7BdistributorName%7D%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC4%22%3E%23%7Bmedia.metadata%5B%27ndn-provider%27%5D.name%7D%2009%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC5%22%3E09%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC6%22%3E%23%7BsiteSection%7D%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC10%22%3E%23%7BproducerCategory%7D%3C/property%3E%3C/property%3E%3Cproperty%20key%3D%22videoStart%22%3E%3Cproperty%20key%3D%22COMSCORE_CSURL%22%3Ehttp%3A//b.scorecardresearch.com/b%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC1%22%3E1%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC2%22%3E11112732%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC3%22%3E%23%7BdistributorName%7D%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC4%22%3E%23%7Bmedia.metadata%5B%27ndn-provider%27%5D.name%7D%20%23%7BmediaAnalyticsC5Value%7D%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC5%22%3E%23%7BmediaAnalyticsC5Value%7D%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC6%22%3E%23%7BsiteSection%7D%3C/property%3E%3Cproperty%20key%3D%22COMSCORE_CSC10%22%3E%23%7BproducerCategory%7D%3C/property%3E%3C/property%3E%3C/vendor%3E%3Cvendor%20id%3D%22comscoreStreamSense%22%3E%3Cproperty%20key%3D%22C2%22%3E11112732%3C/property%3E%3Cproperty%20key%3D%22PUBLISHER_SECRET%22%3Ec3798e9f708f2d61a9cf8232b0503d5a%3C/property%3E%3Cproperty%20key%3D%22CI%22%3E%23%7Bmedia.guid%7D%3C/property%3E%3Cproperty%20key%3D%22C3%22%3E%23%7BdistributorName%7D%3C/property%3E%3Cproperty%20key%3D%22C4%22%3E%23%7Bmedia.metadata%5B%27ndn-provider%27%5D.name%7D%3C/property%3E%3Cproperty%20key%3D%22C6%22%3E%23%7BsiteSection%7D%3C/property%3E%3C/vendor%3E%3C/metrics%3E%3Cadmedia%3E%3Cvendor%20id%3D%22dfp%22%3E%3Cproperty%20key%3D%22DFP_AD_TAG_URL%22%3E%3C%21%5BCDATA%5Bhttp%3A//pubads.g.doubleclick.net/gampad/ads%3Fad_rule%3D1%26sz%3D750x425%26iu%3D%23%7BdfpIuValue%7D%26ciu_szs%3D%23%7BdfpCiuSzsValue%7D%26vid%3D%23%7Bmedia.guid%7D%26cmsid%3D1169%26vpos%3Dpreroll%26scor%3D%23%7Bnow%7D%26vad_type%3Dlinear%26description_url%3D%23%7BencodedEmbedOriginUrl%7D%26playlistId%3D%23%7BplaylistId%7D%26widgetId%3D%23%7BwidgetId%7D%26trackingGroup%3D%23%7BtrackingGroup%7D%26impl%3Ds%26gdfp_req%3D1%26env%3Dvp%26output%3Dxml_vast2%26unviewed_position_start%3D1%26url%3D%23%7BencodedEmbedOriginUrl%7D%26correlator%3D%23%7Bnow%7D%26cust_params%3D%23%7BdfpEncodedParams%7D%5D%5D%3E%3C/property%3E%3Cproperty%20key%3D%22DFP_PPID%22%3E1291657947e74aef1460a62ed15b8c09%3C/property%3E%3Cproperty%20key%3D%22disableCompanionAds%22%3Etrue%3C/property%3E%3C/vendor%3E%3C/admedia%3E%3C/application%3E" />
+                                                            </object>
+                                                        </div>
+                                                        <div class="ndn_pauseOverlayContainer ndn_playerOverlay" style="display: none;">
+                                                            <div class="ndn_pauseVideoInfoContainer">
+                                                                <div class="ndn_pauseVideoInfo">
+                                                                    <img src="http://assets.newsinc.com/eonline.png?t=1430873880" class="ndn_pauseVideoLogo" />
+                                                                    <div class="ndn_videoTitle">"Bachelor" Chris Soules' Emotional "DWTS" Moment</div>
+                                                                    <div class="ndn_videoDescription">Bachelor alum holds back tears</div>
+                                                                    <div class="ndn_videoProviderName">E! Online</div>
+                                                                    <div title="More Info" class="ndn_toggleDescription ndn_icon_info-circled"></div>
+                                                                    <div title="Share" class="ndn_toggleShare ndn_icon_share"></div>
+                                                                    <div class="ndn_infoPanelOverlay"></div>
+                                                                </div>
+                                                            </div>
+                                                            <div class="ndn_pauseOverlay ndn_overlayContainer">
+                                                                <div class="ndn_pauseOverlay_centerContainer">
+                                                                    <div class="ndn_startPlay ndn_fastClick_touchandclickevent"></div>
+                                                                </div>
+                                                                <div class="ndn_pauseCarousel"></div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="akamai-overlays akamai-layer"></div>
+                                                    </div>
+                                                </div>
+                                                <ul class="ndn_sliderItems ndn_selectableVideos">
+                                                    <li class="ndn_selectableVideo ndn_activeVideoNotPlaying" data-video-index="0" title="&quot;Bachelor&quot; Chris Soules' Emotional &quot;DWTS&quot; Moment" data-video-id="29024634" style="width: 300px;">
+                                                        <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29024634&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                            <div class="ndn_sliderThumbnailOverlay">
+                                                                <p class="ndn_sliderVideoTitle">"Bachelor" Chris Soules' Emotional "DWTS" Moment</p>
+                                                                <p class="ndn_producerName">E! Online</p>
+                                                                <img class="ndn_providerLogo" src="http://assets.newsinc.com/eonline.png?t=1430873880" />
+                                                            </div>
+                                                            <img src="http://content-img.newsinc.com/jpg/355/29024634/21532264.jpg?t=1430873880" style="margin-left: -72.5px;" />
+                                                            <div class="ndn_playButton"></div>
+                                                        </a>
+                                                    </li>
+                                                    <li class="ndn_selectableVideo" data-video-index="1" title="Celebrate Cinco de Mayo With The Hottest Mexican Men in Hollywood" data-video-id="29019490" style="width: 300px;">
+                                                        <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29019490&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                            <div class="ndn_sliderThumbnailOverlay">
+                                                                <p class="ndn_sliderVideoTitle">Celebrate Cinco de Mayo With The Hottest Mexican Men in Hollywood</p>
+                                                                <p class="ndn_producerName">Splash News</p>
+                                                                <div data-class="ndn_providerLogo" data-src="http://assets.newsinc.com/splash_75x27.jpg?t=1430819940" class="ndn_imagePlaceholder"></div>
+                                                            </div>
+                                                            <div data-src="http://content-img.newsinc.com/jpg/1736/29019490/21502530.jpg?t=1430819940" class="ndn_imagePlaceholder"></div>
+                                                            <div class="ndn_playButton"></div>
+                                                        </a>
+                                                    </li>
+                                                    <li class="ndn_selectableVideo" data-video-index="2" title="President Obama and David Letterman Discuss Their Retirements" data-video-id="29020708" style="width: 300px;">
+                                                        <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29020708&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                            <div class="ndn_sliderThumbnailOverlay">
+                                                                <p class="ndn_sliderVideoTitle">President Obama and David Letterman Discuss Their Retirements</p>
+                                                                <p class="ndn_producerName">Inside Edition</p>
+                                                                <div data-class="ndn_providerLogo" data-src="http://assets.newsinc.com/ie_75x25.png?t=1430831880" class="ndn_imagePlaceholder"></div>
+                                                            </div>
+                                                            <div data-src="http://content-img.newsinc.com/jpg/1847/29020708/21508105.jpg?t=1430831880" class="ndn_imagePlaceholder"></div>
+                                                            <div class="ndn_playButton"></div>
+                                                        </a>
+                                                    </li>
+                                                    <li class="ndn_selectableVideo" data-video-index="3" title="The Queen Visits Princess Charlotte" data-video-id="29021620" style="width: 300px;">
+                                                        <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29021620&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                            <div class="ndn_sliderThumbnailOverlay">
+                                                                <p class="ndn_sliderVideoTitle">The Queen Visits Princess Charlotte</p>
+                                                                <p class="ndn_producerName">Sky News</p>
+                                                                <div data-class="ndn_providerLogo" data-src="http://assets.newsinc.com/92346_75x27.png?t=1430842980" class="ndn_imagePlaceholder"></div>
+                                                            </div>
+                                                            <div data-src="http://content-img.newsinc.com/jpg/2814/29021620/21512639.jpg?t=1430842980" class="ndn_imagePlaceholder"></div>
+                                                            <div class="ndn_playButton"></div>
+                                                        </a>
+                                                    </li>
+                                                    <li class="ndn_selectableVideo" data-video-index="4" title="Grooming by Em" data-video-id="29002092" style="width: 300px;">
+                                                        <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29002092&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                            <div class="ndn_sliderThumbnailOverlay">
+                                                                <p class="ndn_sliderVideoTitle">Grooming by Em</p>
+                                                                <p class="ndn_producerName">Wells Fargo</p>
+                                                                <div data-class="ndn_providerLogo" data-src="http://assets.newsinc.com/newsinconebyone.png?t=1430507100" class="ndn_imagePlaceholder"></div>
+                                                            </div>
+                                                            <div data-src="http://content-img.newsinc.com/jpg/2395/29002092/21423464.jpg?t=1430507100" class="ndn_imagePlaceholder"></div>
+                                                            <div class="ndn_playButton"></div>
+                                                        </a>
+                                                    </li>
+                                                    <li class="ndn_selectableVideo" data-video-index="5" title="Dog has jealous freakout when neighbor pig gets a belly rub" data-video-id="29019941" style="width: 300px;">
+                                                        <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29019941&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                            <div class="ndn_sliderThumbnailOverlay">
+                                                                <p class="ndn_sliderVideoTitle">Dog has jealous freakout when neighbor pig gets a belly rub</p>
+                                                                <p class="ndn_producerName">Buzz60</p>
+                                                                <div data-class="ndn_providerLogo" data-src="http://assets.newsinc.com/buzz60_75x27.png?t=1430824200" class="ndn_imagePlaceholder"></div>
+                                                            </div>
+                                                            <div data-src="http://content-img.newsinc.com/jpg/1171/29019941/21504499.jpg?t=1430824200" class="ndn_imagePlaceholder"></div>
+                                                            <div class="ndn_playButton"></div>
+                                                        </a>
+                                                    </li>
+                                                </ul>
+                                                <div class="ndn_sliderControls">
+                                                    <div class="ndn_sliderPrev ndn_sliderNavButton">
+                                                        <div class="ndn_arrow"></div>
+                                                    </div>
+                                                    <div class="ndn_sliderNext ndn_sliderNavButton">
+                                                        <div class="ndn_arrow"></div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="ndn_playlistThumbnails">
+                                            <h4>More videos:</h4>
+                                            <div class="ndn_carousel-wrapper" style="max-width: 350px;">
+                                                <div class="ndn_carousel-viewport" style="width: 100%; overflow: hidden; position: relative; height: 73px;">
+                                                    <ul class="ndn_playlistThumbnailsList" style="width: 1290%; position: relative; transition-duration: 0s; transform: translate3d(-304px, 0px, 0px);">
+                                                        <li title="The Queen Visits Princess Charlotte" data-video-id="29021620" data-video-index="3" class="ndn_playlistVideoThumbnail ndn_thumbnail ndn_carousel-clone" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29021620&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/2814/29021620/21512639.jpg?t=1430842980" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">The Queen Visits Princess Charlotte</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="Grooming by Em" data-video-id="29002092" data-video-index="4" class="ndn_playlistVideoThumbnail ndn_thumbnail ndn_carousel-clone" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29002092&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/2395/29002092/21423464.jpg?t=1430507100" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">Grooming by Em</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="Dog has jealous freakout when neighbor pig gets a belly rub" data-video-id="29019941" data-video-index="5" class="ndn_playlistVideoThumbnail ndn_thumbnail ndn_carousel-clone" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29019941&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/1171/29019941/21504499.jpg?t=1430824200" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">Dog has jealous freakout when neighbor pig gets a belly rub</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="&quot;Bachelor&quot; Chris Soules' Emotional &quot;DWTS&quot; Moment" data-video-id="29024634" data-video-index="0" class="ndn_playlistVideoThumbnail ndn_thumbnail" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29024634&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/355/29024634/21532264.jpg?t=1430873880" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">"Bachelor" Chris Soules' Emotional "DWTS" Moment</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="Celebrate Cinco de Mayo With The Hottest Mexican Men in Hollywood" data-video-id="29019490" data-video-index="1" class="ndn_playlistVideoThumbnail ndn_thumbnail" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29019490&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/1736/29019490/21502530.jpg?t=1430819940" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">Celebrate Cinco de Mayo With The Hottest Mexican Men in Hollywood</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="President Obama and David Letterman Discuss Their Retirements" data-video-id="29020708" data-video-index="2" class="ndn_playlistVideoThumbnail ndn_thumbnail" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29020708&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/1847/29020708/21508105.jpg?t=1430831880" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">President Obama and David Letterman Discuss Their Retirements</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="The Queen Visits Princess Charlotte" data-video-id="29021620" data-video-index="3" class="ndn_playlistVideoThumbnail ndn_thumbnail" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29021620&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/2814/29021620/21512639.jpg?t=1430842980" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">The Queen Visits Princess Charlotte</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="Grooming by Em" data-video-id="29002092" data-video-index="4" class="ndn_playlistVideoThumbnail ndn_thumbnail" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29002092&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/2395/29002092/21423464.jpg?t=1430507100" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">Grooming by Em</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="Dog has jealous freakout when neighbor pig gets a belly rub" data-video-id="29019941" data-video-index="5" class="ndn_playlistVideoThumbnail ndn_thumbnail" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29019941&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/1171/29019941/21504499.jpg?t=1430824200" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">Dog has jealous freakout when neighbor pig gets a belly rub</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="&quot;Bachelor&quot; Chris Soules' Emotional &quot;DWTS&quot; Moment" data-video-id="29024634" data-video-index="0" class="ndn_playlistVideoThumbnail ndn_thumbnail ndn_carousel-clone" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29024634&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/355/29024634/21532264.jpg?t=1430873880" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">"Bachelor" Chris Soules' Emotional "DWTS" Moment</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="Celebrate Cinco de Mayo With The Hottest Mexican Men in Hollywood" data-video-id="29019490" data-video-index="1" class="ndn_playlistVideoThumbnail ndn_thumbnail ndn_carousel-clone" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29019490&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/1736/29019490/21502530.jpg?t=1430819940" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">Celebrate Cinco de Mayo With The Hottest Mexican Men in Hollywood</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                        <li title="President Obama and David Letterman Discuss Their Retirements" data-video-id="29020708" data-video-index="2" class="ndn_playlistVideoThumbnail ndn_thumbnail ndn_carousel-clone" style="float: left; list-style: outside none none; position: relative; width: 97.3333px; margin-right: 4px;">
+                                                            <div class="ndn_thumbnailContainer">
+                                                                <a href="http://launch.newsinc.com/?type=VideoPlayer/16x9&amp;videoId=29020708&amp;trackingGroup=45981&amp;widgetId=10991&amp;playlistId=507&amp;siteSection=sfgate2slider_hom_non_fro&amp;embedOriginUrl=http%253A%252F%252Fblog.sfgate.com%252Fontheblock%252F2015%252F05%252F05%252Fnob-hill-one-bedroom-sells-for-2-3-million%252F">
+                                                                    <img src="http://content-img.newsinc.com/jpg/1847/29020708/21508105.jpg?t=1430831880" style="margin-left: -16.5px;" />
+                                                                    <div class="ndn_titleOverlay">
+                                                                        <div class="ndn_thumbTitle">President Obama and David Letterman Discuss Their Retirements</div>
+                                                                    </div>
+                                                                </a>
+                                                            </div>
+                                                            <div class="ndn_currentVideoThumbnail"></div>
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="widget-ad-position-B300 widget ad_position" id="hdn_ad_position-4">
+                            <div class="hdn-ad-position ad-B300 hdn-ap-visible-mobile hdn-ap-visible-desktop">
+                                <div class="juice-ad-position juice-ad-position-B300" id="B300">
+                                    <script id="B300-0-81568700-1430916267" type="text/javascript">
+                                    window.ad_position_widget.place_named_ad('B300', 'B300-0-81568700-1430916267');
+                                    </script>
+                                    <iframe width="1920" height="250" id="B300-ju1c3-TWFobmEgTWFobmE=-1fr4m3-3" name="B300-ju1c3-TWFobmEgTWFobmE=-1fr4m3-3" style="width: 300px; height: 250px; border: medium none; background-color: transparent; vertical-align: bottom;" scrolling="no" src="http://juice-files.sfgate.com/html/juiceframe?generationID=0x8D02BCA19C4A6A4CA4BE819B7EFEE027A26BD40D&amp;dm=sfgate.com&amp;slt=B300"></iframe>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="widget WP_HDN_Recent_Blog_Posts" id="wp_hdn_recent_blog_posts-5">
+                            <h2><span class="title">Recent <span class="widget-title-remainder">On The Block Posts</span></span></h2>
+                            <ul class="rbp_list clearfix">
+                                <li class="rbp_item">
+                                    <div class="rbp_element">
+                                        <a title="Nob Hill one-bedroom sells for $2.3 million" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" class="hdn-analytics">
+                                            <div class="img-aspect">
+                                                <img src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/images/aspect32.png" class="aspect-32" />
+                                                <div class="img-clip">
+                                                    <img alt="One Bedroom" class="attachment-feature-image-thumbnail wp-post-image" src="http://blog.sfgate.com/ontheblock/files/2015/04/One-Bedroom-120x80.jpg" style="width: 100%; height: auto;" /> <span class="hdn-analytics-data">visit|ontheblock-2283-post-9755|ontheblock-2283-recent|1</span>
+                                                </div>
+                                            </div>
+                                        </a>
+                                        <div class="rbp_text ">
+                                            <h4>
+                            <a title="Nob Hill one-bedroom sells for $2.3 million" href="http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/" class="hdn-analytics">Nob Hill one-bedroom sells for $2.3 million<span class="hdn-analytics-data">visit|ontheblock-2283-post-9755|ontheblock-2283-recent|1</span></a>
+                        </h4>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class="rbp_item">
+                                    <div class="rbp_element">
+                                        <a title="Bernal Heights tenant moves out, but continues to dispute 400 percent rent increase" href="http://blog.sfgate.com/ontheblock/2015/05/04/bernal-heights-tenant-moves-out-but-continues-to-dispute-400-percent-rent-increase/" class="hdn-analytics">
+                                            <div class="img-aspect">
+                                                <img src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/images/aspect32.png" class="aspect-32" />
+                                                <div class="img-clip">
+                                                    <img alt="Deb Follingstad was shocked when her landlord slapped her with a four-fold rent increase. (ABC)" class="attachment-feature-image-thumbnail wp-post-image" src="http://blog.sfgate.com/ontheblock/files/2015/05/Deb-Follingstad-120x80.png" style="width: 100%; height: auto;" /> <span class="hdn-analytics-data">visit|ontheblock-2283-post-9775|ontheblock-2283-recent|2</span>
+                                                </div>
+                                            </div>
+                                        </a>
+                                        <div class="rbp_text ">
+                                            <h4>
+                            <a title="Bernal Heights tenant moves out, but continues to dispute 400 percent rent increase" href="http://blog.sfgate.com/ontheblock/2015/05/04/bernal-heights-tenant-moves-out-but-continues-to-dispute-400-percent-rent-increase/" class="hdn-analytics">Bernal Heights tenant moves out, but continues to dispute 400 percent rent increase<span class="hdn-analytics-data">visit|ontheblock-2283-post-9775|ontheblock-2283-recent|2</span></a>
+                        </h4>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class="rbp_item">
+                                    <div class="rbp_element">
+                                        <a title="Joe Montana’s latest score: A $2,275,000 Marina condo" href="http://blog.sfgate.com/ontheblock/2015/05/04/joe-montanas-latest-score-a-2275000-marina-condo/" class="hdn-analytics">
+                                            <div class="img-aspect">
+                                                <img src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/images/aspect32.png" class="aspect-32" />
+                                                <div class="img-clip">
+                                                    <img alt="(Photo by Michael N. Todaro/Getty Images for Sports Illustrated)" class="attachment-feature-image-thumbnail wp-post-image" src="http://blog.sfgate.com/ontheblock/files/2015/05/466013925-120x80.jpg" style="width: 100%; height: auto;" /> <span class="hdn-analytics-data">visit|ontheblock-2283-post-9762|ontheblock-2283-recent|3</span>
+                                                </div>
+                                            </div>
+                                        </a>
+                                        <div class="rbp_text ">
+                                            <h4>
+                            <a title="Joe Montana’s latest score: A $2,275,000 Marina condo" href="http://blog.sfgate.com/ontheblock/2015/05/04/joe-montanas-latest-score-a-2275000-marina-condo/" class="hdn-analytics">Joe Montana’s latest score: A $2,275,000 Marina condo<span class="hdn-analytics-data">visit|ontheblock-2283-post-9762|ontheblock-2283-recent|3</span></a>
+                        </h4>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class="rbp_item">
+                                    <div class="rbp_element">
+                                        <div class="rbp_text no-sidebar-thumb">
+                                            <h4>
+                            <a title="A secret, second market for high-end homes" href="http://blog.sfgate.com/ontheblock/2015/04/30/a-secret-second-market-for-high-end-homes/" class="hdn-analytics">A secret, second market for high-end homes<span class="hdn-analytics-data">visit|ontheblock-2283-post-9701|ontheblock-2283-recent|4</span></a>
+                        </h4>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class="rbp_item">
+                                    <div class="rbp_element">
+                                        <a title="Late Williams-Sonoma CEO’s former home comes to market at $11.5 million" href="http://blog.sfgate.com/ontheblock/2015/04/28/williams-sonoma-founders-former-home-comes-to-market-at-11-5-million/" class="hdn-analytics">
+                                            <div class="img-aspect">
+                                                <img src="http://blog.sfgate.com/ontheblock/wp-content/themes/2014-responsive-base/images/aspect32.png" class="aspect-32" />
+                                                <div class="img-clip">
+                                                    <img alt="Williams Sonoma" class="attachment-feature-image-thumbnail wp-post-image" src="http://blog.sfgate.com/ontheblock/files/2015/04/Williams-Sonoma-120x80.jpg" style="width: 100%; height: auto;" /> <span class="hdn-analytics-data">visit|ontheblock-2283-post-9721|ontheblock-2283-recent|5</span>
+                                                </div>
+                                            </div>
+                                        </a>
+                                        <div class="rbp_text ">
+                                            <h4>
+                            <a title="Late Williams-Sonoma CEO’s former home comes to market at $11.5 million" href="http://blog.sfgate.com/ontheblock/2015/04/28/williams-sonoma-founders-former-home-comes-to-market-at-11-5-million/" class="hdn-analytics">Late Williams-Sonoma CEO’s former home comes to market at $11.5 million<span class="hdn-analytics-data">visit|ontheblock-2283-post-9721|ontheblock-2283-recent|5</span></a>
+                        </h4>
+                                        </div>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="widget widget_categories" id="categories-10">
+                            <h2><span class="title">On <span class="widget-title-remainder">The Block Categories</span></span></h2>
+                            <select class="postform" id="cat" name="cat">
+                                <option value="-1">Select Category</option>
+                                <option value="54" class="level-0">Affordable housing</option>
+                                <option value="38" class="level-0">Agents</option>
+                                <option value="705" class="level-0">Apartments</option>
+                                <option value="89" class="level-0">Architectural Oddities</option>
+                                <option value="33" class="level-0">Architecture</option>
+                                <option value="36" class="level-0">Bay Area</option>
+                                <option value="332" class="level-0">beach houses</option>
+                                <option value="53" class="level-0">Bernal Heights</option>
+                                <option value="791" class="level-0">California</option>
+                                <option value="99" class="level-0">Celebrity</option>
+                                <option value="44" class="level-0">Condomania</option>
+                                <option value="652" class="level-0">Construction</option>
+                                <option value="3" class="level-0">Deals</option>
+                                <option value="73" class="level-0">Design</option>
+                                <option value="10" class="level-0">East Bay</option>
+                                <option value="27" class="level-0">Fixer upper</option>
+                                <option value="708" class="level-0">Flipping</option>
+                                <option value="95" class="level-0">Fun</option>
+                                <option value="710" class="level-0">Hayes Valley</option>
+                                <option value="22" class="level-0">High High-End</option>
+                                <option value="901" class="level-0">Historic</option>
+                                <option value="17" class="level-0">Home prices</option>
+                                <option value="70" class="level-0">Home Sales</option>
+                                <option value="108" class="level-0">Home staging</option>
+                                <option value="42" class="level-0">Housing crisis</option>
+                                <option value="51" class="level-0">Lake Tahoe</option>
+                                <option value="85" class="level-0">Leveraging home value</option>
+                                <option value="25" class="level-0">Local news</option>
+                                <option value="647" class="level-0">Luxury homes</option>
+                                <option value="30" class="level-0">Marin County</option>
+                                <option value="21" class="level-0">Napa</option>
+                                <option value="763" class="level-0">national</option>
+                                <option value="123" class="level-0">National news</option>
+                                <option value="7" class="level-0">New home developments</option>
+                                <option value="6" class="level-0">New listing</option>
+                                <option value="1130" class="level-0">Nob Hill</option>
+                                <option value="110" class="level-0">Noe Valley</option>
+                                <option value="18" class="level-0">Oakland</option>
+                                <option value="1183" class="level-0">Oakland As</option>
+                                <option value="20" class="level-0">Pacific Heights</option>
+                                <option value="41" class="level-0">Palo Alto</option>
+                                <option value="13" class="level-0">Price reductions</option>
+                                <option value="4" class="level-0">Real estate business</option>
+                                <option value="115" class="level-0">Real estate data</option>
+                                <option value="29" class="level-0">Real Estate Listings</option>
+                                <option value="116" class="level-0">Remodeling</option>
+                                <option value="28" class="level-0">Rentals</option>
+                                <option value="900" class="level-0">Russian Hill</option>
+                                <option value="9" class="level-0">Sales</option>
+                                <option value="156" class="level-0">San Anselmo</option>
+                                <option value="128" class="level-0">San Carlos</option>
+                                <option value="23" class="level-0">San Francisco</option>
+                                <option value="103" class="level-0">San Jose</option>
+                                <option value="106" class="level-0">Santa Clara County</option>
+                                <option value="107" class="level-0">Saratoga</option>
+                                <option value="47" class="level-0">Sausalito</option>
+                                <option value="102" class="level-0">Silicon Valley</option>
+                                <option value="5" class="level-0">Sonoma County</option>
+                                <option value="112" class="level-0">South Bay</option>
+                                <option value="98" class="level-0">South of Market</option>
+                                <option value="1" class="level-0">Uncategorized</option>
+                            </select>
+                            <script type="text/javascript">
+                            /* &lt;![CDATA[ */
+                            var dropdown = document.getElementById("cat");
+
+                            function onCatChange() {
+                                if (dropdown.options[dropdown.selectedIndex].value & gt; 0) {
+                                    location.href = "http://blog.sfgate.com/ontheblock/?cat=" + dropdown.options[dropdown.selectedIndex].value + "&amp;cmpid=wp-cat-sidebar";
+                                }
+                            }
+                            dropdown.onchange = onCatChange;
+                            /* ]]&gt; */
+                            </script>
+                        </div>
+                        <!--[<div id="hdn_wcm_most_popular-6" class="widget HDN_WCM_Most_Popular">]-->
+                        <!--[foo]-->
+                        <!--[bar]-->
+                        <div class="widget HDN_WCM_Most_Popular clearfix" id="hdn_wcm_most_popular-6">
+                            <script src="http://www.chron.com/js/hdn/utils/jquery.rot.js"></script>
+                            <!--?xml encoding="UTF-8"-->
+                            <!-- hearst/home/mostPopular.tpl -->
+                            <div class="most-popular">
+                                <!-- hearst/home/most_popular_header.tpl -->
+                                <div class="header clearfix">
+                                    <h2>Most Popular</h2>
+                                </div>
+                                <!-- e hearst/home/most_popular_header.tpl -->
+                                <div class="content">
+                                    <div class="contentGroups">
+                                        <ul>
+                                            <li>
+                                                <span>1</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="SurveyMonkey CEO Dave Goldberg remembered at Stanford memorial" href="http://www.sfgate.com/business/article/SurveyMonkey-CEO-David-Goldberg-remembered-at-6244367.php" class="hdn-analytics">SurveyMonkey CEO Dave Goldberg remembered at Stanford memorial<span style="display:none;" class="hdn-analytics-data">visit|article-6244367|most_popular|1</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                            <li>
+                                                <span>2</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="Ominous signs of problems with new Bay Bridge foundation" href="http://www.sfgate.com/bayarea/article/Ominous-signs-of-problems-with-new-Bay-Bridge-s-6244776.php" class="hdn-analytics">Ominous signs of problems with new Bay Bridge foundation<span style="display:none;" class="hdn-analytics-data">visit|article-6244776|most_popular|2</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                            <li>
+                                                <span>3</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="'Serial stowaway’ Marilyn Hartman arrested at Chicago’s O’Hare" href="http://www.sfgate.com/news/article/Serial-stowaway-Marilyn-Hartman-arrested-at-6244384.php" class="hdn-analytics">'Serial stowaway’ Marilyn Hartman arrested at Chicago’s...<span style="display:none;" class="hdn-analytics-data">visit|article-6244384|most_popular|3</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                            <li>
+                                                <span>4</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="Protesters confront DUI suspect in crash that killed 2" href="http://www.sfgate.com/crime/article/Friends-and-family-rail-at-Livermore-DUI-suspect-6243924.php" class="hdn-analytics">Protesters confront DUI suspect in crash that killed 2<span style="display:none;" class="hdn-analytics-data">visit|article-6243924|most_popular|4</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                            <li>
+                                                <span>5</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="Murder charge filed in gunning down of teen on Oakland street" href="http://www.sfgate.com/crime/article/Man-charged-with-murdering-14-year-old-in-6243547.php" class="hdn-analytics">Murder charge filed in gunning down of teen on Oakland street<span style="display:none;" class="hdn-analytics-data">visit|article-6243547|most_popular|5</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                        </ul>
+                                        <ul>
+                                            <li>
+                                                <span>6</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="Giants Splash: A deal with Mets that would make complete sense" href="http://www.sfgate.com/giants/article/Giants-Splash-Guessing-Padres-will-feel-6241680.php" class="hdn-analytics">Giants Splash: A deal with Mets that would make complete sense<span style="display:none;" class="hdn-analytics-data">visit|article-6241680|most_popular|6</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                            <li>
+                                                <span>7</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="‘The Price Is Right’ Awards a Treadmill to a Wheelchair-Bound Contestant (Video)" href="http://www.sfgate.com/entertainment/article/The-Price-Is-Right-Awards-a-Treadmill-to-a-6244117.php" class="hdn-analytics">‘The Price Is Right’ Awards a Treadmill to a...<span style="display:none;" class="hdn-analytics-data">visit|article-6244117|most_popular|7</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                            <li>
+                                                <span>8</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="Utah mom finds photos of her kids on porn sites" href="http://blog.sfgate.com/sfmoms/2015/05/05/utah-mom-finds-photos-of-her-kids-on-porn-sites/" class="hdn-analytics">Utah mom finds photos of her kids on porn sites<span style="display:none;" class="hdn-analytics-data">visit|blog-sfmoms|most_popular|8</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                            <li>
+                                                <span>9</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="Food critic Josh Ozersky found dead in Chicago hotel" href="http://www.sfgate.com/entertainment/article/Food-critic-Josh-Ozersky-found-dead-in-Chicago-6243817.php" class="hdn-analytics">Food critic Josh Ozersky found dead in Chicago hotel<span style="display:none;" class="hdn-analytics-data">visit|article-6243817|most_popular|9</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                            <li class="last">
+                                                <span>10</span>
+                                                <h4><!-- ux hearst/home/most_popular_title_link.tpl -->
+
+<a title="Condo protesters keep Oakland City Council from meeting" href="http://www.sfgate.com/news/article/Condo-protesters-block-Oakland-City-Council-6244926.php" class="hdn-analytics">Condo protesters keep Oakland City Council from meeting<span style="display:none;" class="hdn-analytics-data">visit|article-6244926|most_popular|10</span></a>
+<!-- e ux hearst/home/most_popular_title_link.tpl -->
+</h4>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!--/most-popular-->
+                            <!--e hearst/home/mostPopular.tpl -->
+                        </div>
+                        <div class="widget widget_text" id="text-15">
+                            <div class="textwidget">
+                                <a href="http://ezads.sfchron.com/"><img src="http://extras.sfgate.com/promotion/ezads-openhomes-300x250.jpg" /></a>
+                            </div>
+                        </div>
+                        <div class="widget-ad-position-S300 widget ad_position" id="hdn_ad_position-16">
+                            <div class="hdn-ad-position ad-S300 hdn-ap-visible-mobile hdn-ap-visible-desktop">
+                                <div class="juice-ad-position juice-ad-position-S300" id="S300">
+                                    <script id="S300-0-90838000-1430916267" type="text/javascript">
+                                    window.ad_position_widget.place_named_ad('S300', 'S300-0-90838000-1430916267');
+                                    </script>
+                                    <iframe width="1920" height="250" id="S300-ju1c3-TWFobmEgTWFobmE=-1fr4m3-4" name="S300-ju1c3-TWFobmEgTWFobmE=-1fr4m3-4" style="width: 300px; height: 250px; border: medium none; background-color: transparent; vertical-align: bottom;" scrolling="no" src="http://juice-files.sfgate.com/html/juiceframe?generationID=0x8D02BCA19C4A6A4CA4BE819B7EFEE027A26BD40D&amp;dm=sfgate.com&amp;slt=S300"></iframe>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="hdn_pm_post_sidebar_ad"></div>
+                    </div>
+                    <span id="blog-extras-anchor-small"></span>
+                    <div id="B728-placeholder" class="collapse"></div>
+                    <span id="comments-anchor-small"></span>
+                </div>
+                <div class="clearfix"></div>
+                <script>
+                var HDN = HDN || {};
+                HDN.ping = function(data) {
+                    var pingUrl = "http://p.ctpost.com/" + (data.type + "?") + (data.id ? "i=" + escape(data.id) + "&amp;" : "") + (data.site ? "s=" + data.site + "&amp;" : "") + (data.channel ? "c=" + data.channel + "&amp;" : "") + (data.title ? "t=" + escape(data.title) + "&amp;" : "") + (data.url ? "u=" + escape(data.url) + "&amp;" : "") + "ts=" + Number(new Date())
+                    new Image().src = pingUrl;
+                };
+                HDN.ping({
+                    "url": window.location.href,
+                    "id": "2283-9755",
+                    "site": "sfgate",
+                    "type": "blogEntry",
+                    "title": "Nob Hill one-bedroom sells for $2.3 million"
+                });
+                </script>
+                <div style="display: none;" id="archive-widget-presentation">
+                    <div class="archive-description">Browse previous blog posts by month and year of entry. You'll see all the posts for that time period.</div>
+                    <div class="archive-dropdown">
+                        <div class="archive-dropdown-item archive-dropdown-header">Select Month<span class="archive-dropdown-header-sprite"></span></div>
+                        <div style="display: none;" class="archive-dropdown-item archive-dropdown-more"><span class="archive-dropdown-more-text">Show Earlier</span></div>
+                    </div>
+                </div>
+                <div style="display: none;" class="clearfix" id="archive-widget-presentation-select">
+                    <div class="archive-contents">
+                        <div class="archive-description">Browse previous blog posts by month and year of entry. You'll see all the posts for that time period.</div>
+                        <div id="archive-select-goes-here"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript">
+        //Mixed/bad jQuery code might rely on this existing, so make sure it does.
+        if (!window.$)
+            window.$ = window.jQuery;
+        </script>
+    </div>
+    <script type="text/javascript" id="sitecatalyst_stub">
+    var s = new SC_Stub();
+    s.tagContainerName = "SFWordPress_s";
+
+    /************* DO NOT ALTER ANYTHING BELOW THIS LINE ! **************/
+    function SC_Stub() {
+        var t = this,
+            w = t.w = window;
+        t.d = w.document;
+        t._c = 's_l';
+        if (!w.s_c_il) {
+            w.s_c_il = [];
+            w.s_c_in = 0
+        }
+        t._il = w.s_c_il;
+        t._in = w.s_c_in;
+        t._il[t._in] = t;
+        w.s_c_in++;
+        t.fs = function(x, y) {
+            if (x & amp; & amp; y) {
+                var a =
+                    x.split(','),
+                    b = y.split(','),
+                    i, j;
+                for (i = 0; i & lt; a.length; i++) {
+                    for (j = 0; j & lt; b.length; j++)
+                        if (a[i] == b[j]) return 1
+                }
+            }
+            return 0
+        };
+        t.aa = function(a) {
+            var b = 0,
+                i;
+            if (a) {
+                b = [];
+                for (i = 0; i & lt; a.length; i++) b[i] = a[i]
+            }
+            return b
+        };
+        t.wl = [];
+        t.wq = [];
+        t.createAsynchronousCustomTagHandler = function(o, f) {
+            var t = this,
+                x, i;
+            if (!f) {
+                f = o;
+                o = 0;
+                x = t.w
+            } else {
+                if (!t.w[o]) t.w[o] = {};
+                x = t.wl[o] = t.w[o]
+            }
+            if (typeof(f) != 'object') f = [f];
+            for (i = 0; i & lt; f.length; i++)
+                if (!x[f[
+                        i]]) x[f[i]] = new Function('var t=s_c_il[' + t._in + '];t.wq[t.wq.length]={' + (o ? 'o:"' + o + '",' : '') + 'f:"' + f[i] + '",a:t.aa(arguments)}')
+        };
+        t.as = function(x) {
+            var y = [],
+                i;
+            for (i = 1; i & lt; x.length; i++) y[y.length] = x[i]
+            return y
+        };
+        t.s = 0;
+        t.contextData = {};
+        t.retrieveLightData = {};
+        if (!w.s_giq) w.s_giq = [];
+        t._gi = w.s_gi;
+        w.s_gi = new Function('u', 'var t=s_c_il[' + t._in +
+            '],w=t.w,l=t._il,i,j,x,s;u=u.toLowerCase();if(l)for(j=0;j&lt;2;j++)for(i=0;i&lt;l.length;i++){s=l[i];x=s._c;if((!x||x=="s_c"||(j&gt;0&amp;&amp;x=="s_l"))&amp;&amp;s.oun&amp;&amp;(s.oun==u||(s.fs&amp;&amp;s.sa&amp;&amp;s.fs(s.oun,u)))){' +
+            'if(s.sa)s.sa(u);return s}}if(!t.oun){t.sa(u);return t}if(t._gi)return t._gi(u);s=new SC_Stub();s.tagContainerName="s_tca_"+w.s_giq.length;s.sa(u);w.s_giq[w.s_giq.length]=s;return s');
+        t.sa = function(u) {
+            var t = this;
+            if (t.s) t.s.sa(u);
+            t.un = u;
+            if (!t.oun) t.oun = u;
+            else if (!t.fs(t.oun, u)) t.oun += ',' + u
+        };
+        t.tq = [];
+        t.track = t.t = function(vo) {
+            var t = this,
+                m;
+            if (t.s) return t.s.t(vo);
+            if (!vo) vo = {};
+            for (m in t) {
+                if (m != 'un' || t.u != t.un) vo[m] = t[m]
+            }
+            t.tq[t.tq.length] = vo;
+            t.lnk = t.linkName = t.linkType = '';
+            return '';
+        };
+        t.trackLink = t.tl = function(o, u, n, vo) {
+            var t = this;
+            if (t.s) return t.s.tl(o, u, v, vo);
+            t.lnk = o;
+            t.linkType = u;
+            t.linkName = n
+            return t.t(vo)
+        };
+        t.trackLight = function(p, ss, i, vo) {
+            var t = this;
+            if (t.s) return t.s.trackLight(p, ss, i, vo);
+            t.lightProfileID = p;
+            t.lightStoreForSeconds = ss;
+            t.lightIncrementBy = i;
+            return t.t(vo)
+        };
+        t.lmq = []
+        t.loadModule = function(n, u, d) {
+            var t = this;
+            if (t.s) return t.s.loadModule(n, u, d);
+            t.lmq[t.lmq.length] = {
+                n: n,
+                u: u,
+                d: d
+            };
+            return 0
+        };
+        t.ml = [];
+        t.mmq = [];
+        t.mo = function(m, f) {
+            var t = this,
+                i;
+            t.ml[m] = t[m] = {};
+            if (f)
+                for (i = 0; i & lt; f.length; i++) t[m][f[i]] = new Function('var t=s_c_il[' + t._in + '];t.mmq[t.mmq.length]={m:"' + m + '",f:"' + f[i] + '",a:t.aa(arguments)}')
+        };
+        t.mo('Media', ['open', 'play', 'stop', 'close', 'track']);
+        t.mo(
+            'Survey', ['launch']);
+    };
+    amc.call('getLoaderById', 0).publish('ontagload.sitecatalyst_stub', {
+        id: 'sitecatalyst_stub',
+        tag: amc.call('getById', 'sitecatalyst_stub')
+    })
+    </script>
+    <script type="text/javascript" id="sitecatalyst" async="" defer="defer" src="//www.adobetag.com/d1/v2/ZDEtaGVhcnN0LTMwNzctMzY0Ni0=/live/sitecatalyst.js"></script>
+    <script type="text/javascript" id="ga">
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-1616916-22']);
+    _gaq.push(['_trackPageview']);
+    _gaq.push(['adSenseTracker._setAccount', 'UA-1616916-28']);
+    _gaq.push(['adSenseTracker._trackPageview']);
+
+    (function() {
+        var ga = document.createElement('script');
+        ga.type = 'text/javascript';
+        ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(ga, s);
+    })();;
+    amc.call('getLoaderById', 0).publish('ontagload.ga', {
+        id: 'ga',
+        tag: amc.call('getById', 'ga')
+    })
+    </script>
+    <script type="text/javascript" id="nielsen">
+    function nielsenEvent() {
+        var d = new Image(1, 1);
+        d.src = ["//secure-us.imrworldwide.com/cgi-bin/m?ci=us-202808h&amp;cg=0&amp;cc=1&amp;si=", escape(window.location.href), "&amp;rp=", escape(document.referrer), "&amp;c0=usergen,1&amp;rnd=", (new Date()).getTime()].join('');
+    }
+    nielsenEvent();;
+    amc.call('getLoaderById', 0).publish('ontagload.nielsen', {
+        id: 'nielsen',
+        tag: amc.call('getById', 'nielsen')
+    })
+    </script><img width="4" height="4" id="moat4887471000000" style="display: none;" />
+    <script type="text/javascript">
+    omni_blogauthor = "Emily Landes";
+    </script>
+    <script>
+    (function(window, document, url, funcName, a, m) {
+        window.plsWidgetPendingObj = funcName;
+        window.plsWidgetLoadBase = url;
+        window[funcName] = window[funcName] || [], a = document.createElement('script'), m = document.getElementsByTagName('script')[0];
+        a.async = 1;
+        a.src = '//' + url + '/api/widgets/';
+        m.parentNode.insertBefore(a, m);
+    })(window, document, 'sfgate.placester.net', 'plsWidgets');
+    </script>
+    <script type="text/javascript" id="perfect_market_js">
+    if (!window.is_mobile) document.write("&lt;script src=\"http:\/\/widget.perfectmarket.com\/wwwsfgate\/load.js\"&gt;&lt;\/script&gt;");
+    </script>
+    <script src="http://widget.perfectmarket.com/wwwsfgate/load.js"></script>
+    <script src="//widget.perfectmarket.com/wwwsfgate/pmk-1.26.js"></script>
+    <div style="position: absolute; left: -9999px; top: -9999px;">
+        <object width="1" height="1" id="moatCap" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" type="application/x-shockwave-flash">
+            <param value="always" name="allowScriptAccess" />
+            <param value="false" name="allowFullScreen" />
+            <param value="http://s.moatads.com/swf/cap.swf" name="movie" />
+            <param value="high" name="quality" />
+            <param value="#ffffff" name="bgcolor" />
+            <embed width="1" height="1" align="middle" allowfullscreen="false" allowscriptaccess="always" id="moatCapEmbed" bgcolor="#ffffff" quality="high" src="http://s.moatads.com/swf/cap.swf" type="application/x-shockwave-flash" />
+        </object>
+    </div>
+    <script type="text/javascript">
+    (function() {
+        function loadHorizon() {
+            var s = document.createElement('script');
+            s.type = 'text/javascript';
+            s.id = 'SailThruHorizon';
+            s.async = true;
+            s.src = location.protocol + '//ak.sail-horizon.com/horizon/v1.js';
+            var x = document.getElementsByTagName('script')[0];
+            x.parentNode.insertBefore(s, x);
+        }
+        loadHorizon();
+        var oldOnLoad = window.onload;
+        window.onload = function() {
+            if (typeof oldOnLoad === 'function') {
+                oldOnLoad();
+            }
+            Sailthru.setup({
+                domain: 'horizon.sfgate.com'
+            });
+        };
+    })();
+    </script>
+    <div style="display: none;" id="sharing_email">
+        <form method="post" action="/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/">
+            <label for="target_email">Send to Email Address</label>
+            <input type="email" value="" id="target_email" name="target_email" />
+            <label for="source_name">Your Name</label>
+            <input type="text" value="" id="source_name" name="source_name" />
+            <label for="source_email">Your Email Address</label>
+            <input type="email" value="" id="source_email" name="source_email" />
+            <div id="sharing_recaptcha" class="recaptcha"></div>
+            <input type="hidden" value="6LcUUOISAAAAACcvgc8wFtiofqc9BvnQoXqqHeem" id="recaptcha_public_key" name="recaptcha_public_key" />
+            <img width="16" height="16" alt="loading" src="http://blog.sfgate.com/ontheblock/wp-content/plugins/jetpack/modules/sharedaddy/images/loading.gif" class="loading" style="float: right; display: none" />
+            <input type="submit" class="sharing_send" value="Send Email" />
+            <a class="sharing_cancel" href="#cancel">Cancel</a>
+            <div style="display: none;" class="errors errors-1">
+                Post was not sent - check your email addresses! </div>
+            <div style="display: none;" class="errors errors-2">
+                Email check failed, please try again </div>
+            <div style="display: none;" class="errors errors-3">
+                Sorry, your blog cannot share posts by email. </div>
+        </form>
+    </div>
+    <script type="text/javascript">
+    jQuery(document).on('ready post-load', function() {
+        jQuery('a.share-facebook').on('click', function() {
+            window.open(jQuery(this).attr('href'), 'wpcomfacebook', 'menubar=1,resizable=1,width=600,height=400');
+            return false;
+        });
+    });
+    </script>
+    <script type="text/javascript">
+    jQuery(document).on('ready post-load', function() {
+        jQuery('a.share-twitter').on('click', function() {
+            window.open(jQuery(this).attr('href'), 'wpcomtwitter', 'menubar=1,resizable=1,width=600,height=350');
+            return false;
+        });
+    });
+    </script>
+    <script type="text/javascript">
+    jQuery(document).on('ready', function() {
+        jQuery('body').on('click', 'a.share-pinterest', function(e) {
+            e.preventDefault();
+
+            // Load Pinterest Bookmarklet code
+            var s = document.createElement("script");
+            s.type = "text/javascript";
+            s.src = window.location.protocol + "//assets.pinterest.com/js/pinmarklet.js?r=" + (Math.random() * 99999999);
+            var x = document.getElementsByTagName("script")[0];
+            x.parentNode.insertBefore(s, x);
+
+            // Trigger Stats
+            var s = document.createElement("script");
+            s.type = "text/javascript";
+            s.src = this + (this.toString().indexOf('?') ? '&amp;' : '?') + 'js_only=1';
+            var x = document.getElementsByTagName("script")[0];
+            x.parentNode.insertBefore(s, x);
+        });
+    });
+    </script>
+    <script type="text/javascript">
+    jQuery(document).on('ready post-load', function() {
+        jQuery('a.share-google-plus-1').on('click', function() {
+            window.open(jQuery(this).attr('href'), 'wpcomgoogle-plus-1', 'menubar=1,resizable=1,width=480,height=550');
+            return false;
+        });
+    });
+    </script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/hdn-viafoura-comments/js/viafouraFooter.js?ver=1.0;183a00449d888c206925d1f2d5194633" type="text/javascript"></script>
+    <script type="text/javascript">
+    /* &lt;![CDATA[ */
+    var pollsL10n = {
+        "ajax_url": "http:\/\/blog.sfgate.com\/ontheblock\/wp-admin\/admin-ajax.php",
+        "text_wait": "Your last request is still being processed. Please wait a while ...",
+        "text_valid": "Please choose a valid poll answer.",
+        "text_multiple": "Maximum number of choices allowed: ",
+        "show_loading": "1",
+        "show_fading": "1"
+    };
+    /* ]]&gt; */
+    </script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/wp-polls/polls-js.js?ver=2.63;b15f2feec63acadb61b656e3caaafd7c" type="text/javascript"></script>
+    <script src="http://s0.wp.com/wp-content/js/devicepx-jetpack.js?ver=201519" type="text/javascript"></script>
+    <script type="text/javascript">
+    /* &lt;![CDATA[ */
+    var hdnShareButtonsScriptLocalization = {
+        "blog_id": "2283",
+        "template": "single"
+    };
+    /* ]]&gt; */
+    </script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/jetpack/modules/sharedaddy/hdnShareButtonsScript.js?ver=20121205" type="text/javascript"></script>
+    <script type="text/javascript">
+    /* &lt;![CDATA[ */
+    var recaptcha_options = {
+        "lang": "en"
+    };
+    /* ]]&gt; */
+    </script>
+    <script src="http://blog.sfgate.com/ontheblock/wp-content/plugins/jetpack/modules/sharedaddy/sharing.js?ver=20121205" type="text/javascript"></script>
+    <!-- Don't forget analytics -->
+    <script type="text/javascript">
+    window.NREUM || (NREUM = {});
+    NREUM.info = {
+        "beacon": "bam.nr-data.net",
+        "licenseKey": "7362bac70a",
+        "applicationID": "1492280",
+        "transactionName": "NlRaZBRTVhBRVRFQWA8eeVMSW1cNH0UMV1ANVA==",
+        "queueTime": 0,
+        "applicationTime": 525,
+        "atts": "GhNZElxJRR4=",
+        "errorBeacon": "bam.nr-data.net",
+        "agent": "js-agent.newrelic.com\/nr-632.min.js"
+    }
+    </script>
+    <div class="autocomplete-suggestions" style="position: absolute; display: none; top: 168px; left: 538px; width: 636px; max-height: 300px; z-index: 9999;"></div>
+    <div style="display:none;"><img width="1" border="0" height="1" alt="Quantcast" src="//pixel.quantserve.com/pixel/p-573scDfDoUH6o.gif?labels=45981,1430917075253" /></div>
+</body>
+
+</html>

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -18,7 +18,7 @@ function reformatError(err) {
 
 function runTestsWithItems(label, beforeFn, expectedContent, expectedMetadata) {
   describe(label, function() {
-    this.timeout(5000);
+    this.timeout(10000);
 
     var result;
 


### PR DESCRIPTION
Refs #209 and http://blog.sfgate.com/ontheblock/2015/05/05/nob-hill-one-bedroom-sells-for-2-3-million/

This page, visibly made using MSWord, seems to have generated, poorly structured semantics ; so this patch doesn't entirely fix the situation with it. Though:
- it boosts scores for traditional elements used to store text containing more than 300 characters, so at least we have the actual article contents now part of the readable version;
- it clears up part of the gallery thing by removing its control bar.

I know this approach is far from ideal (don't ask me why 1.5 or why 300 and not 200 or 400), we could also decide not caring too much for this specific range of websites.
