### PR TITLE
CommonJS support: set `module.exports = Readability`

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1904,3 +1904,7 @@ Readability.prototype = {
     };
   }
 };
+
+if (typeof module === 'object') {
+  module.exports = Readability;
+}


### PR DESCRIPTION
This seems all that is needed to get this library working with e.g. browserify (useful for browser extensions). Also the workaround in `index.js` would not be necessary if the object is exported this way.

Is there a reason why the object is not exported like so?