### PR TITLE
Fix package.json's license to be in SPDX format ("Apache-2.0").

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/mozilla/readability"
   },
   "author": "",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/mozilla/readability/issues"
   },


### PR DESCRIPTION
I pulled this repo and run `npm install`. It showed this warning:

> npm WARN package.json readability@0.0.1 license should be a valid SPDX license expression

According to [the SPDX license database](https://spdx.org/licenses/), the Apache 2.0 license is "Apache-2.0".

See: https://docs.npmjs.com/files/package.json#license
