### PR TITLE
Fix bug 1230050 by checking for the 'hid' class specifically, r?MattN

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -110,7 +110,7 @@ Readability.prototype = {
     unlikelyCandidates: /banner|combx|comment|community|disqus|extra|foot|header|menu|related|remark|rss|share|shoutbox|sidebar|skyscraper|sponsor|ad-break|agegate|pagination|pager|popup/i,
     okMaybeItsACandidate: /and|article|body|column|main|shadow/i,
     positive: /article|body|content|entry|hentry|main|page|pagination|post|text|blog|story/i,
-    negative: /hidden|banner|combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|tool|widget/i,
+    negative: /hidden|^hid$| hid$| hid |^hid |banner|combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|tool|widget/i,
     extraneous: /print|archive|comment|discuss|e[\-]?mail|share|reply|all|login|sign|single|utility/i,
     byline: /byline|author|dateline|writtenby/i,
     replaceFonts: /<(\/?)font[^>]*>/gi,


### PR DESCRIPTION
Matt ( @mnoorenberghe ), does this look right to you? I realize I could use nested `(?: |$)` but that seemed likely to be slower and harder to grok than just this...

The reason that we don't detect this is that we don't use the visibility helper for `parse`, it seems... only for `isProbablyReaderable`. We can fix that separately.