### PR TITLE
exposed textContent to be returned

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1831,6 +1831,7 @@ Readability.prototype = {
              dir: this._articleDir,
              content: articleContent.innerHTML,
              length: articleContent.textContent.length,
+             textContent: articleContent.textContent,
              excerpt: metadata.excerpt };
   }
 };


### PR DESCRIPTION
this returns the text content only, this is useful as it allows the content to be easily accessible