### PR TITLE
Support boolean attributes (closes #55)

### DIFF
--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -888,28 +888,29 @@
      */
     readAttribute: function (node) {
       var name = "";
-
-      var n = this.html.indexOf("=", this.currentChar);
-      if (n === -1) {
-        this.currentChar = this.html.length;
-      } else {
-        // Read until a '=' character is hit; this will be the attribute key
-        name = this.html.substring(this.currentChar, n);
-        this.currentChar = n + 1;
+      var c;
+      while((c = this.nextChar()) && /[\w-]/i.test(c)) {
+        name += c;
       }
 
       if (!name)
         return;
 
-      // After a '=', we should see a '"' for the attribute value
-      var c = this.nextChar();
-      if (c !== '"' && c !== "'") {
-        this.error("Error reading attribute " + name + ", expecting '\"'");
-        return;
-      }
+      var value;
+      if(c === "=") {
+        // After a '=', we should see a '"' for the attribute value
+        c = this.nextChar();
+        if (c !== '"' && c !== "'") {
+          this.error("Error reading attribute " + name + ", expecting '\"'");
+          return;
+        }
 
-      // Read the attribute value (and consume the matching quote)
-      var value = this.readString(c);
+        // Read the attribute value (and consume the matching quote)
+        value = this.readString(c);
+      } else {
+        value = "";
+        this.currentChar--;
+      }
 
       node.attributes.push(new Attribute(name, value));
 

--- a/test/test-jsdomparser.js
+++ b/test/test-jsdomparser.js
@@ -10,7 +10,7 @@ var JSDOMParser = readability.JSDOMParser;
 
 var BASETESTCASE = '<html><body><p>Some text and <a class="someclass" href="#">a link</a></p>' +
                    '<div id="foo">With a <script>With < fancy " characters in it because' +
-                   '</script> that is fun.<span>And another node to make it harder</span></div><form><input type="text"/><input type="number"/>Here\'s a form</form></body></html>';
+                   '</script> that is fun.<span>And another node to make it harder</span></div><form method="GET" novalidate><input type="text"/><input disabled type="number" readonly/>Here\'s a form</form></body></html>';
 
 var baseDoc = new JSDOMParser().parse(BASETESTCASE);
 
@@ -110,6 +110,11 @@ describe("Test JSDOM functionality", function() {
     expect(link.getAttribute("class")).eql(link.className);
     var foo = baseDoc.getElementById("foo");
     expect(foo.id).eql(foo.getAttribute("id"));
+    var form = baseDoc.getElementsByTagName('form')[0];
+    expect(form.getAttribute("novalidate")).eql("");
+    var input = baseDoc.getElementsByTagName("input")[1];
+    expect(input.getAttribute("readonly")).eql("");
+    expect(input.getAttribute("disabled")).eql("");
   });
 
   it("should have a working replaceChild", function() {


### PR DESCRIPTION
Hello, the purpose is clear. Now parsing crashes if HTML has any boolean attribute. And it's very bad because you use JSDOMParser in `generate-testcase` script.