### PR TITLE
jsdom dependency version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "chai": "^2.1.*",
     "js-beautify": "^1.5.5",
-    "jsdom": "^3.1.2",
+    "jsdom": "^3.1.2 < 4.0.0",
     "matcha": "^0.6.0",
     "mocha": "^2.2.*"
   }


### PR DESCRIPTION
jsdom 4.0+ no longer supports nodejs (check https://github.com/tmpvar/jsdom)