### PR TITLE
set direction to rtl in RTL articles

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1696,6 +1696,15 @@ Readability.prototype = {
     this._flags = this._flags & ~flag;
   },
 
+  _isRtl: function(str){           
+      var ltrChars    = 'A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF'+'\u2C00-\uFB1C\uFDFE-\uFE6F\uFEFD-\uFFFF',
+          rtlChars    = '\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC',
+          rtlDirCheck = new RegExp('^[^'+ltrChars+']*['+rtlChars+']');
+
+      return rtlDirCheck.test(str);
+  },
+  
+
   /**
    * Decides whether or not the document is reader-able without parsing the whole thing.
    *
@@ -1805,6 +1814,9 @@ Readability.prototype = {
       if (paragraphs.length > 0) {
         metadata.excerpt = paragraphs[0].textContent.trim();
       }
+    }
+    if (this._isRtl(articleTitle)){
+      this._articleDir = "rtl";
     }
 
     return { uri: this._uri,


### PR DESCRIPTION
if the article direction is not specified, set it to rtl if the title of the page is written in an RTL language.
