### PR TITLE
Ignore script tags when calculating whether something is readable

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -109,6 +109,7 @@ Readability.prototype = {
   REGEXPS: {
     unlikelyCandidates: /banner|combx|comment|community|disqus|extra|foot|header|menu|related|remark|rss|share|shoutbox|sidebar|skyscraper|sponsor|ad-break|agegate|pagination|pager|popup/i,
     okMaybeItsACandidate: /and|article|body|column|main|shadow/i,
+    unlikelyNodes: /script/i, // Because of the internet, we sometimes want to keep things like <header> nodes, so we can't just blinly include nodes in the unlikelyCandidates list above
     positive: /article|body|content|entry|hentry|main|page|pagination|post|text|blog|story/i,
     negative: /hidden|banner|combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|tool|widget/i,
     extraneous: /print|archive|comment|discuss|e[\-]?mail|share|reply|all|login|sign|single|utility/i,
@@ -647,7 +648,7 @@ Readability.prototype = {
 
         // Remove unlikely candidates
         if (stripUnlikelyCandidates) {
-          if (this.REGEXPS.unlikelyCandidates.test(matchString) &&
+          if ((this.REGEXPS.unlikelyCandidates.test(matchString) || this.REGEXPS.unlikelyNodes.test(node.tagName)) &&
               !this.REGEXPS.okMaybeItsACandidate.test(matchString) &&
               node.tagName !== "BODY" &&
               node.tagName !== "A") {
@@ -1716,7 +1717,7 @@ Readability.prototype = {
         return false;
       var matchString = node.className + " " + node.id;
 
-      if (this.REGEXPS.unlikelyCandidates.test(matchString) &&
+      if ((this.REGEXPS.unlikelyCandidates.test(matchString) || this.REGEXPS.unlikelyNodes.test(node.tagName)) &&
           !this.REGEXPS.okMaybeItsACandidate.test(matchString)) {
         return false;
       }

--- a/test/test-pages/bbc-1/expected-metadata.json
+++ b/test/test-pages/bbc-1/expected-metadata.json
@@ -1,0 +1,7 @@
+{
+  "title": "Obama admits US gun laws are his 'biggest frustration' - BBC News",
+  "byline": null,
+  "dir": "ltr",
+  "excerpt": "President Barack Obama tells the BBC his failure to pass",
+  "readerable": true
+}

--- a/test/test-pages/bbc-1/expected.html
+++ b/test/test-pages/bbc-1/expected.html
@@ -1,0 +1,59 @@
+<div id="readability-page-1" class="page">
+    <div class="story-body__inner" property="articleBody">
+        <p class="story-body__introduction">President Barack Obama has admitted that his failure to pass "common sense gun safety laws" in the US is the greatest frustration of his presidency. </p>
+        <p>In an interview with the BBC, Mr Obama said it was "distressing" not to have made progress on the issue "even in the face of repeated mass killings".</p>
+        <p>He vowed to keep trying, but the BBC's North America editor Jon Sopel said the president did not sound very confident. </p>
+        <p>However, Mr Obama said race relations had improved during his presidency. </p>
+        <p>Hours after the interview, a gunman opened fire at a cinema in the US state of Louisiana, killing two people and injuring several others before shooting himself.</p>
+        <p>In a wide-ranging interview, President Obama also said:</p>
+        <ul class="story-body__unordered-list">
+            <li class="story-body__list-item"> <a href="http://www.bbc.co.uk/news/uk-politics-33647154" class="story-body__link">The UK must stay in the EU</a> to have influence on the world stage</li>
+            <li class="story-body__list-item">He is confident the Iran nuclear deal will be passed by Congress </li>
+            <li class="story-body__list-item">Syria needs a political solution in order to defeat the Islamic State group</li>
+            <li class="story-body__list-item">He would speak "bluntly" against corruption <a href="http://www.bbc.co.uk/news/world-us-canada-33646563" class="story-body__link">and human rights violations in Kenya</a> </li>
+            <li class="story-body__list-item">He would defend his advocacy of gay rights following protests in Kenya</li>
+            <li class="story-body__list-item">Despite racial tensions, the US is becoming more diverse and more tolerant</li>
+        </ul>
+        <p><a href="http://www.bbc.co.uk/news/world-us-canada-33646542" class="story-body__link">Read the full transcript of his interview</a></p>
+        <p>Mr Obama lands in Kenya later on Friday for his first visit since becoming president. </p>
+        <p>But with just 18 months left in power, he said gun control was the area where he has been "most frustrated and most stymied" since coming to power in 2009.</p>
+        <p>"If you look at the number of Americans killed since 9/11 by terrorism, it's less than 100. If you look at the number that have been killed by gun violence, it's in the tens of thousands," Mr Obama said. </p>
+        <figure class="media-landscape full-width has-caption"><img src="http://ichef.bbci.co.uk/news/555/cpsprodpb/462D/production/_84456971_gettyimages-167501087.jpg" datasrc="http://ichef.bbci.co.uk/news/976/cpsprodpb/462D/production/_84456971_gettyimages-167501087.jpg" class="js-image-replace" alt="Gun control campaigners protest in McPhearson Square in Washington DC - 25 April 2013" height="549" width="976">
+            <figcaption class="media-caption"> <span class="media-caption__text">
+                        The president said he would continue fighting for greater gun control laws
+                    </span> </figcaption>
+        </figure>
+        <p>"For us not to be able to resolve that issue has been something that is distressing," he added. </p>
+        <p>Mr Obama has pushed for stricter gun control throughout his presidency but has been unable to secure any significant changes to the laws. </p>
+        <p>After nine African-American churchgoers were killed in South Carolina in June, he admitted "politics in this town" meant there were few options available.</p>
+        <figure class="media-landscape body-width no-caption"><img src="http://ichef.bbci.co.uk/news/555/media/images/76020000/jpg/_76020974_line976.jpg" datasrc="http://ichef.bbci.co.uk/news/464/media/images/76020000/jpg/_76020974_line976.jpg" class="js-image-replace" alt="line" height="2" width="464"></figure>
+        <h2 class="story-body__crosshead">Analysis: Jon Sopel, BBC News, Washington</h2>
+        <figure class="media-landscape full-width no-caption"><img src="http://ichef-1.bbci.co.uk/news/555/cpsprodpb/6D3D/production/_84456972_p072315al-0500.jpg" datasrc="http://ichef-1.bbci.co.uk/news/976/cpsprodpb/6D3D/production/_84456972_p072315al-0500.jpg" class="js-image-replace" alt="President Barack Obama participates in an interview with Jon Sopel of BBC in the Roosevelt Room of the White House - 23 July 2015" height="549" width="976"></figure>
+        <p>Nine months ago, the president seemed like a spent force, after taking a beating in the midterm elections, during which members of his own party were reluctant to campaign on his record. </p>
+        <p>But the man sat before me today was relaxed and confident, buoyed by a string of "wins" on healthcare, Cuba and Iran, after bitter and ongoing battles with his many critics. </p>
+        <p>The only body swerve the president performed was when I asked him <a href="http://www.bbc.co.uk/news/world-us-canada-33643168" class="story-body__link"> how many minds he had changed on the Iran nuclear deal </a>after an intense sell aimed at Gulf allies and members of US Congress who remain implacably opposed. </p>
+        <p>There was a momentary flicker across the president's face as if to say "You think you got me?" before his smile returned and he proceeded to talk about how Congress would come round.</p>
+        <p>But notably, he did not give a direct answer to that question, which leaves me with the impression that he has persuaded precisely zero.</p>
+        <p><a href="http://www.bbc.co.uk/news/world-us-canada-33646875" class="story-body__link">Five things we learned from Obama interview</a></p>
+        <p><a href="http://www.bbc.co.uk/news/world-us-canada-33646545" class="story-body__link">The presidential body swerve</a></p>
+        <figure class="media-landscape body-width no-caption"><img src="http://ichef.bbci.co.uk/news/555/media/images/76020000/jpg/_76020974_line976.jpg" datasrc="http://ichef.bbci.co.uk/news/464/media/images/76020000/jpg/_76020974_line976.jpg" class="js-image-replace" alt="line" height="2" width="464"></figure>
+        <p>On race relations, Mr Obama said recent concerns around policing and mass incarcerations were "legitimate and deserve intense attention" but insisted progress had been made. </p>
+        <p>Children growing up during the eight years of his presidency "will have a different view of race relations in this country and what's possible," he said. </p>
+        <p>"There are going to be tensions that arise. But if you look at my daughters' generation, they have an attitude about race that's entirely different than even my generation."</p>
+        <p>Talking about how he was feeling after his recent successes, he said "every president, every leader has strengths and weaknesses". </p>
+        <p>"One of my strengths is I have a pretty even temperament. I don't get too high when it's high and I don't get too low when it's low," he said. </p>
+        <figure class="media-landscape full-width has-caption"><img src="http://ichef-1.bbci.co.uk/news/555/cpsprodpb/142FD/production/_84458628_shirtreuters.jpg" datasrc="http://ichef-1.bbci.co.uk/news/976/cpsprodpb/142FD/production/_84458628_shirtreuters.jpg" class="js-image-replace" alt="Customer looks at Obama shirts at a stall in Nairobi's Kibera slums, 23 July 2015" height="549" width="976">
+            <figcaption class="media-caption"> <span class="media-caption__text">
+                        Kenya is getting ready to welcome the US president
+                    </span> </figcaption>
+        </figure>
+        <h2 class="story-body__crosshead">Kenya trip</h2>
+        <p>Mr Obama was speaking to the BBC at the White House before departing for Kenya.</p>
+        <p>His father was Kenyan and the president is expected to meet relatives in Nairobi.</p>
+        <p>Mr Obama has faced criticism in the country after the US legalised gay marriage. However, in his interview, the president said he would not fall silent on the issue.</p>
+        <p>"I am not a fan of discrimination and bullying of anybody on the basis of race, on the basis of religion, on the basis of sexual orientation or gender," he said.</p>
+        <p>The president also admitted that some African governments, including Kenya's, needed to improve their records on human rights and democracy. However, he defended his decision to engage with and visit those governments. </p>
+        <p>"Well, they're not ideal institutions. But what we found is, is that when we combined blunt talk with engagement, that gives us the best opportunity to influence and open up space for civil society." </p>
+        <p>Mr Obama will become the first US president to address the African Union when he travels on to Ethiopia on Sunday.</p>
+    </div>
+</div>

--- a/test/test-pages/bbc-1/source.html
+++ b/test/test-pages/bbc-1/source.html
@@ -1,0 +1,2557 @@
+<html class="orb-js bbcdotcom bbcdotcom-responsive ads-enabled ctm ff flex bbcdotcom-init bbcdotcom-analytics-init grunticon bbccom-group-2" id="responsive-news" prefix="og: http://ogp.me/ns#" lang="en"><head><script src="http://s0.2mdn.net/instream/html5/gpt_proxy.js" type="text/javascript" async=""></script><script src="http://s0.2mdn.net/instream/html5/gpt_proxy.js" type="text/javascript" async=""></script><script src="http://s0.2mdn.net/instream/html5/gpt_proxy.js" type="text/javascript" async=""></script><script src="http://beacon.krxd.net/optout_check?callback=Krux.ns._default.kxjsonp_optOutCheck" type="text/javascript"></script><script src="http://cdn.krxd.net/userdata/get?pub=5d7aaa39-eeed-454f-bb7d-ecea38d770fc&amp;technographics=1&amp;callback=Krux.ns._default.kxjsonp_userdata" type="text/javascript"></script><script src="http://beacon.krxd.net/optout_check?callback=Krux.ns._default.kxjsonp_optOutCheck" type="text/javascript"></script><script src="http://s0.2mdn.net/instream/html5/gpt_proxy.js" type="text/javascript" async=""></script><script async="" charset="UTF-8" src="http://odb.outbrain.com/utils/get?url=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704&amp;settings=true&amp;recs=true&amp;widgetJSId=AR_9&amp;key=NANOWDGT01&amp;idx=3&amp;version=264730&amp;ref=&amp;apv=false&amp;sig=FC1ReOE3&amp;format=html&amp;rand=48671&amp;lsd=0ac84357-f829-4e49-9e8c-8571d3af928a&amp;t=MV9iYTQ4NWM0YjhkYTA4MWM1M2M3YjBlMmQ0NWViZTI3N18w&amp;winW=584&amp;winH=500" type="text/javascript"></script><style>.svg-icon--audio-dark { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M16%204l-6%206H0v12h10l6%206zM25.3.3l-1.8%201.8c3.7%203.5%206%208.5%206%2014s-2.3%2010.4-6%2014l1.8%201.8c4.1-4%206.7-9.6%206.7-15.7C32%209.9%2029.4%204.3%2025.3.3zm-4.5%204.5L19%206.6c2.4%202.4%203.9%205.8%203.9%209.5s-1.5%207-3.9%209.5l1.8%201.8c2.8-2.9%204.6-6.9%204.6-11.2%200-4.5-1.8-8.5-4.6-11.4z%22%20fill%3D%22%23000%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--audio-light { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M16%204l-6%206H0v12h10l6%206zM25.3.3l-1.8%201.8c3.7%203.5%206%208.5%206%2014s-2.3%2010.4-6%2014l1.8%201.8c4.1-4%206.7-9.6%206.7-15.7C32%209.9%2029.4%204.3%2025.3.3zm-4.5%204.5L19%206.6c2.4%202.4%203.9%205.8%203.9%209.5s-1.5%207-3.9%209.5l1.8%201.8c2.8-2.9%204.6-6.9%204.6-11.2%200-4.5-1.8-8.5-4.6-11.4z%22%20fill%3D%22%23fff%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--email { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M16%2019.37L32%204.43V3H0v26h32V8l-4%204v13H4V8.17l12%2011.2zm0-2.76L5.81%207h20.38L16%2016.61z%22%2F%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--gallery-dark { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M9%205V3H4v2H0v24h32V5H9zm-2.5%208C5.1%2013%204%2011.9%204%2010.5S5.1%208%206.5%208%209%209.1%209%2010.5%207.9%2013%206.5%2013zM20%2026c-5%200-9-4-9-9s4-9%209-9%209%204%209%209-4%209-9%209z%22%20fill%3D%22%23000%22%3E%3C%2Fpath%3E%3Cpath%20d%3D%22M20%2011.5c-3%200-5.5%202.5-5.5%205.5s2.5%205.5%205.5%205.5%205.5-2.5%205.5-5.5-2.5-5.5-5.5-5.5z%22%20fill%3D%22%23000%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--mobile-smart { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M6%200v32h20V0H6zm8%202h4v1h-4V2zm3%2028h-2v-2h2v2zm7-3H8V4h16v23z%22%2F%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--newsletter { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M5%203h22v12h3V0H2v15h3zm5%209h12v3H10zm0%204h12v3H10zm0-8h12v3H10zm19.46%208l-.46.29-13%208.13-13-8.13-.46-.29H0v16h32V16h-2.54zM29%2029H3V17.46l13%208.13%2013-8.13V29z%22%2F%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--rss { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Ccircle%20cx%3D%225.01%22%20cy%3D%2226.98%22%20r%3D%225%22%2F%3E%3Cpath%20d%3D%22M24.99%2031.98V32h7v-.02C31.99%2014.32%2017.67%200%20.01%200v7c13.78%200%2024.98%2011.2%2024.98%2024.98zm-9.99%200V32h7v-.02C22%2019.84%2012.15%209.99.01%209.99v7C8.28%2016.99%2015%2023.71%2015%2031.98z%22%2F%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--to-bottom { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M5.35%201.9H0l15.89%2023.4L32%201.9h-5.34L15.88%2017.48zM.4%2025.3h31.2v4.8H.4z%22%2F%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--twitter { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M32%206.08c-1.18.52-2.45.87-3.77%201.03%201.35-.81%202.4-2.1%202.89-3.64-1.27.75-2.68%201.3-4.17%201.6C25.75%203.8%2024.04%203%2022.16%203c-3.63%200-6.57%202.94-6.57%206.56%200%20.52.06%201.02.17%201.5-5.46-.28-10.3-2.89-13.54-6.86-.56.97-.89%202.1-.89%203.3%200%202.27%201.16%204.28%202.92%205.46-1.08-.04-2.09-.33-2.98-.82v.09c0%203.17%202.27%205.82%205.27%206.43-.54.15-1.12.23-1.72.23-.42%200-.83-.04-1.23-.11.84%202.61%203.25%204.5%206.13%204.55-2.25%201.76-5.08%202.82-8.16%202.82-.53%200-1.05-.04-1.56-.09C2.9%2027.92%206.35%2029%2010.06%2029c12.08%200%2018.68-10%2018.68-18.68%200-.28-.01-.57-.02-.85%201.29-.92%202.4-2.08%203.28-3.39z%22%2F%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--video-dark { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M3%2032l26-16L3%200z%22%20fill%3D%22%23000%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+.svg-icon--video-light { background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20d%3D%22M3%2032l26-16L3%200z%22%20fill%3D%22%23fff%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E'); background-repeat: no-repeat; }
+
+</style><script async="" charset="UTF-8" src="http://odb.outbrain.com/utils/get?url=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704&amp;settings=true&amp;recs=true&amp;widgetJSId=AR_8&amp;key=NANOWDGT01&amp;idx=2&amp;version=264730&amp;ref=&amp;apv=false&amp;sig=FC1ReOE3&amp;format=html&amp;rand=41769&amp;lsd=0ac84357-f829-4e49-9e8c-8571d3af928a&amp;t=MV9iYTQ4NWM0YjhkYTA4MWM1M2M3YjBlMmQ0NWViZTI3N18w&amp;winW=584&amp;winH=500" type="text/javascript"></script><iframe style="width: 0px; height: 0px; border: 0px none; display: none;" title="" src="javascript:false"></iframe><script async="" charset="UTF-8" src="http://odb.outbrain.com/utils/get?url=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704&amp;settings=true&amp;recs=true&amp;widgetJSId=AR_7&amp;key=NANOWDGT01&amp;idx=1&amp;version=264730&amp;ref=&amp;apv=false&amp;sig=FC1ReOE3&amp;format=html&amp;rand=33694&amp;lsd=0ac84357-f829-4e49-9e8c-8571d3af928a&amp;t=MV9iYTQ4NWM0YjhkYTA4MWM1M2M3YjBlMmQ0NWViZTI3N18w&amp;winW=584&amp;winH=500" type="text/javascript"></script><script async="" charset="UTF-8" src="http://odb.outbrain.com/utils/get?url=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704&amp;settings=true&amp;recs=true&amp;widgetJSId=AR_5&amp;key=NANOWDGT01&amp;idx=0&amp;version=264730&amp;ref=&amp;apv=false&amp;sig=FC1ReOE3&amp;format=html&amp;rand=26305&amp;lsd=0ac84357-f829-4e49-9e8c-8571d3af928a&amp;winW=584&amp;winH=500" type="text/javascript"></script><style type="text/css"></style>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Obama admits US gun laws are his 'biggest frustration' - BBC News</title>
+    <meta name="description" content="President Barack Obama tells the BBC his failure to pass " common="" sense="" gun="" safety="" laws"="" is="" the="" greatest="" frustration="" of="" his="" presidency."="">
+
+    <meta name="x-country" content="us">
+    <meta name="x-audience" content="US">
+    <meta name="CPS_AUDIENCE" content="US">
+    <meta name="CPS_CHANGEQUEUEID" content="250829915">
+    <link rel="canonical" href="http://www.bbc.com/news/world-us-canada-33646704">
+
+                        <link rel="alternate" hreflang="en-gb" href="http://www.bbc.co.uk/news/world-us-canada-33646704">
+                                <link rel="alternate" hreflang="en" href="http://www.bbc.com/news/world-us-canada-33646704">
+                            <meta property="og:title" content="Obama admits US gun laws are his 'biggest frustration' - BBC News">
+    <meta property="og:type" content="article">
+    <meta property="og:description" content="President Barack Obama tells the BBC his failure to pass &quot;common sense gun safety laws&quot; is the greatest frustration of his presidency.">
+    <meta property="og:site_name" content="BBC News">
+    <meta property="og:locale" content="en_GB">
+    <meta property="og:article:author" content="BBC News">
+    <meta property="og:article:section" content="US &amp; Canada">
+    <meta property="og:url" content="http://www.bbc.com/news/world-us-canada-33646704">
+    <meta property="og:image" content="http://ichef.bbci.co.uk/news/1024/cpsprodpb/3D8B/production/_84455751_84455749.jpg">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@BBCWorld">
+    <meta name="twitter:title" content="Obama admits US gun laws are his 'biggest frustration' - BBC News">
+    <meta name="twitter:description" content="President Barack Obama tells the BBC his failure to pass &quot;common sense gun safety laws&quot; is the greatest frustration of his presidency.">
+    <meta name="twitter:creator" content="@BBCWorld">
+    <meta name="twitter:image:src" content="http://ichef.bbci.co.uk/news/560/cpsprodpb/3D8B/production/_84455751_84455749.jpg">
+    <meta name="twitter:domain" content="www.bbc.com">
+
+    <script src="http://b.scorecardresearch.com/beacon.js" async=""></script><script src="//cdn.krxd.net/ctjs/controltag.js.875fd5b280a77e06def8c74a5a268e2c" async=""></script><script src="http://cdn.krxd.net/controltag?confid=JZTWpGsM" async="" type="text/javascript"></script><script type="application/ld+json">
+    {
+        "@context": "http://schema.org"
+        ,"@type": "Article"
+        
+        ,"url": "http://www.bbc.com/news/world-us-canada-33646704"
+        ,"publisher": {
+            "@type": "Organization",
+            "name": "BBC News",
+            "logo": "http://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png?cb=1"
+        }
+        
+        ,"headline": "Obama admits US gun laws are his 'biggest frustration'"
+        
+        ,"mainEntityOfPage": "http://www.bbc.com/news/world-us-canada-33646704"
+        ,"articleBody": "President Barack Obama tells the BBC his failure to pass \"common sense gun safety laws\" is the greatest frustration of his presidency."
+        
+        ,"image": {
+            "@list": [
+                "http://ichef.bbci.co.uk/news/560/cpsprodpb/3D8B/production/_84455751_84455749.jpg"
+                ,"http://ichef.bbci.co.uk/news/560/cpsprodpb/6D3D/production/_84456972_p072315al-0500.jpg"
+                ,"http://ichef-1.bbci.co.uk/news/560/cpsprodpb/462D/production/_84456971_gettyimages-167501087.jpg"
+                ,"http://ichef.bbci.co.uk/news/560/media/images/76020000/jpg/_76020974_line976.jpg"
+                ,"http://ichef.bbci.co.uk/news/560/cpsprodpb/142FD/production/_84458628_shirtreuters.jpg"
+            ]
+        }
+        ,"datePublished": "2015-07-24T05:36:09+01:00"
+    }
+    </script>
+
+    
+    
+    <meta name="apple-mobile-web-app-title" content="BBC News">
+    <link rel="apple-touch-icon-precomposed" sizes="57x57" href="http://static.bbci.co.uk/news/1.79.0380/apple-touch-icon-57x57-precomposed.png">
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="http://static.bbci.co.uk/news/1.79.0380/apple-touch-icon-72x72-precomposed.png">
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="http://static.bbci.co.uk/news/1.79.0380/apple-touch-icon-114x114-precomposed.png">
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="http://static.bbci.co.uk/news/1.79.0380/apple-touch-icon.png">
+    <link rel="apple-touch-icon" href="http://static.bbci.co.uk/news/1.79.0380/apple-touch-icon.png">
+    <meta name="application-name" content="BBC News">
+    <meta name="msapplication-TileImage" content="http://static.bbci.co.uk/news/1.79.0380/windows-eight-icon-144x144.png">
+    <meta name="msapplication-TileColor" content="#bb1919">
+    <meta http-equiv="cleartype" content="on">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="robots" content="NOODP,NOYDIR">
+    <meta name="theme-color" content="#bb1919">
+    <script type="text/javascript">var _sf_startpt=(new Date()).getTime()</script>
+
+    <script>
+        (function() {
+            if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
+                var msViewportStyle = document.createElement("style");
+                msViewportStyle.appendChild(
+                    document.createTextNode("@-ms-viewport{width:auto!important}")
+                );
+                document.getElementsByTagName("head")[0].appendChild(msViewportStyle);
+            }
+        })();
+    </script>
+    
+           <meta name="viewport" content="width=device-width, initial-scale=1.0">   <script type="text/javascript">window.bbcredirection={geo:true}</script>  <!--orb.ws.require.lib--> <script type="text/javascript">/*<![CDATA[*/ if (typeof window.define !== 'function' || typeof window.require !== 'function') { document.write('<script class="js-require-lib" src="http://static.bbci.co.uk/frameworks/requirejs/lib.js"><'+'/script>'); } /*]]>*/</script><script class="js-require-lib" src="http://static.bbci.co.uk/frameworks/requirejs/lib.js"></script> <script type="text/javascript">  bbcRequireMap = {"jquery-1":"http://static.bbci.co.uk/frameworks/jquery/0.3.0/sharedmodules/jquery-1.7.2", "jquery-1.4":"http://static.bbci.co.uk/frameworks/jquery/0.3.0/sharedmodules/jquery-1.4", "jquery-1.9":"http://static.bbci.co.uk/frameworks/jquery/0.3.0/sharedmodules/jquery-1.9.1", "swfobject-2":"http://static.bbci.co.uk/frameworks/swfobject/0.1.10/sharedmodules/swfobject-2", "demi-1":"http://static.bbci.co.uk/frameworks/demi/0.10.0/sharedmodules/demi-1", "gelui-1":"http://static.bbci.co.uk/frameworks/gelui/0.9.13/sharedmodules/gelui-1", "cssp!gelui-1/overlay":"http://static.bbci.co.uk/frameworks/gelui/0.9.13/sharedmodules/gelui-1/overlay.css", "istats-1":"http://static.bbci.co.uk/frameworks/istats/0.26.31/modules/istats-1", "relay-1":"http://static.bbci.co.uk/frameworks/relay/0.2.6/sharedmodules/relay-1", "clock-1":"http://static.bbci.co.uk/frameworks/clock/0.1.9/sharedmodules/clock-1", "canvas-clock-1":"http://static.bbci.co.uk/frameworks/clock/0.1.9/sharedmodules/canvas-clock-1", "cssp!clock-1":"http://static.bbci.co.uk/frameworks/clock/0.1.9/sharedmodules/clock-1.css", "jssignals-1":"http://static.bbci.co.uk/frameworks/jssignals/0.3.6/modules/jssignals-1", "jcarousel-1":"http://static.bbci.co.uk/frameworks/jcarousel/0.1.10/modules/jcarousel-1", "bump-3":"//emp.bbci.co.uk/emp/bump-3/bump-3"}; require({ baseUrl: 'http://static.bbci.co.uk/', paths: bbcRequireMap, waitSeconds: 30 }); </script>   <script type="text/javascript">/*<![CDATA[*/ if (typeof bbccookies_flag === 'undefined') { bbccookies_flag = 'ON'; } showCTA_flag = true; cta_enabled = (showCTA_flag && (bbccookies_flag === 'ON')); (function(){var e="ckns_policy",m="Thu, 01 Jan 1970 00:00:00 GMT",k={ads:true,personalisation:true,performance:true,necessary:true};function f(p){if(f.cache[p]){return f.cache[p]}var o=p.split("/"),q=[""];do{q.unshift((o.join("/")||"/"));o.pop()}while(q[0]!=="/");f.cache[p]=q;return q}f.cache={};function a(p){if(a.cache[p]){return a.cache[p]}var q=p.split("."),o=[];while(q.length&&"|co.uk|com|".indexOf("|"+q.join(".")+"|")===-1){if(q.length){o.push(q.join("."))}q.shift()}f.cache[p]=o;return o}a.cache={};function i(o,t,p){var z=[""].concat(a(window.location.hostname)),w=f(window.location.pathname),y="",r,x;for(var s=0,v=z.length;s<v;s++){r=z[s];for(var q=0,u=w.length;q<u;q++){x=w[q];y=o+"="+t+";"+(r?"domain="+r+";":"")+(x?"path="+x+";":"")+(p?"expires="+p+";":"");bbccookies.set(y,true)}}}window.bbccookies={POLICY_REFRESH_DATE_MILLIS:new Date(2015,4,21,0,0,0,0).getTime(),POLICY_EXPIRY_COOKIENAME:"ckns_policy_exp",_setEverywhere:i,cookiesEnabled:function(){var o="ckns_testcookie"+Math.floor(Math.random()*100000);this.set(o+"=1");if(this.get().indexOf(o)>-1){g(o);return true}return false},set:function(o){return document.cookie=o},get:function(){return document.cookie},getCrumb:function(o){if(!o){return null}return decodeURIComponent(document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*"+encodeURIComponent(o).replace(/[\-\.\+\*]/g,"\\$&")+"\\s*\\=\\s*([^;]*).*$)|^.*$"),"$1"))||null},policyRequiresRefresh:function(){var p=new Date();p.setHours(0);p.setMinutes(0);p.setSeconds(0);p.setMilliseconds(0);if(bbccookies.POLICY_REFRESH_DATE_MILLIS<=p.getTime()){var o=bbccookies.getCrumb(bbccookies.POLICY_EXPIRY_COOKIENAME);if(o){o=new Date(parseInt(o));o.setYear(o.getFullYear()-1);return bbccookies.POLICY_REFRESH_DATE_MILLIS>=o.getTime()}else{return true}}else{return false}},_setPolicy:function(o){return h.apply(this,arguments)},readPolicy:function(){return b.apply(this,arguments)},_deletePolicy:function(){i(e,"",m)},isAllowed:function(){return true},_isConfirmed:function(){return c()!==null},_acceptsAll:function(){var o=b();return o&&!(j(o).indexOf("0")>-1)},_getCookieName:function(){return d.apply(this,arguments)},_showPrompt:function(){var o=((!this._isConfirmed()||this.policyRequiresRefresh())&&window.cta_enabled&&this.cookiesEnabled()&&!window.bbccookies_disable);return(window.orb&&window.orb.fig)?o&&(window.orb.fig("no")||window.orb.fig("ck")):o}};bbccookies._getPolicy=bbccookies.readPolicy;function d(p){var o=(""+p).match(/^([^=]+)(?==)/);return(o&&o.length?o[0]:"")}function j(o){return""+(o.ads?1:0)+(o.personalisation?1:0)+(o.performance?1:0)}function h(s){if(typeof s==="undefined"){s=k}if(typeof arguments[0]==="string"){var p=arguments[0],r=arguments[1];if(p==="necessary"){r=true}s=b();s[p]=r}else{if(typeof arguments[0]==="object"){s.necessary=true}}var q=new Date();q.setYear(q.getFullYear()+1);bbccookies.set(e+"="+j(s)+";domain=bbc.co.uk;path=/;expires="+q.toUTCString()+";");bbccookies.set(e+"="+j(s)+";domain=bbc.com;path=/;expires="+q.toUTCString()+";");var o=new Date(q.getTime());o.setMonth(o.getMonth()+1);bbccookies.set(bbccookies.POLICY_EXPIRY_COOKIENAME+"="+q.getTime()+";domain=bbc.co.uk;path=/;expires="+o.toUTCString()+";");bbccookies.set(bbccookies.POLICY_EXPIRY_COOKIENAME+"="+q.getTime()+";domain=bbc.com;path=/;expires="+o.toUTCString()+";");return s}function l(o){if(o===null){return null}var p=o.split("");return{ads:!!+p[0],personalisation:!!+p[1],performance:!!+p[2],necessary:true}}function c(){var o=new RegExp("(?:^|; ?)"+e+"=(\\d\\d\\d)($|;)"),p=document.cookie.match(o);if(!p){return null}return p[1]}function b(o){var p=l(c());if(!p){p=k}if(o){return p[o]}else{return p}}function g(o){return document.cookie=o+"=;expires="+m+";"}function n(){var o='<script type="text/javascript" src="http://static.bbci.co.uk/frameworks/bbccookies/0.6.11/script/bbccookies.js"><\/script>';if(window.bbccookies_flag==="ON"&&!bbccookies._acceptsAll()&&!window.bbccookies_disable){document.write(o)}}n()})(); /*]]>*/</script> <script type="text/javascript">/*<![CDATA[*/
+(function(){window.fig=window.fig||{};window.fig.manager={include:function(a){a=a||window;var e=a.document,g=e.cookie,b=g.match(/(?:^|; ?)ckns_orb_fig=([^;]+)/);if(!b&&g.indexOf("ckns_orb_nofig=1")>-1){this.setFig(a,{no:1})}else{if(b){b=this.deserialise(decodeURIComponent(RegExp.$1));this.setFig(a,b)}e.write('<script src="https://ssl.bbc.co.uk/frameworks/fig/1/fig.js"><'+"/script>")}},confirm:function(a){a=a||window;if(a.orb&&a.orb.fig&&a.orb.fig("no")){this.setNoFigCookie(a)}if(a.orb===undefined||a.orb.fig===undefined){this.setFig(a,{no:1});this.setNoFigCookie(a)}},setNoFigCookie:function(a){a.document.cookie="ckns_orb_nofig=1; expires="+new Date(new Date().getTime()+1000*60*10).toGMTString()+";"},setFig:function(a,b){(function(){var c=b;a.orb=a.orb||{};a.orb.fig=function(d){return(arguments.length)?c[d]:c}})()},deserialise:function(b){var a={};b.replace(/([a-z]{2}):([0-9]+)/g,function(){a[RegExp.$1]=+RegExp.$2});return a}}})();fig.manager.include();/*]]>*/</script><script src="https://ssl.bbc.co.uk/frameworks/fig/1/fig.js"></script>
+ 
+<!--[if (gt IE 8) | (IEMobile)]><!-->
+<link rel="stylesheet" href="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/style/orb.css">
+<!--<![endif]-->
+
+<!--[if (lt IE 9) & (!IEMobile)]>
+<link rel="stylesheet" href="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/style/orb-ie.css">
+<![endif]-->
+
+  <script type="text/javascript">/*<![CDATA[*/ (function(undefined){if(!window.bbc){window.bbc={}}var ROLLING_PERIOD_DAYS=30;window.bbc.Mandolin=function(id,segments,opts){var now=new Date().getTime(),storedItem,DEFAULT_START=now,DEFAULT_RATE=1,COOKIE_NAME="ckpf_mandolin";opts=opts||{};this._id=id;this._segmentSet=segments;this._store=new window.window.bbc.Mandolin.Storage(COOKIE_NAME);this._opts=opts;this._rate=(opts.rate!==undefined)?+opts.rate:DEFAULT_RATE;this._startTs=(opts.start!==undefined)?new Date(opts.start).getTime():new Date(DEFAULT_START).getTime();this._endTs=(opts.end!==undefined)?new Date(opts.end).getTime():daysFromNow(ROLLING_PERIOD_DAYS);this._signupEndTs=(opts.signupEnd!==undefined)?new Date(opts.signupEnd).getTime():this._endTs;this._segment=null;if(typeof id!=="string"){throw new Error("Invalid Argument: id must be defined and be a string")}if(Object.prototype.toString.call(segments)!=="[object Array]"){throw new Error("Invalid Argument: Segments are required.")}if(opts.rate!==undefined&&(opts.rate<0||opts.rate>1)){throw new Error("Invalid Argument: Rate must be between 0 and 1.")}if(this._startTs>this._endTs){throw new Error("Invalid Argument: end date must occur after start date.")}if(!(this._startTs<this._signupEndTs&&this._signupEndTs<=this._endTs)){throw new Error("Invalid Argument: SignupEnd must be between start and end date")}removeExpired.call(this,now);var overrides=window.bbccookies.get().match(/ckns_mandolin_setSegments=([^;]+)/);if(overrides!==null){eval("overrides = "+decodeURIComponent(RegExp.$1)+";");if(overrides[this._id]&&this._segmentSet.indexOf(overrides[this._id])==-1){throw new Error("Invalid Override: overridden segment should exist in segments array")}}if(overrides!==null&&overrides[this._id]){this._segment=overrides[this._id]}else{if((storedItem=this._store.getItem(this._id))){this._segment=storedItem.segment}else{if(this._startTs<=now&&now<this._signupEndTs&&now<=this._endTs&&this._store.isEnabled()===true){this._segment=pick(segments,this._rate);if(opts.end===undefined){this._store.setItem(this._id,{segment:this._segment})}else{this._store.setItem(this._id,{segment:this._segment,end:this._endTs})}log.call(this,"mandolin_segment")}}}log.call(this,"mandolin_view")};window.bbc.Mandolin.prototype.getSegment=function(){return this._segment};function log(actionType,params){var that=this;require(["istats-1"],function(istats){istats.log(actionType,that._id+":"+that._segment,params?params:{})})}function removeExpired(expires){var items=this._store.getItems(),expiresInt=+expires;for(var key in items){if(items[key].end!==undefined&&+items[key].end<expiresInt){this._store.removeItem(key)}}}function getLastExpirationDate(data){var winner=0,rollingExpire=daysFromNow(ROLLING_PERIOD_DAYS);for(var key in data){if(data[key].end===undefined&&rollingExpire>winner){winner=rollingExpire}else{if(+data[key].end>winner){winner=+data[key].end}}}return(winner)?new Date(winner):new Date(rollingExpire)}window.bbc.Mandolin.prototype.log=function(params){log.call(this,"mandolin_log",params)};window.bbc.Mandolin.prototype.convert=function(params){log.call(this,"mandolin_convert",params);this.convert=function(){}};function daysFromNow(n){var endDate;endDate=new Date().getTime()+(n*60*60*24)*1000;return endDate}function pick(segments,rate){var picked,min=0,max=segments.length-1;if(typeof rate==="number"&&Math.random()>rate){return null}do{picked=Math.floor(Math.random()*(max-min+1))+min}while(picked>max);return segments[picked]}window.bbc.Mandolin.Storage=function(name){validateCookieName(name);this._cookieName=name;this._isEnabled=(bbccookies.isAllowed(this._cookieName)===true&&bbccookies.cookiesEnabled()===true)};window.bbc.Mandolin.Storage.prototype.setItem=function(key,value){var storeData=this.getItems();storeData[key]=value;this.save(storeData);return value};window.bbc.Mandolin.Storage.prototype.isEnabled=function(){return this._isEnabled};window.bbc.Mandolin.Storage.prototype.getItem=function(key){var storeData=this.getItems();return storeData[key]};window.bbc.Mandolin.Storage.prototype.removeItem=function(key){var storeData=this.getItems();delete storeData[key];this.save(storeData)};window.bbc.Mandolin.Storage.prototype.getItems=function(){return deserialise(this.readCookie(this._cookieName)||"")};window.bbc.Mandolin.Storage.prototype.save=function(data){window.bbccookies.set(this._cookieName+"="+encodeURIComponent(serialise(data))+"; expires="+getLastExpirationDate(data).toUTCString()+";")};window.bbc.Mandolin.Storage.prototype.readCookie=function(name){var nameEq=name+"=",ca=window.bbccookies.get().split("; "),i,c;validateCookieName(name);for(i=0;i<ca.length;i++){c=ca[i];if(c.indexOf(nameEq)===0){return decodeURIComponent(c.substring(nameEq.length,c.length))}}return null};function serialise(o){var str="";for(var p in o){if(o.hasOwnProperty(p)){str+='"'+p+'"'+":"+(typeof o[p]==="object"?(o[p]===null?"null":"{"+serialise(o[p])+"}"):'"'+o[p].toString()+'"')+","}}return str.replace(/,\}/g,"}").replace(/,$/g,"")}function deserialise(str){var o;str="{"+str+"}";if(!validateSerialisation(str)){throw"Invalid input provided for deserialisation."}eval("o = "+str);return o}var validateSerialisation=(function(){var OBJECT_TOKEN="<Object>",ESCAPED_CHAR='"\\n\\r\\u2028\\u2029\\u000A\\u000D\\u005C',ALLOWED_CHAR="([^"+ESCAPED_CHAR+"]|\\\\["+ESCAPED_CHAR+"])",KEY='"'+ALLOWED_CHAR+'+"',VALUE='(null|"'+ALLOWED_CHAR+'*"|'+OBJECT_TOKEN+")",KEY_VALUE=KEY+":"+VALUE,KEY_VALUE_SEQUENCE="("+KEY_VALUE+",)*"+KEY_VALUE,OBJECT_LITERAL="({}|{"+KEY_VALUE_SEQUENCE+"})",objectPattern=new RegExp(OBJECT_LITERAL,"g");return function(str){if(str.indexOf(OBJECT_TOKEN)!==-1){return false}while(str.match(objectPattern)){str=str.replace(objectPattern,OBJECT_TOKEN)}return str===OBJECT_TOKEN}})();function validateCookieName(name){if(name.match(/ ,;/)){throw"Illegal name provided, must be valid in browser cookie."}}})(); /*]]>*/</script>  <script type="text/javascript">  document.documentElement.className += (document.documentElement.className? ' ' : '') + 'orb-js';  fig.manager.confirm(); </script> <script src="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/script/orb/api.min.js"></script> <script type="text/javascript"> window.orb_masthead_test = new bbc.Mandolin( 'orb_masthead', ['simple', 'control'], { rate: 6/1000, start: new Date('09/22/2014 08:00:00 GMT'), /* format: mm/dd/yyyy hh:mm:ss */ signupEnd: new Date('09/24/2014 08:00:00 GMT'), end: new Date('10/06/2014 08:00:00 GMT') } ); var blq = { environment: function() { return 'live'; } } </script>   <script type="text/javascript"> /*<![CDATA[*/ function oqsSurveyManager(w, flag) { if (flag !== 'OFF') { w.document.write('<script type="text/javascript" src="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/script/vendor/edr.js"><'+'/script>'); } } oqsSurveyManager(window, 'ON'); /*]]>*/ </script><script type="text/javascript" src="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/script/vendor/edr.js"></script><script src="http://static.bbci.co.uk/frameworks/istats/0.26.31/modules/istats-1.js" data-requiremodule="istats-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script>             <!-- BBCDOTCOM template: responsive webservice  -->
+        <!-- BBCDOTCOM head --><script type="text/javascript"> /*<![CDATA[*/ var _sf_startpt = (new Date()).getTime(); /*]]>*/ </script><style type="text/css">.bbccom_display_none{display:none;}</style><script type="text/javascript"> /*<![CDATA[*/ var bbcdotcomConfig, googletag = googletag || {}; googletag.cmd = googletag.cmd || []; var bbcdotcom = false; (function(){ if(typeof require !== 'undefined') { require({ paths:{ "bbcdotcom":"http://static.bbci.co.uk/bbcdotcom/0.3.322/script" } }); } })(); /*]]>*/ </script><script type="text/javascript"> /*<![CDATA[*/ var bbcdotcom = { adverts: { keyValues: { set: function() {} } }, advert: { write: function () {}, show: function () {}, isActive: function () { return false; }, layout: function() { return { reset: function() {} } } }, config: { init: function() {}, isActive: function() {}, setSections: function() {}, isAdsEnabled: function() {}, setAdsEnabled: function() {}, isAnalyticsEnabled: function() {}, setAnalyticsEnabled: function() {}, setAssetPrefix: function() {}, setJsPrefix: function() {}, setSwfPrefix: function() {}, setCssPrefix: function() {}, setConfig: function() {}, getAssetPrefix: function() {}, getJsPrefix: function () {}, getSwfPrefix: function () {}, getCssPrefix: function () {} }, survey: { init: function(){ return false; } }, data: {}, init: function() {}, objects: function(str) { return false; }, locale: { set: function() {} }, setAdKeyValue: function() {}, utils: { addEvent: function() {}, addHtmlTagClass: function() {}, log: function () {} }, addLoadEvent: function() {} }; /*]]>*/ </script><script type="text/javascript"> /*<![CDATA[*/ (function(){ if (typeof orb !== 'undefined' && typeof orb.fig === 'function') { if (orb.fig('ad') && orb.fig('uk') == 0) { bbcdotcom.data = { ads: (orb.fig('ad') ? 1 : 0), stats: (orb.fig('uk') == 0 ? 1 : 0), statsProvider: orb.fig('ap') }; } } else { document.write('<script type="text/javascript" src="'+('https:' == document.location.protocol ? 'https://ssl.bbc.com' : 'http://tps.bbc.com')+'/wwscripts/data">\x3C/script>'); } })(); /*]]>*/ </script><script type="text/javascript"> /*<![CDATA[*/ (function(){ if (typeof orb === 'undefined' || typeof orb.fig !== 'function') { bbcdotcom.data = { ads: bbcdotcom.data.a, stats: bbcdotcom.data.b, statsProvider: bbcdotcom.data.c }; } if (bbcdotcom.data.ads == 1) { document.write('<script type="text/javascript" src="'+('https:' == document.location.protocol ? 'https://ssl.bbc.co.uk' : 'http://www.bbc.co.uk')+'/wwscripts/flag">\x3C/script>'); } })(); /*]]>*/ </script><script type="text/javascript" src="http://www.bbc.co.uk/wwscripts/flag"></script><script type="text/javascript"> /*<![CDATA[*/ (function(){ if (window.bbcdotcom && (typeof bbcdotcom.flag == 'undefined' || (typeof bbcdotcom.data.ads !== 'undefined' && bbcdotcom.flag.a != 1))) { bbcdotcom.data.ads = 0; } if (/[?|&]ads/.test(window.location.href) || /(^|; )ads=on; /.test(document.cookie) || /; ads=on(; |$)/.test(document.cookie)) { bbcdotcom.data.ads = 1; bbcdotcom.data.stats = 1; } if (window.bbcdotcom && (bbcdotcom.data.ads == 1 || bbcdotcom.data.stats == 1)) { bbcdotcom.assetPrefix = "http://static.bbci.co.uk/bbcdotcom/0.3.322/"; document.write('<link rel="stylesheet" type="text/css" href="http://static.bbci.co.uk/bbcdotcom/0.3.322/style/orb/bbccom.css" />'); (function() { var useSSL = 'https:' == document.location.protocol; var src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js'; document.write('<scr' + 'ipt src="' + src + '">\x3C/script>'); })(); if (/(sandbox|int)(.dev)*.bbc.co*/.test(window.location.href) || /[?|&]ads-debug/.test(window.location.href) || document.cookie.indexOf('ads-debug=') !== -1) { document.write('<script type="text/javascript" src="http://static.bbci.co.uk/bbcdotcom/0.3.322/script/orb/individual.js">\x3C/script>'); } else { document.write('<script type="text/javascript" src="http://static.bbci.co.uk/bbcdotcom/0.3.322/script/orb/bbcdotcom.js">\x3C/script>'); } if(/[\\?&]ads=([^&#]*)/.test(window.location.href)) { document.write('<script type="text/javascript" src="http://static.bbci.co.uk/bbcdotcom/0.3.322/script/orb/adverts/adSuites.js">\x3C/script>'); } } })(); /*]]>*/ </script><link rel="stylesheet" type="text/css" href="http://static.bbci.co.uk/bbcdotcom/0.3.322/style/orb/bbccom.css"><script src="http://www.googletagservices.com/tag/js/gpt.js"></script><iframe style="visibility: hidden; display: none;" src="http://tpc.googlesyndication.com/safeframe/1-0-2/html/container.html"></iframe><script type="text/javascript" src="http://static.bbci.co.uk/bbcdotcom/0.3.322/script/orb/bbcdotcom.js"></script><script src="http://universal.iperceptions.com/wrapper.js" type="text/javascript" defer="defer" async="async"></script><script type="text/javascript"> /*<![CDATA[*/ (function(){ if (window.bbcdotcom && (bbcdotcom.data.ads == 1 || bbcdotcom.data.stats == 1)) { bbcdotcomConfig = {"adFormat":"standard","adKeyword":"","adMode":"smart","adsEnabled":true,"appAnalyticsSections":"news>world","asyncEnabled":false,"disableInitialLoad":false,"advertInfoPageUrl":"http:\/\/www.bbc.co.uk\/faqs\/online\/adverts_general","advertisementText":"Advertisement","analyticsEnabled":true,"appName":"tabloid","assetPrefix":"http:\/\/static.bbci.co.uk\/bbcdotcom\/0.3.322\/","continuousPlayEnabled":false,"customAdParams":[],"customStatsParams":[],"headline":"Obama admits US gun laws are his 'biggest frustration'","id":"33646704","inAssociationWithText":"In association with","keywords":"","language":"","orbTransitional":false,"outbrainEnabled":true,"palEnv":"live","productName":"","sections":[],"siteCatalystEnabled":true,"comScoreEnabled":true,"slots":"","sponsoredByText":"Sponsored by","summary":"President Barack Obama tells the BBC his failure to pass \"common sense gun safety laws\" is the greatest frustration of his presidency.","type":"STORY","staticBase":"\/bbcdotcom","staticHost":"http:\/\/static.bbci.co.uk","staticVersion":"0.3.322","staticPrefix":"http:\/\/static.bbci.co.uk\/bbcdotcom\/0.3.322","dataHttp":"tps.bbc.com","dataHttps":"ssl.bbc.com","flagHttp":"www.bbc.co.uk","flagHttps":"ssl.bbc.co.uk","analyticsHttp":"sa.bbc.com","analyticsHttps":"ssa.bbc.com"}; bbcdotcom.config.init(bbcdotcomConfig, bbcdotcom.data, window.location, window.document); bbcdotcom.config.setAssetPrefix("http://static.bbci.co.uk/bbcdotcom/0.3.322/"); document.write('<!--[if IE 7]><script type="text/javascript">bbcdotcom.config.setIE7(true);\x3C/script><![endif]-->'); document.write('<!--[if IE 8]><script type="text/javascript">bbcdotcom.config.setIE8(true);\x3C/script><![endif]-->'); if (!bbcdotcom.config.isAsync() && bbcdotcom.config.isIE7()) { document.write('<link rel="stylesheet" type="text/css" href="http://static.bbci.co.uk/bbcdotcom/0.3.322/style/orb/bbccom-ie7.css" />'); } if (/[?|&]ex-dp/.test(window.location.href) || document.cookie.indexOf('ex-dp=') !== -1) { bbcdotcom.utils.addHtmlTagClass('bbcdotcom-ex-dp'); } } })(); /*]]>*/ </script><!--[if IE 7]><script type="text/javascript">bbcdotcom.config.setIE7(true);</script><![endif]--><!--[if IE 8]><script type="text/javascript">bbcdotcom.config.setIE8(true);</script><![endif]-->            <script type="text/javascript">/*<![CDATA[*/
+    window.bbcFlagpoles_istats = 'ON';
+    window.orb = window.orb || {};
+
+    /*]]>*/</script>
+ <script type="text/javascript"> /* <![CDATA[ */ define('id-statusbar-config', { 'translation_signedout': "Sign in", 'translation_signedin': "Your account", 'use_overlay' : false, 'signin_url' : "https://ssl.bbc.com/id/signin?ptrt=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704", 'locale' : "en-GB", 'policyname' : "", 'ptrt' : "http://www.bbc.com/news/world-us-canada-33646704" }); /* ]]> */ </script>   <script type="text/javascript"> require(['istats-1'], function(istats){ if (typeof(document) != 'undefined' && typeof(document.cookie) != 'undefined') { var cookieAphidMatch = document.cookie.match(/ckpf_APHID=([^;]*)/); if (cookieAphidMatch && typeof(cookieAphidMatch[1]) == 'string') { istats.addLabels({'bbc_hid': cookieAphidMatch[1]}); } } })(); </script>    <script type="text/javascript"> (function () { if (! window.require) { throw new Error('idcta: could not find require module'); } var map = {}; map['idapp-1'] = 'http://static.bbci.co.uk/idapp/0.68.01/modules/idapp/idapp-1'; map['idcta/idcta-1'] = 'http://static.bbci.co.uk/id/0.27.23/modules/idcta/idcta-1'; map['idcta/idCookie'] = 'http://static.bbci.co.uk/id/0.27.23/modules/idcta/idCookie'; map['idcta/overlayManager'] = 'http://static.bbci.co.uk/id/0.27.23/modules/idcta/overlayManager'; require({paths: map}); define('id-config', {"idapp":{"version":"0.68.01","hostname":"ssl.bbc.com","insecurehostname":"www.bbc.com","tld":"bbc.com"},"idtranslations":{"version":"0.31.1"},"identity":{"baseUrl":"https:\/\/talkback.live.bbc.co.uk\/identity","cookieAgeDays":730},"pathway":{"name":null,"staticAssetUrl":"http:\/\/static.bbci.co.uk\/idapp\/0.68.01\/modules\/idapp\/idapp-1\/View.css"}}); })(); </script>                
+        <link type="text/css" rel="stylesheet" href="http://static.bbci.co.uk/news/1.79.0380/stylesheets/services/news/core.css">
+    <!--[if lt IE 9]>
+        <link type="text/css" rel="stylesheet" href="http://static.bbci.co.uk/news/1.79.0380/stylesheets/services/news/old-ie.css">
+        <script src="http://static.bbci.co.uk/news/1.79.0380/js/vendor/html5shiv/html5shiv.js"></script>
+    <![endif]-->
+ <link media="(max-width: 599px)" href="http://static.bbci.co.uk/news/1.79.0380/stylesheets/services/news/compact.css" type="text/css" rel="stylesheet"><script id="news-loader"> if (document.getElementById("responsive-news")) { window.bbcNewsResponsive = true; } var isIE = (function() { var undef, v = 3, div = document.createElement('div'), all = div.getElementsByTagName('i'); while ( div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->', all[0] ); return v > 4 ? v : undef; }()); var modernDevice = 'querySelector' in document && 'localStorage' in window && 'addEventListener' in window, forceCore = document.cookie.indexOf('ckps_force_core') !== -1; window.cutsTheMustard = modernDevice && !forceCore; if (window.cutsTheMustard) { document.documentElement.className += ' ctm'; var insertPoint = document.getElementById('news-loader'), config = {"asset":{"asset_id":"33646704","asset_uri":"\/news\/world-us-canada-33646704","first_created":{"date":"2015-07-23 21:41:27","timezone_type":3,"timezone":"Europe\/London"},"last_updated":{"date":"2015-07-24 05:36:09","timezone_type":3,"timezone":"Europe\/London"},"options":{"allowRightHandSide":true,"allowRelatedStoriesBox":true,"includeComments":true,"isIgorSeoTagsEnabled":false,"hasNewsTracker":true,"allowAdvertising":true,"hasContentWarning":false,"allowDateStamp":true,"allowHeadline":true,"isKeyContent":false,"allowPrintingSharingLinks":true,"isBreakingNews":false,"suitableForSyndication":true},"section":{"name":"US & Canada","id":"99127","uri":"\/news\/world\/us_and_canada","urlIdentifier":"\/news\/world\/us_and_canada"},"edition":"US","audience":null,"iStats_counter_name":"news.world.us_and_canada.story.33646704.page","type":"STY","headline":"Obama admits US gun laws are his 'biggest frustration'","mediaType":"video"},"smpBrand":null,"staticHost":"http:\/\/static.bbci.co.uk","environment":"live","locatorVersion":"0.46.3","pathPrefix":"\/news","staticPrefix":"http:\/\/static.bbci.co.uk\/news\/1.79.0380","jsPath":"http:\/\/static.bbci.co.uk\/news\/1.79.0380\/js","cssPath":"http:\/\/static.bbci.co.uk\/news\/1.79.0380\/stylesheets\/services\/news","cssPostfix":"","dynamic":null,"features":{"localnews":true,"video":true,"liveeventcomponent":true,"mediaassetpage":true,"travel":true,"gallery":true,"rollingnews":true,"rumanalytics":true,"sportstories":true,"radiopromo":true,"fromothernewssites":true,"locallive":true,"weather":true},"features2":{"chartbeat":true,"connected_stream":true,"connected_stream_promo":true,"nav":true,"pulse_survey":false,"local_survey":true,"correspondents":true,"blogs":true,"open_graph":true,"follow_us":true,"marketdata_markets":true,"marketdata_shares":true,"nations_pseudo_nav":true,"politics_vote2014":true,"politics_scotref_polltracker":true,"politics_polltracker":true,"politics_election2015_hub":true,"politics_election2015_nation_hubs":true,"politics_election2015_results":true,"politics_scotref_live":true,"politics_scotref_results":true,"politics_scotref":true,"politics_councils":true,"politics_councils_az":true,"politics_constituencies_az":true,"politics_constituencies":true,"politics_election2015_manifestos":true,"politics_eu_regions":true,"politics_election2015_topic_pages":true,"responsive_breaking_news":true,"live_event":true,"most_popular":true,"most_popular_tabs":true,"most_popular_by_day":true,"routing":true,"rum":true,"radiopromonownext":true,"config_based_layout":true,"orb":true,"enhanced_gallery":true,"map_most_watched":true,"top_stories_promo":true,"features_and_analysis":true,"section_labels":true,"index_title":true,"share_tools":true,"local_live_promo":true,"adverts":true,"adexpert":true,"igor_geo_redirect":true,"igor_device_redirect":true,"live":true,"comscore_mmx":true,"find_local_news":true,"comments":true,"comments_enhanced":true,"browser_notify":true,"stream_grid_promo":true,"breaking_news":true,"top_stories_max_volume":true,"record_livestats":true,"contact_form":true,"channel_page":true,"portlet_global_variants":true,"suppress_lep_timezone":true,"story_recommendations":true,"cedexis":true,"mpulse":true,"story_single_column_layout":true,"ovp_resolve_primary_media_vpids":true},"configuration":{"showtimestamp":"1","showweather":"1","showsport":"1","showolympics":"1","showfeaturemain":"1","showsitecatalyst":"1","candyplatform":"EnhancedMobile","showwatchlisten":"1","showspecialreports":"","videotopiccandyid":"","showvideofeedsections":"1","showstorytopstories":"","showstoryfeaturesandanalysis":"1","showstorymostpopular":"","showgallery":"1","cms":"cps","channelpagecandyid":"10318089"},"pollingHost":"http:\/\/polling.bbc.co.uk","service":"news","locale":"en-GB","locatorHost":null,"locatorFlagPole":true,"local":{"allowLocationLookup":true},"isWorldService":false,"rumAnalytics":{"server":"http:\/\/ingest.rum.bbc.co.uk","key":"news","sample_rate":0.1,"url_params":null,"edition":"us"},"isChannelPage":false,"suitenameMap":"","languageVariant":"","commentsHost":"http:\/\/feeds.bbci.co.uk","search":null}; config.configuration['get'] = function (key) { return this[key.toLowerCase()]; };  var bootstrapUI=function(){var e=function(){if(navigator.userAgent.match(/(Android (2.0|2.1))|(Nokia)|(OSRE\/)|(Opera (Mini|Mobi))|(w(eb)?OSBrowser)|(UCWEB)|(Windows Phone)|(XBLWP)|(ZuneWP)/))return!1;if(navigator.userAgent.match(/MSIE 10.0/))return!0;var e,t=document,n=t.head||t.getElementsByTagName("head")[0],r=t.createElement("style"),s=t.implementation||{hasFeature:function(){return!1}};r.type="text/css",n.insertBefore(r,n.firstChild),e=r.sheet||r.styleSheet;var i=s.hasFeature("CSS2","")?function(t){if(!e||!t)return!1;var n=!1;try{e.insertRule(t,0),n=!/unknown/i.test(e.cssRules[0].cssText),e.deleteRule(e.cssRules.length-1)}catch(r){}return n}:function(t){return e&&t?(e.cssText=t,0!==e.cssText.length&&!/unknown/i.test(e.cssText)&&0===e.cssText.replace(/\r+|\n+/g,"").indexOf(t.split(" ")[0])):!1};return i('@font-face{ font-family:"font";src:"font.ttf"; }')}();e&&(document.getElementsByTagName("html")[0].className+=" ff"),function(){var e=document.documentElement.style;("flexBasis"in e||"WebkitFlexBasis"in e||"msFlexBasis"in e)&&(document.documentElement.className+=" flex")}();var t,n,r,s,i,a,o={},u=function(){t=window.innerWidth,n=window.innerHeight},c=function(e){var t=document.createElement("link");t.setAttribute("rel","stylesheet"),t.setAttribute("type","text/css"),t.setAttribute("href",r+e+s+".css"),t.setAttribute("media",a[e]),i.parentNode.insertBefore(t,i),delete a[e]},l=function(e,r,s){r&&!s&&(t>=r||n>=r)&&c(e),s&&!r&&(s>=t||s>=n)&&c(e),r&&s&&(t>=r||n>=r)&&(s>=t||s>=n)&&c(e)},f=function(e){if(o[e])return o[e];var t=e.match(/\(min\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/),n=e.match(/\(max\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/),r=t&&parseFloat(t[1])||null,s=n&&parseFloat(n[1])||null;return o[e]=[r,s],o[e]},m=function(){var e=0;for(var t in a)e++;return e},d=function(){m()||window.removeEventListener("resize",h,!1);for(var e in a){var t=a[e],n=f(t);l(e,n[0],n[1])}},h=function(){u(),d()},v=function(e,t){a=e,r=t.path+("/"!==t.path.substr(-1)?"/":""),s=t.postfix,i=t.insertBefore,u(),d(),window.addEventListener("resize",h,!1)};return{stylesheetLoaderInit:v}}(); bootstrapUI.stylesheetLoaderInit({ 'compact': '(max-width: 599px)', 'tablet' : '(min-width: 600px)', 'wide' : '(min-width: 1008px)' }, { path: 'http://static.bbci.co.uk/news/1.79.0380/stylesheets/services/news', postfix: '', insertBefore: insertPoint }); var loadRequire = function(){ var js_paths = {"jquery-1.9":"vendor\/jquery-1\/jquery","jquery-1":"http:\/\/static.bbci.co.uk\/frameworks\/jquery\/0.3.0\/sharedmodules\/jquery-1.7.2","demi-1":"http:\/\/static.bbci.co.uk\/frameworks\/demi\/0.10.0\/sharedmodules\/demi-1","swfobject-2":"http:\/\/static.bbci.co.uk\/frameworks\/swfobject\/0.1.10\/sharedmodules\/swfobject-2","jquery":"vendor\/jquery-2\/jquery.min","domReady":"vendor\/require\/domReady","translation":"module\/translations\/en-GB","bump-3":"\/\/emp.bbci.co.uk\/emp\/bump-3\/bump-3"};  js_paths.navigation = 'module/nav/navManager';  requirejs.config({ baseUrl: 'http://static.bbci.co.uk/news/1.79.0380/js', map: { 'vendor/locator': { 'module/bootstrap': 'vendor/locator/bootstrap', 'locator/stats': 'vendor/locator/stats', 'locator/locatorView': 'vendor/locator/locatorView' } }, paths: js_paths, waitSeconds: 30 }); define('config', function () { return config; });             require(['compiled/all'], function() {
+      require(['domReady'], function (domReady) { domReady(function () { require(["module\/dotcom\/handlerAdapter","module\/rumAdaptor","module\/stats\/statsSubscriberAdapter","module\/alternativeJsStrategy\/controller","module\/iconLoaderAdapter","module\/polyfill\/location.origin","module\/components\/breakingNewsAdapter","module\/indexTitleAdaptor","module\/navigation\/handlerAdaptor","module\/noTouchDetectionForCss","module\/components\/responsiveImage","module\/components\/timestampAdaptor","module\/components\/videoPlayer","module\/tableScrollAdapter","module\/components\/commentsButtonAdapter"], function() {  require(["module\/strategiserAdaptor"]);  }); }); });              });
+     };  loadRequire();  } else { var l = document.createElement('link'); l.href = 'http://static.bbci.co.uk/news/1.79.0380/icons/generated/icons.fallback.css'; l.rel = 'stylesheet'; document.getElementsByTagName('head')[0].appendChild(l); } </script>  <script type="text/javascript"> /*<![CDATA[*/ bbcdotcom.init({adsToDisplay:['leaderboard', 'sponsor_section', 'mpu', 'outbrain_ar_5', 'outbrain_ar_7', 'outbrain_ar_8', 'outbrain_ar_9', 'native', 'mpu_bottom', 'adsense', 'inread']}); /*]]>*/ </script><script class="kxct" data-id="JZTWpGsM" data-timing="async" data-version="1.9" type="text/javascript">if (window.bbcdotcom && (bbcdotcom.data.ads == 1 || bbcdotcom.data.stats == 1)) {    window.Krux||((Krux=function(){Krux.q.push(arguments)}).q=[]);    (function(){        var k=document.createElement("script");k.type="text/javascript";k.async=true;        var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]);        k.src = /^https?:\/\/([a-z0-9_\-\.]+\.)?krxd\.net(:\d{1,5})?\//i.test(src) ?            src : src === "disable" ? "" :        (location.protocol==="https:"?"https:":"http:")+"//cdn.krxd.net/controltag?confid=JZTWpGsM";        var s=document.getElementsByTagName("script")[0];s.parentNode.insertBefore(k,s);    }());}</script><script type="text/javascript">    if (window.bbcdotcom && (bbcdotcom.data.ads == 1 || bbcdotcom.data.stats == 1)) {        window.Krux||((Krux=function(){Krux.q.push(arguments);}).q=[]);        (function(){            function  retrieve(n){                var  m,  k="kx"+n;                if  (window.localStorage)  {                    return  window.localStorage[k]  ||  "";                }  else  if  (navigator.cookieEnabled)  {                    m  =  document.cookie.match(k+"=([^;]*)");                    return  (m  &&  unescape(m[1]))  ||  "";                }  else  {                    return  "";                }            }            Krux.user  =  retrieve("user");            Krux.segments  =  retrieve("segs")  &&  retrieve("segs").split(",")  ||  [];        })();    }</script><script type="text/javascript" src="http://partner.googleadservices.com/gpt/pubads_impl_68.js"></script><script src="http://static.bbci.co.uk/news/1.79.0380/js/compiled/all.js" data-requiremodule="compiled/all" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script>      <noscript><link href="http://static.bbci.co.uk/news/1.79.0380/icons/generated/icons.fallback.css" rel="stylesheet"></noscript>
+
+                
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1">
+<script src="http://pagead2.googlesyndication.com/pagead/osd.js" type="text/javascript"></script><script src="http://static.bbci.co.uk/news/1.79.0380/js/vendor/jquery-2/jquery.min.js" data-requiremodule="jquery" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><style type="text/css">.ob-tcolor{color:rgb(64, 64, 64)} .ob-lcolor{color:rgb(64, 64, 64)} .ob-bgtcolor{background-color:rgb(64, 64, 64)} .item-link-container:hover .ob-tcolor{border-color:rgb(64, 64, 64)} </style><script src="http://static.bbci.co.uk/news/1.79.0380/js/module/translations/en-GB.js" data-requiremodule="translation" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="//emp.bbci.co.uk/emp/bump-3/bump-3.js" data-requiremodule="bump-3" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="http://static.bbci.co.uk/bbcdotcom/0.3.322/script/av/emp/analytics.js" data-requiremodule="bbcdotcom/av/emp/analytics" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="http://static.bbci.co.uk/bbcdotcom/0.3.322/script/av/emp/adverts.js" data-requiremodule="bbcdotcom/av/emp/adverts" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="http://static.bbci.co.uk/news/1.79.0380/js/vendor/jquery-1/jquery.js" data-requiremodule="jquery-1.9" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="http://static.bbci.co.uk/frameworks/swfobject/0.1.10/sharedmodules/swfobject-2.js" data-requiremodule="swfobject-2" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="http://static.bbci.co.uk/frameworks/jquery/0.3.0/sharedmodules/jquery-1.7.2.js" data-requiremodule="jquery-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="http://open.live.bbc.co.uk/wurfldemi/network.jsonp?callback=bumpDemiNetwork" async="" charset="utf-8" type="text/javascript"></script><script src="//static.bbc.co.uk/nkdata/echoclient/2.0.0/sharedmodules/echo.js" data-requiremodule="//static.bbc.co.uk/nkdata/echoclient/2.0.0/sharedmodules/echo.js" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><style type="text/css">#edr_survey .edr_lwrap iframe {width:100%;height:100%;}#edr_survey .edr_go {opacity:0;display:block;filter:alpha(opacity = 0);position:absolute;font-size:0;background-color:#000;margin:0;padding:0;z-index:1000000;}#edr_survey .edr_go:focus {opacity:1;filter:alpha(opacity = 50);background-color:rgba(0, 0, 0, 0.1);}#edr_survey .edr_lb {position:fixed;top:0;left:0;right:0;bottom:0;z-index:999998;display:none;}</style><script src="http://static.bbci.co.uk/id/0.27.23/modules/idcta/idcta-1.js" data-requiremodule="idcta/idcta-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="http://static.bbci.co.uk/frameworks/jssignals/0.3.6/modules/jssignals-1.js" data-requiremodule="jssignals-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="http://static.bbci.co.uk/id/0.27.23/modules/idcta/idCookie.js" data-requiremodule="idcta/idCookie" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script></head>
+<!--[if IE]><body id="asset-type-sty" class="ie device--feature"><![endif]-->
+<!--[if !IE]>--><body id="asset-type-sty" class="device--feature bbccom_leaderboard bbccom_outbrain_ar_5 bbccom_outbrain_ar_7 bbccom_outbrain_ar_8 bbccom_outbrain_ar_9 bbccom_adsense no-touch"><!--<![endif]-->
+    <div class="direction">
+
+    
+             <!-- BBCDOTCOM bodyFirst --><div id="bbccom_interstitial_ad" class="bbccom_display_none"></div><div id="bbccom_interstitial" class="bbccom_display_none"><script type="text/javascript"> /*<![CDATA[*/ (function() { if (window.bbcdotcom && bbcdotcom.config.isActive('ads')) { googletag.cmd.push(function() { googletag.display('bbccom_interstitial'); }); } }()); /*]]>*/ </script><script type="text/javascript" src="https://securepubads.g.doubleclick.net/gampad/ads?gdfp_req=1&amp;correlator=4252546614435597&amp;output=json_html&amp;callback=googletag.impl.pubads.setAdContentsBySlotForSync&amp;impl=ss&amp;json_a=1&amp;eid=108809047%2C108809031%2C108809035%2C108809049&amp;sc=0&amp;sfv=1-0-2&amp;iu_parts=4817%2Cbbccom.live.site.mobile.news%2Cnews_usandcanada_content&amp;enc_prev_ius=%2F0%2F1%2F2%2C%2F0%2F1%2F2%2C%2F0%2F1%2F2%2C%2F0%2F1%2F2%2C%2F0%2F1%2F2%2C%2F0%2F1%2F2%2C%2F0%2F1%2F2&amp;prev_iu_szs=516x60%7C320x50%7C300x50%2C88x31%2C516x60%7C300x50%7C320x50%7C300x250%2C336x208%2C300x251%2C6x6%2C1x1&amp;ists=1&amp;prev_scp=slot%3Dleaderboard%26sl%3Dtop%7Cslot%3Dsponsor_section%7Cslot%3Dmpu%26sl%3Dmiddle%7Cslot%3Dnative%7Cslot%3Dmpu_bottom%7Cslot%3Dinread%7Cslot%3Dinterstitial&amp;cust_params=frd%3D1%26channel%3Dnews%26sectn%3Dworlduscanada%26domain%3Dwww.bbc.com%26story_id%3D33646704%26ctype%3Dcontent%26asset_type%3Dstory%26referrer%3Dnonbbc%26esi%3D0%26kuid%3D%26khost%3Dwww.bbc.com&amp;cookie_enabled=1&amp;lmt=1437757077&amp;dt=1437757077386&amp;frm=20&amp;biw=584&amp;bih=500&amp;oid=3&amp;adks=430421793%2C1304435981%2C3569409373%2C209040735%2C267162101%2C3279844221%2C3169298880&amp;gut=v2&amp;ifi=1&amp;u_tz=-420&amp;u_his=9&amp;u_java=true&amp;u_h=500&amp;u_w=584&amp;u_ah=877&amp;u_aw=1436&amp;u_cd=24&amp;u_nplug=10&amp;u_nmime=76&amp;u_sd=2&amp;flash=18.0.0&amp;url=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704&amp;dssz=40&amp;icsg=512&amp;std=5&amp;csl=183&amp;vrg=68&amp;vrp=68&amp;ga_vid=165083980.1437757077&amp;ga_sid=1437757077&amp;ga_hid=702753462"></script></div><div id="bbccom_wallpaper_ad" class="bbccom_display_none"></div><div id="bbccom_wallpaper" class="bbccom_display_none"><script type="text/javascript"> /*<![CDATA[*/ (function() { var wallpaper; if (window.bbcdotcom && bbcdotcom.config.isActive('ads')) { if (bbcdotcom.config.isAsync()) { googletag.cmd.push(function() { googletag.display('bbccom_wallpaper'); }); } else { googletag.display("wallpaper"); } wallpaper = bbcdotcom.adverts.adRegister.getAd('wallpaper'); if (wallpaper !== null && wallpaper !== undefined) { wallpaper.setDomElement('bbccom_wallpaper'); } } }()); /*]]>*/ </script></div><script type="text/javascript"> /*<![CDATA[*/ (function() { if (window.bbcdotcom && bbcdotcom.config.isActive('ads')) { document.write(unescape('%3Cscript id="gnlAdsEnabled" class="bbccom_display_none"%3E%3C/script%3E')); } if (window.bbcdotcom && bbcdotcom.config.isActive('analytics')) { document.write(unescape('%3Cscript id="gnlAnalyticsEnabled" class="bbccom_display_none"%3E%3C/script%3E')); } if (window.bbcdotcom && bbcdotcom.config.isActive('continuousPlay')) { document.write(unescape('%3Cscript id="gnlContinuousPlayEnabled" class="bbccom_display_none"%3E%3C/script%3E')); } }()); /*]]>*/ </script><script id="gnlAdsEnabled" class="bbccom_display_none"></script><script id="gnlAnalyticsEnabled" class="bbccom_display_none"></script> <div id="blq-global"> <div id="blq-pre-mast">  </div> </div>  <script type="text/html" id="blq-bbccookies-tmpl"><![CDATA[ <section> <div id="bbccookies" class="bbccookies-banner orb-banner-wrapper bbccookies-d"> <div id="bbccookies-prompt" class="orb-banner b-g-p b-r b-f"> <h2 class="orb-banner-title"> Cookies on the BBC website </h2> <p class="orb-banner-content" dir="ltr"> The BBC has updated its cookie policy. We use cookies to ensure that we give you the best experience on our website. This includes cookies from third party social media websites if you visit a page which contains embedded content from social media. Such third party cookies may track your use of the BBC website.<span class="bbccookies-international-message"> We and our partners also use cookies to ensure we show you advertising that is relevant to you.</span> If you continue without changing your settings, we'll assume that you are happy to receive all cookies on the BBC website. However, you can change your cookie settings at any time. </p> <ul class="orb-banner-options"> <li id="bbccookies-continue"> <button type="button" id="bbccookies-continue-button">Continue</button> </li> <li id="bbccookies-settings"> <a href="/privacy/cookies/managing/cookie-settings.html">Change settings</a> </li> <li id="bbccookies-more"><a href="/privacy/cookies/bbc">Find out more</a></li></ul> </div> </div> </section> ]]></script> <script type="text/javascript">/*<![CDATA[*/ (function(){if(bbccookies._showPrompt()){var g=document,b=g.getElementById("blq-pre-mast"),e=g.getElementById("blq-bbccookies-tmpl"),a,f;if(b&&g.createElement){a=g.createElement("div");f=e.innerHTML;f=f.replace("<"+"![CDATA[","").replace("]]"+">","");a.innerHTML=f;b.appendChild(a);blqCookieContinueButton=g.getElementById("bbccookies-continue-button");blqCookieContinueButton.onclick=function(){a.parentNode.removeChild(a);return false};bbccookies._setPolicy(bbccookies.readPolicy())}var c=g.getElementById("bbccookies");if(c&&!window.orb.fig("uk")){c.className=c.className.replace(/\bbbccookies-d\b/,"");c.className=c.className+(" bbccookies-w")}}})(); /*]]>*/</script>   <script type="text/javascript">/*<![CDATA[*/ if (bbccookies.isAllowed('s1')) { var istatsTrackingUrl = '//sa.bbc.co.uk/bbc/bbc/s?name=news.world.us_and_canada.story.33646704.page&cps_asset_id=33646704&page_type=Story&section=%2Fnews%2Fworld%2Fus_and_canada&first_pub=2015-07-23T20%3A41%3A27%2B00%3A00&last_editorial_update=2015-07-24T04%3A36%3A09%2B00%3A00&title=Obama+admits+US+gun+laws+are+his+%27biggest+frustration%27&has_video=1&for_nation=us&app_version=1.79.0&pal_route=asset&ml_name=barlesque&app_type=responsive&language=en-GB&ml_version=0.26.31&pal_webapp=tabloid&prod_name=news&app_name=news'; require(['istats-1'], function (istats) {  istats.addCollector({'name': 'default', 'url': '//sa.bbc.co.uk/bbc/bbc/s', 'seperator': '&' }); var counterName = (window.istats_countername) ? window.istats_countername : istatsTrackingUrl.match(/[\?&]name=([^&]*)/i)[1]; istats.setCountername(counterName);  if (/\bIDENTITY=/.test(document.cookie)) { istats.addLabels({'bbc_identity': '1'}); } if (/\bckns_policy=\d\d0/.test(document.cookie)) { istats.addLabels({'ns_nc': '1'}); } var c = (document.cookie.match(/\bckns_policy=(\d\d\d)/) || []).pop() || ''; var screenWidthAndHeight = 'unavailable'; if (window.screen && screen.width && screen.height) { screenWidthAndHeight = screen.width + 'x' + screen.height; } istats.addLabels('cps_asset_id=33646704&page_type=Story&section=%2Fnews%2Fworld%2Fus_and_canada&first_pub=2015-07-23T20%3A41%3A27%2B00%3A00&last_editorial_update=2015-07-24T04%3A36%3A09%2B00%3A00&title=Obama+admits+US+gun+laws+are+his+%27biggest+frustration%27&has_video=1&for_nation=us&app_version=1.79.0&pal_route=asset&ml_name=barlesque&app_type=responsive&language=en-GB&ml_version=0.26.31&pal_webapp=tabloid&prod_name=news&app_name=news'); istats.addLabels({  'blq_s': '4d', 'blq_r': '2.7', 'blq_v': 'default', 'blq_e': 'pal',  'bbc_mc': (c ? 'ad' + c.charAt(0) + 'ps' + c.charAt(1) + 'pf' + c.charAt(2) : 'not_set'), 'screen_resolution': screenWidthAndHeight, 'ns_referrer': encodeURI(((window.orb.referrer) ? window.orb.referrer : document.referrer)) } );  istats.invoke(); }); } /*]]>*/</script>  <!-- Begin iStats 20100118 (UX-CMC 1.1009.3) --> <script type="text/javascript">/*<![CDATA[*/ if (bbccookies.isAllowed('s1')) { (function () { require(['istats-1'], function (istats) { istatsTrackingUrl = istats.getDefaultURL(); if (istats.isEnabled() && bbcFlagpoles_istats === 'ON') { sitestat(istatsTrackingUrl); } else { window.ns_pixelUrl = istatsTrackingUrl; /* used by Flash library to track */ } function sitestat(n) { var j = document, f = j.location, b = ""; if (j.cookie.indexOf("st_ux=") != -1) { var k = j.cookie.split(";"); var e = "st_ux", h = document.domain, a = "/"; if (typeof ns_ != "undefined" && typeof ns_.ux != "undefined") { e = ns_.ux.cName || e; h = ns_.ux.cDomain || h; a = ns_.ux.cPath || a } for (var g = 0, f = k.length; g < f; g++) { var m = k[g].indexOf("st_ux="); if (m != -1) { b = "&" + decodeURI(k[g].substring(m + 6)) } } bbccookies.set(e + "=; expires=" + new Date(new Date().getTime() - 60).toGMTString() + "; path=" + a + "; domain=" + h); } window.ns_pixelUrl = n;  } }); })(); } else { window.istats = {enabled: false}; } /*]]>*/</script> <noscript><p style="position: absolute; top: -999em;"><img src="//sa.bbc.co.uk/bbc/bbc/s?name=news.world.us_and_canada.story.33646704.page&amp;cps_asset_id=33646704&amp;page_type=Story&amp;section=%2Fnews%2Fworld%2Fus_and_canada&amp;first_pub=2015-07-23T20%3A41%3A27%2B00%3A00&amp;last_editorial_update=2015-07-24T04%3A36%3A09%2B00%3A00&amp;title=Obama+admits+US+gun+laws+are+his+%27biggest+frustration%27&amp;has_video=1&amp;for_nation=us&amp;app_version=1.79.0&amp;pal_route=asset&amp;ml_name=barlesque&amp;app_type=responsive&amp;language=en-GB&amp;ml_version=0.26.31&amp;pal_webapp=tabloid&amp;prod_name=news&amp;app_name=news&amp;blq_js_enabled=0&amp;blq_s=4d&amp;blq_r=2.7&amp;blq_v=default&amp;blq_e=pal " height="1" width="1" alt=""/></p></noscript> <!-- End iStats (UX-CMC) -->  
+ <!--[if (gt IE 8) | (IEMobile)]><!--> <header id="orb-banner" role="banner"> <!--<![endif]--> <!--[if (lt IE 9) & (!IEMobile)]> <![if (IE 8)]> <header id="orb-banner" role="banner" class="orb-old-ie orb-ie8"> <![endif]> <![if (IE 7)]> <header id="orb-banner" role="banner" class="orb-old-ie orb-ie7"> <![endif]> <![if (IE 6)]> <header id="orb-banner" role="banner" class="orb-old-ie orb-ie6"> <![endif]> <![endif]--> <div id="orb-header" class="orb-nav-pri orb-nav-pri-white orb-location-w orb-nav-dyn"> <script type="text/javascript"> (function(){var h=document.getElementById('orb-header');if(/bbc\.co\.uk$/i.test(location.hostname)&&orb_masthead_test.getSegment()=='simple'&&(location.pathname===''||location.pathname==='/'||location.pathname==='/frameworks/test/mandolin/acceptance'&&h.setAttribute)){h.setAttribute('data-max-w','0');h.setAttribute('data-max-d','0');}}()); </script> <div class="orb-nav-pri-container b-r b-g-p"> <div class="orb-nav-section orb-nav-blocks"> <a href="/"> <img src="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/img/bbc-blocks-dark.png" alt="BBC" height="24" width="84"> </a> </div> <section> <div class="orb-skip-links"> <h2>Accessibility links</h2> <ul>  <li><a href="#page">Skip to content</a></li>  <li><a id="orb-accessibility-help" href="/accessibility/">Accessibility Help</a></li> </ul> </div> </section>  <div class="orb-nav-section orb-nav-id orb-nav-focus">     <a id="idcta-link" href="https://ssl.bbc.com/id/signin?ptrt=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704"><img id="idcta-image" src="http://static.bbci.co.uk/id/0.27.23/img/bbcid_orb_signin_dark.png" alt="" height="18" width="18"><span id="idcta-username">Sign in</span></a>            </div>  <nav role="navigation" class="orb-nav"> <div class="orb-nav-section orb-nav-links orb-nav-focus" id="orb-nav-links"> <h2>BBC navigation</h2> <ul>        <li class="orb-nav-newsdotcom orb-w"> <a href="http://www.bbc.com/news/">News</a> </li>    <li class="orb-nav-sport"> <a href="/sport/">Sport</a> </li>    <li class="orb-nav-weather"> <a href="/weather/">Weather</a> </li>    <li class="orb-nav-shop orb-w"> <a href="http://shop.bbc.com/">Shop</a> </li>    <li class="orb-nav-earthdotcom orb-w"> <a href="http://www.bbc.com/earth/">Earth</a> </li>    <li class="orb-nav-travel-dotcom orb-w"> <a href="http://www.bbc.com/travel/">Travel</a> </li>    <li class="orb-nav-capital orb-w orb-nav-hide"> <a href="http://www.bbc.com/capital/">Capital</a> </li>        <li class="orb-nav-culture orb-w orb-nav-hide"> <a href="http://www.bbc.com/culture/">Culture</a> </li>    <li class="orb-nav-autos orb-w orb-nav-hide"> <a href="http://www.bbc.com/autos/">Autos</a> </li>    <li class="orb-nav-future orb-w orb-nav-hide"> <a href="http://www.bbc.com/future/">Future</a> </li>    <li class="orb-nav-tv orb-nav-hide"> <a href="/tv/">TV</a> </li>    <li class="orb-nav-radio orb-nav-hide"> <a href="/radio/">Radio</a> </li>    <li class="orb-nav-cbbc orb-nav-hide"> <a href="/cbbc">CBBC</a> </li>    <li class="orb-nav-cbeebies orb-nav-hide"> <a href="/cbeebies">CBeebies</a> </li>        <li class="orb-nav-hide"> <a href="/ww1/">WW1</a> </li>    <li class="orb-nav-food orb-nav-hide"> <a href="/food/">Food</a> </li>    <li class="orb-nav-hide"> <a href="/iwonder">iWonder</a> </li>    <li class="orb-nav-hide"> <a href="/education">Bitesize</a> </li>    <li class="orb-nav-music orb-nav-hide"> <a href="/music/">Music</a> </li>    <li class="orb-nav-nature orb-w orb-nav-hide"> <a href="/nature/">Nature</a> </li>        <li class="orb-nav-local orb-nav-hide"> <a href="/local/">Local</a> </li>        <li aria-controls="orb-panel-more" style="width: 70px;" id="orb-nav-more"><a class="istats-notrack" href="#orb-footer" data-alt="More">More<span class="orb-icon orb-icon-arrow"></span></a></li> </ul> </div> </nav> <div class="orb-nav-section orb-nav-search"> <a href="http://search.bbc.co.uk/search"> <img src="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/img/orb-search-dark.png" alt="Search the BBC" height="18" width="18"> </a> <form class="b-f" id="orb-search-form" role="search" method="get" action="http://search.bbc.co.uk/search" accept-charset="utf-8"> <div>  <input name="uri" value="/news/world-us-canada-33646704" type="hidden">   <label for="orb-search-q">Search the BBC</label> <input id="orb-search-q" name="q" placeholder="Search" type="text"> <input id="orb-search-button" src="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/img/orb-search-dark.png" alt="Search the BBC" height="17" type="image" width="17"> <input name="suggid" id="orb-search-suggid" type="hidden"> </div> </form> </div> </div> <div id="orb-panels">  <div id="orb-panel-more" class="orb-panel" aria-labelledby="orb-nav-more"> <div class="orb-panel-content b-g-p b-r orb-nav-sec"> <h2 id="orb-panel-more-title">More<span class="orb-icon orb-icon-arrow"></span></h2><ul>        <li class="orb-nav-newsdotcom orb-w orb-panel-hide"> <a href="http://www.bbc.com/news/">News</a> </li>    <li class="orb-nav-sport orb-panel-hide"> <a href="/sport/">Sport</a> </li>    <li class="orb-nav-weather orb-panel-hide"> <a href="/weather/">Weather</a> </li>    <li class="orb-nav-shop orb-w orb-panel-hide"> <a href="http://shop.bbc.com/">Shop</a> </li>    <li class="orb-nav-earthdotcom orb-w orb-panel-hide"> <a href="http://www.bbc.com/earth/">Earth</a> </li>    <li class="orb-nav-travel-dotcom orb-w orb-panel-hide"> <a href="http://www.bbc.com/travel/">Travel</a> </li>    <li class="orb-nav-capital orb-w orb-first-visible"> <a href="http://www.bbc.com/capital/">Capital</a> </li>        <li class="orb-nav-culture orb-w"> <a href="http://www.bbc.com/culture/">Culture</a> </li>    <li class="orb-nav-autos orb-w"> <a href="http://www.bbc.com/autos/">Autos</a> </li>    <li class="orb-nav-future orb-w"> <a href="http://www.bbc.com/future/">Future</a> </li>    <li class="orb-nav-tv"> <a href="/tv/">TV</a> </li>    <li class="orb-nav-radio"> <a href="/radio/">Radio</a> </li>    <li class="orb-nav-cbbc"> <a href="/cbbc">CBBC</a> </li>    <li class="orb-nav-cbeebies"> <a href="/cbeebies">CBeebies</a> </li>        <li class=""> <a href="/ww1/">WW1</a> </li>    <li class="orb-nav-food"> <a href="/food/">Food</a> </li>    <li class=""> <a href="/iwonder">iWonder</a> </li>    <li class=""> <a href="/education">Bitesize</a> </li>    <li class="orb-nav-music"> <a href="/music/">Music</a> </li>    <li class="orb-nav-nature orb-w"> <a href="/nature/">Nature</a> </li>        <li class="orb-nav-local"> <a href="/local/">Local</a> </li>        </ul> </div> </div></div> </div> </header> <!-- Styling hook for shared modules only --> <div id="orb-modules">             
+    <div id="site-container">
+    
+    <!--[if lt IE 9]>
+<div class="browser-notify">
+    <div class="browser-notify__banner">
+        <div class="browser-notify__icon"></div>
+        <span>This site is optimised for modern web browsers, and does not fully support your version of Internet Explorer</span>
+    </div>
+</div>
+<![endif]-->
+            <div class="site-brand site-brand--height" role="banner" aria-label="News">
+                        <div class="site-brand-inner site-brand-inner--height">
+                <div class="navigation navigation--primary">
+                    <a href="/news" id="brand">
+            <img class="brand__logo" src="http://static.bbci.co.uk/news/1.79.0380/img/brand/news.png" alt="BBC News">
+        </a>
+                                        <h2 class="navigation__heading off-screen">News navigation</h2>
+                    <a href="#core-navigation" class="navigation__section navigation__section--enhanced" data-event="header">
+                        Sections                    </a>
+                                    </div>
+            </div>
+                        
+
+<div class="navigation navigation--wide">
+    <ul class="navigation-wide-list" role="navigation" aria-label="News" data-panel-id="js-navigation-panel-primary">
+                    <li>
+                <a href="/news" class="navigation-wide-list__link">
+                    <span>Home</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/video_and_audio/international" class="navigation-wide-list__link">
+                    <span>Video</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/world" data-panel-id="js-navigation-panel-World" class="navigation-wide-list__link">
+                    <span>World</span>
+                </a>
+                            </li>
+                    <li class="selected">
+                <a href="/news/world/us_and_canada" class="navigation-wide-list__link navigation-arrow--open">
+                    <span>US &amp; Canada</span>
+                </a>
+                 <span class="off-screen">selected</span>            </li>
+                    <li>
+                <a href="/news/uk" data-panel-id="js-navigation-panel-UK" class="navigation-wide-list__link">
+                    <span>UK</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/business" data-panel-id="js-navigation-panel-Business" class="navigation-wide-list__link">
+                    <span>Business</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/technology" class="navigation-wide-list__link">
+                    <span>Tech</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/science_and_environment" class="navigation-wide-list__link">
+                    <span>Science</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/magazine" class="navigation-wide-list__link">
+                    <span>Magazine</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/entertainment_and_arts" class="navigation-wide-list__link">
+                    <span>Entertainment &amp; Arts</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/health" class="navigation-wide-list__link">
+                    <span>Health</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/in_pictures" class="navigation-wide-list__link">
+                    <span>In Pictures</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/also_in_the_news" class="navigation-wide-list__link">
+                    <span>Also in the News</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/special_reports" class="navigation-wide-list__link">
+                    <span>Special Reports</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/explainers" class="navigation-wide-list__link">
+                    <span>Explainers</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/the_reporters" class="navigation-wide-list__link">
+                    <span>The Reporters</span>
+                </a>
+                            </li>
+                    <li>
+                <a href="/news/have_your_say" class="navigation-wide-list__link navigation-wide-list__link--last">
+                    <span>Have Your Say</span>
+                </a>
+                            </li>
+            </ul>
+</div>
+
+                    </div><div class="secondary-navigation secondary-navigation--narrow secondary-navigation--narrow-closed"></div><nav id="navigation--top" class="navigation navigation--narrow" role="navigation" aria-label="News">
+                    
+                <ul class="navigation--narrow__toplevel">
+                        <li class="">
+                    <a href="/news" class="">
+                        <span>Home</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/video_and_audio/international" class="">
+                        <span>Video</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/world" data-panel-id="js-navigation-panel-World" class="navigation-arrow">
+                        <span>World</span>
+                    </a>
+                                                                <div class="navigation-panel navigation-panel--closed js-navigation-panel-World">
+                            <div class="navigation-panel__content">
+                                <ul class="navigation-panel-secondary">
+                                    <li><a href="/news/world"><span>World Home</span></a></li>
+                                                                            <li>
+                                            <a href="/news/world/africa"><span>Africa</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/asia"><span>Asia</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/australia"><span>Australia</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/europe"><span>Europe</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/latin_america"><span>Latin America</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/middle_east"><span>Middle East</span></a>                                        </li>
+                                                                    </ul>
+                            </div>
+                        </div>
+                                    </li>
+                            <li class="selected ">
+                    <a href="/news/world/us_and_canada" class="navigation-arrow--open">
+                        <span>US &amp; Canada</span>
+                    </a>
+                     <span class="off-screen">selected</span>                                    </li>
+                            <li class="">
+                    <a href="/news/uk" data-panel-id="js-navigation-panel-UK" class="navigation-arrow">
+                        <span>UK</span>
+                    </a>
+                                                                <div class="navigation-panel navigation-panel--closed js-navigation-panel-UK">
+                            <div class="navigation-panel__content">
+                                <ul class="navigation-panel-secondary">
+                                    <li><a href="/news/uk"><span>UK Home</span></a></li>
+                                                                            <li>
+                                            <a href="/news/england"><span>England</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/northern_ireland"><span>N. Ireland</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/scotland"><span>Scotland</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/wales"><span>Wales</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/politics"><span>Politics</span></a>                                        </li>
+                                                                    </ul>
+                            </div>
+                        </div>
+                                    </li>
+                            <li class="">
+                    <a href="/news/business" data-panel-id="js-navigation-panel-Business" class="navigation-arrow">
+                        <span>Business</span>
+                    </a>
+                                                                <div class="navigation-panel navigation-panel--closed js-navigation-panel-Business">
+                            <div class="navigation-panel__content">
+                                <ul class="navigation-panel-secondary">
+                                    <li><a href="/news/business"><span>Business Home</span></a></li>
+                                                                            <li>
+                                            <a href="http://www.bbc.co.uk/news/business/market_data"><span>Market Data</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business/markets"><span>Markets</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business/economy"><span>Economy</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business/companies"><span>Companies</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business-22434141"><span>Entrepreneurship</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business-11428889"><span>Technology of Business</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business/business_of_sport"><span>Business of Sport</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business-12686570"><span>Knowledge economy</span></a>                                        </li>
+                                                                    </ul>
+                            </div>
+                        </div>
+                                    </li>
+                            <li class="">
+                    <a href="/news/technology" class="">
+                        <span>Tech</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/science_and_environment" class="">
+                        <span>Science</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/magazine" class="">
+                        <span>Magazine</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/entertainment_and_arts" class="">
+                        <span>Entertainment &amp; Arts</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/health" class="">
+                        <span>Health</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/in_pictures" class="">
+                        <span>In Pictures</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/also_in_the_news" class="">
+                        <span>Also in the News</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/special_reports" class="">
+                        <span>Special Reports</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/explainers" class="">
+                        <span>Explainers</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/the_reporters" class="">
+                        <span>The Reporters</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/have_your_say" class="">
+                        <span>Have Your Say</span>
+                    </a>
+                                                        </li>
+                    </ul>
+    </nav>
+    
+        
+    
+<div id="bbccom_leaderboard_1_2_3_4" class="bbccom_slot  bbccom_standard_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_leaderboard" class="bbccom_advert">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('leaderboard', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><a tabindex="-1" class="bbccom_text" href="http://www.bbc.co.uk/faqs/online/adverts_general">Advertisement</a><script type="text/javascript">bbcdotcom.ad("leaderboard").setBaseContent();googletag.display("leaderboard");</script><div id="leaderboard_ad_container">
+<ins style="width: 320px; height: 50px; display: inline-table; position: relative; border: 0px none; vertical-align: bottom;"><ins style="width: 320px; height: 50px; display: block; position: relative; border: 0px none;"><iframe tabindex="-1" style="border: 0px none; position: absolute; top: 0px; left: 0px;" marginheight="0" marginwidth="0" scrolling="no" name="google_ads_iframe_/4817/bbccom.live.site.mobile.news/news_usandcanada_content_0" id="google_ads_iframe_/4817/bbccom.live.site.mobile.news/news_usandcanada_content_0" frameborder="0" height="50" width="320"></iframe></ins></ins></div>
+<script>googletag.impl.pubads.createDomIframe("leaderboard_ad_container" ,"/4817/bbccom.live.site.mobile.news/news_usandcanada_content_0",false,false);</script>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>
+    <div id="breaking-news-container" data-polling-url="http://polling.bbc.co.uk/news/latest_breaking_news?audience=US" aria-live="polite"></div>
+
+                        <div class="container-width-only">
+                            <span class="index-title" id="comp-index-title" data-index-title-meta="{&quot;id&quot;:&quot;comp-index-title&quot;,&quot;type&quot;:&quot;index-title&quot;,&quot;handler&quot;:&quot;indexTitle&quot;,&quot;deviceGroups&quot;:null,&quot;opts&quot;:{&quot;alwaysVisible&quot;:false,&quot;onFrontPage&quot;:false},&quot;template&quot;:&quot;index-title&quot;}">
+        <span class="index-title__container"><span class="bbccom_index_title">
+        
+            US &amp; Canada
+        
+    </span><a class="bbccom_text" href="http://www.bbc.co.uk/faqs/online/adverts_general" tabindex="-1" aria-hidden="true">is sponsored by</a></span>
+    </span>
+            
+<div id="bbccom_sponsor_section_1_2_3_4" class="bbccom_slot  bbccom_sponsor_section_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_sponsor_section" class="bbccom_advert bbccom_display_none bbccom_responsive">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('sponsor_section', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><a tabindex="-1" class="bbccom_text" href="http://www.bbc.co.uk/faqs/online/adverts_general">is sponsored by</a><script type="text/javascript">bbcdotcom.ad("sponsor_section").setBaseContent();googletag.display("sponsor_section");</script>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>            </div>
+            
+         <div id="page" class="configurable story " data-story-id="world-us-canada-33646704">      <div role="main"> <div class="container-width-only">       <span class="index-title index-title--redundant " id="comp-index-title" data-index-title-meta="{&quot;id&quot;:&quot;comp-index-title&quot;,&quot;type&quot;:&quot;index-title&quot;,&quot;handler&quot;:&quot;indexTitle&quot;,&quot;deviceGroups&quot;:null,&quot;opts&quot;:{&quot;alwaysVisible&quot;:false,&quot;onFrontPage&quot;:false},&quot;template&quot;:&quot;index-title&quot;}">
+        <span class="index-title__container"><span class="bbccom_index_title">
+        
+            US &amp; Canada
+        
+    </span><a class="bbccom_text" href="http://www.bbc.co.uk/faqs/online/adverts_general" tabindex="-1" aria-hidden="true">is sponsored by</a></span>
+    </span>
+ 
+<div id="" class="bbccom_slot " aria-hidden="true">
+    <div class="bbccom_advert bbccom_display_none">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('sponsor_section', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>   </div>      <div class="container">       <div class="container--primary-and-secondary-columns column-clearfix">                         <div class="column--primary">
+                                                                            <div class="story-body">
+    <h1 class="story-body__h1">Obama admits US gun laws are his 'biggest frustration'</h1>
+
+    
+    <div class="story-body__mini-info-list-and-share">
+        <ul class="mini-info-list">
+    <li class="mini-info-list__item">    <div data-timestamp-inserted="true" class="date date--v2" data-seconds="1437712569" data-datetime="24 July 2015">24 July 2015</div>
+</li>
+    <li class="mini-info-list__item"><span class="mini-info-list__section-desc off-screen">From the section </span><a href="/news/world/us_and_canada" class="mini-info-list__section">US &amp; Canada</a></li>
+    <li class="mini-info-list__item"><span id="dna-comment-count___CPS__33646704" class="js-comment-count comment-count dna-comment-count-show" data-comments-id="__CPS__33646704">941</span><span class="off-screen"> comments</span></li>
+</ul>
+            </div>
+
+    <div class="story-body__inner" property="articleBody">
+        <div class="media-placeholder lead-video-placeholder enabled" id="84457006" data-media-type="video" data-media-meta="{&quot;duration&quot;:&quot;PT1M1S&quot;,&quot;available&quot;:true,&quot;image&quot;:{&quot;height&quot;:360,&quot;width&quot;:640,&quot;href&quot;:&quot;http:\/\/c.files.bbci.co.uk\/8269\/production\/_84458333_gunslawstext.jpg&quot;,&quot;altText&quot;:&quot;Obama on gun laws&quot;,&quot;copyrightHolder&quot;:&quot;(C) British Broadcasting Corporation&quot;,&quot;originCode&quot;:&quot;cpsprodpb&quot;},&quot;mimeType&quot;:&quot;application\/xml&quot;,&quot;href&quot;:&quot;http:\/\/playlists.bbc.co.uk\/news\/world-us-canada-33629023A\/playlist.sxml&quot;,&quot;externalId&quot;:&quot;p02xw7bz&quot;,&quot;caption&quot;:&quot;Mr Obama told the BBC that gun control was his biggest frustration&quot;,&quot;allowOffSiteEmbedding&quot;:true,&quot;live&quot;:false,&quot;entityType&quot;:&quot;Version&quot;,&quot;durationInSeconds&quot;:61}"><figure class="media-item default-player has-caption"><div style="background-repeat: no-repeat; background-position: center center; background-size: contain; background-color: black; overflow: hidden;" class="media-container media-wrapper" id="media-84457006"><div id="smphtml5iframemedia-84457006wrp" style="border-bottom: 0px none; z-index: 999; position: relative; height: 100%; width: 100%; padding-bottom: 56.25%;"><iframe style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;" src="//emp.bbc.com/emp/SMPj/1.5.37/iframe.html" scrolling="no" name="smphtml5iframemedia-84457006" id="smphtml5iframemedia-84457006" frameborder="0"></iframe></div></div><figcaption class="media-caption"><span class="off-screen">Media caption</span> <span class="media-caption__text">Mr Obama told the BBC that gun control was his biggest frustration</span></figcaption><div id="bbccom_companion_84457006" class="bbccom_companion_outer"></div></figure></div><p class="story-body__introduction">President Barack Obama has admitted that his failure to pass "common sense gun safety laws" in the US is the greatest frustration of his presidency. </p><p>In an interview with the BBC, Mr Obama said it was "distressing" not to have made progress on the issue "even in the face of repeated mass killings".</p><p>He vowed to keep trying, but the BBC's North America editor Jon Sopel said the president did not sound very confident. </p><p>However, Mr Obama said race relations had improved during his presidency. </p><p>Hours after the interview, a gunman opened fire at a cinema in the US state of Louisiana, killing two people and injuring several others before shooting himself.</p><div id="bbccom_mpu_1_2_3" class="bbccom_slot mpu-ad bbccom_standard_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_mpu" class="bbccom_advert bbccom_display_none">
+        <script type="text/javascript">
+        /**/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('mpu', [1,2,3]);
+        }
+        /**/
+        </script><a tabindex="-1" class="bbccom_text" href="http://www.bbc.co.uk/faqs/online/adverts_general">Advertisement</a><script type="text/javascript">bbcdotcom.ad("mpu").setBaseContent();googletag.display("mpu");</script><div id="mpu_ad_container"><!--  Begin Rubicon Project Tag -->
+<!--  Site: BBC.com - US Only_MWeb_RFM   Zone: BBC Properties_MWeb_RFM_ATF   Size: Medium Rectangle  -->
+<!--  PLACEMENT: Above the Fold;   -->
+<script language="JavaScript" type="text/javascript">
+rp_account   = '9176';
+rp_site      = '21342';
+rp_zonesize  = '72686-15';
+rp_adtype    = 'js';
+rp_smartfile = '[SMART FILE URL]';
+</script>
+<script type="text/javascript" src="http://ads.rubiconproject.com/ad/9176.js"></script><script type="text/javascript" src="http://gum.criteo.com/sync?c=2&amp;r=2&amp;j=rp_onUserIdLoaded_72686_15"></script><script type="text/javascript">rp_requests = new RubiconAdServing.Requests();     rp_requests.sendRequest('72686-15');</script><script type="text/javascript" src="http://optimized-by.rubiconproject.com/a/9176/21342/72686-15.js?&amp;cb=0.19712674965035237&amp;tk_st=1&amp;rp_s=c&amp;p_exp=1&amp;p_pos=btf&amp;p_screen_res=584x500&amp;put_2054=3zr_sADHcp7bJibfUKesqs-8ROJWhKnp&amp;put_2138=3zr_sADHcp7bJibfUKesqs-8ROJWhKnp&amp;put_2149=3zr_sADHcp7bJibfUKesqs-8ROJWhKnp&amp;put_2532=3zr_sADHcp7bJibfUKesqs-8ROJWhKnp&amp;put_3410=3zr_sADHcp7bJibfUKesqs-8ROJWhKnp"></script>
+<div style="width: 0; height: 0; overflow: hidden;">
+<img src="http://beacon-us-east.rubiconproject.com/beacon/d/c7fc9a18-e658-40cb-b122-2a67ac137253?accountId=9176&amp;siteId=21342&amp;zoneId=72686&amp;e=6A1E40E384DA563BC35D424639CBC3996755004D5E9E92FCC5D5975482C06D202AFB0309050CE4C9FDBCCA75EDC6570644136BD09AD42E178F043B3A9B3D44DFCACFFC2D53F6EA7AC793078C8D240C81172CD28438FCBB6A0A85F1B2498A61AE3074348E62474919C04AE81C6C1B6F10D4119A84C501229B0FF33AE9256AA201" alt="" height="1" border="0" width="1">
+</div>
+
+<script type="text/javascript">
+/*<![CDATA[*/
+(function() {
+    try {
+        if (typeof BBC !== 'undefined' &&
+            typeof BBC.adverts !== 'undefined' &&
+            typeof BBC.adverts.close !== 'undefined') {
+            BBC.adverts.close('mpu');
+        }
+        if (typeof bbcdotcom !== 'undefined' &&
+            typeof bbcdotcom.objects !== 'undefined' &&
+            bbcdotcom.objects('bbcdotcom.adverts.adRegister')) {
+            var ad = bbcdotcom.adverts.adRegister.getAd('mpu');
+            if (typeof ad !== 'undefined' &&
+                typeof ad.close !== 'undefined') {
+                ad.close();
+            }
+        }
+    } catch(e) {}
+}());
+/*]]>*/
+</script><script>
+var _comscore = _comscore || [];
+(function() {
+  var rp_cats = "IAB12,IAB9,IAB3,IAB1,IAB13,IAB20,IAB19,IAB17,IAB15";
+  var rp_cat = 24*1000;
+  if (rp_cats) {
+    rp_cats = rp_cats.replace(/IAB/g,"").split(",");
+    if (rp_cats.length > 0 && rp_cats[0] && rp_cats[0].length > 0) {
+    rp_cat = rp_cats[0].split("-")[0];
+    rp_cat = rp_cat * 1000;
+  }
+}
+_comscore.push({ c1: "8", c2: "6135404", c3: rp_cat, c4: "21342", c10: "3947362" }); 
+
+var country_code = "us"; 
+var eligible = { us : 1, at: 1, be: 1, dk: 1, fi: 1, it: 1, nl: 1, no: 1, se: 1, uk: 1, au: 1, jp: 1 };
+
+if ( eligible[country_code] ) { 
+  (function() { 
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; 
+    s.async = true; 
+    s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
+    el.parentNode.insertBefore(s, el); })(); } 
+  })();
+</script><div style="height: 0px; width: 0px; overflow: hidden">
+<script>
+(function() {var proto = document.location.protocol; var server="http://tap2-cdn.rubiconproject.com"; if (proto == "https:") server="https://tap-secure.rubiconproject.com"; document.write('<IFRAME SRC="'+server+'/partner/scripts/rubicon/emily.html?rtb_ext=1&pc=9176/21342&geo=na&co=us" FRAMEBORDER="0" MARGINWIDTH="0" MARGINHEIGHT="0" SCROLLING="NO" WIDTH="0" HEIGHT="0" style="height: 0px; width: 0px"></IFRAME>'); })();
+</script><iframe tabindex="-1" src="http://tap2-cdn.rubiconproject.com/partner/scripts/rubicon/emily.html?rtb_ext=1&amp;pc=9176/21342&amp;geo=na&amp;co=us" marginwidth="0" marginheight="0" scrolling="NO" style="height: 0px; width: 0px" frameborder="0" height="0" width="0"></iframe>
+
+</div>
+<!--  End Rubicon Project Tag -->
+<script type="text/javascript">(function(){var h=this,k=function(a){var b=typeof a;if("object"==b)if(a){if(a instanceof Array)return"array";if(a instanceof Object)return b;var c=Object.prototype.toString.call(a);if("[object Window]"==c)return"object";if("[object Array]"==c||"number"==typeof a.length&&"undefined"!=typeof a.splice&&"undefined"!=typeof a.propertyIsEnumerable&&!a.propertyIsEnumerable("splice"))return"array";if("[object Function]"==c||"undefined"!=typeof a.call&&"undefined"!=typeof a.propertyIsEnumerable&&!a.propertyIsEnumerable("call"))return"function"}else return"null";else if("function"==b&&"undefined"==typeof a.call)return"object";return b},n=function(a){return"string"==typeof a},aa=function(a,b){var c=Array.prototype.slice.call(arguments,1);return function(){var b=c.slice();b.push.apply(b,arguments);return a.apply(this,b)}},p=Date.now||function(){return+new Date},q=function(a,b){var c=a.split("."),d=h;c[0]in d||!d.execScript||d.execScript("var "+c[0]);for(var e;c.length&&(e=c.shift());)c.length||void 0===b?d=d[e]?d[e]:d[e]={}:d[e]=b};var t=function(a,b,c,d,e){if(e)c=a+("&"+b+"="+c);else{var f="&"+b+"=",g=a.indexOf(f);0>g?c=a+f+c:(g+=f.length,f=a.indexOf("&",g),c=0<=f?a.substring(0,g)+c+a.substring(f):a.substring(0,g)+c)}return 2E3<c.length?void 0!==d?t(a,b,d,void 0,e):a:c};var ba=function(){var a=/[&\?]exk=([^& ]+)/.exec(u.location.href);return a&&2==a.length?a[1]:null};var ca=function(a){var b=a.toString();a.name&&-1==b.indexOf(a.name)&&(b+=": "+a.name);a.message&&-1==b.indexOf(a.message)&&(b+=": "+a.message);if(a.stack){a=a.stack;var c=b;try{-1==a.indexOf(c)&&(a=c+"\n"+a);for(var d;a!=d;)d=a,a=a.replace(/((https?:\/..*\/)[^\/:]*:\d+(?:.|\n)*)\2/,"$1");b=a.replace(/\n */g,"\n")}catch(e){b=c}}return b},v=function(a,b){a.google_image_requests||(a.google_image_requests=[]);var c=a.document.createElement("img");c.src=b;a.google_image_requests.push(c)};var w=document,u=window;var da=String.prototype.trim?function(a){return a.trim()}:function(a){return a.replace(/^[\s\xa0]+|[\s\xa0]+$/g,"")},ea=function(a,b){return a<b?-1:a>b?1:0};var x=null,fa=function(a,b){for(var c in a)Object.prototype.hasOwnProperty.call(a,c)&&b.call(null,a[c],c,a)};function y(a){return"function"==typeof encodeURIComponent?encodeURIComponent(a):escape(a)}var ga=function(){if(!w.body)return!1;if(!x){var a=w.createElement("iframe");a.style.display="none";a.id="anonIframe";x=a;w.body.appendChild(a)}return!0},ha={};var ia=!0,ja={},ma=function(a,b,c,d){var e=ka,f,g=ia;try{f=b()}catch(l){try{var r=ca(l);b="";l.fileName&&(b=l.fileName);var G=-1;l.lineNumber&&(G=l.lineNumber);g=e(a,r,b,G,c)}catch(m){try{var B=ca(m);a="";m.fileName&&(a=m.fileName);c=-1;m.lineNumber&&(c=m.lineNumber);ka("pAR",B,a,c,void 0,void 0)}catch(Ma){la({context:"mRE",msg:Ma.toString()+"\n"+(Ma.stack||"")},void 0)}}if(!g)throw l;}finally{if(d)try{d()}catch(Wb){}}return f},ka=function(a,b,c,d,e,f){var g={};if(e)try{e(g)}catch(l){}g.context=a;g.msg=b.substring(0,512);c&&(g.file=c);0<d&&(g.line=d.toString());g.url=w.URL.substring(0,512);g.ref=w.referrer.substring(0,512);na(g);la(g,f);return ia},la=function(a,b){try{if(Math.random()<(b||.01)){var c="/pagead/gen_204?id=jserror"+oa(a),d="http"+("http:"==u.location.protocol?"":"s")+"://pagead2.googlesyndication.com"+c,d=d.substring(0,2E3);v(u,d)}}catch(e){}},na=function(a){var b=a||{};fa(ja,function(a,d){b[d]=u[a]})},z=function(a,b,c,d,e){return function(){var f=arguments;return ma(a,function(){return b.apply(c,f)},d,e)}},oa=function(a){var b="";fa(a,function(a,d){if(0===a||a)b+="&"+d+"="+y(String(a))});return b};var A=Array.prototype,pa=A.indexOf?function(a,b,c){return A.indexOf.call(a,b,c)}:function(a,b,c){c=null==c?0:0>c?Math.max(0,a.length+c):c;if(n(a))return n(b)&&1==b.length?a.indexOf(b,c):-1;for(;c<a.length;c++)if(c in a&&a[c]===b)return c;return-1},qa=A.map?function(a,b,c){return A.map.call(a,b,c)}:function(a,b,c){for(var d=a.length,e=Array(d),f=n(a)?a.split(""):a,g=0;g<d;g++)g in f&&(e[g]=b.call(c,f[g],g,a));return e};var ra=function(a,b){for(var c in a)b.call(void 0,a[c],c,a)},sa=function(a){var b=arguments.length;if(1==b&&"array"==k(arguments[0]))return sa.apply(null,arguments[0]);for(var c={},d=0;d<b;d++)c[arguments[d]]=!0;return c};var C;a:{var ta=h.navigator;if(ta){var ua=ta.userAgent;if(ua){C=ua;break a}}C=""}var D=function(a){return-1!=C.indexOf(a)};var E=function(){return D("Opera")||D("OPR")},va=function(){return(D("Chrome")||D("CriOS"))&&!E()&&!D("Edge")};var wa=function(){return D("iPhone")&&!D("iPod")&&!D("iPad")};var xa=E(),F=D("Trident")||D("MSIE"),ya=D("Edge"),za=D("Gecko")&&!(-1!=C.toLowerCase().indexOf("webkit")&&!D("Edge"))&&!(D("Trident")||D("MSIE"))&&!D("Edge"),Aa=-1!=C.toLowerCase().indexOf("webkit")&&!D("Edge"),Ba=function(){var a=C;if(za)return/rv\:([^\);]+)(\)|;)/.exec(a);if(ya)return/Edge\/([\d\.]+)/.exec(a);if(F)return/\b(?:MSIE|rv)[: ]([^\);]+)(\)|;)/.exec(a);if(Aa)return/WebKit\/(\S+)/.exec(a)},Ca=function(){var a=h.document;return a?a.documentMode:void 0},Da=function(){if(xa&&h.opera){var a=h.opera.version;return"function"==k(a)?a():a}var a="",b=Ba();b&&(a=b?b[1]:"");return F&&(b=Ca(),b>parseFloat(a))?String(b):a}(),Ea={},Fa=function(a){if(!Ea[a]){for(var b=0,c=da(String(Da)).split("."),d=da(String(a)).split("."),e=Math.max(c.length,d.length),f=0;0==b&&f<e;f++){var g=c[f]||"",l=d[f]||"",r=RegExp("(\\d*)(\\D*)","g"),G=RegExp("(\\d*)(\\D*)","g");do{var m=r.exec(g)||["","",""],B=G.exec(l)||["","",""];if(0==m[0].length&&0==B[0].length)break;b=ea(0==m[1].length?0:parseInt(m[1],10),0==B[1].length?0:parseInt(B[1],10))||ea(0==m[2].length,0==B[2].length)||ea(m[2],B[2])}while(0==b)}Ea[a]=0<=b}},Ga=h.document,Ha=Ga&&F?Ca()||("CSS1Compat"==Ga.compatMode?parseInt(Da,10):5):void 0;var Ia=function(a,b,c){if("array"==k(b))for(var d=0;d<b.length;d++)Ia(a,String(b[d]),c);else null!=b&&c.push("&",a,""===b?"":"=",encodeURIComponent(String(b)))},Ja=function(a,b,c){for(c=c||0;c<b.length;c+=2)Ia(b[c],b[c+1],a);return a},Ka=function(a,b){var c=2==arguments.length?Ja([a],arguments[1],0):Ja([a],arguments,1);if(c[1]){var d=c[0],e=d.indexOf("#");0<=e&&(c.push(d.substr(e)),c[0]=d=d.substr(0,e));e=d.indexOf("?");0>e?c[1]="?":e==d.length-1&&(c[1]=void 0)}return c.join("")};var La={l:947190538,m:947190541,o:947190542,h:79463068,i:79463069},Na={g:"ud=1",f:"ts=0",s:"sc=1",c:"gz=1",j:"lp=1"};if(w&&w.URL){var Oa=w.URL,Pa;if(Pa=Oa){var Qa;if(Oa){var H=/.*[&#?]google_debug(=[^&]*)?(&.*)?$/.exec(decodeURIComponent(Oa));Qa=H?H[1]&&1<H[1].length?H[1].substring(1):"true":""}else Qa="";Pa=0<Qa.length}ia=!Pa}var I=function(a,b,c,d){c=z(d||"osd_or_lidar::"+b,c,void 0,void 0,void 0);a.addEventListener?a.addEventListener(b,c,!1):a.attachEvent&&a.attachEvent("on"+b,c)},Ra=function(a,b,c){if(!(0>=b)){var d=0,e=function(){a();d++;d<b&&u.setTimeout(z(c,e,void 0,void 0,void 0),100)};e()}};var J=function(a,b){this.b=a||0;this.a=b||""},K=function(a,b){a.b&&(b[4]=a.b);a.a&&(b[12]=a.a)};J.prototype.match=function(a){return(this.b||this.a)&&(a.b||a.a)?this.a||a.a?this.a==a.a:this.b||a.b?this.b==a.b:!1:!1};J.prototype.toString=function(){var a=""+this.b;this.a&&(a+="-"+this.a);return a};var Sa=function(){var a=L,b=[];a.b&&b.push("adk="+a.b);a.a&&b.push("exk="+a.a);return b},M=function(a){var b=[];ra(a,function(a,d){var e=y(d),f=a;n(f)&&(f=y(f));b.push(e+"="+f)});return b.join("\n")},N=0,Ta=0,Ua=function(a){var b=0,c=u;try{if(c&&c.Goog_AdSense_getAdAdapterInstance)return c}catch(d){}try{for(;c&&5>b;){if(c.google_osd_static_frame)return c;if(c.aswift_0&&(!a||c.aswift_0.google_osd_static_frame))return c.aswift_0;b++;c=c!=c.parent?c.parent:null}}catch(e){}return null},Va=function(a,b,c,d,e){if(10<Ta)u.clearInterval(N);else if(++Ta,u.postMessage&&(b.b||b.a)){var f=Ua(!0);if(f){var g={};K(b,g);g[0]="goog_request_monitoring";g[6]=a;g[16]=c;d&&d.length&&(g[17]=d.join(","));e&&(g[19]=e);try{var l=M(g);f.postMessage(l,"*")}catch(r){}}}},Wa=function(a){var b=Ua(!1),c=!b;!b&&u&&(b=u.parent);if(b&&b.postMessage)try{b.postMessage(a,"*"),c&&u.postMessage(a,"*")}catch(d){}};sa("area base br col command embed hr img input keygen link meta param source track wbr".split(" "));var O=function(a,b){this.width=a;this.height=b};O.prototype.round=function(){this.width=Math.round(this.width);this.height=Math.round(this.height);return this};var Xa;if(!(Xa=!za&&!F)){var Ya;if(Ya=F)Ya=9<=Ha;Xa=Ya}Xa||za&&Fa("1.9.1");F&&Fa("9");var P=!1,Q=function(a){if(a=a.match(/[\d]+/g))a.length=3};if(navigator.plugins&&navigator.plugins.length){var Za=navigator.plugins["Shockwave Flash"];Za&&(P=!0,Za.description&&Q(Za.description));navigator.plugins["Shockwave Flash 2.0"]&&(P=!0)}else if(navigator.mimeTypes&&navigator.mimeTypes.length){var $a=navigator.mimeTypes["application/x-shockwave-flash"];(P=$a&&$a.enabledPlugin)&&Q($a.enabledPlugin.description)}else try{var ab=new ActiveXObject("ShockwaveFlash.ShockwaveFlash.7"),P=!0;Q(ab.GetVariable("$version"))}catch(bb){try{ab=new ActiveXObject("ShockwaveFlash.ShockwaveFlash.6"),P=!0}catch(cb){try{ab=new ActiveXObject("ShockwaveFlash.ShockwaveFlash"),P=!0,Q(ab.GetVariable("$version"))}catch(db){}}};var eb=D("Firefox"),fb=wa()||D("iPod"),gb=D("iPad"),hb=D("Android")&&!(va()||D("Firefox")||E()||D("Silk")),ib=va(),jb=D("Safari")&&!(va()||D("Coast")||E()||D("Edge")||D("Silk")||D("Android"))&&!(wa()||D("iPad")||D("iPod"));var R=function(a){return(a=a.exec(C))?a[1]:""};(function(){if(eb)return R(/Firefox\/([0-9.]+)/);if(F||xa)return Da;if(ib)return R(/Chrome\/([0-9.]+)/);if(jb&&!(wa()||D("iPad")||D("iPod")))return R(/Version\/([0-9.]+)/);if(fb||gb){var a;if(a=/Version\/(\S+).*Mobile\/(\S+)/.exec(C))return a[1]+"."+a[2]}else if(hb)return(a=R(/Android\s+([0-9.]+)/))?a:R(/Version\/([0-9.]+)/);return""})();var lb=function(){var a=u.parent&&u.parent!=u,b=a&&0<="//tpc.googlesyndication.com".indexOf(u.location.host);if(a&&u.name&&0==u.name.indexOf("google_ads_iframe")||b){var c;a=u||u;try{var d;if(a.document&&!a.document.body)d=new O(-1,-1);else{var e=(a||window).document,f="CSS1Compat"==e.compatMode?e.documentElement:e.body;d=(new O(f.clientWidth,f.clientHeight)).round()}c=d}catch(g){c=new O(-12245933,-12245933)}return kb(c)}c=u.document.getElementsByTagName("SCRIPT");return 0<c.length&&(c=c[c.length-1],c.parentElement&&c.parentElement.id&&0<c.parentElement.id.indexOf("_ad_container"))?kb(void 0,c.parentElement):null},kb=function(a,b){var c=mb("IMG",a,b);return c||(c=mb("IFRAME",a,b))?c:(c=mb("OBJECT",a,b))?c:null},mb=function(a,b,c){var d=document;c=c||d;d=a&&"*"!=a?a.toUpperCase():"";c=c.querySelectorAll&&c.querySelector&&d?c.querySelectorAll(d+""):c.getElementsByTagName(d||"*");for(d=0;d<c.length;d++){var e=c[d];if("OBJECT"==a)a:{var f=e.getAttribute("height");if(null!=f&&0<f&&0==e.clientHeight)for(var f=e.children,g=0;g<f.length;g++){var l=f[g];if("OBJECT"==l.nodeName||"EMBED"==l.nodeName){e=l;break a}}}f=e.clientHeight;g=e.clientWidth;if(l=b)l=new O(g,f),l=Math.abs(b.width-l.width)<.1*b.width&&Math.abs(b.height-l.height)<.1*b.height;if(l||!b&&10<f&&10<g)return e}return null};var nb,S=0,T="",U=!1,V=!1,ob=!1,pb=!0,qb=!1,rb=!1,sb=!1,tb=!1,ub="",vb=0,wb=0,W=0,xb=[],L=null,yb="",zb=[],Ab=null,Bb=[],Cb=!1,Db="",Eb="",Fb=(new Date).getTime(),Gb=!1,Hb="",Ib=!1,Jb=["1","0","3"],X=0,Y=0,Kb=0,Lb="",Nb=function(a,b,c){U&&(pb||3!=(c||3)||rb)&&Mb(a,b,!0);(ob||V&&qb)&&Mb(a,b)},Ob=function(){var a=Ab;return a?2!=a():!0},Mb=function(a,b,c){(b=b||yb)&&!Cb&&(2==Y||c)&&Ob()&&(b=Pb(b,c),v(a,b),tb=!0,c?U=!1:Cb=!0)},Pb=function(a,b){var c;c=b?"osdim":ob?"osd2":"osdtos";var d=["//pagead2.googlesyndication.com/activeview","?id=",c];"osd2"==c&&V&&qb&&d.push("&ts=1");T&&d.push("&avi=",T);nb&&d.push("&cid=",nb);d.push("&ti=1");d.push("&",a);d.push("&uc="+Kb);Gb?d.push("&tgt="+Hb):d.push("&tgt=nf");d.push("&cl="+(Ib?1:0));""!=ub&&(d.push("&lop=1"),c=p()-vb,d.push("&tslp="+c));d=d.join("");for(c=0;c<zb.length;c++){try{var e=zb[c]()}catch(f){}var g="max_length";2<=e.length&&(3==e.length&&(g=e[2]),d=t(d,y(e[0]),y(e[1]),g))}2E3<d.length&&(d=d.substring(0,2E3));return d},Z=function(a,b){if(Db){try{var c=t(Db,"vi",a);ga()&&v(x.contentWindow,c)}catch(d){}0<=pa(Jb,a)&&(Db="");var c=b||yb,e;e=t("//pagead2.googlesyndication.com/pagead/gen_204?id=sldb","avi",T);e=t(e,"vi",a);c&&(e+="&"+c);try{v(u,e)}catch(f){}}},Qb=function(){Z("-1")},Sb=function(a){if(a&&a.data&&n(a.data)){var b;var c=a.data;if(n(c)){b={};for(var c=c.split("\n"),d=0;d<c.length;d++){var e=c[d].indexOf("=");if(!(0>=e)){var f=Number(c[d].substr(0,e)),e=c[d].substr(e+1);switch(f){case 5:case 8:case 11:case 15:case 16:case 18:e="true"==e;break;case 4:case 7:case 6:case 14:case 20:case 21:case 22:case 23:e=Number(e);break;case 3:case 19:if("function"==k(decodeURIComponent))try{e=decodeURIComponent(e)}catch(g){throw Error("Error: URI malformed: "+e);}break;case 17:e=qa(decodeURIComponent(e).split(","),Number)}b[f]=e}}b=b[0]?b:null}else b=null;if(b&&(c=new J(b[4],b[12]),L&&L.match(c))){for(c=0;c<Bb.length;c++)Bb[c](b);void 0!=b[18]&&(rb=b[18],rb||2!=W||(W=3,Rb()));c=b[0];if("goog_acknowledge_monitoring"==c)u.clearInterval(N),X=2;else if("goog_get_mode"==c){X=1;d={};L&&K(L,d);d[0]="goog_provide_mode";d[6]=Y;d[19]=Lb;d[16]=V;try{var l=M(d);a.source.postMessage(l,a.origin)}catch(r){}u.clearInterval(N);X=2}else"goog_update_data"==c?(yb=b[3],++Kb):"goog_image_request"==c&&(Nb(u,b[3]),b[5]||b[11]||Z("0",b[3]));if("goog_update_data"==c||"goog_image_request"==c)(1==Y||2==Y||U)&&b[5]&&(a=1==b[15]&&"goog_update_data"==c,qb=!0,Z("1"),Eb&&Ob()&&(l=Eb,ga()&&v(x.contentWindow,l),Eb=""),U&&!a&&(Mb(u,void 0,!0),sb=!0,wb=p()),3==W&&(W=4,Rb()),U||1!=Y||(Cb=!0)),(1==Y||2==Y||U)&&b[11]&&(V=!1,Z("3"),U&&(Mb(u,void 0,!0),1==W&&rb&&(W=2)))}}},Rb=function(){var a=u,b=W;0!=b&&1!=b&&Tb(a,"osdim","zas="+b)},Tb=function(a,b,c){b="//pagead2.googlesyndication.com/pagead/gen_204?id="+b+"&";var d=[];d.push("ovr_value="+S);d.push("avi="+T);L&&(d=d.concat(Sa()));d.push("tt="+((new Date).getTime()-Fb));d.push(c);a.document&&a.document.referrer&&d.push("ref="+y(a.document.referrer));b+=d.join("&");try{v(a,b)}catch(e){}},Ub=function(){Nb(u);Z("0");2>X&&!V&&2==Y&&Tb(u,"osd2","hs="+X)},Vb=function(){var a={};K(L,a);a[0]="goog_dom_content_loaded";var b=M(a);try{Ra(function(){Wa(b)},10,"osd_listener::ldcl_int")}catch(c){}},Xb=function(){var a={};K(L,a);a[0]="goog_creative_loaded";var b=M(a);Ra(function(){Wa(b)},10,"osd_listener::lcel_int");Ib=!0},Yb=function(a){if(n(a)){a=a.split("&");for(var b=a.length-1;0<=b;b--){var c=a[b],d=Na;c==d.g?(pb=!1,a.splice(b,1)):c==d.c?(W=1,a.splice(b,1)):c==d.f&&(V=!1,a.splice(b,1))}Lb=a.join("&")}},Zb=function(){if(!Gb){var a=lb();a&&(Gb=!0,Hb=a.tagName,a.complete||a.naturalWidth?Xb():I(a,"load",Xb,"osd_listener::creative_load"))}};q("osdlfm",z("osd_listener::init",function(a,b,c,d,e,f,g,l,r,G){S=a;Db=b;Eb=d;U=f;nb=G;l&&Yb(l);V=f;1!=r&&2!=r&&3!=r||xb.push(La["MRC_TEST_"+r]);L=new J(e,ba());I(u,"load",Qb,"osd_listener::load");I(u,"message",Sb,"osd_listener::message");T=c||"";I(u,"unload",Ub,"osd_listener::unload");var m=u.document;!m.readyState||"complete"!=m.readyState&&"loaded"!=m.readyState?("msie"in ha?ha.msie:ha.msie=-1!=navigator.userAgent.toLowerCase().indexOf("msie"))&&!window.opera?I(m,"readystatechange",function(){"complete"!=m.readyState&&"loaded"!=m.readyState||Vb()},"osd_listener::rsc"):I(m,"DOMContentLoaded",Vb,"osd_listener::dcl"):Vb();-1==S?Y=f?3:1:-2==S?Y=3:0<S&&(Y=2,ob=!0);V&&!ob&&-1==S&&(Y=2);L&&(L.b||L.a)&&(X=1,N=u.setInterval(z("osd_proto::reqm_int",aa(Va,Y,L,V,xb,Lb),void 0,void 0,void 0),500));Ra(Zb,5,"osd_listener:sfc")}));q("osdlac",z("osd_listener::lac_ex",function(a){zb.push(a)}));q("osdlamrc",z("osd_listener::lamrc_ex",function(a){Bb.push(a)}));q("osdsir",z("osd_listener::sir_ex",Nb));q("osdacrc",z("osd_listener::acrc_ex",function(a){Ab=a}));q("osdpcls",z("osd_listener::acrc_ex",function(a){if(""==a||u==u.top||Cb||tb&&!sb)return!1;ub=a;if(sb){var b=T;T=a;var c=Pb(yb,!0);T=b;b=p()-wb;c=Ka(c,"tsvp",b);v(u,c)}T=""==T?a:T+","+a;vb=p();return!0}));}).call(this);osdlfm(-1,'','BWz45lW6yVeCgI9D7-QOox5q4BwAAAAAQATgByAEJwAIC4AIA4AQBoAYWwhMDEIAB','',3569409373,true,true,'ud\x3d1\x26la\x3d0\x26',3,'');</script>
+</div>
+
+    </div>
+    <script type="text/javascript">
+        /**/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /**/
+    </script>
+</div><p>In a wide-ranging interview, President Obama also said:</p><ul class="story-body__unordered-list">
+<li class="story-body__list-item">
+<a href="http://www.bbc.co.uk/news/uk-politics-33647154" class="story-body__link">The UK must stay in the EU</a> to have influence on the world stage</li>
+<li class="story-body__list-item">He is confident the Iran nuclear deal will be passed by Congress </li>
+<li class="story-body__list-item">Syria needs a political solution in order to defeat the Islamic State group</li>
+<li class="story-body__list-item">He would speak "bluntly" against corruption <a href="http://www.bbc.co.uk/news/world-us-canada-33646563" class="story-body__link">and human rights violations in Kenya</a>
+</li>
+<li class="story-body__list-item">He would defend his advocacy of gay rights following protests in Kenya</li>
+<li class="story-body__list-item">Despite racial tensions, the US is becoming more diverse and more tolerant</li>
+</ul><p><a href="http://www.bbc.co.uk/news/world-us-canada-33646542" class="story-body__link">Read the full transcript of his interview</a></p><p>Mr Obama lands in Kenya later on Friday for his first visit since becoming president. </p><p>But with just 18 months left in power, he said gun control was the area where he has been "most frustrated and most stymied" since coming to power in 2009.</p><p>"If you look at the number of Americans killed since 9/11 by terrorism, it's less than 100. If you look at the number that have been killed by gun violence, it's in the tens of thousands," Mr Obama said. </p><div class="media-placeholder narrative-video-placeholder enabled" id="84457698" data-media-type="video" data-media-meta="{&quot;duration&quot;:&quot;PT3M52S&quot;,&quot;available&quot;:true,&quot;image&quot;:{&quot;height&quot;:360,&quot;width&quot;:640,&quot;href&quot;:&quot;http:\/\/c.files.bbci.co.uk\/B0E5\/production\/_84458254_mediaitemuk.jpg&quot;,&quot;altText&quot;:&quot;Obama on the US-UK Relationship&quot;,&quot;copyrightHolder&quot;:&quot;(C) British Broadcasting Corporation&quot;,&quot;originCode&quot;:&quot;cpsprodpb&quot;},&quot;mimeType&quot;:&quot;application\/xml&quot;,&quot;href&quot;:&quot;http:\/\/playlists.bbc.co.uk\/news\/world-us-canada-33647052A\/playlist.sxml&quot;,&quot;externalId&quot;:&quot;p02xwdcy&quot;,&quot;caption&quot;:&quot;Barack Obama: \u0022Great Britain has always been our best partner\u0022&quot;,&quot;allowOffSiteEmbedding&quot;:true,&quot;live&quot;:false,&quot;entityType&quot;:&quot;Version&quot;,&quot;durationInSeconds&quot;:232}"><figure class="media-item default-player has-caption"><div style="background-repeat: no-repeat; background-position: center center; background-size: contain; background-color: black; overflow: hidden;" class="media-container media-wrapper" id="media-84457698"><div id="smphtml5iframemedia-84457698wrp" style="border-bottom: 0px none; z-index: 999; position: relative; height: 100%; width: 100%; padding-bottom: 56.25%;"><iframe style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;" src="//emp.bbc.com/emp/SMPj/1.5.37/iframe.html" scrolling="no" name="smphtml5iframemedia-84457698" id="smphtml5iframemedia-84457698" frameborder="0"></iframe></div></div><figcaption class="media-caption"><span class="off-screen">Media caption</span> <span class="media-caption__text">Barack Obama: "Great Britain has always been our best partner"</span></figcaption><div id="bbccom_companion_84457698" class="bbccom_companion_outer"></div></figure></div><figure class="media-landscape full-width has-caption"><img src="http://ichef.bbci.co.uk/news/555/cpsprodpb/462D/production/_84456971_gettyimages-167501087.jpg" datasrc="http://ichef.bbci.co.uk/news/976/cpsprodpb/462D/production/_84456971_gettyimages-167501087.jpg" class="js-image-replace" alt="Gun control campaigners protest in McPhearson Square in Washington DC - 25 April 2013" height="549" width="976">
+                <figcaption class="media-caption">
+                    <span class="media-caption__text">
+                        The president said he would continue fighting for greater gun control laws
+                    </span>
+                </figcaption></figure><p>"For us not to be able to resolve that issue has been something that is distressing," he added. </p><p>Mr Obama has pushed for stricter gun control throughout his presidency but has been unable to secure any significant changes to the laws. </p><p>After nine African-American churchgoers were killed in South Carolina in June, he admitted "politics in this town" meant there were few options available.</p><figure class="media-landscape body-width no-caption"><img src="http://ichef.bbci.co.uk/news/555/media/images/76020000/jpg/_76020974_line976.jpg" datasrc="http://ichef.bbci.co.uk/news/464/media/images/76020000/jpg/_76020974_line976.jpg" class="js-image-replace" alt="line" height="2" width="464"></figure><h2 class="story-body__crosshead">Analysis: Jon Sopel, BBC News, Washington</h2><figure class="media-landscape full-width no-caption"><img src="http://ichef-1.bbci.co.uk/news/555/cpsprodpb/6D3D/production/_84456972_p072315al-0500.jpg" datasrc="http://ichef-1.bbci.co.uk/news/976/cpsprodpb/6D3D/production/_84456972_p072315al-0500.jpg" class="js-image-replace" alt="President Barack Obama participates in an interview with Jon Sopel of BBC in the Roosevelt Room of the White House - 23 July 2015" height="549" width="976"></figure><p>Nine months ago, the president seemed like a spent force, after taking a beating in the midterm elections, during which members of his own party were reluctant to campaign on his record. </p><p>But the man sat before me today was relaxed and confident, buoyed by a string of "wins" on healthcare, Cuba and Iran, after bitter and ongoing battles with his many critics. </p><p>The only body swerve the president performed was when I asked him <a href="http://www.bbc.co.uk/news/world-us-canada-33643168" class="story-body__link"> how many minds he had changed on the Iran nuclear deal </a>after an intense sell aimed at Gulf allies and members of US Congress who remain implacably opposed. </p><p>There was a momentary flicker across the president's face as if to say "You think you got me?" before his smile returned and he proceeded to talk about how Congress would come round.</p><p>But notably, he did not give a direct answer to that question, which leaves me with the impression that he has persuaded precisely zero.</p><p><a href="http://www.bbc.co.uk/news/world-us-canada-33646875" class="story-body__link">Five things we learned from Obama interview</a></p><p><a href="http://www.bbc.co.uk/news/world-us-canada-33646545" class="story-body__link">The presidential body swerve</a></p><figure class="media-landscape body-width no-caption"><img src="http://ichef.bbci.co.uk/news/555/media/images/76020000/jpg/_76020974_line976.jpg" datasrc="http://ichef.bbci.co.uk/news/464/media/images/76020000/jpg/_76020974_line976.jpg" class="js-image-replace" alt="line" height="2" width="464"></figure><div class="media-placeholder narrative-video-placeholder enabled" id="83728567" data-media-type="video" data-media-meta="{&quot;duration&quot;:&quot;PT2M1S&quot;,&quot;available&quot;:true,&quot;image&quot;:{&quot;height&quot;:360,&quot;width&quot;:640,&quot;href&quot;:&quot;http:\/\/c.files.bbci.co.uk\/11F6E\/production\/_83728537_obama.jpg&quot;,&quot;altText&quot;:&quot;Images of Obama making speeches after mass shootings&quot;,&quot;copyrightHolder&quot;:&quot;Getty Images&quot;,&quot;originCode&quot;:&quot;cpsprodpb&quot;},&quot;mimeType&quot;:&quot;application\/xml&quot;,&quot;href&quot;:&quot;http:\/\/playlists.bbc.co.uk\/news\/world-us-canada-33193314A\/playlist.sxml&quot;,&quot;externalId&quot;:&quot;p02v1qt1&quot;,&quot;caption&quot;:&quot;The BBC contrasts President Obama\u0027s reactions after mass shootings, with the levels of US gun ownership during his terms in office. (Video by David Botti)&quot;,&quot;allowOffSiteEmbedding&quot;:true,&quot;live&quot;:false,&quot;entityType&quot;:&quot;Version&quot;,&quot;durationInSeconds&quot;:121}"><figure class="media-item default-player has-caption"><div style="background-repeat: no-repeat; background-position: center center; background-size: contain; background-color: black; overflow: hidden;" class="media-container media-wrapper" id="media-83728567"><div id="smphtml5iframemedia-83728567wrp" style="border-bottom: 0px none; z-index: 999; position: relative; height: 100%; width: 100%; padding-bottom: 56.25%;"><iframe style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;" src="//emp.bbc.com/emp/SMPj/1.5.37/iframe.html" scrolling="no" name="smphtml5iframemedia-83728567" id="smphtml5iframemedia-83728567" frameborder="0"></iframe></div></div><figcaption class="media-caption"><span class="off-screen">Media caption</span> <span class="media-caption__text">The BBC contrasts President Obama's reactions after mass shootings, with the levels of US gun ownership during his terms in office. (Video by David Botti)</span></figcaption><div id="bbccom_companion_83728567" class="bbccom_companion_outer"></div></figure></div><p>On race relations, Mr Obama said recent concerns around policing and mass incarcerations were "legitimate and deserve intense attention" but insisted progress had been made. </p><p>Children growing up during the eight years of his presidency "will have a different view of race relations in this country and what's possible," he said. </p><p>"There are going to be tensions that arise. But if you look at my daughters' generation, they have an attitude about race that's entirely different than even my generation."</p><p>Talking about how he was feeling after his recent successes, he said "every president, every leader has strengths and weaknesses".  </p><p>"One of my strengths is I have a pretty even temperament.  I don't get too high when it's high and I don't get too low when it's low," he said.   </p><figure class="media-landscape full-width has-caption"><img src="http://ichef-1.bbci.co.uk/news/555/cpsprodpb/142FD/production/_84458628_shirtreuters.jpg" datasrc="http://ichef-1.bbci.co.uk/news/976/cpsprodpb/142FD/production/_84458628_shirtreuters.jpg" class="js-image-replace" alt="Customer looks at Obama shirts at a stall in Nairobi's Kibera slums, 23 July 2015" height="549" width="976">
+                <figcaption class="media-caption">
+                    <span class="media-caption__text">
+                        Kenya is getting ready to welcome the US president
+                    </span>
+                </figcaption></figure><h2 class="story-body__crosshead">Kenya trip</h2><p>Mr Obama was speaking to the BBC at the White House before departing for Kenya.</p><p>His father was Kenyan and the president is expected to meet relatives in Nairobi.</p><p>Mr Obama has faced criticism in the country after the US legalised gay marriage. However, in his interview, the president said he would not fall silent on the issue.</p><div class="media-placeholder narrative-video-placeholder enabled" id="84459510" data-media-type="video" data-media-meta="{&quot;duration&quot;:&quot;PT3M16S&quot;,&quot;available&quot;:true,&quot;image&quot;:{&quot;height&quot;:549,&quot;width&quot;:976,&quot;href&quot;:&quot;http:\/\/c.files.bbci.co.uk\/14749\/production\/_84458738_x_maincomp-0;03;11;18_1.jpg&quot;,&quot;altText&quot;:&quot;Obama&quot;,&quot;copyrightHolder&quot;:&quot;BBC&quot;,&quot;originCode&quot;:&quot;cpsprodpb&quot;},&quot;mimeType&quot;:&quot;application\/xml&quot;,&quot;href&quot;:&quot;http:\/\/playlists.bbc.co.uk\/news\/world-africa-33647495A\/playlist.sxml&quot;,&quot;externalId&quot;:&quot;p02xx8zl&quot;,&quot;caption&quot;:&quot;President Obama told the BBC he would deliver a blunt message on gay rights when he travelled to Africa&quot;,&quot;allowOffSiteEmbedding&quot;:true,&quot;live&quot;:false,&quot;entityType&quot;:&quot;Version&quot;,&quot;durationInSeconds&quot;:196}"><figure class="media-item default-player has-caption"><div style="background-repeat: no-repeat; background-position: center center; background-size: contain; background-color: black; overflow: hidden;" class="media-container media-wrapper" id="media-84459510"><div id="smphtml5iframemedia-84459510wrp" style="border-bottom: 0px none; z-index: 999; position: relative; height: 100%; width: 100%; padding-bottom: 56.25%;"><iframe style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;" src="//emp.bbc.com/emp/SMPj/1.5.37/iframe.html" scrolling="no" name="smphtml5iframemedia-84459510" id="smphtml5iframemedia-84459510" frameborder="0"></iframe></div></div><figcaption class="media-caption"><span class="off-screen">Media caption</span> <span class="media-caption__text">President Obama told the BBC he would deliver a blunt message on gay rights when he travelled to Africa</span></figcaption><div id="bbccom_companion_84459510" class="bbccom_companion_outer"></div></figure></div><p>"I am not a fan of discrimination and bullying of anybody on the basis of race, on the basis of religion, on the basis of sexual orientation or gender," he said.</p><ul class="story-body__unordered-list"><li class="story-body__list-item"><a href="http://www.bbc.co.uk/news/live/world-africa-33577232" class="story-body__link">BBC Africa Live updates from Kenya</a></li></ul><p>The president also admitted that some African governments, including Kenya's, needed to improve their records on human rights and democracy. However, he defended his decision to engage with and visit those governments. </p><p>"Well, they're not ideal institutions.  But what we found is, is that when we combined blunt talk with engagement, that gives us the best opportunity to influence and open up space for civil society." </p><p>Mr Obama will become the first US president to address the African Union when he travels on to Ethiopia on Sunday.</p>
+    </div>
+</div>
+                                                                                            <div id="comp-comments-button" data-comp-meta="{&quot;id&quot;:&quot;comp-comments-button&quot;,&quot;type&quot;:&quot;comments-button&quot;,&quot;handler&quot;:&quot;commentsButton&quot;,&quot;deviceGroups&quot;:null,&quot;opts&quot;:{&quot;treatment&quot;:&quot;ghost_column&quot;,&quot;jsEnabled&quot;:true,&quot;commentsId&quot;:&quot;__CPS__33646704&quot;,&quot;position_info&quot;:{&quot;instanceNo&quot;:1,&quot;positionInRegion&quot;:2,&quot;lastInRegion&quot;:false,&quot;lastOnPage&quot;:false,&quot;column&quot;:&quot;primary_column&quot;}},&quot;template&quot;:&quot;\/component\/comments-button&quot;}" class="js-iframe-container comments-button ghost-column">
+    <a class="comments-button__link  js-comments-button__link" href="/news/world-us-canada-33646704/comments" id="comments-iframe-33646704" data-iframe-src="/news/world-us-canada-33646704/comments/iframe" data-static-iframe-height="600">
+        <span class="comments-button__icon">View comments</span><span id="dna-comment-count___CPS__33646704" class="js-comment-count comments-button__count dna-comment-count-show" data-comments-id="__CPS__33646704">941</span>
+    </a>
+</div>
+                                                                                                <div class="share share--lightweight  show ghost-column">
+            <a name="share-tools"></a>
+            <h2 class="share__title share__title--lightweight">
+        Share this story        <a href="http://www.bbc.co.uk/help/web/sharing.shtml">About&nbsp;sharing</a>
+    </h2>
+        <ul class="share__tools share__tools--lightweight">
+                            <li class="share__tool share__tool--email">
+        <a href="mailto:?subject=Shared%20from%20BBC%20News&amp;body=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704">
+            <span>Email</span>
+        </a>
+    </li>
+                            <li class="share__tool share__tool--facebook">
+        <a href="http://www.facebook.com/dialog/feed?app_id=58567469885&amp;redirect_uri=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704&amp;link=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704%3FSThisFB">
+            <span>Facebook</span>
+        </a>
+    </li>
+                            <li class="share__tool share__tool--twitter">
+        <a href="https://twitter.com/intent/tweet?text=BBC%20News%20-%20Obama%20admits%20US%20gun%20laws%20are%20his%20%27biggest%20frustration%27&amp;url=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704" class="shortenUrl" data-social-url="https://twitter.com/intent/tweet?text=BBC+News+-+Obama+admits+US+gun+laws+are+his+%27biggest+frustration%27&amp;url=" data-target-url="http://www.bbc.com/news/world-us-canada-33646704">
+            <span>Twitter</span>
+        </a>
+    </li>
+                            <li class="share__tool share__tool--whatsapp">
+        <a href="whatsapp://send?text=BBC%20News%20%7C%20Obama%20admits%20US%20gun%20laws%20are%20his%20%27biggest%20frustration%27%20-%20http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704%3Focid%3Dwsnews_chatapps_whatsapp_msg_trial_link1">
+            <span>WhatsApp</span>
+        </a>
+    </li>
+                            <li class="share__tool share__tool--linkedin">
+        <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704&amp;title=Obama%20admits%20US%20gun%20laws%20are%20his%20%27biggest%20frustration%27&amp;summary=President%20Barack%20Obama%20tells%20the%20BBC%20his%20failure%20to%20pass%20%22common%20sense%20gun%20safety%20laws%22%20is%20the%20greatest%20frustration%20of%20his%20presidency.&amp;source=BBC">
+            <span>Linkedin</span>
+        </a>
+    </li>
+            </ul>
+</div>
+
+                                                                                                <div class="story-more">
+          <div class="group story-alsos more-on-this-story"> <div class="group__header"> <h2 class="group__title">More on this story</h2> </div> <div class="group__body"> <ul class="units-list ">    <li class="unit unit--regular">  <a href="/news/uk-politics-33647154" class="unit__link-wrapper"> <div class="unit__body"> <div class="unit__header">  <div class="unit__title">     <span class="cta"> Obama urges UK to stay in European Union </span> </div>    <div class="unit__meta"> <div data-timestamp-inserted="true" class="date date--v1 relative-time" data-seconds="1437741970" data-datetime="24 July 2015">4 hours ago</div> </div>  </div> </div> </a>  </li>     <li class="unit unit--regular">  <a href="/news/world-us-canada-33646875" class="unit__link-wrapper"> <div class="unit__body"> <div class="unit__header">  <div class="unit__title">     <span class="cta"> Interview at-a-glance </span> </div>    <div class="unit__meta"> <div data-timestamp-inserted="true" class="date date--v1" data-seconds="1437707069" data-datetime="24 July 2015">24 July 2015</div> </div>  </div> </div> </a>  </li>     <li class="unit unit--regular">  <a href="/news/world-us-canada-33629023" class="unit__link-wrapper"> <div class="unit__body"> <div class="unit__header">  <div class="unit__title">        
+    <span class="icon-new icon-new--video-square-red"><span class="off-screen"> Video</span></span>
+    
+    
+   <span class="cta"> Obama 'distress' over gun laws </span> </div>    <div class="unit__meta"> <div data-timestamp-inserted="true" class="date date--v1" data-seconds="1437685924" data-datetime="23 July 2015">23 July 2015</div> </div>  </div> </div> </a>  </li>     <li class="unit unit--regular">  <a href="/news/world-us-canada-33647052" class="unit__link-wrapper"> <div class="unit__body"> <div class="unit__header">  <div class="unit__title">        
+    <span class="icon-new icon-new--video-square-red"><span class="off-screen"> Video</span></span>
+    
+    
+   <span class="cta"> 'UK is our best partner' </span> </div>    <div class="unit__meta"> <div data-timestamp-inserted="true" class="date date--v1" data-seconds="1437691167" data-datetime="23 July 2015">23 July 2015</div> </div>  </div> </div> </a>  </li>   </ul> </div> </div>      </div>
+                                                                                            
+                                                                                                    
+
+    <div id="comp-pattern-library" class="distinct-component-group container-more-from-this-index">
+        
+            <h2 class="group-title " data-entityid="strapline#">
+    <a href="/news/world/us_and_canada" class="group-title__link">US &amp; Canada</a>
+    
+</h2>
+<div class="sparrow-container sparrow-columns">
+    <div class="sparrow sparrow__3 sparrow__">
+        <div class="sparrow-item faux-block-link">
+            <div class="sparrow-item__image">
+                <div class="responsive-image responsive-image--16by9">
+                    
+                        <img src="http://ichef-1.bbci.co.uk/news/200/cpsprodpb/77FD/production/_84471703_houser.jpg" datasrc="http://ichef-1.bbci.co.uk/news/200/cpsprodpb/77FD/production/_84471703_houser.jpg" class="js-image-replace" alt="A police officer holds an image of John Houser at a news conference in Lafayette. Louisiana - 24 July 2015" height="549" width="976">
+                        <!--[if lt IE 9]>
+                        <img src="http://ichef-1.bbci.co.uk/news/200/cpsprodpb/77FD/production/_84471703_houser.jpg" class="js-image-replace" alt="A police officer holds an image of John Houser at a news conference in Lafayette. Louisiana - 24 July 2015" width="976" height="549" />
+                        <![endif]-->
+                </div>
+            </div>
+
+            <div class="sparrow-item__body">
+                <a href="/news/world-us-canada-33654509" class="title-link">
+                    
+                    <h3 class="title-link__title">
+                        
+                        <span class="title-link__title-text">US cinema gunman 'had violent past'</span>
+                    </h3>
+                </a>                <div class="sparrow-item__info">
+
+                    <ul class="mini-info-list">
+                        <li class="mini-info-list__item"><div data-timestamp-inserted="true" class="date date--v2 relative-time" data-seconds="1437754133" data-datetime="24 July 2015">49 minutes ago</div></li>
+                        <li class="mini-info-list__item"><span class="mini-info-list__section-desc off-screen">From the section </span><a href="/news/world/us_and_canada" class="mini-info-list__section">US &amp; Canada</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <a href="/news/world-us-canada-33654509" class="faux-block-link__overlay-link" tabindex="-1" aria-hidden="true">Full article US cinema gunman 'had violent past'</a>
+        </div>
+        <div class="sparrow-item faux-block-link">
+            <div class="sparrow-item__image">
+                <div class="responsive-image responsive-image--16by9">
+                    
+                        <img src="http://ichef.bbci.co.uk/news/200/cpsprodpb/FFB1/production/_84475456_84474093.jpg" datasrc="http://ichef.bbci.co.uk/news/200/cpsprodpb/FFB1/production/_84475456_84474093.jpg" class="js-image-replace" alt="A 2012 image of wrestler Hulk Hogan" height="549" width="976">
+                        <!--[if lt IE 9]>
+                        <img src="http://ichef.bbci.co.uk/news/200/cpsprodpb/FFB1/production/_84475456_84474093.jpg" class="js-image-replace" alt="A 2012 image of wrestler Hulk Hogan" width="976" height="549" />
+                        <![endif]-->
+                </div>
+            </div>
+
+            <div class="sparrow-item__body">
+                <a href="/news/world-us-canada-33657483" class="title-link">
+                    
+                    <h3 class="title-link__title">
+                        
+                        <span class="title-link__title-text">WWE terminates Hulk Hogan's contract</span>
+                    </h3>
+                </a>                <div class="sparrow-item__info">
+
+                    <ul class="mini-info-list">
+                        <li class="mini-info-list__item"><div data-timestamp-inserted="true" class="date date--v2 relative-time" data-seconds="1437754721" data-datetime="24 July 2015">39 minutes ago</div></li>
+                        <li class="mini-info-list__item"><span class="mini-info-list__section-desc off-screen">From the section </span><a href="/news/world/us_and_canada" class="mini-info-list__section">US &amp; Canada</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <a href="/news/world-us-canada-33657483" class="faux-block-link__overlay-link" tabindex="-1" aria-hidden="true">Full article WWE terminates Hulk Hogan's contract</a>
+        </div>
+        <div class="sparrow-item faux-block-link">
+            <div class="sparrow-item__image">
+                <div class="responsive-image responsive-image--16by9">
+                    
+                        <img src="http://ichef.bbci.co.uk/news/200/cpsprodpb/1657D/production/_84471519_0a0e2152-cb23-4b8a-91cd-715e7dd42c1c.jpg" datasrc="http://ichef.bbci.co.uk/news/200/cpsprodpb/1657D/production/_84471519_0a0e2152-cb23-4b8a-91cd-715e7dd42c1c.jpg" class="js-image-replace" alt="Civilians have begun guarding military recruiting centres in several US states" height="549" width="976">
+                        <!--[if lt IE 9]>
+                        <img src="http://ichef.bbci.co.uk/news/200/cpsprodpb/1657D/production/_84471519_0a0e2152-cb23-4b8a-91cd-715e7dd42c1c.jpg" class="js-image-replace" alt="Civilians have begun guarding military recruiting centres in several US states" width="976" height="549" />
+                        <![endif]-->
+                </div>
+            </div>
+
+            <div class="sparrow-item__body">
+                <a href="/news/world-us-canada-33655502" class="title-link">
+                    
+                    <h3 class="title-link__title">
+                        
+                        <span class="title-link__title-text">US military wary of civilian guards</span>
+                    </h3>
+                </a>                <div class="sparrow-item__info">
+
+                    <ul class="mini-info-list">
+                        <li class="mini-info-list__item"><div data-timestamp-inserted="true" class="date date--v2 relative-time" data-seconds="1437754090" data-datetime="24 July 2015">49 minutes ago</div></li>
+                        <li class="mini-info-list__item"><span class="mini-info-list__section-desc off-screen">From the section </span><a href="/news/world/us_and_canada" class="mini-info-list__section">US &amp; Canada</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <a href="/news/world-us-canada-33655502" class="faux-block-link__overlay-link" tabindex="-1" aria-hidden="true">Full article US military wary of civilian guards</a>
+        </div>
+    </div>
+</div>
+
+        
+    </div>
+
+                                                                                                    <div id="comp-from-other-news-sites" class="hidden" data-comp-meta="{&quot;id&quot;:&quot;comp-from-other-news-sites&quot;,&quot;type&quot;:&quot;from-other-news-sites&quot;,&quot;handler&quot;:&quot;default&quot;,&quot;deviceGroups&quot;:null,&quot;opts&quot;:{&quot;conditions&quot;:[&quot;is_local_page&quot;],&quot;loading_strategy&quot;:&quot;post_load&quot;,&quot;asset_id&quot;:&quot;world-us-canada-33646704&quot;,&quot;position_info&quot;:{&quot;instanceNo&quot;:1,&quot;positionInRegion&quot;:7,&quot;lastInRegion&quot;:true,&quot;lastOnPage&quot;:false,&quot;column&quot;:&quot;primary_column&quot;}},&quot;template&quot;:&quot;\/component\/from-other-news-sites&quot;}">
+        </div>                                
+<div id="bbccom_outbrain_ar_5_1_2_3_4" class="bbccom_slot outbrain-ad bbccom_outbrain_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_outbrain_ar_5" class="bbccom_advert bbccom_responsive">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('outbrain_ar_5', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><div class="bbccom_outbrain_container bbccom_outbrain_ar_5"><div style="display: none;" id="ob_holder"><iframe tabindex="-1" src="http://widgets.outbrain.com/nanoWidget/3rd/comScore/comScore.htm" style="display: none; width: 1px; height: 1px;" id="ob_iframe"></iframe><script async="" charset="UTF-8" src="http://log.outbrain.com/loggerServices/widgetGlobalEvent?tm=311&amp;pid=4799&amp;sid=5053546&amp;wId=125&amp;wRV=264730&amp;rId=ba485c4b8da081c53c7b0e2d45ebe277&amp;eT=0&amp;idx=0&amp;eIdx=&amp;pvId=ba485c4b8da081c53c7b0e2d45ebe277&amp;org=6&amp;pad=0&amp;ab=false" type="text/javascript"></script><script async="" charset="UTF-8" src="http://log.outbrain.com/loggerServices/widgetGlobalEvent?tm=517&amp;pid=4799&amp;sid=5053546&amp;wId=146&amp;wRV=264730&amp;rId=8f662bbcc683465faee757a770a5173e&amp;eT=0&amp;idx=1&amp;eIdx=&amp;pvId=ba485c4b8da081c53c7b0e2d45ebe277&amp;org=3&amp;pad=0&amp;ab=false" type="text/javascript"></script><script async="" charset="UTF-8" src="http://log.outbrain.com/loggerServices/widgetGlobalEvent?tm=808&amp;pid=4799&amp;sid=5053546&amp;wId=149&amp;wRV=264730&amp;rId=9d632d057d21ad330434e4cd095ba3ad&amp;eT=0&amp;idx=2&amp;eIdx=&amp;pvId=ba485c4b8da081c53c7b0e2d45ebe277&amp;org=3&amp;pad=0&amp;ab=false" type="text/javascript"></script><script async="" charset="UTF-8" src="http://log.outbrain.com/loggerServices/widgetGlobalEvent?tm=1190&amp;pid=4799&amp;sid=5053546&amp;wId=150&amp;wRV=264730&amp;rId=c86028e5a7ae581ff579cd604bbd7630&amp;eT=0&amp;idx=3&amp;eIdx=&amp;pvId=ba485c4b8da081c53c7b0e2d45ebe277&amp;org=0&amp;pad=6&amp;ab=false" type="text/javascript"></script></div><div id="outbrain_widget_0" data-dynload="" data-os="macintel" data-browser="safari" data-ob-mark="true" class="OUTBRAIN" data-src="http://www.bbc.com/news/world-us-canada-33646704" data-widget-id="AR_5" data-ob-template="bbc.com/News"><div class="ob-widget ob-strip-layout AR_5">
+      <span style="position:fixed;top:-200px;">&nbsp;</span>
+    <style type="text/css">
+      /* dynamic basic css */
+.AR_5.ob-widget .ob-widget-items-container {margin:0;padding:0;}
+.AR_5.ob-widget .ob-widget-items-container .ob-clearfix {display:block;width:100%;float:none;clear:both;height:0px;line-height:0px;font-size:0px;}
+.AR_5.ob-widget .ob-widget-items-container.ob-multi-row {padding-top: 2%;}
+.AR_5.ob-widget .ob-dynamic-rec-container {position:relative;margin:0;padding;0;}
+.AR_5.ob-widget .ob-dynamic-rec-link,
+.AR_5.ob-widget .ob-dynamic-rec-link:hover {text-decoration:none;}
+.AR_5.ob-widget .ob-rec-image-container .ob-video-icon-container {position:absolute;height:20%;width:100%;text-align:center;top:40%;}
+[data-browser=safari] .AR_5.ob-widget .ob-rec-image-container .ob-video-icon-container {display:none;}
+.AR_5.ob-widget .ob-rec-image-container .ob-video-icon {display:inline-block;height:100%;opacity:0.7;transition: opacity 500ms;}
+.AR_5.ob-widget .ob-rec-image-container .ob-video-icon:hover {opacity:1;}
+.AR_5.ob-widget .ob_what{direction:ltr;clear:both;padding:5px 10px 0px;}
+.AR_5.ob-widget .ob_what a{color:#999;font-size:11px;font-family:arial;text-decoration: none;}
+.AR_5.ob-widget .ob_what.ob-hover:hover a{text-decoration: underline;}
+.AR_5.ob-widget .ob_amelia,
+.AR_5.ob-widget .ob_logo,
+.AR_5.ob-widget .ob_text_logo{vertical-align:baseline !important;display:inline-block;vertical-align:text-bottom;padding:0px 5px;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;}
+.AR_5.ob-widget .ob_amelia{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_16x16.png') no-repeat center top;width:16px;height:16px;margin-bottom:-2px;}
+.AR_5.ob-widget .ob_logo{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_67x12.png') no-repeat center top;width:67px;height:12px;}
+.AR_5.ob-widget .ob_text_logo{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_text_logo_66x23.png') no-repeat center top;width:66px;height:23px;}
+.AR_5.ob-widget:hover .ob_amelia,
+.AR_5.ob-widget:hover .ob_logo,
+.AR_5.ob-widget:hover .ob_text_logo{background-position:center bottom;}
+  .AR_5.ob-widget .ob_what{text-align:right;}
+.AR_5.ob-widget .ob-rec-image-container .ob-rec-image {display:block;}
+      /* dynamic strip css */
+.AR_5.ob-widget .ob-rec-image-container {position:relative;}
+.AR_5.ob-widget .ob-rec-image-container .ob-image-ratio {height:0px;line-height:0px;padding-top:56.00000000000001%;}
+.AR_5.ob-widget .ob-rec-image-container img.ob-rec-image {width:100%;position:absolute;top:0;bottom:0;left:0;right:0;opacity:0;transition:all 750ms;}
+.AR_5.ob-widget .ob-rec-image-container img.ob-show {opacity:1;}
+.AR_5.ob-widget .ob-rec-image-container .ob-rec-label {position:absolute;bottom:0px;left:0px;padding:0px 3px;background-color:#666;color:white;font-size:10px;line-height:15px;}
+.AR_5.ob-widget {width:auto;min-width:360px;}
+.AR_5.ob-widget .ob-dynamic-rec-container {display:inline-block;vertical-align:top;min-width:50px;width:31.8%;box-sizing:border-box;-moz-box-sizing:border-box;}
+  .AR_5.ob-widget .ob-widget-items-container {direction: ltr;}
+  .AR_5.ob-widget .ob-dynamic-rec-container {margin-left:0;}
+  .AR_5.ob-widget .ob-dynamic-rec-container ~ .ob-dynamic-rec-container {margin:0 0 0 2.3%; }
+.AR_5.ob-widget .ob-widget-header {direction:ltr; }
+.AR_5.ob-widget .ob-unit {display:block;}
+.AR_5.ob-widget .ob-rec-text {max-height:63.0px;overflow:hidden;}
+.AR_5.ob-widget .ob-rec-source {font-weight:bold;}
+.AR_5.ob-widget .ob-rec-date {font-weight:bold;}
+
+
+
+
+
+      /* dynamic customized css */
+      
+.AR_5.ob-strip-layout .ob-widget-header {font-family:inherit;font-size:24px;color:black;padding-bottom:0px;padding-top:0px;}
+.AR_5.ob-strip-layout .ob-dynamic-rec-container {max-width:200px;}
+.AR_5.ob-strip-layout .ob-rec-text {font-family:inherit;color:black;padding:0px 0 0px;text-align:left;line-height:1.5;font-size:14px;}
+.AR_5.ob-strip-layout .ob-rec-text:hover {color:#1167a8;}
+.AR_5.ob-strip-layout .ob-rec-source {font-family:inherit;color:black;padding:0px 0 0px;text-align:left;font-size:12px;}
+.AR_5.ob-strip-layout .ob-rec-date {font-family:inherit;color:black;padding:0px 0 0px;text-align:left;font-size:12px;}
+.AR_5.ob-strip-layout .ob-rec-author {font-family:inherit;color:black;padding:0px 0 0px;text-align:left;font-size:12px;}
+.AR_5.ob-strip-layout .ob-rec-description {font-family:inherit;color:black;padding:0px 0 0px;text-align:left;font-size:12px;}
+    </style>
+    <style type="text/css" class="ob-custom-css">
+      .AR_5 .ob-widget-header {
+  margin-bottom: 12px;
+  text-align: left;
+}
+.AR_5.ob-strip-layout .ob-dynamic-rec-container {
+  max-width: none !important;
+}
+.AR_5.ob-strip-layout .ob-rec-text {
+  margin-top: 15px;
+}
+.AR_5.ob-widget .ob_what {
+  margin-top: 10px;
+  padding: 0;
+  text-align: left;
+}
+.AR_5.ob-widget .ob-rec-image-container .ob-video-icon-container {
+  left: 0;
+}
+.AR_5.ob-widget .ob-rec-image-container .ob-video-icon-container {
+  height: 20%;
+  left: -42% !important;
+  position: absolute;
+  text-align: center;
+  top: 76%;
+  width: 100%;
+}
+.AR_5.ob-strip-layout .ob-dynamic-rec-container {
+  max-width: none !important;
+}
+.AR_5.ob-widget {
+  max-width: none !important;
+  width: auto;
+}
+.AR_5 .ob-unit.ob-rec-text {
+  line-height: 18px !important;
+}
+.OUTBRAIN .AR_5.ob-widget .ob-rec-image-container .ob-video-icon-container {
+  background-color: #fff;
+  background-image: url("http://static.bbci.co.uk/news/1.55.2536/img/news--icons-sprite.png");
+  background-position: -4px -2604px;
+  background-repeat: no-repeat;
+  bottom: -9px;
+  display: block;
+  height: 25px;
+  left: 0 !important;
+  position: absolute;
+  top: auto;
+  width: 25px;
+}
+.AR_5 .ob-video-icon {
+  display: none !important;
+}
+
+/* EDIT OFF BCC CSS */
+#bbccom_outbrain_ar_1 {
+  display: block;
+}
+.bbccom_slot.outbrain-ad.bbccom_standard_slot.bbccom_visible {
+  background-color: white;
+}
+#bbccom_outbrain_ar_2 {
+  display: block !important;
+}
+.AR_5.ob-widget .ob-dynamic-rec-link:hover .ob-rec-text {
+  color: #1167a8;
+}
+.AR_5.ob-strip-layout .ob-rec-text {
+  color: #000000;
+/*  font-family: Long Primer; */
+  font-size: 14px;
+  line-height: 18px;
+  padding: 0;
+  text-align: left;
+}
+.AR_5.ob-widget .ob-widget-items-container.ob-multi-row {
+  padding-top: 12px !important;
+}
+.AR_5.ob-widget .ob-widget-items-container.ob-multi-row {
+  padding-top: 20px !important;
+}
+
+
+/* TABLET */
+@media screen and (min-width: 1px) and (max-width: 1000px)  {
+#bbccom_outbrain_ar_2 {
+  display: block !important;
+  float: left;
+  margin-bottom: 20px !important;
+}
+.AR_5 .ob-unit.ob-rec-text {
+  line-height: 22px !important;
+  font-size: 16px;
+}
+.AR_5.ob-strip-layout .ob-rec-text {
+  margin-top: 18px;
+}
+.AR_5.ob-strip-layout .ob-widget-header {
+  font-size: 28px;
+  line-height: 32px;
+}
+}
+
+
+/* MOBILE */
+@media screen and (min-width: 1px) and (max-width: 600px)  {
+.AR_5.ob-strip-layout .ob-widget-header {
+  font-size: 20px;
+  line-height: 24px;
+}
+.AR_5 .ob-unit.ob-rec-text {
+  font-size: 15px;
+  height: 36px;
+  line-height: 18px !important;
+  max-height: 36px;
+  overflow: hidden;
+}
+.AR_5.ob-widget .ob-dynamic-rec-container ~ .ob-dynamic-rec-container {
+  margin-bottom: 8px;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  margin-top: 0 !important;
+}
+.AR_5.ob-widget .ob-dynamic-rec-container {
+  width: 100%;
+}
+.AR_5.ob-strip-layout .ob-dynamic-rec-container {
+  margin-bottom: 10px;
+  max-width: none !important;
+}
+#bbccom_outbrain_ar_2_1_2_3_4 {
+  margin-top: 20px !important;
+}
+/*
+.AR_5 .ob-widget-items-container.ob-multi-row.ob-row-1 {
+  display: none !important;
+}
+.AR_5 .ob-dynamic-rec-container.ob-recIdx-2 {
+  display: none !important;
+}
+*/
+.AR_5.ob-strip-layout .ob-dynamic-rec-container {
+  margin-bottom: 8px;
+  max-width: none !important;
+}
+.AR_5.ob-widget {
+  max-width: none !important;
+  min-width: auto !important;
+  width: auto;
+}
+.AR_5 .ob-widget-items-container {
+  float: left;
+  margin-right: 2.4% !important;
+  width: 48.33%;
+}
+body .AR_5 .ob-widget-items-container.ob-multi-row.ob-row-1 {
+  float: left !important;
+  margin-right: 0 !important;
+  padding-top: 0 !important;
+  width: 48.333% !important;
+}
+body .bbccom_advert div {
+  clear: both !important;
+}
+}
+
+    </style>
+        <div class="ob-widget-section ob-first">
+            <div class="ob-widget-header">More Videos from the BBC</div>
+            <ul class="ob-widget-items-container"><li class="ob-dynamic-rec-container ob-recIdx-0 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=5u4Uxi1-fK7UpqQEngPthbMP2DbptLQwBz5H4SwCUt87OABfrsGWMkflJd0JDP2UFKLIC-jGiLOHpnYbgHUBA_CDEsmumQscev_hFZ4E-DBT3KlCQLgyUVZuBy57398TJmhBZf7FT1eefm2e6epd32Gf4H63ZTRACX_GQzJlJaTW3b2u0QG7-T489TMN2f6FRBtS0JQ8zBQ8AwVNXZIYtzZY8CMh8mINaga8Q_gyFeT9Lv9md0yZjtl0cXk6hZB4_RVxtZiFqxVNiFLxW_WmOB_aaBQUY_cMYwyeLgDQSPVRyzvSWDUYklszW5E8wDboMKOf4AObMVI2Qoz7RGEGYtU_K08AN0z9ifyiXhsCuceIM_uItEYz1h91doiH8KEBzTRkQXkpaRynnfxb_d7Bz4ZpoaWeqZV0P-X74xNE9GiSbhF88L1BG42D99MbFeen6B8LYUxEWdP_N89tp5EEQEoACMgwwCaAeI4BJro5HLdaL_cWi8M0DVn0rOi4USp8fzrACWO5MpudXfeYPUZDj8eec4YRjA-vXhAe1MJbLRo&amp;c=9a07cc1b&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-image-container" data-type="Image">
+  <div class="ob-image-ratio"></div>
+  <img class="ob-rec-image ob-show" src="http://images.outbrain.com/imageserver/v2/s/Mmsn/n/19bHAj/abc/15R3qX/19bHAj-1Vhi-360x202.jpg" onload="this.className+=' ob-show'" alt="" title="" onerror="outbrain.imageError(this)">
+          <span class="ob-video-icon-container">
+    <img class="ob-video-icon" src="http://widgets.outbrain.com/images/widgetIcons/play_100x100.png" alt="" title="">
+  </span>
+  </span>
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Russia using North Korean 'slave labour', say human rights groups">Russia using North Korean 'slave labour', say human rights groups</span>      
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-1 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=9RAkW_NHVqJUIBw2ADm6u7XE1r06a6_yLMcMcluPLUTnwqOqVCRq2bFs9wkDnmIbrUO8VZDVyxfJZAUFlCjOQdEJBYyopceJNkkexHu92zFL5gcggwHGbwhhk2YfN_lMrBIeRcVOyC4-1WV8ASO1GzXwLs0DADOsAJp4eGmpp8yudsfm_YPnVbcKPt1bI7KOY1mmp1RZUw5XRSA4ruShhEJebT7aEJNizD7R8DIVD5Um0-JvigxjJdw3luZtuvnFkxdNBqxM-gTCuK46-r5f3mfb9j23zqdCbQsyAoluKyuTKvrp8-iCjtbWCpMiVvwDjE5tgT7K5zXQz8RMAaC-mR-GkFT_A2DOH2UsS3yWFSGmcUpvYVi4y2RR0K1yhGpdOmPj7K7pClJsaFDlLvvAqBlicBD_IV-JDUllMMwoJXQdIE8mukL5NOl2peKTCLe2n6hVHlYsDuDcq0Ew5vLg_YQazcEQUWv0HQscXwb8Ur1LrBzmxyhRJJnSwwwINsfsapG503GZhepqqSGE33c2CFmNAkeGnznRM0RKpg04Q_Q&amp;c=58733978&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-image-container" data-type="Image">
+  <div class="ob-image-ratio"></div>
+  <img class="ob-rec-image ob-show" src="http://images.outbrain.com/imageserver/v2/s/Mmsn/n/19bhaS/abc/15RUvY/19bhaS-1Vhi-360x202.jpg" onload="this.className+=' ob-show'" alt="" title="" onerror="outbrain.imageError(this)">
+          <span class="ob-video-icon-container">
+    <img class="ob-video-icon" src="http://widgets.outbrain.com/images/widgetIcons/play_100x100.png" alt="" title="">
+  </span>
+  </span>
+      <span class="ob-unit ob-rec-text" data-type="Title" title="#BBCtrending: Why are people getting semicolon tattoos?">#BBCtrending: Why are people getting semicolon tattoos?</span>      
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-2 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=tkbey84g-Ru33F7pkq9DhrGMB7cY85zzMllE_bhSg-_V9RjZ1i7gj_qm_izZk4EESy17vfJdbn6VbShlgmXFOCF_P7chrAxm31ytG3VRLdYOcMlRDLakpoPkaCmSnvlEwnKttOrb23uMQ6k6qHssrMJYwNkSf79fUu4N0XMsq8BjsA-0Dd71C3KoY5CDPSumCKvVn1QyaqPqL-e78IfX0Zdjcgpy4FdyxsMS1pcx4C0M3R_LGVxweUuhSNn2vXbMdXsc1od0ADgdZB5VpHJWiRcOryBl6B5qnoFsMYQ7PdhrN4naeg48c94QbXQHnL2TkplmiTB2bl_oirFzPkj5defwk8kAaFy7s-UTx1AqtaftmMnyDqlfvlt_79eXiXAv3zrv_LoFWAAeEy1Uk7usgMF1Qit5o0WNzggVaVKQ7RfIkiBE3HitV0JcHft297cxIC0PfWLqKlxTMEVkg9GfmwYfuf0sLVVNKs9DgJJsguoA7tKFU1C2_8Dzc8LrC7kToHLwBXCTU0yaCIi_q2QGGKwJTdfuGwXJwnEX24EMnjM&amp;c=8ec3786f&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-image-container" data-type="Image">
+  <div class="ob-image-ratio"></div>
+  <img class="ob-rec-image ob-show" src="http://images.outbrain.com/imageserver/v2/s/Mmsn/n/19SE13/abc/15IA8u/19SE13-1Vhi-360x202.jpg" onload="this.className+=' ob-show'" alt="" title="" onerror="outbrain.imageError(this)">
+          <span class="ob-video-icon-container">
+    <img class="ob-video-icon" src="http://widgets.outbrain.com/images/widgetIcons/play_100x100.png" alt="" title="">
+  </span>
+  </span>
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Plane in emergency landing on US highway">Plane in emergency landing on US highway</span>      
+        </a>
+    </li></ul><ul class="ob-widget-items-container ob-multi-row ob-row-1"><li class="ob-dynamic-rec-container ob-recIdx-3 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=87aXdWBEZDE-HzNum9oCWXy_ElrGGLHECsp3SiMqc03tiM16_66GhVT1s8rmvLzLQ7IwNihvHAWDOI5z3CrVOQ6RlUkhEI__dvbFXu3_oybMkanmWgtSPIZG0DOPTtHb2-eaImG0R4Deds_GfVL1W8GTF_vVqJAufFGLYrVygIFFh8R6b5vJ9m3-yRgs5QcT-DloiyK_zmT0VALzLtAZsDvphIuWypNGsSlIYRtYl1C54pn6q0zp51TnU4mwwv3pyuLc5uh9SoHwsBhsBz_9VTxVVrgQWaWG_T6UoF4V9D5TSWDZNSinFZBFaEcErUJ4V2dErr0GNwCV1EZge9bRI_VZV8AHGjBuhKiogDagniF9OgNwnK1PeHB_Tyiy1sZn47lpTVzls-F-4WK9v7J0jodQEeEUXF-AsggHoelGbnKihyDIBMqkZ915oq4QJz1znkwvhEUMU_e-dJOSGrxfgHdsBEpVQS_W8ziEHikbt98y2xW-A-Ra7N8KcmcssAz3EgP5grdXj416SQkfY6qisw9KUTfl17ci1galbybh2_U&amp;c=3ce97664&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-image-container" data-type="Image">
+  <div class="ob-image-ratio"></div>
+  <img class="ob-rec-image ob-show" src="http://images.outbrain.com/imageserver/v2/s/Mmsn/n/19c1tt/abc/15Rr3E/19c1tt-1Vhi-360x202.jpg" onload="this.className+=' ob-show'" alt="" title="" onerror="outbrain.imageError(this)">
+          <span class="ob-video-icon-container">
+    <img class="ob-video-icon" src="http://widgets.outbrain.com/images/widgetIcons/play_100x100.png" alt="" title="">
+  </span>
+  </span>
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Obama on The Daily Show: 'I can't believe you're leaving before me'">Obama on The Daily Show: 'I can't believe you're leaving before me'</span>      
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-4 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=NA14KZdtXSogH952nF5CNEt2SjJ7IwMEvya6_C7C4BSZ9AmOXcQbTXzG0zVZa-sERBTUBxN2jwGzALjlH0F7gcexQhuaT1-KyNEOkUSmo9_Do9kFeEFzAmj8PTipkYF-nKfBoDyaz7Ybu1kbqQmvLYTKs2UGIMi1hjnvkNwvHHjLtQwTbDzgHqXKgQXQzkRHP2U3vUJ5BMt8QV_M56kdBj5dWVuJPbuO0Z_MubFhmGo41kGw18AVMCj69r4E7hFQBdHXBfThEb7qr8SKYHDQeA3eCk3Xfd-4nZqg2RaF8DkGWZOvS8MehI2bDUafKI-lbQPA-3-lm-5UScpfWOB98AvsVWrMQX90QGkoKT7XllWLLi5b2vKZyPaC7tp5gKUgofTNgq90Vmo7glgergd7NXGYm9tCferfx2drGtVCHJc6bN7AFdGp48eLo4QSGj7vYETK-KBPHUOEJ1lJJifdu8TST96_cWMY5bOjBkjXSF_T2Ub10z0H_GW8Gr8Dh8dANWU5qEE33GMVYkOsyDCUi5JkAvUhZ0fSBDLtW-ZWiAA&amp;c=356fe0bf&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-image-container" data-type="Image">
+  <div class="ob-image-ratio"></div>
+  <img class="ob-rec-image ob-show" src="http://images.outbrain.com/imageserver/v2/s/Mmsn/n/19eehl/abc/15UV9a/19eehl-1Vhi-360x202.jpg" onload="this.className+=' ob-show'" alt="" title="" onerror="outbrain.imageError(this)">
+          <span class="ob-video-icon-container">
+    <img class="ob-video-icon" src="http://widgets.outbrain.com/images/widgetIcons/play_100x100.png" alt="" title="">
+  </span>
+  </span>
+      <span class="ob-unit ob-rec-text" data-type="Title" title="President Obama's Kenyan uncle on promise of future">President Obama's Kenyan uncle on promise of future</span>      
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-5 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=ktS1VKM_WFvb-Jp8FyVN1NAGclrB_lUZuaMtSv67wArWqSQI6_ex-I18xkmMbZu3WTaxT-4v0VNGU8Av1kl20OREpbBLxzBdEJAFfGTD5C5txd3FBuOo-xlQeOL-Gqp-c7uUbI4GgkV5q6X066JPH0JzYGXpb1QMoHFr_L01_jQHCXxCMgJq81RibgQhzTfiovjwHrXPka3jKGE7AtF7uWjxN5JWWnNUM4mr21EN_gqY66JTeg75u3PqU4VCcLehorXRhUZCOJoRYT9nJHg3SlsTkllmPvk30FbLC1H1cxMobekPeDe_2t8cMQUYNBiTTTarx7YvLzp5rXsMvi23pgm_vanSZ0jooyertoil-lokAnzIMPeMavM0Lijj1CDc4akcNRj_XXksn2yxoI9ZFKS4FypINXxwrCKf-RMbr13CVjMC4Lz-3Qii8SljN_4CqG9dgMVBxRMDyEchJo7I6yNO-k9_6YtZ2mUF5qRXcozQ_fz9cb5ui8DucGaQPt9Wt3CmTvCh2ea0DaCZIcwxjpTO7rhM4mcdXprbUg4lcNg&amp;c=a7706fb4&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-image-container" data-type="Image">
+  <div class="ob-image-ratio"></div>
+  <img class="ob-rec-image ob-show" src="http://images.outbrain.com/imageserver/v2/s/Mmsn/n/19jeNg/abc/15Zgfg/19jeNg-1Vhi-360x202.jpg" onload="this.className+=' ob-show'" alt="" title="" onerror="outbrain.imageError(this)">
+          <span class="ob-video-icon-container">
+    <img class="ob-video-icon" src="http://widgets.outbrain.com/images/widgetIcons/play_100x100.png" alt="" title="">
+  </span>
+  </span>
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Earth-like planet discovered by Kepler telescope">Earth-like planet discovered by Kepler telescope</span>      
+        </a>
+    </li></ul>
+    </div>
+                <div class="ob_what">
+    
+    <a tabindex="-1" href="#" onmousedown="" onclick="OBR.extern.callWhatIs('http://www.outbrain.com/what-is/default/en','',-1,-1, false ,null);return false">
+        Recommended by Outbrain
+    </a>
+</div>
+  </div></div><script type="text/javascript">    document.write(unescape('%3Cscript src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"%3E%3C/script%3E'));</script><script src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"></script></div>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>
+<div id="bbccom_outbrain_ar_7_1_2_3_4" class="bbccom_slot outbrain-ad bbccom_outbrain_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_outbrain_ar_7" class="bbccom_advert bbccom_responsive">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('outbrain_ar_7', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><div class="bbccom_outbrain_container bbccom_outbrain_ar_7"><div id="outbrain_widget_1" data-dynload="" data-os="macintel" data-browser="safari" data-ob-mark="true" class="OUTBRAIN" data-src="http://www.bbc.com/news/world-us-canada-33646704" data-widget-id="AR_7" data-ob-template="bbc.com/News"><div class="ob-widget ob-classic-layout AR_7">
+      <span style="position:fixed;top:-200px;">&nbsp;</span>
+    <style type="text/css">
+      /* dynamic basic css */
+.AR_7.ob-widget .ob-widget-items-container {margin:0;padding:0;}
+.AR_7.ob-widget .ob-widget-items-container .ob-clearfix {display:block;width:100%;float:none;clear:both;height:0px;line-height:0px;font-size:0px;}
+.AR_7.ob-widget .ob-widget-items-container.ob-multi-row {padding-top: 2%;}
+.AR_7.ob-widget .ob-dynamic-rec-container {position:relative;margin:0;padding;0;}
+.AR_7.ob-widget .ob-dynamic-rec-link,
+.AR_7.ob-widget .ob-dynamic-rec-link:hover {text-decoration:none;}
+.AR_7.ob-widget .ob-rec-image-container .ob-video-icon-container {position:absolute;}
+[data-browser=safari] .AR_7.ob-widget .ob-rec-image-container .ob-video-icon-container {display:none;}
+.AR_7.ob-widget .ob-rec-image-container .ob-video-icon {display:inline-block;height:100%;opacity:0.7;transition: opacity 500ms;}
+.AR_7.ob-widget .ob-rec-image-container .ob-video-icon:hover {opacity:1;}
+.AR_7.ob-widget .ob_what{direction:ltr;clear:both;padding:5px 10px 0px;}
+.AR_7.ob-widget .ob_what a{color:#999;font-size:11px;font-family:arial;text-decoration: none;}
+.AR_7.ob-widget .ob_what.ob-hover:hover a{text-decoration: underline;}
+.AR_7.ob-widget .ob_amelia,
+.AR_7.ob-widget .ob_logo,
+.AR_7.ob-widget .ob_text_logo{vertical-align:baseline !important;display:inline-block;vertical-align:text-bottom;padding:0px 5px;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;}
+.AR_7.ob-widget .ob_amelia{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_16x16.png') no-repeat center top;width:16px;height:16px;margin-bottom:-2px;}
+.AR_7.ob-widget .ob_logo{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_67x12.png') no-repeat center top;width:67px;height:12px;}
+.AR_7.ob-widget .ob_text_logo{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_text_logo_66x23.png') no-repeat center top;width:66px;height:23px;}
+.AR_7.ob-widget:hover .ob_amelia,
+.AR_7.ob-widget:hover .ob_logo,
+.AR_7.ob-widget:hover .ob_text_logo{background-position:center bottom;}
+  .AR_7.ob-widget .ob_what{text-align:right;}
+.AR_7.ob-widget .ob-rec-image-container .ob-rec-image {display:block;}
+      /* dynamic classic css */
+.AR_7.ob-classic-layout {width:auto;}
+.AR_7.ob-classic-layout:after {content:"";display:block;height:0px;float:none;clear:both;}
+.AR_7.ob-classic-layout .ob-widget-section {width:50%;box-sizing:border-box;-moz-box-sizing:border-box;}
+.AR_7.ob-classic-layout .ob-widget-section > * {margin:0px 10px;}
+
+.AR_7.ob-classic-layout .ob-widget-section {
+      float:left;
+  }
+.AR_7.ob-classic-layout .ob-widget-header,
+.AR_7.ob-classic-layout .ob-dynamic-rec-container,
+.AR_7.ob-classic-layout .ob-dynamic-rec-container .ob-unit{direction:ltr;}
+
+.AR_7.ob-classic-layout .ob-dynamic-rec-container {display:block;}
+.AR_7.ob-classic-layout .ob-dynamic-rec-container:hover {text-decoration:underline;}
+.AR_7.ob-classic-layout .ob-unit{display:inline;margin-bottom:10px;}
+.AR_7.ob-classic-layout .ob-widget-header {}
+.AR_7.ob-classic-layout .ob-unit.ob-rec-text {font-weight:bold;}
+.AR_7.ob-classic-layout .ob-unit.ob-rec-source {font-weight:bold;}
+.AR_7.ob-classic-layout .ob-unit.ob-rec-date {font-weight:bold;}
+      /* dynamic customized css */
+      
+.AR_7.ob-classic-layout .ob-widget-header {font-family:inherit;font-size:24px;color:black;padding-bottom:0px;padding-top:0px;}
+.AR_7.ob-classic-layout .ob-widget-items-container {padding:0px 0px 0px 10px;}
+.AR_7.ob-classic-layout .ob-dynamic-rec-container {color:black;margin-bottom:0px;}
+.AR_7.ob-classic-layout .ob-dynamic-rec-container:hover {color:#1167a8;}
+.AR_7.ob-classic-layout .ob-dynamic-rec-link {color:black;}
+.AR_7.ob-classic-layout .ob-dynamic-rec-link:hover {color:#1167a8;}
+.AR_7.ob-classic-layout .ob-rec-text {color:black;font-family:inherit;font-size:16px;line-height:1.5;}
+.AR_7.ob-classic-layout .ob-rec-source {font-family:inherit;color:#cc0101;font-size:16px;}
+.AR_7.ob-classic-layout .ob-rec-date {font-family:inherit;font-size:12px;color:black;}
+.AR_7.ob-classic-layout .ob-rec-author {font-family:inherit;font-size:12px;color:black;}
+.AR_7.ob-classic-layout .ob-rec-description {font-family:inherit;font-size:12px;color:black;}
+    </style>
+    <style type="text/css" class="ob-custom-css">
+      .AR_7 .ob-dynamic-rec-container {
+  max-width: none !important;
+}
+.AR_7.ob-classic-layout .ob-widget-section {
+  box-sizing: border-box;
+  text-align: left;
+  width: 100%;
+}
+.AR_7.ob-classic-layout .ob-widget-items-container {
+  padding: 0;
+}
+.AR_7.ob-classic-layout .ob-widget-section  * {
+  margin: 0;
+}
+.AR_7 .ob-widget-header {
+  margin-bottom: 12px !important;
+  text-align: left;
+}
+.AR_7 .ob-dynamic-rec-container {
+  margin-bottom: 15px !important;
+}
+
+
+/* HEADER, TITLES, SOURCES */
+.AR_7.ob-classic-layout .ob-widget-header {
+  color: #000000;
+  font-size: 24px;
+  line-height: 24px;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+.AR_7.ob-classic-layout .ob-unit.ob-rec-text {
+  font-size: 16px !important;
+  font-weight: bold;
+  line-height: 22px;
+}
+.AR_7.ob-classic-layout .ob-unit.ob-rec-source {
+  color: #000000;
+  display: block;
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 16px;
+  margin-top: 0;
+}
+
+
+
+.AR_7.ob-classic-layout {
+  float: left;
+  width: auto;
+}
+.AR_7.ob-widget .ob_what {
+  padding: 0;
+  text-align: left;
+}
+/*.bbccom_advert div {
+  clear: none !important;
+}*/
+
+/*.AR_7.ob-classic-layout {
+  float: left;
+  margin-right: 1%;
+  width: 49%;
+}*/
+
+#bbccom_outbrain_ar_7_1_2_3_4 {
+  clear: none !important;
+  float: left;
+  margin-right: 1%;
+  width: 49%;
+}
+
+.AR_7.ob-classic-layout .ob-dynamic-rec-container:hover {
+  text-decoration: none !important;
+}
+.AR_7.ob-classic-layout .ob-dynamic-rec-link:hover {
+  color: #1167a8 !important;
+  text-decoration: none !important;
+}
+.AR_7.ob-classic-layout .ob-dynamic-rec-link:hover .ob-unit.ob-rec-text {
+  color: #1167a8 !important;
+  text-decoration: none !important;
+}
+
+/* TABLET */
+@media screen and (min-width: 1px) and (max-width: 1000px)  {
+.AR_7.ob-classic-layout .ob-widget-header {
+  font-size: 28px;
+  line-height: 32px;
+}
+.AR_7 {
+  margin-bottom: 40px;
+}
+.AR_7.ob-classic-layout .ob-unit.ob-rec-source {
+  font-size: 14px !important;
+}
+}
+
+/* MOBILE */
+@media screen and (min-width: 1px) and (max-width: 600px)  {
+.AR_7.ob-classic-layout {
+  float: none !important;
+  width: auto;
+}
+.AR_7.ob-classic-layout .ob-widget-section {
+  float: none;
+}
+#bbccom_outbrain_ar_2 {
+  display: block !important;
+  float: none;
+  margin-bottom: 20px !important;
+}
+.AR_7.ob-classic-layout .ob-widget-header {
+  font-size: 20px;
+  line-height: 24px;
+}
+.AR_7 .ob_what.ob-hover {
+  display: none;
+}
+.AR_7.ob-classic-layout {
+  float: none;
+  margin-right: 0;
+  width: 100% !important;
+}
+.AR_7.ob-widget .ob_what {
+  display: none;
+}
+.AR_7 {
+  margin-bottom: 0px;
+}
+#bbccom_outbrain_ar_7_1_2_3_4 {
+  clear: none !important;
+  float: none !important;
+  margin-right: 0;
+  width: 100%;
+}
+}
+
+/* MOBILE */
+@media screen and (min-width: 1px) and (max-width: 599px)  {
+body .AR_7 .ob-unit.ob-rec-text {
+  font-size: 16px !important;
+  line-height: 20px !important;
+}
+}
+
+@media screen and (min-width: 1px) and (max-width: 399px)  {
+body .OUTBRAIN .AR_7 .ob-unit.ob-rec-text {
+  font-size: 15px !important;
+  line-height:18px !important;
+}
+}
+
+#bbccom_outbrain_ar_7 {
+  clear: none !important;
+}
+#bbccom_outbrain_ar_7 div {
+  clear: none !important;
+}
+.bbccom_outbrain_container.bbccom_outbrain_ar_7 {
+  clear: none !important;
+}
+.bbccom_outbrain_container.bbccom_outbrain_ar_7 div {
+  clear: none !important;
+}
+#bbccom_outbrain_ar_8 {
+  clear: none !important;
+}
+#bbccom_outbrain_ar_8 div {
+  clear: none !important;
+}
+.bbccom_outbrain_container.bbccom_outbrain_ar_8 {
+  clear: none !important;
+}
+.bbccom_outbrain_container.bbccom_outbrain_ar_8 div {
+  clear: none !important;
+}
+    </style>
+        <div class="ob-widget-section ob-first">
+            <div class="ob-widget-header">Elsewhere on BBC</div>
+            <ul class="ob-widget-items-container"><li class="ob-dynamic-rec-container ob-recIdx-0 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=0-p_YVzTneoy858e17xlQtk5z0-ABtJBkysZcUN0jcnshIHX4by3jqEbbR-Bc4izG_YYIvymP7SmvIaIuI2ARRvdqqo46dI_2NfpN0acezVO02nB9KOaN4jNJ9sGLhoVjIy4jHL7wp_1xY73rBhOx0BeZRU8xbCjFNGK3rwG8a0IRzxdC9AbUZUoRDbmwsnvxQHJm1nMvpltZRXgd3u6rujE9boFqJNKCVbOZMe5bs_pkFl0ZCUv_UpN-pwv3wFXtQf8ocREK1H71-oXdix45Auf2iL3RLOK4FAX0OrgLMeL8q4mA_5nAz0HUoZ_WN6_e3C8-ayfz_BjCaBiWdDgUFHCe9XVemP7t6r5cRJtCug-J5qe_H4YMYeNVuosx9Yrj0-K6g5QjBp3qVp8m_8yeLU7TuV7UBbA9SAooGwB8RayJaISEylP07k5f0SJQApg4mQz29AtQXovaNaYVV1WwtGZigW97_n8bsm3O40J-mp6m1b52dkNLknTrhsK29Pv_vNRwRsZi0i6zQzeRpHvXQ&amp;c=61dab60c&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Spain raises marrying age from 14 to 16">Spain raises marrying age from 14 to 16</span>            <span class="ob-unit ob-rec-source" data-type="Source">BBC News</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-1 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=akyKg-ot69kKEAfRV8QDDrPZcRC3PgWGbSiYz1B9K8eR68Pj6WdlItLeE5LPtK3Tyl7-ADx_fvaDliu-AKVO9EnqG-xKxTszFLjwS7I35qOoI82HJIfh5ad3v72JKZHNr7dX-r60ikSbphxKLzQ_xbpKTswvbb72q4H4k1hAQglwT6xFc3212Cvw_O1ZP3SRqyk9lVt02DdHqAyQ9ht9V1znkDct5FgGWGMfgtLJRA080vAqFPd7QsNU7TVHofIKTJlUJ2IdB0k2Is0ZwngT-gxS3VXd-JcWV9wCWkr_MhqkLva4kRQ433N3KfrQFYSBMOwx-m25T9Pd8_kE07g6urdzw0GByosM7XFalQOVpGIrgXw_V3s3tnR3m0MLefaFbWGoyHjODBQSbAP8KWiyHy3XtXbK3mqheRp4_iOSOzKJh4jRAcDnQhyOkV6_nlFp5H-KzGx88LytfxrPpbVAaA2t_IvDi5zHi9g_YgybLYzwEQvALj7TOnlKBCJ6G_ujoS1IuVqQp5xmW4rnGhuB0A&amp;c=47b0a0ca&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Yorkshire schoolgirl, Jessica Lawson, 12, dies on French trip">Yorkshire schoolgirl, Jessica Lawson, 12, dies on French trip</span>            <span class="ob-unit ob-rec-source" data-type="Source">BBC News</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-2 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=NISM48odPjGG6JIxYW_qKuin4bJOyzkQUOR6YuO0T_UZA2G5K-Y-D0QsB6AMMrryZnb7VwDxd0UuDCWg0Nha6a8xdJcXxSd4ERmzYRStTxK8ZG6knhPMuKw1AsWmnGpqUBWOHh1CxAo_0mmEO9QI5_0IJV1i5tLOpVQj__Ow7n8geFJizOoO6cQak94xKDGUxf8RWXIi0YuKctGJIl6oyw5T-cg37wfdLDFw_Tr9dWfGVqgPNaAFkglrgX_YpuDknAv4h1AyAaFE8stbK-GUTmT7iDuVbHxEkhRH34Rtp7s1J986bXSJrXYnOsD18nsIwsA7sf42QqXeOugC3q0ztTNnNzraj27x35Vf0GFmTkIg1yvxunRp4exjHoxY8M5lVvBbX_eF-lsA2c5I7DA9BePMVTER0-h0Q8Ov4Ioz2aRJbltw01-gOXFS-GM-RF-uMbCterh0tQHNf85KhYmTFCVuX7NeiaQzWWC_Y6WmrghULsk2TeoEsOH2NPCJXB_7BBbDMaOH0CjnxgBBg-1G_g&amp;c=57cff0dc&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Iran executions see 'unprecedented spike' - Amnesty">Iran executions see 'unprecedented spike' - Amnesty</span>            <span class="ob-unit ob-rec-source" data-type="Source">BBC News</span>
+
+        </a>
+    </li></ul>
+    </div>
+                <div class="ob_what">
+    
+    <a tabindex="-1" href="#" onmousedown="" onclick="OBR.extern.callWhatIs('http://www.outbrain.com/what-is/default/en','',-1,-1, false ,null);return false">
+        Recommended by Outbrain
+    </a>
+</div>
+  </div></div><script type="text/javascript">    document.write(unescape('%3Cscript src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"%3E%3C/script%3E'));</script><script src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"></script></div>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>
+<div id="bbccom_outbrain_ar_8_1_2_3_4" class="bbccom_slot outbrain-ad bbccom_outbrain_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_outbrain_ar_8" class="bbccom_advert bbccom_responsive">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('outbrain_ar_8', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><div class="bbccom_outbrain_container bbccom_outbrain_ar_8"><div id="outbrain_widget_2" data-dynload="" data-os="macintel" data-browser="safari" data-ob-mark="true" class="OUTBRAIN" data-src="http://www.bbc.com/news/world-us-canada-33646704" data-widget-id="AR_8" data-ob-template="bbc.com/News"><div class="ob-widget ob-classic-layout AR_8">
+      <span style="position:fixed;top:-200px;">&nbsp;</span>
+    <style type="text/css">
+      /* dynamic basic css */
+.AR_8.ob-widget .ob-widget-items-container {margin:0;padding:0;}
+.AR_8.ob-widget .ob-widget-items-container .ob-clearfix {display:block;width:100%;float:none;clear:both;height:0px;line-height:0px;font-size:0px;}
+.AR_8.ob-widget .ob-widget-items-container.ob-multi-row {padding-top: 2%;}
+.AR_8.ob-widget .ob-dynamic-rec-container {position:relative;margin:0;padding;0;}
+.AR_8.ob-widget .ob-dynamic-rec-link,
+.AR_8.ob-widget .ob-dynamic-rec-link:hover {text-decoration:none;}
+.AR_8.ob-widget .ob-rec-image-container .ob-video-icon-container {position:absolute;}
+[data-browser=safari] .AR_8.ob-widget .ob-rec-image-container .ob-video-icon-container {display:none;}
+.AR_8.ob-widget .ob-rec-image-container .ob-video-icon {display:inline-block;height:100%;opacity:0.7;transition: opacity 500ms;}
+.AR_8.ob-widget .ob-rec-image-container .ob-video-icon:hover {opacity:1;}
+.AR_8.ob-widget .ob_what{direction:ltr;clear:both;padding:5px 10px 0px;}
+.AR_8.ob-widget .ob_what a{color:#999;font-size:11px;font-family:arial;text-decoration: none;}
+.AR_8.ob-widget .ob_what.ob-hover:hover a{text-decoration: underline;}
+.AR_8.ob-widget .ob_amelia,
+.AR_8.ob-widget .ob_logo,
+.AR_8.ob-widget .ob_text_logo{vertical-align:baseline !important;display:inline-block;vertical-align:text-bottom;padding:0px 5px;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;}
+.AR_8.ob-widget .ob_amelia{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_16x16.png') no-repeat center top;width:16px;height:16px;margin-bottom:-2px;}
+.AR_8.ob-widget .ob_logo{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_67x12.png') no-repeat center top;width:67px;height:12px;}
+.AR_8.ob-widget .ob_text_logo{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_text_logo_66x23.png') no-repeat center top;width:66px;height:23px;}
+.AR_8.ob-widget:hover .ob_amelia,
+.AR_8.ob-widget:hover .ob_logo,
+.AR_8.ob-widget:hover .ob_text_logo{background-position:center bottom;}
+  .AR_8.ob-widget .ob_what{text-align:right;}
+.AR_8.ob-widget .ob-rec-image-container .ob-rec-image {display:block;}
+      /* dynamic classic css */
+.AR_8.ob-classic-layout {width:auto;}
+.AR_8.ob-classic-layout:after {content:"";display:block;height:0px;float:none;clear:both;}
+.AR_8.ob-classic-layout .ob-widget-section {width:50%;box-sizing:border-box;-moz-box-sizing:border-box;}
+.AR_8.ob-classic-layout .ob-widget-section > * {margin:0px 10px;}
+
+.AR_8.ob-classic-layout .ob-widget-section {
+      float:left;
+  }
+.AR_8.ob-classic-layout .ob-widget-header,
+.AR_8.ob-classic-layout .ob-dynamic-rec-container,
+.AR_8.ob-classic-layout .ob-dynamic-rec-container .ob-unit{direction:ltr;}
+
+.AR_8.ob-classic-layout .ob-dynamic-rec-container {display:block;}
+.AR_8.ob-classic-layout .ob-dynamic-rec-container:hover {text-decoration:underline;}
+.AR_8.ob-classic-layout .ob-unit{display:inline;margin-bottom:10px;}
+.AR_8.ob-classic-layout .ob-widget-header {}
+.AR_8.ob-classic-layout .ob-unit.ob-rec-text {font-weight:bold;}
+.AR_8.ob-classic-layout .ob-unit.ob-rec-source {font-weight:bold;}
+.AR_8.ob-classic-layout .ob-unit.ob-rec-date {font-weight:bold;}
+      /* dynamic customized css */
+      
+.AR_8.ob-classic-layout .ob-widget-header {font-family:inherit;font-size:24px;color:black;padding-bottom:0px;padding-top:0px;}
+.AR_8.ob-classic-layout .ob-widget-items-container {padding:0px 0px 0px 10px;}
+.AR_8.ob-classic-layout .ob-dynamic-rec-container {color:black;margin-bottom:0px;}
+.AR_8.ob-classic-layout .ob-dynamic-rec-container:hover {color:#1167a8;}
+.AR_8.ob-classic-layout .ob-dynamic-rec-link {color:black;}
+.AR_8.ob-classic-layout .ob-dynamic-rec-link:hover {color:#1167a8;}
+.AR_8.ob-classic-layout .ob-rec-text {color:black;font-family:inherit;font-size:16px;line-height:1.5;}
+.AR_8.ob-classic-layout .ob-rec-source {font-family:inherit;color:#cc0101;font-size:16px;}
+.AR_8.ob-classic-layout .ob-rec-date {font-family:inherit;font-size:12px;color:black;}
+.AR_8.ob-classic-layout .ob-rec-author {font-family:inherit;font-size:12px;color:black;}
+.AR_8.ob-classic-layout .ob-rec-description {font-family:inherit;font-size:12px;color:black;}
+    </style>
+    <style type="text/css" class="ob-custom-css">
+      .AR_8 .ob-dynamic-rec-container {
+  max-width: none !important;
+}
+.AR_8 .ob-rec-text {
+  margin-top: 15px;
+}
+.AR_8.ob-classic-layout .ob-widget-section {
+  box-sizing: border-box;
+  text-align: left;
+  width: 100%;
+}
+.AR_8.ob-classic-layout .ob-widget-items-container {
+  padding: 0;
+}
+.AR_8.ob-classic-layout .ob-widget-section  * {
+  margin: 0;
+}
+.AR_8 .ob-widget-header {
+  margin-bottom: 12px !important;
+  text-align: left;
+}
+.AR_8 .ob-dynamic-rec-container {
+  margin-bottom: 15px !important;
+}
+.AR_8.ob-widget .ob_what {
+  padding: 0;
+  text-align: left;
+}
+.AR_8 .ob-widget-header {
+  display: none;
+}
+.AR_8 .ob_what.ob-hover {
+  display: none;
+}
+/*.AR_8.ob-classic-layout {
+  float: left;
+  margin-left: 1%;
+  margin-top: 39px;
+  width: 49%;
+}*/
+
+#bbccom_outbrain_ar_8_1_2_3_4 {
+  float: left;
+  width: 49%;
+  margin-left: 1%;
+  margin-top: 77px;
+}
+
+.AR_8.ob-classic-layout .ob-dynamic-rec-container:hover {
+  text-decoration: none !important;
+}
+.AR_8.ob-classic-layout .ob-dynamic-rec-link:hover {
+  color: #1167a8 !important;
+  text-decoration: none !important;
+}
+.AR_8.ob-classic-layout .ob-dynamic-rec-link:hover .ob-unit.ob-rec-text {
+  color: #1167a8 !important;
+  text-decoration: none !important;
+}
+.AR_8.ob-widget .ob_what {
+  display: none;
+}
+
+
+/* TITLES AND SOURCES */
+.AR_8.ob-classic-layout .ob-unit.ob-rec-text {
+  font-size: 16px !important;
+  font-weight: bold;
+  line-height: 22px;
+}
+
+.AR_8.ob-classic-layout .ob-unit.ob-rec-source {
+  color: #000000;
+  display: block;
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 16px;
+  margin-top: 0;
+}
+
+/* TABLET */
+@media screen and (min-width: 1px) and (max-width: 1000px)  {
+.AR_8.ob-classic-layout .ob-widget-header {
+  font-size: 28px;
+  line-height: 32px;
+}
+.AR_8.ob-classic-layout .ob-unit.ob-rec-source {
+  font-size: 14px !important;
+}
+.AR_8.ob-classic-layout .ob-unit.ob-rec-text {
+  font-size: 18px !important;
+  line-height: 22px;
+}
+}
+
+/* MOBILE */
+@media screen and (min-width: 1px) and (max-width: 600px)  {
+.AR_8.ob-classic-layout {
+  float: none !important;
+  width: auto;
+}
+.AR_8.ob-classic-layout .ob-widget-section {
+  float: none;
+}
+#bbccom_outbrain_ar_2 {
+  display: block !important;
+  float: none;
+  margin-bottom: 20px !important;
+}
+.AR_8.ob-classic-layout .ob-widget-header {
+  font-size: 20px;
+  line-height: 24px;
+}
+.AR_8 .ob_what.ob-hover {
+  display: block;
+}
+.AR_8.ob-widget .ob_what {
+  display: block;
+}
+.AR_8.ob-classic-layout {
+  float: none;
+  margin-left: 0;
+  margin-top: 0;
+  width: 100%;
+}
+#bbccom_outbrain_ar_8_1_2_3_4 {
+  float: none;
+  width: 100%;
+  margin-left: 0%;
+}
+#bbccom_outbrain_ar_8_1_2_3_4 {
+  margin-top: 0 !important;
+}
+.AR_8.ob-classic-layout .ob-unit.ob-rec-text {
+  font-size: 16px !important;
+  line-height: 20px;
+}
+}
+
+
+/* MOBILE */
+@media screen and (min-width: 1px) and (max-width: 599px)  {
+body .AR_8 .ob-unit.ob-rec-text {
+  font-size: 16px !important;
+  line-height: 20px !important;
+}
+}
+
+@media screen and (min-width: 1px) and (max-width: 399px)  {
+body .OUTBRAIN .AR_8 .ob-unit.ob-rec-text {
+  font-size: 15px !important;
+  line-height:18px !important;
+}
+}
+
+.bbccom_outbrain_container.bbccom_outbrain_ar_8 {
+  clear: none !important;
+}
+.bbccom_outbrain_container.bbccom_outbrain_ar_8 div {
+  clear: none;
+}
+    </style>
+        <div class="ob-widget-section ob-first">
+            <div class="ob-widget-header">You Might Also Like</div>
+            <ul class="ob-widget-items-container"><li class="ob-dynamic-rec-container ob-recIdx-0 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=ERo9anya6qatS86kPqvODOTktX8sCtGTmnYvn5YPuT3zhDfsmxvvdz1tMoRMRSNekXzR7sW88ANiPY_uVBMGCYSUqszCoX9tDc7hASlfuIPk4JftW3EfYMQVDDKdcgHlikf1Ns2kW3DdWNL0RUWDIHhkrxpL0g6FsHufI7m8taXVxt5jREIE2E97CHSG3nX26_waAJCp1jWUEibg3uB8BmAAAuc5mLdqykTwekxzFHu5GqKdPAkCgrC1yp_bivUWz4R7JxQBuRRLu1_xjCYmF_-iQdF2r0JGtXdP6Ru651WXFybxOCRMHQndfEBZFMNowiNjUOzJBXNI17plF0pQ00rdiFBDRjXN9ydJY2DrY2AtcSI69ZKcCPHTk46mNRTYxAd3pPRFLYWV4whjklDd3a4U3ud4f1x4V-5Th7q67JrE-LIyqJ1jAxNWfrpC9Gte105-6_I99IyPCIfFGt36809xmHPHsds6tUgPwftC-TWGSP27MNdo9-2nBBVIH0Nz&amp;c=9b1959db&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Is your office full of insecure people?">Is your office full of insecure people?</span>            <span class="ob-unit ob-rec-source" data-type="Source">BBC Capital</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-1 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=hZgRZCdiZJ2xpplcTU19tv4AkOUixrF0ik_iuyJUr8qNgY8P9H49r5ye49YHsedLv2YOZ_dW2OyRCUBGV1_BpJL6lZWkW5zD-tDBXPfUZU1HOuYIqTcsqFt-ildXn1ey5vo_bSuc1vqrBteckMgYhk0SBRZhw96PO2-_a8DlKgqwy6DI3jsCIsN5b4oq23ysN6AHhc19TbQN65y-Cm1P9iJ0jSheBzzxXIZ9ppFZRpMsA7IfB2xGrnwH62J960zs1bhXf5cNxJCTaECLITVTS-1LXk3gJz6dwP7RXwNvb7Van3bbTEZM18Dk198s4waoX0sCIQHiTyVq_bmPCcH1bSMgDJ2mAhnMAxds-CJkhosDQ7pByWHlNelt8jNtt5VJ48ydWHaxwoWWgX9y7smBqcF18UMxvnHvZHFYScBLe2no7URsZ1NbdYh4LG8rt40Fbv6PXS5NC02eaPNLNOdrwgyhHcei1USaf9ssseIjFd9I1AhW7bZR6pG_I8xr9j5t&amp;c=73a738b0&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Image of the day: London's nightmare commute">Image of the day: London's nightmare commute</span>            <span class="ob-unit ob-rec-source" data-type="Source">BBC Autos</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-2 ob-o"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://traffic.outbrain.com/network/redir?p=ZAzsQPnyz_jfTOW_eEtiBk67CepdHqAdMDLZpuZzBeZZz4J2_OkMb1SwmNZPok1p2blEOQ6dJ5J_3BQpJ9jJ57owxPJgYf81ZGbNMfgatgYM2y-J_DdgpLDfgGjDG1EVgMqJGci8bdIbbcZgAiXTGMcxj5ClHPpWKUwaBHi-ZcMQEzUXB60rPbs2Ld6YAx5o_lZsweVPNt8QpHVYmkgLQLjOEabWc9lUhfyZjio4xm48moSMnxxOu0PBLVpw3hyn_AM1-iOqObruP33LS2we2md907fJlvXPfmp7btrn5Bd-GoRu7BvrkkLy8Nq7nnLxgYjifSIu0CWHlNBi0fL-_okp2b000cGRf7Wt1yRRfVBrq8gZc7Ecul8V66lkTt2TNCX_lnoQx6jt9d2zc_cQgoza4lXORqTXiBYh0Ud60s56g9Mhhl4VCvNBtBmbNQIjp_-0wdWdk7fVfBotKcuExrWO3ilFGwKTMeR8NDXlaHx6C0_Vva5ITpefRstiJQcb&amp;c=6a0f494d&amp;v=3" onmousedown="" target="_self" rel="">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Tesla's 'Ludicrous' Model S is a 2.8-second monster">Tesla's 'Ludicrous' Model S is a 2.8-second monster</span>            <span class="ob-unit ob-rec-source" data-type="Source">BBC Autos</span>
+
+        </a>
+    </li></ul>
+    </div>
+                <div class="ob_what">
+    
+    <a tabindex="-1" href="#" onmousedown="" onclick="OBR.extern.callWhatIs('http://www.outbrain.com/what-is/default/en','',-1,-1, false ,null);return false">
+        Recommended by Outbrain
+    </a>
+</div>
+  </div></div><script type="text/javascript">    document.write(unescape('%3Cscript src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"%3E%3C/script%3E'));</script><script src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"></script></div>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>                                        </div>
+                                     <div class="column--secondary" role="complementary">
+                                                                            <div id="comp-top-stories-promo" class="top-stories-promo">
+    <h2 class="top-stories-promo__title">Top Stories</h2>
+                <a href="/news/world-us-canada-33646704" class="top-stories-promo-story" data-asset-id="/news/world-us-canada-33646704">
+        <strong class="top-stories-promo-story__title">Obama: Gun laws my biggest frustration</strong>
+                    <p class="top-stories-promo-story__summary ">President Barack Obama tells the BBC his failure to pass "common sense gun safety laws" is the greatest frustration of his presidency.</p>
+                    <div data-timestamp-inserted="true" class="date date--v2" data-seconds="1437712569" data-datetime="24 July 2015">24 July 2015</div>
+    </a>
+                <a href="/news/world-us-canada-33654509" class="top-stories-promo-story" data-asset-id="/news/world-us-canada-33654509">
+        <strong class="top-stories-promo-story__title">US cinema gunman 'had violent past'</strong>
+                    <div data-timestamp-inserted="true" class="date date--v2 relative-time" data-seconds="1437754133" data-datetime="24 July 2015">49 minutes ago</div>
+    </a>
+                <a href="/news/world-us-canada-33657483" class="top-stories-promo-story" data-asset-id="/news/world-us-canada-33657483">
+        <strong class="top-stories-promo-story__title">WWE terminates Hulk Hogan's contract</strong>
+                    <div data-timestamp-inserted="true" class="date date--v2 relative-time" data-seconds="1437754721" data-datetime="24 July 2015">39 minutes ago</div>
+    </a>
+        </div>                                
+<div id="bbccom_mpu_4" class="bbccom_slot mpu-ad bbccom_standard_slot" aria-hidden="true">
+    <div class="bbccom_advert bbccom_display_none">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('mpu', [4]);
+        }
+        /*]]>*/
+        </script>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>                                                            
+<div class="features-and-analysis" id="comp-features-and-analysis">
+    <h2 class="features-and-analysis__title">
+        
+        Features &amp; Analysis
+    </h2>
+    <div class="features-and-analysis__stories promo-unit-spacer">
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/blogs-trending-33604916" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/787E/production/_84464803_ifidie4.jpg" datasrc="http://ichef.bbci.co.uk/news/304/cpsprodpb/787E/production/_84464803_ifidie4.jpg" class="js-image-replace" alt="If I die in police custody video" height="351" width="624">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/787E/production/_84464803_ifidie4.jpg" class="js-image-replace" alt="If I die in police custody video" width="624" height="351" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">'If I die...'</h3>
+                <p class="bold-image-promo__summary">How black Americans are reacting to Sandra Bland's death</p>
+            </a>
+        </div>
+        
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/world-us-canada-33644498" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/A7B7/production/_84453924_5fa7af8b-bd47-44b4-a454-160cb7e8e49a.jpg" datasrc="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/A7B7/production/_84453924_5fa7af8b-bd47-44b4-a454-160cb7e8e49a.jpg" class="js-image-replace" alt="Donald Trump" height="549" width="976">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/A7B7/production/_84453924_5fa7af8b-bd47-44b4-a454-160cb7e8e49a.jpg" class="js-image-replace" alt="Donald Trump" width="976" height="549" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">The Donald's dollars</h3>
+                <p class="bold-image-promo__summary">What we learned from Trump's financial disclosure </p>
+            </a>
+        </div>
+        
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/blogs-china-blog-33647396" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/A91F/production/_84459234_u1ntitled.jpg" datasrc="http://ichef.bbci.co.uk/news/304/cpsprodpb/A91F/production/_84459234_u1ntitled.jpg" class="js-image-replace" alt="Taylor Swift in China" height="549" width="976">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/A91F/production/_84459234_u1ntitled.jpg" class="js-image-replace" alt="Taylor Swift in China" width="976" height="549" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">T.S. Made in China</h3>
+                <p class="bold-image-promo__summary">The Taylor Swift fakes on the Chinese internet</p>
+            </a>
+        </div>
+        
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/world-us-canada-33646875" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/183D5/production/_84458299_p072315al-0500.jpg" datasrc="http://ichef.bbci.co.uk/news/304/cpsprodpb/183D5/production/_84458299_p072315al-0500.jpg" class="js-image-replace" alt="President Barack Obama participates in an interview with Jon Sopel of BBC in the Roosevelt Room of the White House - 23 July 2015" height="549" width="976">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/183D5/production/_84458299_p072315al-0500.jpg" class="js-image-replace" alt="President Barack Obama participates in an interview with Jon Sopel of BBC in the Roosevelt Room of the White House - 23 July 2015" width="976" height="549" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">Five Obama take-aways</h3>
+                <p class="bold-image-promo__summary">At-a-glance - what the US president told the BBC </p>
+            </a>
+        </div>
+        
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/world-asia-india-33639456" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/D510/production/_84444545_gettyimages-479284580.jpg" datasrc="http://ichef.bbci.co.uk/news/304/cpsprodpb/D510/production/_84444545_gettyimages-479284580.jpg" class="js-image-replace" alt="Ghantewala" height="549" width="976">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/D510/production/_84444545_gettyimages-479284580.jpg" class="js-image-replace" alt="Ghantewala" width="976" height="549" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">Sweet memories</h3>
+                <p class="bold-image-promo__summary">Delhi's oldest candy shop goes out of business</p>
+            </a>
+        </div>
+        
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/world-europe-33634214" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/372C/production/_84442141_ntv_2.jpg" datasrc="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/372C/production/_84442141_ntv_2.jpg" class="js-image-replace" alt="Image from Russian Channel 1 TV showing Varvara Karaulova" height="549" width="976">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/372C/production/_84442141_ntv_2.jpg" class="js-image-replace" alt="Image from Russian Channel 1 TV showing Varvara Karaulova" width="976" height="549" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">Raw recruits</h3>
+                <p class="bold-image-promo__summary">Why Russian students are targets for Islamic State</p>
+            </a>
+        </div>
+        
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/magazine-33629011" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/0DF4/production/_84427530_thinkstockphotos-87713420.jpg" datasrc="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/0DF4/production/_84427530_thinkstockphotos-87713420.jpg" class="js-image-replace" alt="Shark" height="1152" width="2048">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef-1.bbci.co.uk/news/304/cpsprodpb/0DF4/production/_84427530_thinkstockphotos-87713420.jpg" class="js-image-replace" alt="Shark" width="2048" height="1152" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">News quiz</h3>
+                <p class="bold-image-promo__summary">How did a surfer fend off a shark attack?</p>
+            </a>
+        </div>
+        
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/science-environment-33479507" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/C415/production/_84379105_84306592.jpg" datasrc="http://ichef.bbci.co.uk/news/304/cpsprodpb/C415/production/_84379105_84306592.jpg" class="js-image-replace" alt="The buoy contains sensors that measure the salinity and temperature of the sea" height="549" width="976">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/C415/production/_84379105_84306592.jpg" class="js-image-replace" alt="The buoy contains sensors that measure the salinity and temperature of the sea" width="976" height="549" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">Salt and fresh</h3>
+                <p class="bold-image-promo__summary">Trying to predict the South Asian monsoon by studying the ocean</p>
+            </a>
+        </div>
+        
+        
+        <div class="features-and-analysis__story">
+            <a href="/news/business-33620066" class="bold-image-promo">
+                <div class="bold-image-promo__image">
+                            <div class="responsive-image responsive-image--16by9">
+                                
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/313D/production/_84450621_thinkstockphotos-482433887.jpg" datasrc="http://ichef.bbci.co.uk/news/304/cpsprodpb/313D/production/_84450621_thinkstockphotos-482433887.jpg" class="js-image-replace" alt="Elderly man in wheelchair" height="351" width="624">
+                                    <!--[if lt IE 9]>
+                                    <img src="http://ichef.bbci.co.uk/news/304/cpsprodpb/313D/production/_84450621_thinkstockphotos-482433887.jpg" class="js-image-replace" alt="Elderly man in wheelchair" width="624" height="351" />
+                                    <![endif]-->
+                            </div>
+                </div>
+                <h3 class="bold-image-promo__title">Dementia research</h3>
+                <p class="bold-image-promo__summary">How drugs firms are spending more on chronic illnesses</p>
+            </a>
+        </div>
+        
+    </div>
+</div>
+                                
+<div id="bbccom_native_1_2_3_4" class="bbccom_slot native-ad bbccom_standard_slot bbccom_visible">
+    <div id="bbccom_native" class="bbccom_advert bbccom_display_none bbccom_responsive">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('native', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><script type="text/javascript">bbcdotcom.ad("native").setBaseContent();googletag.display("native");</script>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>                                                                    <div id="comp-most-popular" class="most-popular">
+    <h2 class="most-popular__title">Most Popular<span class="off-screen"> popular</span></h2>
+            <ul role="tablist" class="most-popular__header__tabs">
+            <li role="presentation" id="most-popular__tab-1" class="most-popular__header__tabs--read open"><a tabindex="0" role="tab" href="#">Read<span class="off-screen"> selected</span></a></li>
+            <li role="presentation" id="most-popular__tab-2" class="most-popular__header__tabs--watched"><a tabindex="-1" role="tab" href="#">Watched</a></li>
+        </ul>
+        <div class="most-popular__panels">
+                <div role="tabpanel" aria-labelledby="most-popular__tab-1" class="most-popular__list-container panel-1 open">
+                        <h3 class="off-screen">Most read</h3>
+                        <ul class="most-popular__list panel-read collection">
+            <li class="most-popular-list-item column-1">
+        <a href="/news/technology-33650491" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">1</span>
+            <span class="most-popular-list-item__headline">Jeep hack prompts 1.4m car recall</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-1">
+        <a href="/news/science-environment-33621491" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">2</span>
+            <span class="most-popular-list-item__headline">Four-legged snake fossil discovered</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-1">
+        <a href="/news/world-us-canada-33655502" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">3</span>
+            <span class="most-popular-list-item__headline">US military wary of civilian guards</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-1">
+        <a href="/news/magazine-32821678" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">4</span>
+            <span class="most-popular-list-item__headline">US students go to Germany for free college</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-1">
+        <a href="/news/world-us-canada-33646704" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">5</span>
+            <span class="most-popular-list-item__headline">Obama: Gun laws my big frustration</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-2">
+        <a href="/news/technology-33655417" class="most-popular-list-item__link column-2--first-item">
+            <span class="most-popular-list-item__rank">6</span>
+            <span class="most-popular-list-item__headline">Apple stops Nest sales in the US</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-2">
+        <a href="/news/world-europe-33654021" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">7</span>
+            <span class="most-popular-list-item__headline">Turkey vows to follow up IS strikes</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-2">
+        <a href="/news/world-us-canada-33657483" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">8</span>
+            <span class="most-popular-list-item__headline">WWE terminates Hulk Hogan's contract</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-2">
+        <a href="/news/world-africa-33629577" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">9</span>
+            <span class="most-popular-list-item__headline">The airlift education scholarship that changed the world</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-2">
+        <a href="/news/world-australia-33647183" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">10</span>
+            <span class="most-popular-list-item__headline">Australian returns from IS in Syria</span>
+        </a>
+            </li>
+    </ul>
+        </div>
+                        <div role="tabpanel" aria-labelledby="most-popular__tab-2" class="most-popular__list-container panel-2 closed">
+                        <h3 class="off-screen">Most watched</h3>
+                        <ul class="most-popular__list panel-watched collection">
+            <li class="most-popular-list-item column-1">
+        <a href="/news/world-us-canada-33629023" class="most-popular-list-item__link ">
+            <span class="most-popular-list-item__rank">1</span>
+            <span class="most-popular-list-item__headline">
+    Obama 'most frustrated' by gun laws</span>
+        </a>
+            </li>
+        <li class="most-popular-list-item column-2">
+        <a href="/news/magazine-33636790" class="most-popular-list-item__link column-2--first-item">
+            <span class="most-popular-list-item__rank">2</span>
+            <span class="most-popular-list-item__headline">
+    What happens to the Glastonbury wellies?</span>
+        </a>
+            </li>
+    </ul>
+        </div>
+            </div>
+</div>
+
+                                
+<div id="bbccom_mpu_bottom_1_2_3_4" class="bbccom_slot mpu-bottom-ad bbccom_standard_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_mpu_bottom" class="bbccom_advert bbccom_display_none">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('mpu_bottom', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><a tabindex="-1" class="bbccom_text" href="http://www.bbc.co.uk/faqs/online/adverts_general">Advertisement</a><script type="text/javascript">bbcdotcom.ad("mpu_bottom").setBaseContent();googletag.display("mpu_bottom");</script>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>
+<div id="bbccom_outbrain_ar_9_1_2_3_4" class="bbccom_slot outbrain-ad bbccom_outbrain_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_outbrain_ar_9" class="bbccom_advert bbccom_responsive">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('outbrain_ar_9', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><div class="bbccom_outbrain_container bbccom_outbrain_ar_9"><div id="outbrain_widget_3" data-dynload="" data-os="macintel" data-browser="safari" data-ob-mark="true" class="OUTBRAIN" data-src="http://www.bbc.com/news/world-us-canada-33646704" data-widget-id="AR_9" data-ob-template="bbc.com/News"><div class="ob-widget ob-classic-layout AR_9">
+      <span style="position:fixed;top:-200px;">&nbsp;</span>
+    <style type="text/css">
+      /* dynamic basic css */
+.AR_9.ob-widget .ob-widget-items-container {margin:0;padding:0;}
+.AR_9.ob-widget .ob-widget-items-container .ob-clearfix {display:block;width:100%;float:none;clear:both;height:0px;line-height:0px;font-size:0px;}
+.AR_9.ob-widget .ob-widget-items-container.ob-multi-row {padding-top: 2%;}
+.AR_9.ob-widget .ob-dynamic-rec-container {position:relative;margin:0;padding;0;}
+.AR_9.ob-widget .ob-dynamic-rec-link,
+.AR_9.ob-widget .ob-dynamic-rec-link:hover {text-decoration:none;}
+.AR_9.ob-widget .ob-rec-image-container .ob-video-icon-container {position:absolute;}
+[data-browser=safari] .AR_9.ob-widget .ob-rec-image-container .ob-video-icon-container {display:none;}
+.AR_9.ob-widget .ob-rec-image-container .ob-video-icon {display:inline-block;height:100%;opacity:0.7;transition: opacity 500ms;}
+.AR_9.ob-widget .ob-rec-image-container .ob-video-icon:hover {opacity:1;}
+.AR_9.ob-widget .ob_what{direction:ltr;clear:both;padding:5px 10px 0px;}
+.AR_9.ob-widget .ob_what a{color:#999;font-size:11px;font-family:arial;text-decoration: none;}
+.AR_9.ob-widget .ob_what.ob-hover:hover a{text-decoration: underline;}
+.AR_9.ob-widget .ob_amelia,
+.AR_9.ob-widget .ob_logo,
+.AR_9.ob-widget .ob_text_logo{vertical-align:baseline !important;display:inline-block;vertical-align:text-bottom;padding:0px 5px;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;}
+.AR_9.ob-widget .ob_amelia{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_16x16.png') no-repeat center top;width:16px;height:16px;margin-bottom:-2px;}
+.AR_9.ob-widget .ob_logo{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_logo_67x12.png') no-repeat center top;width:67px;height:12px;}
+.AR_9.ob-widget .ob_text_logo{background:url('http://widgets.outbrain.com/images/widgetIcons/ob_text_logo_66x23.png') no-repeat center top;width:66px;height:23px;}
+.AR_9.ob-widget:hover .ob_amelia,
+.AR_9.ob-widget:hover .ob_logo,
+.AR_9.ob-widget:hover .ob_text_logo{background-position:center bottom;}
+  .AR_9.ob-widget .ob_what{text-align:right;}
+.AR_9.ob-widget .ob-rec-image-container .ob-rec-image {display:block;}
+      /* dynamic classic css */
+.AR_9.ob-classic-layout {width:auto;}
+.AR_9.ob-classic-layout:after {content:"";display:block;height:0px;float:none;clear:both;}
+.AR_9.ob-classic-layout .ob-widget-section {width:50%;box-sizing:border-box;-moz-box-sizing:border-box;}
+.AR_9.ob-classic-layout .ob-widget-section > * {margin:0px 10px;}
+
+.AR_9.ob-classic-layout .ob-widget-section {
+      float:left;
+  }
+.AR_9.ob-classic-layout .ob-widget-header,
+.AR_9.ob-classic-layout .ob-dynamic-rec-container,
+.AR_9.ob-classic-layout .ob-dynamic-rec-container .ob-unit{direction:ltr;}
+
+.AR_9.ob-classic-layout .ob-dynamic-rec-container {display:block;}
+.AR_9.ob-classic-layout .ob-dynamic-rec-container:hover {text-decoration:underline;}
+.AR_9.ob-classic-layout .ob-unit{display:inline;margin-bottom:10px;}
+.AR_9.ob-classic-layout .ob-widget-header {font-weight:bold;}
+.AR_9.ob-classic-layout .ob-unit.ob-rec-text {font-weight:bold;}
+.AR_9.ob-classic-layout .ob-unit.ob-rec-source {}
+.AR_9.ob-classic-layout .ob-unit.ob-rec-date {font-weight:bold;}
+      /* dynamic customized css */
+      
+.AR_9.ob-classic-layout .ob-widget-header {font-family:inherit;font-size:24px;color:black;padding-bottom:0px;padding-top:0px;}
+.AR_9.ob-classic-layout .ob-widget-items-container {padding:0px 0px 0px 10px;}
+.AR_9.ob-classic-layout .ob-dynamic-rec-container {color:black;margin-bottom:0px;}
+.AR_9.ob-classic-layout .ob-dynamic-rec-container:hover {color:#1167a8;}
+.AR_9.ob-classic-layout .ob-dynamic-rec-link {color:black;}
+.AR_9.ob-classic-layout .ob-dynamic-rec-link:hover {color:#1167a8;}
+.AR_9.ob-classic-layout .ob-rec-text {color:black;font-family:inherit;font-size:14px;line-height:1.5;}
+.AR_9.ob-classic-layout .ob-rec-source {font-family:inherit;color:black;font-size:12px;}
+.AR_9.ob-classic-layout .ob-rec-date {font-family:inherit;font-size:12px;color:black;}
+.AR_9.ob-classic-layout .ob-rec-author {font-family:inherit;font-size:12px;color:black;}
+.AR_9.ob-classic-layout .ob-rec-description {font-family:inherit;font-size:12px;color:black;}
+    </style>
+    <style type="text/css" class="ob-custom-css">
+      .AR_9 .ob-last .ob-widget-header { display: none; } .AR_9.ob-dynamic-rec-container { max-width: none !important; } .AR_9 .ob-rec-text { margin-top: 15px; } .AR_9.ob-classic-layout .ob-widget-section { width: 100%; } .AR_9 .ob-widget-header { margin-bottom: 12px !important; text-align: left; } .AR_9.ob-classic-layout .ob-widget-items-container { padding: 0 !important; } .AR_9.ob-widget .ob_what { padding: 0; text-align: left; } .AR_9.ob-classic-layout .ob-dynamic-rec-container:hover { text-decoration: none !important; } .AR_9.ob-classic-layout .ob-dynamic-rec-link:hover { color: #1167a8 !important; text-decoration: none !important; } .AR_9.ob-classic-layout .ob-dynamic-rec-link:hover .ob-unit.ob-rec-text { color: #1167a8 !important; text-decoration: none !important; } .AR_9 li { background-image: url("http://static.bbci.co.uk/news/1.55.2536/img/news--icons-sprite.png"); background-position: -4px -4405px; background-repeat: no-repeat; padding-left: 30px; } /* GROUP 4 more than 1008px */ .AR_9.ob-classic-layout .ob-widget-header { color: #000000; font-size: 24px; line-height: 24px; padding-bottom: 0; padding-top: 0; } .AR_9.ob-classic-layout .ob-unit.ob-rec-text { display: block; font-size: 16px; font-weight: bold; line-height: 22px; margin-bottom: 0; } .AR_9.ob-classic-layout .ob-rec-source { color: #000000; display: block; font-size: 13px; font-weight: normal; line-height: 16px; margin-bottom: 8px !important; margin-top: 0 !important; } /* TABLET */ /* GROUP 3 600 to 1007px */ @media screen and (min-width: 1px) and (max-width: 1007px) { .AR_9.ob-classic-layout .ob-widget-header { font-size: 28px; line-height: 32px; } #bbccom_outbrain_ar_3 { display: block; } .AR_9.ob-classic-layout .ob-dynamic-rec-container { display: inline-block !important; float: none; padding-right: 2% !important; vertical-align: top; width: 42% !important; } .AR_9.ob-classic-layout .ob-rec-text { color: black; font-family: inherit; font-size: 16px; line-height: 20px !important; } .AR_9.ob-classic-layout .ob-unit.ob-rec-source { display: block; font-weight: normal; padding-top: 0px; } .AR_9.ob-classic-layout .ob-widget-header { color: #000000; font-size: 28px; line-height: 32px; padding-bottom: 0; padding-top: 0; } .AR_9 .ob-unit.ob-rec-text { font-size: 18px !important; line-height: 22px !important; margin-top: 0 !important; } .AR_9.ob-classic-layout .ob-rec-source { color: #000000; font-size: 14px !important; line-height: 16px !important; } } /* MOBILE */ @media screen and (min-width: 1px) and (max-width: 599px) { .AR_7.ob-classic-layout { float: none !important; width: auto; } .AR_7.ob-classic-layout .ob-widget-section { float: none; } #bbccom_outbrain_ar_2 { display: block !important; float: none; margin-bottom: 20px !important; } .AR_7.ob-classic-layout .ob-widget-header { font-size: 20px; line-height: 24px; } .OUTBRAIN .AR_9.ob-classic-layout .ob-dynamic-rec-container { display: list-item; float: none; margin-bottom: 12px !important; padding-bottom: 1px; padding-right: 0 !important; vertical-align: top; width: 100% !important; } .OUTBRAIN .AR_9 .ob-dynamic-rec-container.ob-recIdx-5 { margin-bottom: 0 !important; padding-bottom: 0 !important; } .AR_9 .ob-unit.ob-rec-source { margin-bottom: 8px !important; margin-top: 0 !important; padding-top: 0 !important; } .AR_9.ob-classic-layout .ob-widget-header { color: #000000; font-size: 20px; line-height: 24px !important; padding-bottom: 0; padding-top: 0; } .AR_9 .ob-unit.ob-rec-text { font-size: 16px !important; line-height: 20px !important; } .AR_9 .ob-widget-header { margin-left: 0 !important; } .OUTBRAIN .AR_9.ob-classic-layout .ob-dynamic-rec-container { width: 92% !important; } } @media screen and (min-width: 1px) and (max-width: 399px) { .AR_9 .ob-unit.ob-rec-text { font-size: 15px !important; line-height:18px !important; } .AR_9 .ob-widget-header { margin-left: 0 !important; } .OUTBRAIN .AR_9.ob-classic-layout .ob-dynamic-rec-container { width: 92% !important; } }
+    </style>
+        <div class="ob-widget-section ob-first">
+            <div class="ob-widget-header">From Around the Web</div>
+            <ul class="ob-widget-items-container"><li class="ob-dynamic-rec-container ob-recIdx-0 ob-p"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://paid.outbrain.com/network/redir?p=rq4a_ASjttzFNp4vY6tvpw8WS9moM9MtaMU-DeedJzqQRj3AIbAMrVqycPHHN6lPmt868hj4ueMTBxFIWxmio-L7GZzQd9MPv1AsQQx5b6eAELLxQAiwir-aWzzpC4C1WaPqBtaHVpZEYCre-2HM1zcKuTAuf3Ugff6Nnw2xEGRwF1r2tKjuf16fwVg2wSPOzajkUUKKs4CCviYcaGTTEV_deNQROaqAMWj0FVtKdr4aRCoE3WYKRmqoQyHqg-vB8fBMEhL2znhEl7HotLpo68_p4FIY9CoBEoESuhxslAOHVVml9zBvrmXoyrSvDaNCcO8vuyJtjNiRQ4XJQ15iWQ1vNCdgXGfCGPE8jwG6t3qqFCupvU9BS9m5Lv-21u4-VMeMkKYrUSAJY3HVpAddSUB241rEJD3Edh2Y7cTEtcQsu2XKFEDNooRgPbKEDhYsaqWZmfUTZ9wn3hfaV3ZorSx3EjCa5a2cD6GTQoM7Qe75PnC5pvJ6Ggw9dvtFF6L04mZtX4BP7Wx9QJQ3kYWFQGi3ydEQHISBTXjEkLqGNj6EfO3ffDg4ThmFH8PjeHl9&amp;c=2680ac1d&amp;v=3" onmousedown="" target="_blank" rel="nofollow">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="The 25 Toughest U.S. Colleges to Get Into">The 25 Toughest U.S. Colleges to Get Into</span>            <span class="ob-unit ob-rec-source" data-type="Source">(TheStreet)</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-1 ob-p"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://paid.outbrain.com/network/redir?p=cLJdfsNZv8gdGM2jDYzgbCzNY7LlzWIUojrYPIAZ9vJzUwCMkWlM_HFImuwvgJtVGDRVQO7GS5Wo69tmig4ewYfHwQi8u1qB92ahrdAceWTrfj2Bq0qgvqLp2yuqaHxV53gRWMGD6cnTyIeJhj5vD27pIp346X0auIDvaHvNHfLdYURcXm3gmGyJ7Y41V3py-6o6ctzO7aEhSmj4DPcKAUXszh84SuLJlU5nAVcDHC4kSE2-BSXJpeYytK-pWRi7i5p1hmib0Y1id7w_5CPMAVndnBPbILUBlFR1RwRaQCiIUPqn-hvFsG8LRujcPY-MZ6-2hS0VKVLHN2jJ6hQ0HQ4J_ugszIaF-ckRw-HSLMqRsw3JjJ9ekPDd9MMWElK2gxUfFRnv5j9KM6qqW-8eU8XeEn8SCWgtylYnkGxgEhYEgPugopY1Zaf9aUoMIGHgfyIAhI5lli5hyftUci7zbpcIb2kuJoEe7sVc02umwFT198iqcpW4yf7JzGcM6lEBecdNl7PMFST1eo_LMuBZExnz7YNMmPqxSD40qqMOzkp5oMMEtNHv-FYL7j97IyKa&amp;c=66165faa&amp;v=3" onmousedown="" target="_blank" rel="nofollow">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Having 1 Of These 7 Credit Cards Means You Have Excellent Credit">Having 1 Of These 7 Credit Cards Means You Have Excellent Credit</span>            <span class="ob-unit ob-rec-source" data-type="Source">(NextAdvisor)</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-2 ob-p"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://paid.outbrain.com/network/redir?p=ubmI-nZpje_hcd24WEPrIxsnWghii227cwvwiAmT5pq_5bldfhbDD4iVkls2nBWosJsZeRyXJ7WvRi459yAKdKidBJjQW55Ry3TBKHUYkuO-LRcTwvSho_Blg6CFELjVv0UBV_o3g8Jr1F5e3YavgfahTZfiEOgKnpgWr4yMkt7qggZ_mtYYcFAlgSJ5Xvudz6_y7n6IvXN_wSjEeXj03lzfJqDZHiAOzEvXNZbZ4Ngs2mLg5PEs83EseFD6iN9sAuBSSCXg6WaVqyPzPdVxUuBNfSxKdhCtn4ioKjw7CFyE01-GfNvyRNriqe4ehTw-KE_Ee1wftWH1QaHklJ-FwdQLu5EsysjRn-c6mOioHwPcV54bf083hs8UQmIWTspzUSOUPPdlSGPZ_6svLdWI2a2IDgksV7wsPwajeOVPo_NESHSDxnL3Eo8L2JDZhM8sMY3SD9gfux4x5oixRm2FFx_zowfWT6DtRPYpbkoD8zqSh_QjejhbB19nJ66c1gTnsBnY6zGZlVv1sO8k2tpWmGsF1hDOsTnKlaKu3qFr6RF9lBPpaMnYZqi4zaK4ePgL&amp;c=9e31e665&amp;v=3" onmousedown="" target="_blank" rel="nofollow">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="The Sweeping Views in This U.S. Town Will Take Your Breath Away">The Sweeping Views in This U.S. Town Will Take Your Breath Away</span>            <span class="ob-unit ob-rec-source" data-type="Source">(Paid Post On NYTimes.com)</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-3 ob-p"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://paid.outbrain.com/network/redir?p=SLESGYw6Si6eBl-1G7b3o2Kt0-p122pXZsHI8VvJlTfSDgYrmNOMPKDoevopz6r09Z-Oin0gNBFUReevm0FdTeUcMs-GvC4QYJ7wbdM-zzP5sFA3KSm3yCbHsn6HpIKcpVCNznpk6w3r8yXpoR-NtX7XL3_ipFtlkc3m9OzAsmLjr_vm4xUNfZ0zB_6PUXWOVZIyRVvK7D7izLvVeVnoHt7ZSKgPmJeq5dDhpN6bJ632ePY7SPUmqUT1E1p03UE0FH1fc1xtZQEqOawemU6iAraNeTdEJNNbPfhqtV4K7hKE-ZCtky3-4KVsxBya4zdBYoDW6RJMbUc8ROUK90OKKfq5yc144WkSeERaMq5-ZAn2ItUZcErrmFcPEL85QGrYUf-JCLOBxUer1kLzyZZhQ5bTLKAe5MCgrPYjZEfrYMlj6NRRHsvjZGe9LjVOzjDvrndpwsuLwKRX1m7maYqBi-ZkBKOm7rj3bZ1PBePbIai9nQ7tDbiHFCgD9YV7VmsAEBZ8qivtgbmAnXXlfNsA5rlHpNkA0xZfsCZi-9RttUvAFvZmOGW8vz63i2eWhg5o&amp;c=47420445&amp;v=3" onmousedown="" target="_blank" rel="nofollow">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="5 Things The Wealthy Do With Credit Cards That You Should Also Do">5 Things The Wealthy Do With Credit Cards That You Should Also Do</span>            <span class="ob-unit ob-rec-source" data-type="Source">(NextAdvisor)</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-4 ob-p"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://paid.outbrain.com/network/redir?p=VLWE0I4Y4BDZMCX7BG_67myiNY-TjV76_zb9-CwcFUdn65juHw9jeAPnTpqCHCkajLvHP42Aun089ShC8wjxaF8dbFMXAQspNO7iXL005wJc-7wUbqZSAqF6b_6hPFnehLBnRm9c6uaMpDiZ3T5t-q8LQ0VjT6nuvVpLi9nKFNwgtBs2emFEO8yyGONXj7M1daLGOR_KC3LPiCxd3nQ94VxVM4BRZmuc5331u3c8ZVv_DnnDaeKnEbQ6UVr2A9R1yONCZnYqSLzB7pcPoY5d14gU5k6n6ULC5IDL0iitzbcsLOcQjesVZhCoz8MUT8Mqd_fDH8He9RVTKl-ABuEscDkE_XYQFOIUAPJoLkhqOfr8vmQWzGeLDpmU7_NkNsLh77Yn4YmXsIGZrjqKKlGdN92Nhz8WW_SWHZldpULpn0q2IuuE1loXZKMtzT7xIto1_w3XryzGPEVBH4wLaZAnEZQ9ew6yuhhJF_qK9fzwTN6b9xxIt-BLZX-yKdTCJqyG4Jjjywd2psA9HKlw4bsxRZRgEKkymiNq2v8J83kT7jWqXMsPFqdGCAKj3IUjF4W0&amp;c=3c62a2eb&amp;v=3" onmousedown="" target="_blank" rel="nofollow">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="Obama Visits Prison, Says He Could Have Wound Up There">Obama Visits Prison, Says He Could Have Wound Up There</span>            <span class="ob-unit ob-rec-source" data-type="Source">(Newser)</span>
+
+        </a>
+    </li><li class="ob-dynamic-rec-container ob-recIdx-5 ob-p"><a tabindex="-1" class="ob-dynamic-rec-link" onclick="" href="http://paid.outbrain.com/network/redir?p=6O8A_4PTFEjKxFW5I3JJF27NGy_HK0TRquMFH00NhShBqUNV2kTj3uju_QebEWVuW4eWgjZKsdOFhA0iEqWRj-pXD1aV6F_nE3Xe40aMS7nHZ4Qkp3zc7nMAL-FjlPGItdPTx-hzOn7ck-HIFMr5yvg6FwYZBbMPuNrTqykyxlZ3-VPj0sZpQKOdtNp_mQDt9Eb6oCOlg1uM72YbryodX7jqTpy0IeUPcyEB5sw71uYm7zV5_74sDyQPrAUuIhxDuIJncNO-JlI2Pk3lNImwnVQlJLtCDkaFlxCEcFy6jk43djSygiH531IP1QgzBqQRIkx4lFjEeYtHZofTHFfKC29xGxwrFOre82GQEp3Xpb9SrF_A3xor2qZXD7UJrDAzgFHCzWWhYEAZvSmlzC2aF-ZJPOahQYTJ9WvTRWfhPcRjAl__4vgc8K_jz2lDhlqwFNRLFRDI72WrW1n7QEKIsrT91Vi7PAWD96xQ2MCU7bx_rU7VnKzxi-bve4oEQccaikm2nohDKM0C7P-yywuTx4bcrC9pyLrnMWhD5CKhkCg6xAM-L0vrfwTDL9uNbEpd&amp;c=5cfff822&amp;v=3" onmousedown="" target="_blank" rel="nofollow">
+
+      <span class="ob-unit ob-rec-text" data-type="Title" title="What Is Considered a Good Credit Score?">What Is Considered a Good Credit Score?</span>            <span class="ob-unit ob-rec-source" data-type="Source">(Better Money Habits™ by Bank of America)</span>
+
+        </a>
+    </li></ul>
+    </div>
+                <div class="ob_what">
+    
+    <a tabindex="-1" href="#" onmousedown="" onclick="OBR.extern.callWhatIs('http://www.outbrain.com/what-is/default/en','',-1,-1,true ,null);return false">
+        Promoted content by Outbrain
+    </a>
+</div>
+  </div></div><script type="text/javascript">    document.write(unescape('%3Cscript src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"%3E%3C/script%3E'));</script><script src="http://widgets.outbrain.com/outbrain.js" type="text/javascript"></script></div>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>
+<div id="bbccom_adsense_1_2_3_4" class="bbccom_slot adsense-ad bbccom_adsense_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_adsense" class="bbccom_advert bbccom_responsive">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('adsense', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><script type="text/javascript" src="http://pagead2.googlesyndication.com/pagead/show_ads.js"></script><script src="http://pagead2.googlesyndication.com/pagead/js/r20150721/r20150720/show_ads_impl.js"></script><script language="JavaScript1.1" src="https://googleads.g.doubleclick.net/pagead/ads?client=ca-bbccom&amp;output=js&amp;adk=1893803208&amp;lmt=1437757078&amp;num_ads=3&amp;channel=globalnews&amp;ad_type=text&amp;ea=0&amp;flash=18.0.0&amp;url=http%3A%2F%2Fwww.bbc.com%2Fnews%2Fworld-us-canada-33646704&amp;dt=1437757078592&amp;bdt=2083&amp;shv=r20150721&amp;cbv=r20150720&amp;saldr=sb&amp;correlator=3931185939561&amp;frm=20&amp;ga_vid=165083980.1437757077&amp;ga_sid=1437757077&amp;ga_hid=702753462&amp;ga_fc=0&amp;u_tz=-420&amp;u_his=9&amp;u_java=1&amp;u_h=500&amp;u_w=584&amp;u_ah=877&amp;u_aw=1436&amp;u_cd=24&amp;u_nplug=10&amp;u_nmime=76&amp;dff=helmet&amp;dfs=16&amp;biw=584&amp;bih=500&amp;eid=575144605%2C317150304&amp;oid=3&amp;rx=0&amp;eae=2&amp;fc=24&amp;plat=1%3A13%2C8%3A12%2C9%3A12%2C16%3A32%2C17%3A32&amp;brdim=%2C%2C16%2C26%2C1436%2C23%2C1409%2C767%2C584%2C500&amp;vis=1&amp;rsz=%7C%7Con%7C&amp;abl=CS&amp;ppjl=u&amp;fu=16&amp;bc=1&amp;ifi=9&amp;dtd=71"></script><div class="bbccom_adsense_container"><h3><a href="http://www.bbc.co.uk/bbc.com/faq/ads_by_google.shtml" tabindex="-1">Ads by Google</a></h3><ul><li><h4><a href="http://googleads.g.doubleclick.net/aclk?sa=l&amp;ai=CbI3llm6yVd7-KsSipgPztp6wD5GrsaQH8fmIi84B_JKlk2MQASDnhfQSKANgye7rhsijoBmgAcOI6OYDyAEBqAMBqgSGAU_QiNWwZegVcytCGFt-Sq8hfBNfj6ZRd8li_ZpNtanVEEnEuA69QEWqftfk9Znzh0Mri2dkrfvZ7Kxp7DX-kSw2diP5Rk8ujVLs3SqJJ99y59mb_qKGK_F4jtomL3BXmwDd_b-Oc_9NaREbeMVp1B3Z5OvodFcLCxQVG2twubWec-lu9B-T2AYEgAel95cZqAemvhvYBwE&amp;num=1&amp;sig=AOD64_1tTvNu12Bkxzd7KkOZU-dY9j-WAg&amp;client=ca-bbccom&amp;adurl=http://www.medicaresupplemental.com/get-quotes/%3FCID%3D24390%26SRC%3Dmstal_google%26bw_keyword%3D%26Sub_ID%3D" onmouseout="window.status=''" onmouseover="window.status='go to www.medicaresupplemental.com';return true;" target="_blank" tabindex="-1">Medicare Supplement Plans</a></h4><p>Medigap Options for (65 &amp; older). Compare Plans &amp; Prices for 2015.</p><p><a href="http://googleads.g.doubleclick.net/aclk?sa=l&amp;ai=CbI3llm6yVd7-KsSipgPztp6wD5GrsaQH8fmIi84B_JKlk2MQASDnhfQSKANgye7rhsijoBmgAcOI6OYDyAEBqAMBqgSGAU_QiNWwZegVcytCGFt-Sq8hfBNfj6ZRd8li_ZpNtanVEEnEuA69QEWqftfk9Znzh0Mri2dkrfvZ7Kxp7DX-kSw2diP5Rk8ujVLs3SqJJ99y59mb_qKGK_F4jtomL3BXmwDd_b-Oc_9NaREbeMVp1B3Z5OvodFcLCxQVG2twubWec-lu9B-T2AYEgAel95cZqAemvhvYBwE&amp;num=1&amp;sig=AOD64_1tTvNu12Bkxzd7KkOZU-dY9j-WAg&amp;client=ca-bbccom&amp;adurl=http://www.medicaresupplemental.com/get-quotes/%3FCID%3D24390%26SRC%3Dmstal_google%26bw_keyword%3D%26Sub_ID%3D" onmouseout="window.status=''" onmouseover="window.status='go to www.medicaresupplemental.com';return true;" target="_blank" tabindex="-1">www.medicaresupplemental.com</a></p></li><li><h4><a href="http://googleads.g.doubleclick.net/aclk?sa=l&amp;ai=CzVeIlm6yVd7-KsSipgPztp6wD5nYrOkFufW0j5cCwI23ARACIOeF9BIoA2DJ7uuGyKOgGaAB58GL2gPIAQGoAwGqBIMBT9D4gqpl6hVzK0IYW35KryF8E1-PplF3yWL9mk21qdUQScS4Dr1ARap-1-T1mfOHQyuLZ2St-9nsrGnsNf6RLDZ2I_lGTy6NUuzdKolv39KFXF-hAlXAGvcAMc2hyrZtutQAvMqO_DmdEiuMxmlhFtFR4OCBUgr-ERTmbHBRt28fKarYBgSAB4GJwzSoB6a-G9gHAQ&amp;num=3&amp;sig=AOD64_0CGeduVg9Ewe3HTDDIqdmtGw79Xg&amp;client=ca-bbccom&amp;adurl=http://tracker.marinsm.com/rd%3Fcid%3D93095py25419%26mkwid%3DcqJnflV6d_dt%26pcrid%3D74877453265%26pkw%3D%26pmt%3D%26rd%3Dhttp://genealogy.com/lp/military-records%26lp%3Dhttp://www.ancestry.com/s66298/t30294/rd.ashx%3F%2526s_kwcid%253D" onmouseout="window.status=''" onmouseover="window.status='go to genealogy.com/Records_War';return true;" target="_blank" tabindex="-1">Draft History Records</a></h4><p>1) Simply enter their name. 2) View their war record online!</p><p><a href="http://googleads.g.doubleclick.net/aclk?sa=l&amp;ai=CzVeIlm6yVd7-KsSipgPztp6wD5nYrOkFufW0j5cCwI23ARACIOeF9BIoA2DJ7uuGyKOgGaAB58GL2gPIAQGoAwGqBIMBT9D4gqpl6hVzK0IYW35KryF8E1-PplF3yWL9mk21qdUQScS4Dr1ARap-1-T1mfOHQyuLZ2St-9nsrGnsNf6RLDZ2I_lGTy6NUuzdKolv39KFXF-hAlXAGvcAMc2hyrZtutQAvMqO_DmdEiuMxmlhFtFR4OCBUgr-ERTmbHBRt28fKarYBgSAB4GJwzSoB6a-G9gHAQ&amp;num=3&amp;sig=AOD64_0CGeduVg9Ewe3HTDDIqdmtGw79Xg&amp;client=ca-bbccom&amp;adurl=http://tracker.marinsm.com/rd%3Fcid%3D93095py25419%26mkwid%3DcqJnflV6d_dt%26pcrid%3D74877453265%26pkw%3D%26pmt%3D%26rd%3Dhttp://genealogy.com/lp/military-records%26lp%3Dhttp://www.ancestry.com/s66298/t30294/rd.ashx%3F%2526s_kwcid%253D" onmouseout="window.status=''" onmouseover="window.status='go to genealogy.com/Records_War';return true;" target="_blank" tabindex="-1">genealogy.com/Records_War</a></p></li><li><h4><a href="http://googleads.g.doubleclick.net/aclk?sa=l&amp;ai=C2YE9lm6yVd7-KsSipgPztp6wD7jHhqYE0P2x-ZMC_JKlk2MQAyDnhfQSKANgye7rhsijoBmgAZKLpvYDyAEBqQJE4ZAgvKipPqgDAaoEhgFP0KjAumXrFXMrQhhbfkqvIXwTX4-mUXfJYv2aTbWp1RBJxLgOvUBFqn7X5PWZ84dDK4tnZK372eysaew1_pEsNnYj-UZPLo1S7N0qiSffcufZip-R8SvxeI7aJi9wV5sA3f2_jnP_TWkRG3jFadQd2eTr6HRXCwsUFRtrcLm1nnPpI4Ngj9gGBIAH1vTZCagHpr4b2AcB&amp;num=2&amp;sig=AOD64_0V0UZOV10jiiQb6dBac8JhselSdw&amp;client=ca-bbccom&amp;adurl=http://annuities.advisorworld.com/highest-annuity-returns-2014/%3Futm_source%3DAWGOOG%26utm_campaign%3Dmutfuncon16%26placement%3Dwww.bbc.com" onmouseout="window.status=''" onmouseover="window.status='go to advisorworld.com/CompareAnnuities';return true;" target="_blank" tabindex="-1">16% Annuity Return 2014</a></h4><p>True Investor Returns with no Risk. Find out how with our Free Report.</p><p><a href="http://googleads.g.doubleclick.net/aclk?sa=l&amp;ai=C2YE9lm6yVd7-KsSipgPztp6wD7jHhqYE0P2x-ZMC_JKlk2MQAyDnhfQSKANgye7rhsijoBmgAZKLpvYDyAEBqQJE4ZAgvKipPqgDAaoEhgFP0KjAumXrFXMrQhhbfkqvIXwTX4-mUXfJYv2aTbWp1RBJxLgOvUBFqn7X5PWZ84dDK4tnZK372eysaew1_pEsNnYj-UZPLo1S7N0qiSffcufZip-R8SvxeI7aJi9wV5sA3f2_jnP_TWkRG3jFadQd2eTr6HRXCwsUFRtrcLm1nnPpI4Ngj9gGBIAH1vTZCagHpr4b2AcB&amp;num=2&amp;sig=AOD64_0V0UZOV10jiiQb6dBac8JhselSdw&amp;client=ca-bbccom&amp;adurl=http://annuities.advisorworld.com/highest-annuity-returns-2014/%3Futm_source%3DAWGOOG%26utm_campaign%3Dmutfuncon16%26placement%3Dwww.bbc.com" onmouseout="window.status=''" onmouseover="window.status='go to advisorworld.com/CompareAnnuities';return true;" target="_blank" tabindex="-1">advisorworld.com/CompareAnnuities</a></p></li></ul></div>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>
+<div id="bbccom_inread_1_2_3_4" class="bbccom_slot inread bbccom_inread_slot bbccom_visible" aria-hidden="true">
+    <div id="bbccom_inread" class="bbccom_advert bbccom_display_none bbccom_responsive">
+        <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.slot) {
+            bbcdotcom.slot('inread', [1,2,3,4]);
+        }
+        /*]]>*/
+        </script><script type="text/javascript">bbcdotcom.ad("inread").setBaseContent();googletag.display("inread");</script>
+    </div>
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if (window.bbcdotcom && bbcdotcom.show) {
+            bbcdotcom.show()
+        }
+        /*]]>*/
+    </script>
+</div>                                        </div>
+             </div>          </div> </div>      </div> 
+  
+
+<div id="core-navigation" class="navigation--footer">
+    <h2 class="navigation--footer__heading">News navigation</h2>
+
+    
+    <button class="navigation__cta-footer navigation__footerButton">Sections</button><nav id="navigation--bottom" class="navigation navigation--bottom" role="navigation" aria-label="News">
+                    
+                <ul class="navigation--bottom__toplevel">
+                        <li class="">
+                    <a href="/news" class="">
+                        <span>Home</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/video_and_audio/international" class="">
+                        <span>Video</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/world" data-panel-id="js-navigation-panel-World" class="navigation-arrow">
+                        <span>World</span>
+                    </a>
+                                                                <div class="navigation-panel navigation-panel--closed js-navigation-panel-World">
+                            <div class="navigation-panel__content">
+                                <ul class="navigation-panel-secondary">
+                                    <li><a href="/news/world"><span>World Home</span></a></li>
+                                                                            <li>
+                                            <a href="/news/world/africa"><span>Africa</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/asia"><span>Asia</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/australia"><span>Australia</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/europe"><span>Europe</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/latin_america"><span>Latin America</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/world/middle_east"><span>Middle East</span></a>                                        </li>
+                                                                    </ul>
+                            </div>
+                        </div>
+                                    </li>
+                            <li class="selected ">
+                    <a href="/news/world/us_and_canada" class="navigation-arrow--open">
+                        <span>US &amp; Canada</span>
+                    </a>
+                     <span class="off-screen">selected</span>                                    </li>
+                            <li class="">
+                    <a href="/news/uk" data-panel-id="js-navigation-panel-UK" class="navigation-arrow">
+                        <span>UK</span>
+                    </a>
+                                                                <div class="navigation-panel navigation-panel--closed js-navigation-panel-UK">
+                            <div class="navigation-panel__content">
+                                <ul class="navigation-panel-secondary">
+                                    <li><a href="/news/uk"><span>UK Home</span></a></li>
+                                                                            <li>
+                                            <a href="/news/england"><span>England</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/northern_ireland"><span>N. Ireland</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/scotland"><span>Scotland</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/wales"><span>Wales</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/politics"><span>Politics</span></a>                                        </li>
+                                                                    </ul>
+                            </div>
+                        </div>
+                                    </li>
+                            <li class="">
+                    <a href="/news/business" data-panel-id="js-navigation-panel-Business" class="navigation-arrow">
+                        <span>Business</span>
+                    </a>
+                                                                <div class="navigation-panel navigation-panel--closed js-navigation-panel-Business">
+                            <div class="navigation-panel__content">
+                                <ul class="navigation-panel-secondary">
+                                    <li><a href="/news/business"><span>Business Home</span></a></li>
+                                                                            <li>
+                                            <a href="http://www.bbc.co.uk/news/business/market_data"><span>Market Data</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business/markets"><span>Markets</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business/economy"><span>Economy</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business/companies"><span>Companies</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business-22434141"><span>Entrepreneurship</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business-11428889"><span>Technology of Business</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business/business_of_sport"><span>Business of Sport</span></a>                                        </li>
+                                                                            <li>
+                                            <a href="/news/business-12686570"><span>Knowledge economy</span></a>                                        </li>
+                                                                    </ul>
+                            </div>
+                        </div>
+                                    </li>
+                            <li class="">
+                    <a href="/news/technology" class="">
+                        <span>Tech</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/science_and_environment" class="">
+                        <span>Science</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/magazine" class="">
+                        <span>Magazine</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/entertainment_and_arts" class="">
+                        <span>Entertainment &amp; Arts</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/health" class="">
+                        <span>Health</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/in_pictures" class="">
+                        <span>In Pictures</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/also_in_the_news" class="">
+                        <span>Also in the News</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/special_reports" class="">
+                        <span>Special Reports</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/explainers" class="">
+                        <span>Explainers</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/the_reporters" class="">
+                        <span>The Reporters</span>
+                    </a>
+                                                        </li>
+                            <li class="">
+                    <a href="/news/have_your_say" class="">
+                        <span>Have Your Say</span>
+                    </a>
+                                                        </li>
+                    </ul>
+    </nav>
+</div>
+   <div id="services-bar" class="blue-tit" role="navigation" aria-label="BBC News Services">
+    <div class="blue-tit__inner">
+        <h2 class="blue-tit__title">BBC News Services</h2>
+        <ul class="blue-tit__list">
+            <li class="blue-tit__list-item">
+                <a href="http://www.bbc.co.uk/news/10628994" class="blue-tit__list-item-link mobile">On your mobile</a>
+            </li>
+            <li class="blue-tit__list-item">
+                <a href="http://www.bbc.co.uk/news/help-17655000" class="blue-tit__list-item-link connected-tv">On your connected TV</a>
+            </li>
+            <li class="blue-tit__list-item">
+                <a href="http://www.bbc.co.uk/news/10628323" class="blue-tit__list-item-link newsletter">Get news alerts</a>
+            </li>
+            <li class="blue-tit__list-item">
+                <a href="http://www.bbc.co.uk/news/20039682" class="blue-tit__list-item-link contact-us">Contact BBC News</a>
+            </li>
+        </ul>
+    </div>
+</div>
+ </div><!-- closes #site-container -->      </div> <div id="orb-footer" class="orb-footer orb-footer-grey orb-location-w"> <aside role="complementary"> <div id="orb-aside" class="orb-nav-sec b-r b-g-p"> <div class="orb-footer-inner" role="navigation"> <h2 class="orb-footer-lead">Explore the BBC</h2>  <div id="orb-footer-promo" class="orb-d"></div>  <div class="orb-footer-primary-links"> <ul>        <li class="orb-nav-newsdotcom orb-w"> <a href="http://www.bbc.com/news/">News</a> </li>    <li class="orb-nav-sport"> <a href="/sport/">Sport</a> </li>    <li class="orb-nav-weather"> <a href="/weather/">Weather</a> </li>    <li class="orb-nav-shop orb-w"> <a href="http://shop.bbc.com/">Shop</a> </li>    <li class="orb-nav-earthdotcom orb-w"> <a href="http://www.bbc.com/earth/">Earth</a> </li>    <li class="orb-nav-travel-dotcom orb-w"> <a href="http://www.bbc.com/travel/">Travel</a> </li>    <li class="orb-nav-capital orb-w"> <a href="http://www.bbc.com/capital/">Capital</a> </li>        <li class="orb-nav-culture orb-w"> <a href="http://www.bbc.com/culture/">Culture</a> </li>    <li class="orb-nav-autos orb-w"> <a href="http://www.bbc.com/autos/">Autos</a> </li>    <li class="orb-nav-future orb-w"> <a href="http://www.bbc.com/future/">Future</a> </li>    <li class="orb-nav-tv"> <a href="/tv/">TV</a> </li>    <li class="orb-nav-radio"> <a href="/radio/">Radio</a> </li>    <li class="orb-nav-cbbc"> <a href="/cbbc">CBBC</a> </li>    <li class="orb-nav-cbeebies"> <a href="/cbeebies">CBeebies</a> </li>        <li> <a href="/ww1/">WW1</a> </li>    <li class="orb-nav-food"> <a href="/food/">Food</a> </li>    <li> <a href="/iwonder">iWonder</a> </li>    <li> <a href="/education">Bitesize</a> </li>    <li class="orb-nav-music"> <a href="/music/">Music</a> </li>    <li class="orb-nav-nature orb-w"> <a href="/nature/">Nature</a> </li>        <li class="orb-nav-local"> <a href="/local/">Local</a> </li>        </ul> </div> </div> </div> </aside> <footer role="contentinfo"> <div id="orb-contentinfo" class="orb-nav-sec b-r b-g-p"> <div class="orb-footer-inner"> <ul>        <li> <a href="/terms/">Terms of Use</a> </li>    <li> <a href="/aboutthebbc/">About the BBC</a> </li>    <li> <a href="/privacy/">Privacy Policy</a> </li>    <li> <a href="/privacy/cookies/about">Cookies</a> </li>    <li> <a href="/accessibility/">Accessibility Help</a> </li>    <li> <a href="/guidance/">Parental Guidance</a> </li>    <li> <a href="/contact/">Contact the BBC</a> </li>        </ul> <small> <span class="orb-hilight">Copyright © 2015 BBC.</span> The BBC is not responsible for the content of external sites. <a href="/help/web/links/" class="orb-hilight">Read about our approach to external linking.</a> </small> </div> </div> </footer> </div>     <!-- BBCDOTCOM bodyLast --><div class="bbccom_display_none"><script type="text/javascript"> /*<![CDATA[*/ if (window.bbcdotcom && window.bbcdotcom.analytics) { bbcdotcom.analytics.page(); } if (window.bbcdotcom && bbcdotcom.currencyProviders) { bbcdotcom.currencyProviders.write(); } /*]]>*/ </script><img src="http://b.scorecardresearch.com/p?c1=2&amp;c2=6035051&amp;c4=www.bbc.com/news/world-us-canada-33646704" alt=""><script type="text/javascript"> /*<![CDATA[*/ if (window.bbcdotcom && bbcdotcom.currencyProviders) { bbcdotcom.currencyProviders.postWrite(); } /*]]>*/ </script><script type="text/javascript"> /*<![CDATA[*/ /** * ASNYC waits to make any gpt requests until the bottom of the page */ /*]]>*/ </script><script type="text/javascript"> /*<![CDATA[*/ if (window.bbcdotcom && bbcdotcom.data && bbcdotcom.data.stats && bbcdotcom.data.stats === 1 && bbcdotcom.utils && window.location.pathname === '/' && window.bbccookies && bbccookies.readPolicy('performance') ) { var wwhpEdition = bbcdotcom.utils.getMetaPropertyContent('wwhp-edition'); var _sf_async_config={}; /** CONFIGURATION START **/ _sf_async_config.uid = 50924; _sf_async_config.domain = "bbc.co.uk"; _sf_async_config.title = "Homepage"+(wwhpEdition !== '' ? ' - '+wwhpEdition : ''); _sf_async_config.sections = "Homepage"+(wwhpEdition !== '' ? ', Homepage - '+wwhpEdition : ''); _sf_async_config.region = wwhpEdition; _sf_async_config.path = "/"+(wwhpEdition !== '' ? '?'+wwhpEdition : ''); /** CONFIGURATION END **/ (function(){ function loadChartbeat() { window._sf_endpt=(new Date()).getTime(); var e = document.createElement("script"); e.setAttribute("language", "javascript"); e.setAttribute("type", "text/javascript"); e.setAttribute('src', '//static.chartbeat.com/js/chartbeat.js'); document.body.appendChild(e); } var oldonload = window.onload; window.onload = (typeof window.onload != "function") ? loadChartbeat : function() { oldonload(); loadChartbeat(); }; })(); } /*]]>*/ </script></div> <!-- BBCDOTCOM all code in page -->  <script type="text/javascript"> document.write('<' + 'script id="orb-js-script" data-assetpath="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/" src="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/script' + (( document.cookie.indexOf('ckns_debugorbjs') > -1 )? '-debug' : '') + '/orb.js"><' + '/script>'); </script><script id="orb-js-script" data-assetpath="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/" src="http://static.bbci.co.uk/frameworks/barlesque/2.83.10/orb/4/script/orb.js"></script>  <script type="text/javascript"> (function() {
+    'use strict';
+
+    var promoManager = {
+        url: '',
+        segments: ['a', 'b'],
+        promoLoaded: false,
+                makeUrl: function (variant, theme, win) {
+            var loc = win? win.location : window.location,
+                proto = loc.protocol,
+                host = loc.host,
+                url = proto + '//' + ((proto.match(/s:/i) && !host.match(/^www\.(int|test)\./i))? 'ssl.' : 'www.'),
+                themes = ['light', 'dark'];
+
+            if ( host.match(/^(?:www|ssl)\.(int|test|stage|live)\.bbc\./i) ) {
+                url += RegExp.$1 + '.';
+            }
+            else if ( host.match(/^pal\.sandbox\./i) ) {
+                url += 'test.';
+            }
+ 
+                        theme = themes[ +(theme === themes[0]) ];
+           
+           return url + 'bbc.co.uk/navpromo/' + variant + '/' + theme;
+        },
+                validSegment: function (segment) {
+            var validSegments = this.segments;
+            
+            for (var i = 0, len = validSegments.length; i < len; i++) {
+                if (validSegments[i] === segment) {
+                    return segment;
+                }
+            }
+            
+            return validSegments[0];
+        },
+                init: function(node) {
+            var disabledByCookie = (document.cookie.indexOf('ckns_orb_nopromo=1') > -1),
+                orbFullWidth     = (document.getElementById('orb-aside').offsetWidth >= 1008),
+                that = this;
+            
+            if (window.promomanagerOverride) {
+                for (var p in promomanagerOverride) {
+                    that[p] = promomanagerOverride[p];
+                }
+            }
+                
+            if ( window.orb.fig('uk') && orbFullWidth && !disabledByCookie ) {
+                require(['orb/async/_footerpromo', 'istats-1'], function(promo, istats) {
+                                        var mandolinEndDate = new Date().getTime() + (7 * 60 * 60 * 24) * 1000,
+                        mandolin = new bbc.Mandolin('footer-promo', that.segments, {rate: 0.2, end: mandolinEndDate}),
+                        segmentToRequest = that.validSegment(mandolin.getSegment());
+
+                    that.url = (window.promomanagerOverride || that).makeUrl(segmentToRequest, 'light');
+
+                    if (that.url) { 
+                        promo.load(that.url, node, {
+                                                          onSuccess: function(e) {
+                                istats.addLabels({ 'campaignID': e.campaignID });
+                                if (segmentToRequest === mandolin.getSegment()) {
+                                    istats.addLabels({ 'promo_id_segment': e.campaignID + ':' + mandolin.getSegment() });
+                                }
+                                istats.track('internal', {region: node, linkLocation : 'orb-footer-promo'});
+
+                                istats.log('display', 'orb-footer-promo-displayed', {campaignID : e.campaignID, testVariant: segmentToRequest});
+                                node.className = node.className + ' orb-footer-promo-loaded';
+                                promoManager.promoLoaded = true;
+                                promoManager.event('promo-loaded').fire(e);
+                             },
+                             onError: function() {
+                                istats.log('error', 'orb-footer-promo-failed');
+                                document.cookie = 'ckns_orb_nopromo=1; expires=' + new Date(new Date().getTime() + 1000 * 60 * 10).toGMTString() + ';';
+                             }
+                        });   
+                    }
+                });
+            }
+        }
+    };
+    
+        
+    define('orb/promomanager', ['orb/lib/_event'], function (event) {
+        event.mixin(promoManager);
+        return promoManager;
+    });
+    
+    require(['orb/promomanager'], function (promoManager) {
+        promoManager.init(document.getElementById('orb-footer-promo'));
+    })
+})();
+ </script>   <script type="text/javascript"> if (typeof require !== 'undefined') { require(['istats-1'], function(istats){ istats.track('external', { region: document.getElementsByTagName('body')[0] }); istats.track('download', { region: document.getElementsByTagName('body')[0] }); }); } </script>               <img alt="" id="livestats" src="http://stats.bbc.co.uk/o.gif?~RS~s~RS~News~RS~t~RS~HighWeb_Story~RS~i~RS~33646704~RS~p~RS~99127~RS~a~RS~US~RS~u~RS~/news/world-us-canada-33646704~RS~r~RS~0~RS~q~RS~0~RS~z~RS~8469~RS~">     <script> window.old_onload = window.onload; window.onload = function() { if(window.old_onload) { window.old_onload(); } window.loaded = true; }; </script> <!-- Chartbeat Web Analytics code - start -->
+<script type="text/javascript">
+    var _sf_async_config={};
+    /** CONFIGURATION START **/
+    _sf_async_config.uid = "50924";
+    _sf_async_config.domain = "www.bbc.co.uk";
+    _sf_async_config.sections = "News, News - us-and-canada, News - STY, News - us-and-canada - STY";
+    <!-- if page is an index, add the edition to the path -->
+    _sf_async_config.path = "bbc.co.uk/news/world-us-canada-33646704";
+    (function() {
+        var noCookies = true;
+        var cookiePrefix = '_chartbeat';
+        if ("object" === typeof bbccookies && typeof bbccookies.readPolicy == 'function') {
+            noCookies = !bbccookies.readPolicy().performance;
+        }
+        if (noCookies && document.cookie.indexOf(cookiePrefix) !== -1) {
+            //Find and remove cookies whose names begin with '_chartbeat'
+            var cookieSplit = document.cookie.split(';');
+            var cookieLength = cookieSplit.length;
+            while (cookieLength--) {
+                var cookie = cookieSplit[cookieLength].replace(/^\s+|\s+$/g, '');
+                var cookieName = cookie.split('=')[0];
+
+                if (cookieName.indexOf(cookiePrefix) === 0) {
+                    document.cookie = cookieName + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;';
+                }
+            }
+        }
+        _sf_async_config.noCookies = noCookies;
+    }());
+
+    /** CONFIGURATION END **/
+    (function(){
+        function loadChartbeat() {
+            window._sf_endpt=(new Date()).getTime();
+            var e = document.createElement("script");
+            e.setAttribute("language", "javascript");
+            e.setAttribute("type", "text/javascript");
+            e.setAttribute('src', '//static.chartbeat.com/js/chartbeat.js');
+            document.body.appendChild(e);
+        }
+        var oldonload = window.onload;
+        window.onload = (typeof window.onload != "function") ?
+            loadChartbeat : function() { oldonload(); loadChartbeat(); };
+    }());
+</script>
+<!-- Chartbeat Web Analytics code - end -->
+   <!-- mpulse start -->
+<script>
+    var random = Math.random();
+    var rate   = 1;
+    if (rate && (random < rate)) {
+        var account = (location.host.indexOf('.co.uk') !== -1) ? 'WDD4L-XTNMF-UDE8D-52W9K-N4FX8' : 'X5H9R-GT47V-WJULQ-CWND4-S7WY8';
+        // mpulse vendor code
+        (function(){
+            if(window.BOOMR && window.BOOMR.version){return;}
+            var dom,doc,where,iframe = document.createElement('iframe');
+            iframe.src = "javascript:false";
+            iframe.title = ""; iframe.role="presentation";
+            (iframe.frameElement || iframe).style.cssText = "width:0;height:0;border:0;display:none;";
+            where = document.getElementsByTagName('script')[0];
+            where.parentNode.insertBefore(iframe, where);
+
+            try {
+                doc = iframe.contentWindow.document;
+            } catch(e) {
+                dom = document.domain;
+                iframe.src="javascript:var d=document.open();d.domain='"+dom+"';void(0);";
+                doc = iframe.contentWindow.document;
+            }
+            doc.open()._l = function() {
+                var js = this.createElement("script");
+                if(dom) this.domain = dom;
+                js.id = "boomr-if-as";
+                js.src = '//c.go-mpulse.net/boomerang/' +
+                    account;
+                BOOMR_lstart=new Date().getTime();
+                this.body.appendChild(js);
+            };
+            doc.write('<body onload="document._l();">');
+            doc.close();
+        })();
+        // mpulse vendor code - end
+    }
+</script>
+<!-- mpulse end -->
+   
+
+
+
+
+
+
+
+
+
+</div><script src="http://b.scorecardresearch.com/beacon.js" type="text/javascript" async=""></script><div class="kxhead" data-id="JZTWpGsM" style="display:none !important;"><span class="kxtag kxinvisible" data-id="29292" data-alias="Krux Track Social"><script type="text/javascript">Krux('social.init');</script></span><span class="kxtag kxinvisible" data-id="48940" data-alias="DTC Ad Units on Legacy sites"><script>
+var krrain1 = document.getElementsByTagName('script');
+for(var i = 0; i < krrain1.length; i++) {
+  if(krrain1[i].src.indexOf("doubleclick.net") > 0) {
+   var krrain2 = krrain1[i].src.split("/");
+   if (krrain2[3] != null && krrain2[3] != ""){
+     if (krrain2[3] == "adj"){
+      Krux('set', 'page_attr_adunit1', krrain2[4]);
+      var krrain3 = krrain2[5].split(";");
+      Krux('set', 'page_attr_adunit2', krrain3[0]);
+     }
+     else if (krrain2[4] == "adj") {
+      Krux('set', 'page_attr_adunit1', krrain2[5]);
+      var krrain3 = krrain2[6].split(";");
+      Krux('set', 'page_attr_adunit2', krrain3[0]);
+     }        
+   }
+    break;
+  }
+}
+</script></span><span class="kxtag kxinvisible" data-id="34352" data-alias="DTC v1"><script>
+Krux('scrape', { "page_attr_keywords": {meta_name: "keywords"}});
+Krux('scrape', { 'page_attr_url_path_1': {url_path: '1'}});
+Krux('scrape', { 'page_attr_url_path_2': {url_path: '2'}});
+Krux('scrape', { 'page_attr_url_path_3': {url_path: '3'}});
+Krux('scrape', { 'page_attr_url_path_4': {url_path: '4'}});
+Krux('scrape', { 'page_attr_url_path_5': {url_path: '5'}});
+Krux('set', 'page_attr_sections', typeof window._sf_async_config === 'object' && window._sf_async_config['sections']);
+Krux('set', 'page_attr_title', typeof window._sf_async_config === 'object' && window._sf_async_config['title']);
+Krux('set', 'page_attr_region', typeof window._sf_async_config === 'object' && window._sf_async_config['region']);
+</script></span><span class="kxtag kxinvisible" data-id="44488" data-alias="BBC Meta Description">Krux('scrape', { 'page_attr_description': {meta_name: 'Description'}});</span><span class="kxtag kxinvisible" data-id="43732" data-alias="DTC v2"><script>
+Krux('set', 'page_attr_cb_title', typeof window._sf_async_config === 'object' && window._sf_async_config['title']);
+Krux('set', 'page_attr_cb_path', typeof window._sf_async_config === 'object' && window._sf_async_config['path']);
+
+Krux('scrape', { 'page_attr_google_ad.type': {js_global: "google_ad.type"}});
+Krux('scrape', { 'page_attr_google_ad.bidtype': {js_global: "google_ad.bidtype"}});
+Krux('scrape', { 'page_attr_google_ad.targeting_type': {js_global: "google_ad.targeting_type"}});
+Krux('scrape', { 'page_attr_google_ad.visible_url': {js_global: "google_ad.visible_url"}});
+Krux('scrape', { 'page_attr_scw_account': {js_global: "s_account"}});
+Krux('scrape', { 'page_attr_scw_site_section': {js_global: "scw.prop7"}});
+Krux('scrape', { 'page_attr_scw_ad_enabled': {js_global: "scw.prop57"}});
+Krux('scrape', { 'page_attr_scw_hour': {js_global: "s_hour"}});
+Krux('scrape', { 'page_attr_scw_day': {js_global: "s_day"}});
+Krux('scrape', { 'page_attr_scw_timepart': {js_global: "s_timepart"}});
+
+
+Krux('scrape', { 'page_attr_dart_tag': {dart: "tag"}});
+Krux('scrape', { 'page_attr_dart_page': {dart: "page"}});
+Krux('scrape', { 'page_attr_dart_referrer': {dart: "referrer"}});
+Krux('scrape', { 'page_attr_dart_domain': {dart: "domain"}});
+Krux('scrape', { 'page_attr_dart_headline': {dart: "headline"}});
+Krux('scrape', { 'page_attr_dart_is_sponsor': {dart: "is_sponsor"}});
+Krux('scrape', { 'page_attr_dart_is_mpu': {dart: "is_mpu"}});
+
+Krux('scrape', { 'page_attr_dfpZone': {js_global: "dfpZone"}});
+</script></span><span class="kxtag kxinvisible" data-id="40186" data-alias="BBC News DTC"><script>
+Krux('scrape', { 'page_attr_dart_ctype': {dart: "ctype"}});
+Krux('scrape', { 'page_attr_dart_news': {dart: "news"}});
+for(i=0;i<document.getElementsByTagName('meta').length;i++) {
+  if(document.getElementsByTagName('meta')[i].getAttribute('name') == 'CPS_SECTION_PATH'){
+    var sec_hier = document.getElementsByTagName('meta')[i].getAttribute('content').split('/');
+    Krux('set', 'section', sec_hier[0]);
+    if(sec_hier.length > 1) {
+      Krux('set', 'subsection', sec_hier[1]);
+    }
+  }
+}
+</script></span></div><script src="//static.chartbeat.com/js/chartbeat.js" type="text/javascript" language="javascript"></script><iframe id="iPerceptionsFrame" style="display: none;" src="//universal.iperceptions.com/iFrame.html"></iframe><div id="edr_survey"></div><iframe style="display: none; width: 0px; height: 0px;" name="google_osd_static_frame" id="google_osd_static_frame_5275862176938"></iframe></body></html>


### PR DESCRIPTION
BBC stories on the iPad have lots of scripts mixed in the body element. Some of these are huge and have lots of commas which gives them huge readability scores. Readability should probably just ignore all script tags (or anything with display: none?)