### PR TITLE
Fix #280 and #271 by being more careful about how we iterate over node lists in case they're live

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -155,7 +155,15 @@ Readability.prototype = {
    * @return void
    */
   _forEachNode: function(nodeList, fn) {
-    return Array.prototype.forEach.call(nodeList, fn, this);
+    var i = 0;
+    while (nodeList[i]) {
+      var el = nodeList[i];
+      fn.call(this, el, i, nodeList);
+      // Only increment i if the element is still in the list:
+      if (nodeList[i] == el) {
+        i++
+      }
+    }
   },
 
   /**


### PR DESCRIPTION
This is a plain JS fix without copying arrays. The performance aspects of this in the JSDOM/JSDOMParser case are fine, at least.

However... for those of us on iOS or other consumers that use a "real" DOM implementation, I actually suspect that creating a 'real' Array copy of the list might be better - there's good evidence that iterating over live NodeLists is very slow, because they have to be updated every time someone touches the DOM.

So we can take this, and it will be fine for iOS and Android... but I wonder if we should instead just check whether:

```
Array.isArray(nodeList)
```
and if not, use `Array.from` to create one. Then we always have a static array, and can just use `arrayInstance.forEach` directly.

It's not possible for me to benchmark this easily with representative examples on iOS / a "real" DOM implementation.

@leibovic, @st3fan, what do you think and/or can you help with the benchmark problem? :-)