### PR TITLE
Use jsdom for parsing the document to determine readability (fixes #325)

### DIFF
--- a/test/generate-testcase.js
+++ b/test/generate-testcase.js
@@ -111,8 +111,21 @@ function runReadability(source, destPath, metadataDestPath) {
   var myReader, result, readerable;
   try {
     myReader = new Readability(uri, doc);
-    readerable = myReader.isProbablyReaderable();
     result = myReader.parse();
+  } catch (ex) {
+    console.error(ex);
+    ex.stack.forEach(console.log.bind(console));
+  }
+  // Use jsdom for isProbablyReaderable because it supports querySelectorAll
+  try {
+    var jsdomDoc = jsdom(source, {
+      features: {
+        FetchExternalResources: false,
+        ProcessExternalResources: false
+      }
+    });
+    myReader = new Readability(uri, jsdomDoc);
+    readerable = myReader.isProbablyReaderable();
   } catch (ex) {
     console.error(ex);
     ex.stack.forEach(console.log.bind(console));

--- a/test/test-pages/blogger/expected-metadata.json
+++ b/test/test-pages/blogger/expected-metadata.json
@@ -1,6 +1,7 @@
 {
   "title": "Open Verilog flow for Silego GreenPak4 programmable logic devices",
   "byline": null,
+  "dir": "ltr",
   "excerpt": "I've written a couple of posts in the past few months but they were all for",
   "readerable": true
 }


### PR DESCRIPTION
This is a leftover from #310, where we changed `isProbablyReaderable` to check for `<br>` tags. That check only works with jsdom documents because JSDOMParser does not support `querySelectorAll`. This is OK in production because we use real DOMs to check `isProbablyReaderable`. Unfortunately we forgot to update `generate-testcase.js`, so now it produces the wrong output.

@evanxd, does this look OK?

CC @Archaeopteryx