### PR TITLE
Fixes #232 - Stack Exchange pages seem to show only the question or on e answer in Reader View

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -887,7 +887,7 @@ Readability.prototype = {
         // and whose scores are quite closed with current `topCandidate` node.
         var alternativeCandidateAncestors = [];
         for (var i = 1; i < topCandidates.length; i++) {
-          if (topCandidates[i].readability.contentScore / topCandidate.readability.contentScore >= 0.75) {
+          if (topCandidates[i].readability.contentScore / topCandidate.readability.contentScore >= 0.4) {
             alternativeCandidateAncestors.push(this._getNodeAncestors(topCandidates[i]));
           }
         }

--- a/test/test-pages/stack-exchange/expected-metadata.json
+++ b/test/test-pages/stack-exchange/expected-metadata.json
@@ -1,0 +1,7 @@
+{
+  "title": "single word requests - A hypernym for 'insects', 'worms' and the like",
+  "byline": null,
+  "dir": null,
+  "excerpt": "From Oxford:\n\ninsect:\n  any small creature with six legs and a body divided into three parts. Insects usually also have wings. Ants, bees and flies are all insects\n  \n  Insect is often used to ref...",
+  "readerable": true
+}

--- a/test/test-pages/stack-exchange/expected.html
+++ b/test/test-pages/stack-exchange/expected.html
@@ -1,0 +1,609 @@
+<div id="readability-page-1" class="page">
+    <div id="mainbar">
+        <div class="question" data-questionid="250245" id="question">
+            <table>
+                <tbody>
+                    <tr>
+                        <td class="votecell">
+                        </td>
+                        <td class="postcell">
+                            <div>
+                                <div class="post-text" itemprop="text">
+
+                                    <p>From Oxford:</p>
+
+                                    <p><strong><a href="http://www.oxforddictionaries.com/definition/learner/insect">insect</a></strong>:</p>
+
+                                    <blockquote>
+                                        <p>any small creature with six legs and a body divided into three parts. Insects usually also have wings. Ants, bees and flies are all insects</p>
+
+                                        <p>Insect is often used to refer to other small creatures, for example spiders, although this is not correct scientific language.</p>
+                                    </blockquote>
+
+                                    <p><strong><a href="http://www.oxforddictionaries.com/definition/learner/worm">worm</a></strong>:</p>
+
+                                    <blockquote>
+                                        <ol>
+                                            <li>
+                                                <p>a long thin creature with no bones or legs, that lives in soil</p>
+                                            </li>
+                                            <li>
+                                                <p>long thin creatures that live inside the bodies of humans or animals and can cause illness</p>
+                                            </li>
+                                            <li>
+                                                <p>the young form of an insect when it looks like a short worm</p>
+                                            </li>
+                                        </ol>
+                                    </blockquote>
+
+                                    <p>I find both these definitions oddly restrictive. Insects have 6 legs and worms (in the primary sense) have none. The other senses of worm are also specific. There are many small creatures who do not fall into these categories. Centipedes definity have legs, and a lot more than six. Is there a common (not too scientific) word to refer to all small creatures?</p>
+
+                                    <hr/>
+
+                                    <p>A <strong><a href="http://www.oxforddictionaries.com/definition/english/bug">bug</a></strong> doesn't work, as is defined as</p>
+
+                                    <blockquote>
+                                        <p><em>chiefly North American</em> A small <strong>insect</strong>:</p>
+
+                                        <p><em>a thick green scum which crawls with bugs, centipedes, and worse</em></p>
+                                    </blockquote>
+
+                                    <p>Insect, not creature, not worm. Also note the exclusion of centipedes from the umbrella of bugs. In fact, Oxford defines <a href="http://www.oxforddictionaries.com/definition/english/centipede">centipedes</a> exclusively in scientific terms.</p>
+
+                                    <blockquote>
+                                        <p>A <strong>predatory myriapod invertebrate</strong> with a flattened elongated body composed of many segments. Most segments bear a single pair of legs, the front pair being modified as poison fangs.</p>
+                                    </blockquote>
+
+                                    <p>Although Oxford <a href="http://www.oxforddictionaries.com/definition/english/insect">here</a> lists an informal sense of insect:</p>
+
+                                    <blockquote>
+                                        <p><em>informal</em> Any small invertebrate animal such as a spider or tick.</p>
+                                    </blockquote>
+
+                                    <p>It curiously drops this definition in the advanced learners' version. Moreover, it's reluctant to use the term in its own definition of <a href="http://www.oxforddictionaries.com/definition/english/spider">spider</a>:</p>
+
+                                    <blockquote>
+                                        <p>An eight-legged <strong>predatory arachnid</strong> with an unsegmented body consisting of a fused head and thorax and a rounded abdomen. Spiders have fangs which inject poison into their prey, and most kinds spin webs in which to capture insects.</p>
+                                    </blockquote>
+
+                                    <hr/>
+
+                                    <p><strong>Questions:</strong></p>
+
+                                    <ul>
+                                        <li>
+                                            <p>Is there any word, preferably not too informal, which would include all small creatures like insects, worms, spiders and centipedes; without having to resort to biological jargon? </p>
+                                        </li>
+                                        <li>
+                                            <p>Also, how right/wrong is it to use <code>insect</code> or <code>bug</code> for this purpose?</p>
+                                        </li>
+                                    </ul>
+                                </div>
+
+
+                            </div>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td class="votecell"></td>
+                        <td>
+
+
+
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div id="answers">
+
+            <a name="tab-top"></a>
+
+
+
+
+
+            <a name="250251"></a>
+            <div id="answer-250251" class="answer accepted-answer" data-answerid="250251" itemscope="" itemtype="http://schema.org/Answer" itemprop="acceptedAnswer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p>Small children are easily interested in small creatures and, unsurprisingly, primary schools in Britain find the study of such animals a good starting point for much of the curriculum. However, it is was thought that calling them "creepy-crawlies" would risk alienating pupils and trigger the fear and distaste which was common in their grandparents' day.</p>
+
+                                    <p>So the term for these small creatures most often used in British Primary Education is <strong><a href="http://en.wiktionary.org/wiki/minibeast#English">minibeasts</a></strong> For a general view of UK minibeast history <a href="http://en.wikipedia.org/wiki/Minibeast">see this wikipedia article</a>.</p>
+
+                                    <blockquote>
+                                        <p>"Minibeast" or "Minibeasts" is a term for <strong>a variety of arthropods and other invertebrates</strong>, including spiders, ants, butterflies, bees, wasps, flies, woodlice <a href="http://en.wiktionary.org/wiki/minibeast#English">1</a>, and many others.</p>
+                                    </blockquote>
+                                </div>
+
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250247"></a>
+            <div id="answer-250247" class="answer" data-answerid="250247" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p><a href="http://www.oxforddictionaries.com/definition/english/creepy-crawly"><em>Creepy-crawlies</em></a>.</p>
+
+                                    <blockquote>
+                                        <p>informal<br/> A spider, worm, or other small flightless creature, especially when considered unpleasant or frightening:</p>
+                                    </blockquote>
+
+                                    <p>^ Covers all three cases.</p>
+
+                                    <hr/>
+
+                                    <p>Also, despite your dictionary defining "bug" as an insect specifically, i wouldn't balk at using it to describe worms or spiders as well.</p>
+                                </div>
+
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250404"></a>
+            <div id="answer-250404" class="answer" data-answerid="250404" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p><strong>Bug</strong> is certainly what I would use, and what I would expect those around me to use. And I am American, so I think Oxford is simply wrong about how we use the word. Merriam-Webster, for instance, gives <a href="http://www.merriam-webster.com/dictionary/bug">the principal definition of bug</a> as</p>
+
+                                    <blockquote>
+                                        <p>1 a : an insect or other creeping or crawling invertebrate (as a spider or centipede)</p>
+                                    </blockquote>
+
+                                    <p>This matches your desired usage perfectly. Note the near-reference to Scimonster’s suggestion of <em>creepy-crawlies</em> – Merriam-Webster here makes it pretty clear that <em>bug</em> is used as a more-formal <em>creepy-crawly</em>.</p>
+
+                                    <p>That said, if we are being truly formal (read: technical), the third definition is the “formal” one:</p>
+
+                                    <blockquote>
+                                        <p>1 c : any of an order (<em>Hemiptera</em> and especially its suborder <em>Heteroptera</em>) of insects that have sucking mouthparts, forewings thickened at the base, and incomplete metamorphosis and are often economic pests —called also <em>true bug</em></p>
+                                    </blockquote>
+
+                                    <p>This fact is, however, outside entomology, not widely known, and would be regarded by most as trivia. By comparison, the specifics of <em>insect</em> are much more widely known, though I’d guess the majority of speakers are unlikely to care very much in practice – just because someone knows, or at least at one point learned, that insects have three body parts, six legs, etc., doesn’t mean they care to use the word so exactly. But many more know/care about <em>insect</em>’s specific definition than do about <em>bug</em>, as indicated by the fact that some entomologists have resorted to the phrase <em>true bug</em> for <em>Heteroptera</em>. Thus bug is very much my recommendation.</p>
+                                </div>
+
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250250"></a>
+            <div id="answer-250250" class="answer" data-answerid="250250" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p>If you're looking for a negative sense, you might use "vermin" -- small, swarming, repulsive, potentially-disease-bearing creatures.</p>
+
+                                    <p>It's a very unscientific term, including rats, frogs, toads, centipedes, and millipedes, as well as insects and most types of worms (except earthworms and redworms, which are good for the soil). Depending on your sensibilities, it might also include mice, spiders, ants, and termites; it might even encompass scorpions and lizards, and maybe even lobsters.</p>
+                                </div>
+
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250285"></a>
+            <div id="answer-250285" class="answer" data-answerid="250285" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <blockquote>
+                                        <p>preferably not too informal</p>
+                                    </blockquote>
+
+                                    <p>This is the most formal one: they are all <a href="https://en.wikipedia.org/wiki/Invertebrate" rel="nofollow">invertebrates</a>. </p>
+
+                                    <blockquote>
+                                        <p>Invertebrates are animals that neither possess nor develop a vertebral column, derived from the notochord. This includes all animals apart from the subphylum Vertebrata. Familiar examples of invertebrates include <strong>insects</strong>, crabs, lobsters and their kin, snails, clams, octopuses and their kin, starfish, sea-urchins and their kin, and <strong>worms</strong>.</p>
+                                    </blockquote>
+
+                                    <p>But the usage depends on the context.</p>
+
+                                    <p>If your text is somehow related to science, don't call spider an "insect". Spiders &amp; insects are <a href="https://en.wikipedia.org/wiki/Arthropod" rel="nofollow">"arthropods"</a> (not "arthropod<strong>e</strong>s"), together with worms they are "invertebrates".</p>
+                                </div>
+
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250265"></a>
+            <div id="answer-250265" class="answer" data-answerid="250265" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p>"Vermin" or "pests" can be any small creature, usually with a negative connotation, but including things as large as rats or even opossums. "Creepy-crawlies" is good but very informal. But as for "bug" -- scientifically, only a small subset of insects are bugs. But the word has expanded, and can now also mean an infection, or a computer glitch. I would argue that as long as the context doesn't imply you mean only insects, "bug" isn't actually wrong in informal English.</p>
+
+                                    <p>(Scientifically, both worms and insects are invertebrates -- creatures without an internal spine -- which then includes spiders and even coral.)</p>
+                                </div>
+                                <table class="fw">
+                                    <tbody>
+                                        <tr>
+                                            <td class="vt">
+
+                                            </td>
+
+
+
+                                            <td class="post-signature" align="right">
+
+
+                                                <div class="user-info ">
+                                                    <p class="user-action-time">
+                                                        answered <span title="2015-06-03 20:58:44Z" class="relativetime">Jun 3 '15 at 20:58</span>
+                                                    </p>
+                                                    <div class="user-gravatar32">
+                                                        <a href="http://fakehost/users/113411/vynce">
+                                                            <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/6cb16a7a9af0cfbe5ad85848024b4cfa?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                        </a>
+                                                    </div>
+
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250281"></a>
+            <div id="answer-250281" class="answer" data-answerid="250281" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p><strong><a href="http://en.wikipedia.org/wiki/Minibeast" rel="nofollow">Minibeast</a></strong> - this term is commonly used (at least in the UK) by charities and other groups which involve children in outdoor activities learning about nature. See also Cbeebies <a href="http://www.bbc.co.uk/cbeebies/shows/mini-beast-adventure-with-jess" rel="nofollow"><em>Minibeasts with Jess</em></a></p>
+
+                                    <p>The UK organisation <a href="https://www.buglife.org.uk/bugs-and-habitats/all-about-bugs" rel="nofollow">Buglife</a> works to protect ALL invertebrates regardless of size or number of legs, and uses the term <em>bug</em> to encompass all of these.</p>
+
+                                    <blockquote>
+                                        <p>Invertebrates are animals without backbones and make up the great majority of animal life, with 40,000 species in Britain alone and many millions on Earth.</p>
+                                    </blockquote>
+                                </div>
+                                <table class="fw">
+                                    <tbody>
+                                        <tr>
+                                            <td class="vt">
+
+                                            </td>
+
+
+
+                                            <td class="post-signature" align="right">
+
+
+                                                <div class="user-info ">
+                                                    <p class="user-action-time">
+                                                        answered <span title="2015-06-03 23:19:53Z" class="relativetime">Jun 3 '15 at 23:19</span>
+                                                    </p>
+                                                    <div class="user-gravatar32">
+                                                        <a href="http://fakehost/users/33153/mynamite">
+                                                            <div class="gravatar-wrapper-32"><img src="https://i.stack.imgur.com/6uP5m.jpg?s=32&amp;g=1" alt="" height="32" width="32" /></div>
+                                                        </a>
+                                                    </div>
+
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250602"></a>
+            <div id="answer-250602" class="answer" data-answerid="250602" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p>I would say that in the Swedish language the word "kryp" have this meaning. Small creatures that is not built like us mammals, birds and fish. Non vegetable things that move around, but do not have a skeleton. (Or we just can't tell.)</p>
+
+                                    <p>A direct translation to English would be "crawl". But "crawlers" would perhaps correspond more closely to how it is perceived. Yes, it comes from the verb crawl, even if many of them can jump, fly and swim. But it is usually when they crawl on our bodies we notice them.</p>
+
+                                    <p>The word often have a negative association to it, but not necessary.</p>
+                                </div>
+                                <table class="fw">
+                                    <tbody>
+                                        <tr>
+                                            <td class="vt">
+
+                                            </td>
+
+
+
+                                            <td class="post-signature" align="right">
+
+
+                                                <div class="user-info ">
+                                                    <p class="user-action-time">
+                                                        answered <span title="2015-06-05 13:06:44Z" class="relativetime">Jun 5 '15 at 13:06</span>
+                                                    </p>
+                                                    <div class="user-gravatar32">
+                                                        <a href="http://fakehost/users/124155/henriko">
+                                                            <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/004664ea648043a0be46ae6830aabbbf?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                        </a>
+                                                    </div>
+
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250344"></a>
+            <div id="answer-250344" class="answer" data-answerid="250344" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p>In french, it is common to see products to kill calling them <em>"<strong>indésirables</strong>"</em> or <em>"<strong>nuisibles</strong>"</em>.</p>
+
+                                    <p>You can translate to get :</p>
+
+                                    <blockquote>
+                                        <p><strong>undesirable</strong>, unwanted, unwelcome, <strong>pest</strong></p>
+                                    </blockquote>
+                                </div>
+
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+            <a name="250846"></a>
+            <div id="answer-250846" class="answer" data-answerid="250846" itemscope="" itemtype="http://schema.org/Answer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td class="votecell">
+
+
+
+
+                            </td>
+
+
+
+                            <td class="answercell">
+                                <div class="post-text" itemprop="text">
+                                    <p><strong>Wug</strong> is a portmanteau of <em>worm</em> and <em>bug</em>. It's not very common though, and might need to be explained.</p>
+
+                                    <p>A Google search for <a href="https://www.google.co.il/webhp?sourceid=chrome-instant&amp;ion=1&amp;espv=2&amp;es_th=1&amp;ie=UTF-8#q=wug%20worm%20bug" rel="nofollow"><code>wug worm bug</code></a> reveals hundreds of results, many from books on taxonomy. I couldn't just search for <code>wug</code> because it has other meanings as well.</p>
+
+                                    <p>This is either very informal or very formal -- i can't quite tell. :P</p>
+                                </div>
+
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td class="votecell"></td>
+                            <td>
+
+
+
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <a name="new-answer"></a>
+
+
+
+
+            <h2 class="bottom-notice" data-loc="1">
+                Not the answer you're looking for? Browse other questions tagged <a href="http://fakehost/questions/tagged/single-word-requests" class="post-tag" title="show questions tagged 'single-word-requests'" rel="tag">single-word-requests</a> <a href="http://fakehost/questions/tagged/hypernyms" class="post-tag" title="show questions tagged 'hypernyms'" rel="tag">hypernyms</a> <a href="http://fakehost/questions/tagged/nuance" class="post-tag" title="show questions tagged 'nuance'" rel="tag">nuance</a> or <a href="http://fakehost/questions/ask">ask your own question</a>. </h2>
+        </div>
+    </div>
+</div>

--- a/test/test-pages/stack-exchange/source.html
+++ b/test/test-pages/stack-exchange/source.html
@@ -1,0 +1,3398 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" itemscope="" itemtype="http://schema.org/QAPage">
+
+<head>
+
+    <title>single word requests - A hypernym for 'insects', 'worms' and the like - English Language &amp; Usage Stack Exchange</title>
+    <link rel="shortcut icon" href="https://cdn.sstatic.net/Sites/english/img/favicon.ico?v=cafbfc112fb2" />
+    <link rel="apple-touch-icon image_src" href="https://cdn.sstatic.net/Sites/english/img/apple-touch-icon.png?v=5979aff4e7a9" />
+    <link rel="search" type="application/opensearchdescription+xml" title="English Language &amp; Usage Stack Exchange" href="/opensearch.xml" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@StackEnglish" />
+    <meta name="twitter:domain" content="english.stackexchange.com" />
+    <meta property="og:type" content="website" />
+
+    <meta property="og:image" itemprop="image primaryImageOfPage" content="https://cdn.sstatic.net/Sites/english/img/apple-touch-icon@2.png?v=5bebfd2a0d06" />
+    <meta name="twitter:title" property="og:title" itemprop="title name" content="A hypernym for 'insects', 'worms' and the like" />
+    <meta name="twitter:description" property="og:description" itemprop="description" content="From Oxford:
+
+insect:
+  any small creature with six legs and a body divided into three parts. Insects usually also have wings. Ants, bees and flies are all insects
+  
+  Insect is often used to ref..." />
+    <meta property="og:url" content="http://english.stackexchange.com/questions/250245/a-hypernym-for-insects-worms-and-the-like" />
+    <link rel="canonical" href="http://english.stackexchange.com/questions/250245/a-hypernym-for-insects-worms-and-the-like" />
+
+
+
+    <script src="http://rules.quantcount.com/rules-p-c1rF4kxgLUzNc.js"></script>
+    <script async="" src="http://edge.quantserve.com/quant.js"></script>
+    <script async="" src="http://b.scorecardresearch.com/beacon.js"></script>
+    <script async="" src="https://www.google-analytics.com/analytics.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="https://cdn.sstatic.net/Js/stub.en.js?v=01d9387a67d6"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.sstatic.net/Sites/english/all.css?v=0adb0de0530e" />
+
+    <link rel="alternate" type="application/atom+xml" title="Feed for question 'A hypernym for 'insects', 'worms' and the like'" href="/feeds/question/250245" />
+    <meta name="twitter:app:country" content="US" />
+    <meta name="twitter:app:name:iphone" content="Stack Exchange iOS" />
+    <meta name="twitter:app:id:iphone" content="871299723" />
+    <meta name="twitter:app:url:iphone" content="se-zaphod://english.stackexchange.com/questions/250245/a-hypernym-for-insects-worms-and-the-like" />
+    <meta name="twitter:app:name:ipad" content="Stack Exchange iOS" />
+    <meta name="twitter:app:id:ipad" content="871299723" />
+    <meta name="twitter:app:url:ipad" content="se-zaphod://english.stackexchange.com/questions/250245/a-hypernym-for-insects-worms-and-the-like" />
+    <meta name="twitter:app:name:googleplay" content="Stack Exchange Android" />
+    <meta name="twitter:app:url:googleplay" content="http://english.stackexchange.com/questions/250245/a-hypernym-for-insects-worms-and-the-like" />
+    <meta name="twitter:app:id:googleplay" content="com.stackexchange.marvin" />
+    <script>
+        StackExchange.ready(function() {
+
+            StackExchange.using("postValidation", function() {
+                StackExchange.postValidation.initOnBlurAndSubmit($('#post-form'), 2, 'answer');
+            });
+
+
+            StackExchange.question.init({
+                showAnswerHelp: true,
+                totalCommentCount: 14,
+                shownCommentCount: 5,
+                highlightColor: '#F4A83D',
+                backgroundColor: '#FFF',
+                questionId: 250245
+            });
+
+            styleCode();
+
+            StackExchange.realtime.subscribeToQuestion('97', '250245');
+            StackExchange.using("gps", function() {
+                StackExchange.gps.trackOutboundClicks('#content', '.post-text', false);
+            });
+
+        });
+    </script>
+
+
+    <script>
+        StackExchange.ready(function() {
+            StackExchange.realtime.init('wss://qa.sockets.stackexchange.com,ws://qa.sockets.stackexchange.com');
+            StackExchange.realtime.subscribeToReputationNotifications('97');
+            StackExchange.realtime.subscribeToTopBarNotifications('97');
+        });
+    </script>
+    <script>
+        StackExchange.init({
+            "locale": "en",
+            "stackAuthUrl": "https://stackauth.com",
+            "networkMetaHostname": "meta.stackexchange.com",
+            "serverTime": 1488967137,
+            "routeName": "Questions/Show",
+            "site": {
+                "name": "English Language &amp; Usage Stack Exchange",
+                "description": "Q&amp;A for linguists, etymologists, and serious English language enthusiasts",
+                "isNoticesTabEnabled": true,
+                "recaptchaPublicKey": "6LdsB7sSAAAAAAzjgEF_Hd8vXv-C42sa_KyofaGR",
+                "recaptchaAudioLang": "en",
+                "enableNewTagCreationWarning": true,
+                "insertSpaceAfterNameTabCompletion": false,
+                "id": 97,
+                "enableInsertDocLinkDialog": false,
+                "enableSocialMediaInSharePopup": true,
+                "protocol": "http"
+            },
+            "user": {
+                "fkey": "bb931690941949cbbfdc4a6f840da0f8",
+                "rep": 0,
+                "isAnonymous": true,
+                "isAnonymousNetworkWide": true,
+                "ab": {
+                    "question_show_tweaks": {
+                        "v": "altern_unansw_cta",
+                        "g": 2
+                    }
+                }
+            },
+            "realtime": {
+                "newest": true,
+                "active": true,
+                "tagged": true,
+                "staleDisconnectIntervalInHours": 0,
+                "workerIframeDomain": "https://cdn.sstatic.net"
+            },
+            "events": {
+                "postType": {
+                    "question": 1
+                },
+                "postEditionSection": {
+                    "title": 1,
+                    "body": 2,
+                    "tags": 3
+                }
+            },
+            "story": {
+                "minCompleteBodyLength": 75
+            }
+        }, {
+            "site": {
+                "allowImageUploads": true,
+                "enableUserHovercards": true,
+                "enableImgurHttps": true,
+                "forceHttpsImages": true
+            },
+            "comments": {},
+            "userProfile": {},
+            "tags": {},
+            "accounts": {
+                "currentPasswordRequiredForChangingStackIdPassword": true
+            },
+            "flags": {
+                "allowRetractingFlags": true
+            },
+            "analytics": {
+                "clientTimingsAbsoluteTimeout": 30000,
+                "clientTimingsDebounceTimeout": 1000
+            },
+            "snippets": {
+                "renderDomain": "stacksnippets.net"
+            },
+            "markdown": {
+                "asteriskIntraWordEmphasis": true
+            }
+        });
+        StackExchange.using.setCacheBreakers({
+            "js/prettify-full.en.js": "848c5965d3e6",
+            "js/moderator.en.js": "807bb02152f9",
+            "js/full-anon.en.js": "04758254b3b5",
+            "js/full.en.js": "90435d2ca815",
+            "js/wmd.en.js": "4c05bcf337d1",
+            "js/third-party/jquery.autocomplete.min.js": "d3b8fa7fdf74",
+            "js/third-party/jquery.autocomplete.min.en.js": "",
+            "js/mobile.en.js": "c37948fe0a99",
+            "js/help.en.js": "118cb359bcc6",
+            "js/tageditor.en.js": "248fce004255",
+            "js/tageditornew.en.js": "253eeb7b3008",
+            "js/inline-tag-editing.en.js": "e445e14be978",
+            "js/revisions.en.js": "8f22ba768cac",
+            "js/review.en.js": "7884923db2c6",
+            "js/tagsuggestions.en.js": "ddb0e41afe26",
+            "js/post-validation.en.js": "fce27e94a6e2",
+            "js/explore-qlist.en.js": "e71f14781288",
+            "js/events.en.js": "3ca3f038145b",
+            "js/keyboard-shortcuts.en.js": "c07f3b7e8f50",
+            "js/external-editor.en.js": "8d2d531d73f0",
+            "js/adops.en.js": "9a6a7812a212"
+        });
+        StackExchange.using("gps", function() {
+            StackExchange.gps.init(true);
+        });
+    </script>
+
+    <script>
+        StackExchange.ready(function() {
+            $('#nav-tour').click(function() {
+                StackExchange.using("gps", function() {
+                    StackExchange.gps.track("aboutpage.click", {
+                        aboutclick_location: "headermain"
+                    }, true);
+                });
+            });
+        });
+    </script>
+    <script async="" src="https://cdn.sstatic.net/Js/full-anon.en.js?v=04758254b3b5"></script>
+    <script async="" src="https://cdn.sstatic.net/Js/post-validation.en.js?v=fce27e94a6e2"></script>
+    <script async="" src="https://cdn.sstatic.net/Js/external-editor.en.js?v=8d2d531d73f0"></script>
+</head>
+
+<body class="question-page new-topbar">
+    <noscript>&lt;div id="noscript-padding"&gt;&lt;/div&gt;</noscript>
+
+    <div id="notify-container"></div>
+    <div id="custom-header"></div>
+
+
+
+
+
+    <div class="topbar">
+        <div class="topbar-wrapper">
+
+            <div class="js-topbar-dialog-corral">
+
+
+                <div class="topbar-dialog siteSwitcher-dialog dno">
+                    <div class="header">
+                        <h3><a href="http://english.stackexchange.com">current community</a>
+                        </h3>
+                    </div>
+                    <div class="modal-content current-site-container">
+                        <ul class="current-site">
+                            <li>
+                                <div class="related-links">
+                                    <a href="http://chat.stackexchange.com?tab=site&amp;host=english.stackexchange.com" class="js-gps-track" data-gps-track="site_switcher.click({ item_type:6 })">chat</a>
+                                </div>
+
+                                <a href="http://english.stackexchange.com" class="current-site-link site-link js-gps-track" data-id="97" data-gps-track="site_switcher.click({ item_type:3 })">
+                                    <div class="site-icon favicon favicon-english" title="English Language &amp; Usage"></div>
+                                    English Language &amp; Usage
+                                </a>
+
+                            </li>
+                            <li class="related-site">
+                                <div class="L-shaped-icon-container">
+                                    <span class="L-shaped-icon"></span>
+                                </div>
+
+
+                                <a href="http://meta.english.stackexchange.com" class="site-link js-gps-track" data-id="99" data-gps-track="site.switch({ target_site:99, item_type:3 }),site_switcher.click({ item_type:4 })">
+                                    <div class="site-icon favicon favicon-englishmeta" title="English Language &amp; Usage Meta"></div>
+                                    English Language &amp; Usage Meta
+                                </a>
+
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div class="header" id="your-communities-header">
+                        <h3>
+                            your communities </h3>
+
+                    </div>
+                    <div class="modal-content" id="your-communities-section">
+
+                        <div class="call-to-login">
+                            <a href="https://english.stackexchange.com/users/signup?ssrc=site_switcher&amp;returnurl=http%3a%2f%2fenglish.stackexchange.com%2fquestions%2f250245%2fa-hypernym-for-insects-worms-and-the-like" class="login-link js-gps-track" data-gps-track="site_switcher.click({ item_type:10 })">Sign up</a> or <a href="https://english.stackexchange.com/users/login?ssrc=site_switcher&amp;returnurl=http%3a%2f%2fenglish.stackexchange.com%2fquestions%2f250245%2fa-hypernym-for-insects-worms-and-the-like" class="login-link js-gps-track" data-gps-track="site_switcher.click({ item_type:11 })">log in</a> to customize your list.
+                        </div>
+                    </div>
+
+                    <div class="header">
+                        <h3><a href="http://stackexchange.com/sites">more stack exchange communities</a>
+                        </h3>
+                        <a href="http://stackoverflow.blog" class="fr">company blog</a>
+                    </div>
+                    <div class="modal-content">
+                        <div class="child-content"></div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="network-items">
+                <a href="http://stackexchange.com" class="topbar-icon icon-site-switcher yes-hover js-site-switcher-button js-gps-track" data-gps-track="site_switcher.show" title="A list of all 166 Stack Exchange sites">
+                    <span class="hidden-text">Stack Exchange</span>
+                </a>
+
+                <a href="#" class="topbar-icon icon-inbox yes-hover js-inbox-button" title="Recent inbox messages">
+                    <span class="hidden-text">Inbox</span>
+                    <span class="unread-count" style="display:none"></span>
+                </a>
+                <a href="#" class="topbar-icon icon-achievements yes-hover js-achievements-button " data-unread-class="" title="Recent achievements: reputation, badges, and privileges earned">
+                    <span class="hidden-text">Reputation and Badges</span>
+                    <span class="unread-count" style="display:none">
+            
+        </span>
+                </a>
+            </div>
+
+            <div class="topbar-links">
+
+                <div class="links-container">
+                    <span class="topbar-menu-links">
+                                    <a href="https://english.stackexchange.com/users/signup?ssrc=head&amp;returnurl=http%3a%2f%2fenglish.stackexchange.com%2fquestions%2f250245%2fa-hypernym-for-insects-worms-and-the-like" class="login-link" rel="nofollow">sign up</a>
+                                <a href="https://english.stackexchange.com/users/login?ssrc=head&amp;returnurl=http%3a%2f%2fenglish.stackexchange.com%2fquestions%2f250245%2fa-hypernym-for-insects-worms-and-the-like" class="login-link" rel="nofollow">log in</a>
+
+                            <a href="/tour">tour</a>
+        <a href="#" class="icon-help js-help-button" title="Help Center and other resources">
+            help
+            <span class="triangle"></span>
+                    </a>
+                    <div class="topbar-dialog help-dialog js-help-dialog dno">
+                        <div class="modal-content">
+                            <ul>
+                                <li>
+                                    <a href="/tour" class="js-gps-track" data-gps-track="help_popup.click({ item_type:1 })">
+                            Tour
+                            <span class="item-summary">
+                                Start here for a quick overview of the site
+                            </span>
+                        </a>
+                                </li>
+                                <li>
+                                    <a href="/help" class="js-gps-track" data-gps-track="help_popup.click({ item_type:4 })">
+                        Help Center
+                        <span class="item-summary">
+                            Detailed answers to any questions you might have
+                        </span>
+                    </a>
+                                </li>
+                                <li>
+                                    <a href="http://meta.english.stackexchange.com" class="js-gps-track" data-gps-track="help_popup.click({ item_type:2 })">
+                                Meta
+                                <span class="item-summary">
+                                    Discuss the workings and policies of this site
+                                </span>
+                            </a>
+                                </li>
+                                <li>
+                                    <a href="http://stackoverflow.com/company/about" class="js-gps-track" data-gps-track="help_popup.click({ item_type:6 })">
+                                About Us
+                                <span class="item-summary">
+                                    Learn more about Stack Overflow the company
+                                </span>
+                            </a>
+                                </li>
+                                <li>
+                                    <a href="https://www.stackoverflowbusiness.com/?ref=topbar_help" class="js-gps-track" data-gps-track="help_popup.click({ item_type:7 })">
+                                Business
+                                <span class="item-summary">
+                                    Learn more about hiring developers or posting ads with us
+                                </span>
+                            </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    </span>
+                </div>
+
+                <div class="search-container">
+                    <form id="search" action="/search" method="get" autocomplete="off">
+                        <input name="q" placeholder="Search Q&amp;A" value="" tabindex="1" autocomplete="off" maxlength="240" type="text" />
+                    </form>
+                </div>
+
+            </div>
+        </div>
+    </div>
+    <script>
+        StackExchange.ready(function() {
+            StackExchange.topbar.init();
+        });
+    </script>
+
+    <div class="container">
+        <div id="header">
+            <br class="cbt" />
+            <div id="hlogo">
+                <a href="http://english.stackexchange.com">
+                        English Language &amp; Usage
+                    </a>
+            </div>
+            <div id="hmenus">
+                <div class="nav mainnavs">
+                    <ul>
+                        <li class="youarehere">
+                            <a id="nav-questions" href="/questions" class="js-gps-track" data-gps-track="top_nav.click({is_current:true, location:2, destination:1})">
+        Questions
+        </a>
+                        </li>
+
+                        <li>
+                            <a id="nav-tags" href="/tags" class="js-gps-track" data-gps-track="top_nav.click({is_current:false, location:2, destination:2})">
+        Tags
+        </a>
+                        </li>
+
+                        <li>
+                            <a id="nav-users" href="/users" class="js-gps-track" data-gps-track="top_nav.click({is_current:false, location:2, destination:3})">
+        Users
+        </a>
+                        </li>
+
+                        <li>
+                            <a id="nav-badges" href="/help/badges" class="js-gps-track" data-gps-track="top_nav.click({is_current:false, location:2, destination:4})">
+        Badges
+        </a>
+                        </li>
+
+                        <li>
+                            <a id="nav-unanswered" href="/unanswered" class="js-gps-track" data-gps-track="top_nav.click({is_current:false, location:2, destination:5})">
+        Unanswered
+        </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="nav askquestion">
+                    <ul>
+                        <li>
+                            <a id="nav-askquestion" href="/questions/ask">Ask Question</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+
+
+        <div id="content">
+
+
+
+
+
+            <div itemscope="" itemtype="http://schema.org/Question">
+                <link itemprop="image" href="https://cdn.sstatic.net/Sites/english/img/apple-touch-icon.png?v=5979aff4e7a9" />
+
+
+                <div id="herobox">
+                    <div id="hero-content">
+                        <div id="close"><a title="click to minimize">_</a></div>
+                        <div id="blurb">
+                            English Language &amp; Usage Stack Exchange is a question and answer site for linguists, etymologists, and serious English language enthusiasts. Join them; it only takes a minute:
+                            <br />
+                            <br />
+                            <a href="/users/signup?ssrc=hero&amp;returnurl=http%3a%2f%2fenglish.stackexchange.com%2fquestions%2f250245%2fa-hypernym-for-insects-worms-and-the-like" id="tell-me-more" class="button">Sign up</a>
+                        </div>
+                        <div id="desc">
+                            <b>Here's how it works:</b>
+                            <ol id="hiw">
+                                <li id="q">
+                                    Anybody can ask a question
+                                </li>
+                                <li id="an">
+                                    Anybody can answer
+                                </li>
+                                <li id="b">
+                                    The best answers are voted up and rise to the top
+                                </li>
+                            </ol>
+                        </div>
+                        <div style="clear: both"></div>
+                    </div>
+                </div>
+                <script>
+                    StackExchange.ready(function() {
+
+                        var location = 0;
+                        if ($("body").hasClass("questions-page")) {
+                            location = 1;;
+                        } else if ($("body").hasClass("question-page")) {
+                            location = 1;;
+                        } else if ($("body").hasClass("faq-page")) {
+                            location = 5;;
+                        } else if ($("body").hasClass("home-page")) {
+                            location = 3;;
+                        }
+
+                        $('#tell-me-more').click(function() {
+                            StackExchange.using("gps", function() {
+                                StackExchange.gps.track("hero.action", {
+                                    hero_action_type: 'cta',
+                                    location: location
+                                }, true);
+                            });
+                        });
+                        $('#herobox #close').click(function() {
+                            StackExchange.using("gps", function() {
+                                StackExchange.gps.track("hero.action", {
+                                    hero_action_type: "minimize",
+                                    location: location
+                                }, true);
+                            });
+                            $.cookie("hero", "mini", {
+                                path: "/",
+                                expires: 365
+                            });
+                            $.ajax({
+                                url: "/hero-mini",
+                                success: function(data) {
+                                    $("#herobox").fadeOut("fast", function() {
+                                        $("#herobox").replaceWith(data);
+                                        $("#herobox-mini").fadeIn("fast");
+                                    });
+                                }
+                            });
+                            return false;
+                        });
+                    });
+                </script>
+                <div id="question-header">
+                    <h1 itemprop="name"><a href="/questions/250245/a-hypernym-for-insects-worms-and-the-like" class="question-hyperlink">A hypernym for 'insects', 'worms' and the like</a></h1>
+
+
+                </div>
+                <div id="mainbar">
+
+
+
+                    <div class="question" data-questionid="250245" id="question">
+
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td class="votecell">
+
+
+                                        <div class="vote">
+                                            <input name="_id_" value="250245" type="hidden" />
+                                            <a class="vote-up-off" title="This question shows research effort; it is useful and clear">up vote</a>
+                                            <span itemprop="upvoteCount" class="vote-count-post ">17</span>
+                                            <a class="vote-down-off" title="This question does not show any research effort; it is unclear or not useful">down vote</a>
+
+                                            <a class="star-off" href="#">favorite</a>
+                                            <div class="favoritecount"><b>2</b></div>
+
+
+                                        </div>
+
+                                    </td>
+
+                                    <td class="postcell">
+                                        <div>
+                                            <div class="post-text" itemprop="text">
+
+                                                <p>From Oxford:</p>
+
+                                                <p><strong><a href="http://www.oxforddictionaries.com/definition/learner/insect">insect</a></strong>:</p>
+
+                                                <blockquote>
+                                                    <p>any small creature with six legs and a body divided into three parts. Insects usually also have wings. Ants, bees and flies are all insects</p>
+
+                                                    <p>Insect is often used to refer to other small creatures, for example spiders, although this is not correct scientific language.</p>
+                                                </blockquote>
+
+                                                <p><strong><a href="http://www.oxforddictionaries.com/definition/learner/worm">worm</a></strong>:</p>
+
+                                                <blockquote>
+                                                    <ol>
+                                                        <li>
+                                                            <p>a long thin creature with no bones or legs, that lives in soil</p>
+                                                        </li>
+                                                        <li>
+                                                            <p>long thin creatures that live inside the bodies of humans or animals and can cause illness</p>
+                                                        </li>
+                                                        <li>
+                                                            <p>the young form of an insect when it looks like a short worm</p>
+                                                        </li>
+                                                    </ol>
+                                                </blockquote>
+
+                                                <p>I find both these definitions oddly restrictive. Insects have 6 legs and worms (in the primary sense) have none. The other senses of worm are also specific. There are many small creatures who do not fall into these categories. Centipedes definity have legs, and a lot more than six. Is there a common (not too scientific) word to refer to all small creatures?</p>
+
+                                                <hr />
+
+                                                <p>A <strong><a href="http://www.oxforddictionaries.com/definition/english/bug">bug</a></strong> doesn't work, as is defined as</p>
+
+                                                <blockquote>
+                                                    <p><em>chiefly North American</em> A small <strong>insect</strong>:</p>
+
+                                                    <p><em>a thick green scum which crawls with bugs, centipedes, and worse</em></p>
+                                                </blockquote>
+
+                                                <p>Insect, not creature, not worm. Also note the exclusion of centipedes from the umbrella of bugs. In fact, Oxford defines <a href="http://www.oxforddictionaries.com/definition/english/centipede">centipedes</a> exclusively in scientific terms.</p>
+
+                                                <blockquote>
+                                                    <p>A <strong>predatory myriapod invertebrate</strong> with a flattened elongated body composed of many segments. Most segments bear a single pair of legs, the front pair being modified as poison fangs.</p>
+                                                </blockquote>
+
+                                                <p>Although Oxford <a href="http://www.oxforddictionaries.com/definition/english/insect">here</a> lists an informal sense of insect:</p>
+
+                                                <blockquote>
+                                                    <p><em>informal</em> Any small invertebrate animal such as a spider or tick.</p>
+                                                </blockquote>
+
+                                                <p>It curiously drops this definition in the advanced learners' version. Moreover, it's reluctant to use the term in its own definition of <a href="http://www.oxforddictionaries.com/definition/english/spider">spider</a>:</p>
+
+                                                <blockquote>
+                                                    <p>An eight-legged <strong>predatory arachnid</strong> with an unsegmented body consisting of a fused head and thorax and a rounded abdomen. Spiders have fangs which inject poison into their prey, and most kinds spin webs in which to capture insects.</p>
+                                                </blockquote>
+
+                                                <hr />
+
+                                                <p><strong>Questions:</strong></p>
+
+                                                <ul>
+                                                    <li>
+                                                        <p>Is there any word, preferably not too informal, which would include all small creatures like insects, worms, spiders and centipedes; without having to resort to biological jargon? </p>
+                                                    </li>
+                                                    <li>
+                                                        <p>Also, how right/wrong is it to use <code>insect</code> or <code>bug</code> for this purpose?</p>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="post-taglist">
+                                                <a href="/questions/tagged/single-word-requests" class="post-tag js-gps-track" title="show questions tagged 'single-word-requests'" rel="tag">single-word-requests</a> <a href="/questions/tagged/hypernyms" class="post-tag js-gps-track" title="show questions tagged 'hypernyms'" rel="tag">hypernyms</a> <a href="/questions/tagged/nuance" class="post-tag js-gps-track" title="show questions tagged 'nuance'" rel="tag">nuance</a>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/q/250245" title="short permalink to this question" class="short-link" id="link-post-250245">share</a><span class="lsep">|</span><a href="/posts/250245/edit" class="suggest-edit-post" title="">improve this question</a></div>
+                                                        </td>
+                                                        <td class="post-signature" align="right">
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    <a href="/posts/250245/revisions" title="show all edits to this post">edited <span title="2015-06-03 19:39:40Z" class="relativetime">Jun 3 '15 at 19:39</span></a>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+
+                                                                </div>
+                                                                <div class="user-details">
+
+                                                                    <div class="-flair">
+
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                        <td class="post-signature owner">
+                                                            <div class="user-info user-hover">
+                                                                <div class="user-action-time">
+                                                                    asked <span title="2015-06-03 19:33:46Z" class="relativetime">Jun 3 '15 at 19:33</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/77339/tushar-raj">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://i.stack.imgur.com/RfXCK.jpg?s=32&amp;g=1" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/77339/tushar-raj">Tushar Raj</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score 16,459" dir="ltr">16.5k</span><span title="5 gold badges"><span class="badge1"></span><span class="badgecount">5</span></span><span title="55 silver badges"><span class="badge2"></span><span class="badgecount">55</span></span><span title="96 bronze badges"><span class="badge3"></span><span class="badgecount">96</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </td>
+                                </tr>
+
+                                <tr>
+                                    <td class="votecell"></td>
+                                    <td>
+                                        <div id="comments-250245" class="comments ">
+                                            <table>
+                                                <tbody data-remaining-comments-count="9" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                    <tr id="comment-544268" class="comment ">
+                                                        <td class="comment-actions">
+                                                            <table>
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <td class=" comment-score">
+                                                                            <span title="number of 'useful comment' votes received" class="warm">10</span>
+                                                                        </td>
+                                                                        <td>
+                                                                        
+                                                                        </td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                        <td class="comment-text">
+                                                            <div style="display: block;" class="comment-body">
+                                                                <span class="comment-copy">For all those critters <i>except worms</i>, the word is arthropods. Worms, however are not arthropods. You can choose to ignore biology, but worms are simply very, very different. You could go for <i>critters</i>, which would prolly include all you mentioned. Insect is plain wrong, spiders and worms are not insects. As for <i>bug</i>, it excludes worms as well according to <a href="http://en.wikipedia.org/wiki/Bug" rel="nofollow noreferrer">Wikipedia</a>.</span> –
+                                                                <a href="/users/54363/oerkelens" title="27,556 reputation" class="comment-user">oerkelens</a>
+                                                                <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544268_250245"><span title="2015-06-03 19:38:53Z" class="relativetime-clean">Jun 3 '15 at 19:38</span></a>
+                                                                </span>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                    <tr id="comment-544274" class="comment ">
+                                                        <td class="comment-actions">
+                                                            <table>
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <td class=" comment-score">
+                                                                            <span title="number of 'useful comment' votes received" class="hot">15</span>
+                                                                        </td>
+                                                                        <td>
+                                                                        
+                                                                        </td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                        <td class="comment-text">
+                                                            <div style="display: block;" class="comment-body">
+                                                                <span class="comment-copy">I don't know if you'd consider <b><i>invertebrates</i></b> to be "biological jargon", but it would work for me - either ignore bigger ones like octopuses and giant squid, or go for <b><i>small</i></b><i> invertebrates</i>.</span> –
+                                                                <a href="/users/2637/fumblefingers" title="108,819 reputation" class="comment-user">FumbleFingers</a>
+                                                                <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544274_250245"><span title="2015-06-03 19:49:45Z" class="relativetime-clean">Jun 3 '15 at 19:49</span></a>
+                                                                </span>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                    <tr id="comment-544310" class="comment ">
+                                                        <td class="comment-actions">
+                                                            <table>
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <td class=" comment-score">
+                                                                            <span title="number of 'useful comment' votes received" class="warm">7</span>
+                                                                        </td>
+                                                                        <td>
+                                                                        
+                                                                        </td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                        <td class="comment-text">
+                                                            <div style="display: block;" class="comment-body">
+                                                                <span class="comment-copy">I find ODO's restriction of <i>bug</i> to insects to be overly restrictive. My understanding of it is closer to AHD: <i><a href="https://ahdictionary.com/word/search.html?q=bug" rel="nofollow noreferrer">b. An insect of any kind, such as a cockroach or a ladybug. c. A small invertebrate with many legs, such as a spider or a centipede.</a></i>. I don't consider worms to be <i>bugs</i>, but perhaps they fall under MW's definition: <i><a href="http://www.merriam-webster.com/dictionary/bug" rel="nofollow noreferrer">an insect or other creeping or crawling invertebrate (as a spider or centipede)</a></i></span> –
+                                                                <a href="/users/16052/choster" title="29,151 reputation" class="comment-user">choster</a>
+                                                                <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544310_250245"><span title="2015-06-03 20:39:56Z" class="relativetime-clean">Jun 3 '15 at 20:39</span></a>
+                                                                </span>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                    <tr id="comment-544311" class="comment ">
+                                                        <td class="comment-actions">
+                                                            <table>
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <td class=" comment-score">
+                                                                            <span title="number of 'useful comment' votes received" class="cool">1</span>
+                                                                        </td>
+                                                                        <td>
+                                                                        
+                                                                        </td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                        <td class="comment-text">
+                                                            <div style="display: block;" class="comment-body">
+                                                                <span class="comment-copy">@choster: Thanks for the AHD link. That's the best and most comprehensive entry, I think.</span> –
+                                                                <a href="/users/77339/tushar-raj" title="16,459 reputation" class="comment-user owner">Tushar Raj</a>
+                                                                <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544311_250245"><span title="2015-06-03 20:42:53Z" class="relativetime-clean">Jun 3 '15 at 20:42</span></a>
+                                                                </span>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                    <tr id="comment-545448" class="comment ">
+                                                        <td class="comment-actions">
+                                                            <table>
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <td class=" comment-score">
+                                                                            <span title="number of 'useful comment' votes received" class="cool">2</span>
+                                                                        </td>
+                                                                        <td>
+                                                                        
+                                                                        </td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </td>
+                                                        <td class="comment-text">
+                                                            <div style="display: block;" class="comment-body">
+                                                                <span class="comment-copy">I expect questions on etymology on this site; I'm amused by the question on entomology!</span> –
+                                                                <a href="/users/4489/ray" title="736 reputation" class="comment-user">Ray</a>
+                                                                <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment545448_250245"><span title="2015-06-05 15:49:44Z" class="relativetime-clean">Jun 5 '15 at 15:49</span></a>
+                                                                </span>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+
+                                        <div id="comments-link-250245" data-rep="50" data-anon="true">
+
+                                            <a class="js-add-link comments-link  dno" title="Use comments to ask for more information or suggest improvements. Avoid answering questions in comments."></a><span class="js-link-separator dno"> | </span>
+                                            <a class="js-show-link comments-link " title="expand to show all comments on this post" href="#" onclick="">show <b>9</b> more comments</a>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div id="answers">
+
+                        <a name="tab-top"></a>
+                        <div id="answers-header">
+                            <div class="subheader answers-subheader">
+                                <h2>
+                                    10 Answers
+                                    <span style="display:none;" itemprop="answerCount">10</span>
+                                </h2>
+                                <div>
+                                    <div id="tabs">
+                                        <a href="/questions/250245/a-hypernym-for-insects-worms-and-the-like?answertab=active#tab-top" data-nav-xhref="" title="Answers with the latest activity first" data-value="active" data-shortcut="A">
+            active</a>
+                                        <a href="/questions/250245/a-hypernym-for-insects-worms-and-the-like?answertab=oldest#tab-top" data-nav-xhref="" title="Answers in the order they were provided" data-value="oldest" data-shortcut="O">
+            oldest</a>
+                                        <a class="youarehere" href="/questions/250245/a-hypernym-for-insects-worms-and-the-like?answertab=votes#tab-top" data-nav-xhref="" title="Answers with the highest score first" data-value="votes" data-shortcut="V">
+            votes</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+
+
+
+
+                        <a name="250251"></a>
+                        <div id="answer-250251" class="answer accepted-answer" data-answerid="250251" itemscope="" itemtype="http://schema.org/Answer" itemprop="acceptedAnswer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250251" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">33</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+                                                <span class="vote-accepted-on load-accepted-answer-date" title="loading when this answer was accepted...">accepted</span>
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p>Small children are easily interested in small creatures and, unsurprisingly, primary schools in Britain find the study of such animals a good starting point for much of the curriculum. However, it is was thought that calling them "creepy-crawlies" would risk alienating pupils and trigger the fear and distaste which was common in their grandparents' day.</p>
+
+                                                <p>So the term for these small creatures most often used in British Primary Education is <strong><a href="http://en.wiktionary.org/wiki/minibeast#English">minibeasts</a></strong> For a general view of UK minibeast history <a href="http://en.wikipedia.org/wiki/Minibeast">see this wikipedia article</a>.</p>
+
+                                                <blockquote>
+                                                    <p>"Minibeast" or "Minibeasts" is a term for <strong>a variety of arthropods and other invertebrates</strong>, including spiders, ants, butterflies, bees, wasps, flies, woodlice <a href="http://en.wiktionary.org/wiki/minibeast#English">1</a>, and many others.</p>
+                                                </blockquote>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250251" title="short permalink to this answer" class="short-link" id="link-post-250251">share</a><span class="lsep">|</span><a href="/posts/250251/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+                                                        <td class="post-signature" align="right">
+                                                            <div class="user-info user-hover">
+                                                                <div class="user-action-time">
+                                                                    <a href="/posts/250251/revisions" title="show all edits to this post">edited <span title="2015-06-03 20:33:42Z" class="relativetime">Jun 3 '15 at 20:33</span></a>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/77339/tushar-raj">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://i.stack.imgur.com/RfXCK.jpg?s=32&amp;g=1" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/77339/tushar-raj">Tushar Raj</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score 16,459" dir="ltr">16.5k</span><span title="5 gold badges"><span class="badge1"></span><span class="badgecount">5</span></span><span title="55 silver badges"><span class="badge2"></span><span class="badgecount">55</span></span><span title="96 bronze badges"><span class="badge3"></span><span class="badgecount">96</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-03 19:55:45Z" class="relativetime">Jun 3 '15 at 19:55</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/121987/margana">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/34fa732f041f9d954e43d034ac054545?s=32&amp;d=identicon&amp;r=PG&amp;f=1" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/121987/margana">Margana</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">3,767</span><span title="1 gold badge"><span class="badge1"></span><span class="badgecount">1</span></span><span title="5 silver badges"><span class="badge2"></span><span class="badgecount">5</span></span><span title="21 bronze badges"><span class="badge3"></span><span class="badgecount">21</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250251" class="comments ">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="8" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                        <tr id="comment-544290" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">Related link: <a href="http://english.stackexchange.com/questions/166006/origin-of-minibeasts" title="origin of minibeasts">english.stackexchange.com/questions/166006/origin-of-minibea‌​sts</a></span> –
+                                                                    <a href="/users/66974/josh" title="130,034 reputation" class="comment-user">Josh</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544290_250251"><span title="2015-06-03 20:06:30Z" class="relativetime-clean">Jun 3 '15 at 20:06</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544298" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@TusharRaj I added a link to your wiktionary page, but, re-reading it find the definition to be essentially limited to "insects and bugs", with "etc" leaving the rest to the imagination.</span> –
+                                                                    <a href="/users/121987/margana" title="3,767 reputation" class="comment-user">Margana</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544298_250251"><span title="2015-06-03 20:27:00Z" class="relativetime-clean">Jun 3 '15 at 20:27</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544300" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@MARGANA: Gotta love the <code>etc</code>! Anyway, here's the <a href="http://en.wikipedia.org/wiki/Minibeast" rel="nofollow noreferrer">wikipedia link</a></span> –
+                                                                    <a href="/users/77339/tushar-raj" title="16,459 reputation" class="comment-user owner">Tushar Raj</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544300_250251"><span title="2015-06-03 20:28:51Z" class="relativetime-clean">Jun 3 '15 at 20:28</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544334" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">2</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">Being from the U.S. I haven't heard this, but I do like it. Unfortunately, without having the actual definition there I might think small animals were included as well depending on the context it was used in. (like mice, squirrels, etc)</span> –
+                                                                    <a href="/users/60910/doubledouble" title="567 reputation" class="comment-user">DoubleDouble</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544334_250251"><span title="2015-06-03 21:09:58Z" class="relativetime-clean">Jun 3 '15 at 21:09</span></a>
+                                                                    </span>
+                                                                    <span class="edited-yes" title="this comment was edited 3 times"></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544767" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">2</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@TusharRaj I'm aware of that, since the definition is right there. I was saying as somebody who hasn't heard the term before, The term is clear enough that I have an idea of what it is, but I wouldn't go to Wikipedia to see the exact definition if I came across it in text, so the wrong meaning may get across to me if its really so important for the OP to distinguish between these. Since it says its mostly a British term, that might be more or less of a risk depending on the audience.</span> –
+                                                                    <a href="/users/60910/doubledouble" title="567 reputation" class="comment-user">DoubleDouble</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544767_250251"><span title="2015-06-04 14:49:09Z" class="relativetime-clean">Jun 4 '15 at 14:49</span></a>
+                                                                    </span>
+                                                                    <span class="edited-yes" title="this comment was edited 1 time"></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250251" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link  dno" title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”."></a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link " title="expand to show all comments on this post" href="#" onclick="">show <b>8</b> more comments</a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250247"></a>
+                        <div id="answer-250247" class="answer" data-answerid="250247" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250247" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">80</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p><a href="http://www.oxforddictionaries.com/definition/english/creepy-crawly"><em>Creepy-crawlies</em></a>.</p>
+
+                                                <blockquote>
+                                                    <p>informal<br /> A spider, worm, or other small flightless creature, especially when considered unpleasant or frightening:</p>
+                                                </blockquote>
+
+                                                <p>^ Covers all three cases.</p>
+
+                                                <hr />
+
+                                                <p>Also, despite your dictionary defining "bug" as an insect specifically, i wouldn't balk at using it to describe worms or spiders as well.</p>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250247" title="short permalink to this answer" class="short-link" id="link-post-250247">share</a><span class="lsep">|</span><a href="/posts/250247/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info user-hover">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-03 19:37:41Z" class="relativetime">Jun 3 '15 at 19:37</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/73553/scimonster">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/40119dd76422b3d9c696051014ae6ff3?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/73553/scimonster">Scimonster</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">1,102</span><span title="1 gold badge"><span class="badge1"></span><span class="badgecount">1</span></span><span title="5 silver badges"><span class="badge2"></span><span class="badgecount">5</span></span><span title="22 bronze badges"><span class="badge3"></span><span class="badgecount">22</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250247" class="comments ">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="8" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                        <tr id="comment-544271" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="warm">6</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">+1 for your footnote especially. Also <i>critter</i> (especially in the Southern U.S.).</span> –
+                                                                    <a href="/users/55623/dan-bron" title="21,097 reputation" class="comment-user">Dan Bron</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544271_250247"><span title="2015-06-03 19:43:54Z" class="relativetime-clean">Jun 3 '15 at 19:43</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544286" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="warm">5</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">I happen to agree with that definition of "critter". There's a reason i didn't include it in my answer.  @TusharRaj</span> –
+                                                                    <a href="/users/73553/scimonster" title="1,102 reputation" class="comment-user">Scimonster</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544286_250247"><span title="2015-06-03 20:00:42Z" class="relativetime-clean">Jun 3 '15 at 20:00</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544287" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="warm">9</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">Entomology be damned, I can't see how one can conceive of the demotic use of "bug" as <i>excluding</i> spiders and centipedes. Worms, no.</span> –
+                                                                    <a href="/users/117675/david-pugh" title="2,679 reputation" class="comment-user">David Pugh</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544287_250247"><span title="2015-06-03 20:01:35Z" class="relativetime-clean">Jun 3 '15 at 20:01</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544337" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="warm">7</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">I agree with @David, "bug" covers insects, spiders and centipedes, but <i>not</i> worms (unless the "worm" is really an insect, for instance an inchworm).  I've only ever heard <i>critter</i> as a synonym for "creature" and generally meaning a small to mid-sized animal (mammal, reptile or amphibian).</span> –
+                                                                    <a href="/users/54466/chris-sunami" title="17,741 reputation" class="comment-user">Chris Sunami</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544337_250247"><span title="2015-06-03 21:14:16Z" class="relativetime-clean">Jun 3 '15 at 21:14</span></a>
+                                                                    </span>
+                                                                    <span class="edited-yes" title="this comment was edited 2 times"></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544365" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">4</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">I think of "critter" as any smallish animal - rats, yes, rabbits, yes, lizards, yes, dogs and cats, no. Also, large lizards like say komodo dragons, also no.</span> –
+                                                                    <a href="/users/36225/neminem" title="201 reputation" class="comment-user">neminem</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544365_250247"><span title="2015-06-03 22:02:54Z" class="relativetime-clean">Jun 3 '15 at 22:02</span></a>
+                                                                    </span>
+                                                                    <span class="edited-yes" title="this comment was edited 2 times"></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250247" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link  dno" title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”."></a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link " title="expand to show all comments on this post" href="#" onclick="">show <b>8</b> more comments</a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250404"></a>
+                        <div id="answer-250404" class="answer" data-answerid="250404" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250404" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">30</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p><strong>Bug</strong> is certainly what I would use, and what I would expect those around me to use. And I am American, so I think Oxford is simply wrong about how we use the word. Merriam-Webster, for instance, gives <a href="http://www.merriam-webster.com/dictionary/bug">the principal definition of bug</a> as</p>
+
+                                                <blockquote>
+                                                    <p>1 a : an insect or other creeping or crawling invertebrate (as a spider or centipede)</p>
+                                                </blockquote>
+
+                                                <p>This matches your desired usage perfectly. Note the near-reference to Scimonster’s suggestion of <em>creepy-crawlies</em> – Merriam-Webster here makes it pretty clear that <em>bug</em> is used as a more-formal <em>creepy-crawly</em>.</p>
+
+                                                <p>That said, if we are being truly formal (read: technical), the third definition is the “formal” one:</p>
+
+                                                <blockquote>
+                                                    <p>1 c : any of an order (<em>Hemiptera</em> and especially its suborder <em>Heteroptera</em>) of insects that have sucking mouthparts, forewings thickened at the base, and incomplete metamorphosis and are often economic pests —called also <em>true bug</em></p>
+                                                </blockquote>
+
+                                                <p>This fact is, however, outside entomology, not widely known, and would be regarded by most as trivia. By comparison, the specifics of <em>insect</em> are much more widely known, though I’d guess the majority of speakers are unlikely to care very much in practice – just because someone knows, or at least at one point learned, that insects have three body parts, six legs, etc., doesn’t mean they care to use the word so exactly. But many more know/care about <em>insect</em>’s specific definition than do about <em>bug</em>, as indicated by the fact that some entomologists have resorted to the phrase <em>true bug</em> for <em>Heteroptera</em>. Thus bug is very much my recommendation.</p>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250404" title="short permalink to this answer" class="short-link" id="link-post-250404">share</a><span class="lsep">|</span><a href="/posts/250404/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+                                                        <td class="post-signature" align="right">
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    <a href="/posts/250404/revisions" title="show all edits to this post">edited <span title="2015-06-05 12:33:50Z" class="relativetime">Jun 5 '15 at 12:33</span></a>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/95331/brian-hitchcock">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/e3982d3921f087a8a75b279efc1b260f?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/95331/brian-hitchcock">Brian Hitchcock</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score 12,041" dir="ltr">12k</span><span title="1 gold badge"><span class="badge1"></span><span class="badgecount">1</span></span><span title="13 silver badges"><span class="badge2"></span><span class="badgecount">13</span></span><span title="34 bronze badges"><span class="badge3"></span><span class="badgecount">34</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info user-hover">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-04 14:12:32Z" class="relativetime">Jun 4 '15 at 14:12</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/24589/kryan">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://i.stack.imgur.com/oyv6J.png?s=32&amp;g=1" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/24589/kryan">KRyan</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">1,571</span><span title="10 silver badges"><span class="badge2"></span><span class="badgecount">10</span></span><span title="17 bronze badges"><span class="badge3"></span><span class="badgecount">17</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250404" class="comments ">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="10" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                        <tr id="comment-544744" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">4</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">I would never refer to a worm as a bug. That seems to be a pretty significant part of the asker's requirements.</span> –
+                                                                    <a href="/users/78544/talrnu" title="4,897 reputation" class="comment-user">talrnu</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544744_250404"><span title="2015-06-04 14:31:07Z" class="relativetime-clean">Jun 4 '15 at 14:31</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544745" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="warm">10</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@talrnu I certainly would, and the definition given by M-W would definitely include them, since they are invertebrates that both creep and crawl.</span> –
+                                                                    <a href="/users/24589/kryan" title="1,571 reputation" class="comment-user">KRyan</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544745_250404"><span title="2015-06-04 14:32:30Z" class="relativetime-clean">Jun 4 '15 at 14:32</span></a>
+                                                                    </span>
+                                                                    <span class="edited-yes" title="this comment was edited 1 time"></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544885" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">2</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@talrnu You already said as much, and I already said I disagree. I am not going to change my answer to match your opinion, because I disagree with you. I address the OED's inaccurate statements about how the word is used in North America in my answer. I do not feel that their error deserves more mention than I have already given it. If you wish to do the research to actually back up your statements, and make them more than mere opinion, I suggest you do so and make it an answer, if your research actually does back you up. Either way, continued commenting is inappropriate.</span> –
+                                                                    <a href="/users/24589/kryan" title="1,571 reputation" class="comment-user">KRyan</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544885_250404"><span title="2015-06-04 18:11:15Z" class="relativetime-clean">Jun 4 '15 at 18:11</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544916" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="warm">6</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">I have to agree with @KRyan: in North American usage, bug is very close and less informal than creepy-crawly (which is even closer).  Since "bugs and worms" is also common, there is somewhat of a distinction between them, but most people would not quibble -- after all, worms "bug" a lot of people as well.</span> –
+                                                                    <a href="/users/7734/shipr" title="1,406 reputation" class="comment-user">shipr</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544916_250404"><span title="2015-06-04 19:14:29Z" class="relativetime-clean">Jun 4 '15 at 19:14</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-545107" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">2</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">Seems like part of the conflict between KRyan and tarlnu here could be attributed to regional differences in usage, which can be surprisingly wide in AmE.  I would never call an earthworm a "bug" and I would do a double-take if I heard anyone else do so, but then I have lived in the Pacific Northwest almost all my life.  I'm certainly open to the idea that that usage may be perfectly ordinary elsewhere in the country.  The OED isn't much help validating US dialects and regionalisms, as others have pointed out, since it tends to lump all of AmE together.</span> –
+                                                                    <a href="/users/46495/dodgethesteamroller" title="310 reputation" class="comment-user">dodgethesteamroller</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment545107_250404"><span title="2015-06-05 04:44:29Z" class="relativetime-clean">Jun 5 '15 at 4:44</span></a>
+                                                                    </span>
+                                                                    <span class="edited-yes" title="this comment was edited 2 times"></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250404" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link  dno" title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”."></a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link " title="expand to show all comments on this post" href="#" onclick="">show <b>10</b> more comments</a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250250"></a>
+                        <div id="answer-250250" class="answer" data-answerid="250250" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250250" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">15</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p>If you're looking for a negative sense, you might use "vermin" -- small, swarming, repulsive, potentially-disease-bearing creatures.</p>
+
+                                                <p>It's a very unscientific term, including rats, frogs, toads, centipedes, and millipedes, as well as insects and most types of worms (except earthworms and redworms, which are good for the soil). Depending on your sensibilities, it might also include mice, spiders, ants, and termites; it might even encompass scorpions and lizards, and maybe even lobsters.</p>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250250" title="short permalink to this answer" class="short-link" id="link-post-250250">share</a><span class="lsep">|</span><a href="/posts/250250/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+                                                        <td class="post-signature" align="right">
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    <a href="/posts/250250/revisions" title="show all edits to this post">edited <span title="2015-06-03 19:54:17Z" class="relativetime">Jun 3 '15 at 19:54</span></a>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+
+                                                                </div>
+                                                                <div class="user-details">
+
+                                                                    <div class="-flair">
+
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-03 19:51:47Z" class="relativetime">Jun 3 '15 at 19:51</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/62452/exottoyuhr">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/e03628ebd4102641e231e42c9ba32e57?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/62452/exottoyuhr">ExOttoyuhr</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">403</span><span title="2 silver badges"><span class="badge2"></span><span class="badgecount">2</span></span><span title="9 bronze badges"><span class="badge3"></span><span class="badgecount">9</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250250" class="comments ">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="0" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                        <tr id="comment-544281" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">1</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@Tushar Raj: Thanks! But you're right, it's a pretty broad term, not something to use when you want precision. I think it dates back to the Middle Ages, which classified animals by habits and habitat much more than by biology. ("Fish" included turtles and whales, for example.)</span> –
+                                                                    <a href="/users/62452/exottoyuhr" title="403 reputation" class="comment-user">ExOttoyuhr</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544281_250250"><span title="2015-06-03 19:57:33Z" class="relativetime-clean">Jun 3 '15 at 19:57</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544319" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">3</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">This was my first instinct upon reading the question too, though it doesn't fit perfectly. I think for clarity, it would be acceptable to say "worms, bugs and other vermin", for instance, or something similar. On the other hand, simply saying vermin by itself, as in "an abandoned house infested with vermin", would generally imply rats or other vertebrates as well.</span> –
+                                                                    <a href="/users/120713/recognizer" title="1,285 reputation" class="comment-user">recognizer</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544319_250250"><span title="2015-06-03 20:54:45Z" class="relativetime-clean">Jun 3 '15 at 20:54</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250250" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link disabled-link " title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”.">add a comment</a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link dno" title="expand to show all comments on this post" href="#" onclick=""></a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250285"></a>
+                        <div id="answer-250285" class="answer" data-answerid="250285" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250285" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">12</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <blockquote>
+                                                    <p>preferably not too informal</p>
+                                                </blockquote>
+
+                                                <p>This is the most formal one: they are all <a href="https://en.wikipedia.org/wiki/Invertebrate" rel="nofollow">invertebrates</a>. </p>
+
+                                                <blockquote>
+                                                    <p>Invertebrates are animals that neither possess nor develop a vertebral column, derived from the notochord. This includes all animals apart from the subphylum Vertebrata. Familiar examples of invertebrates include <strong>insects</strong>, crabs, lobsters and their kin, snails, clams, octopuses and their kin, starfish, sea-urchins and their kin, and <strong>worms</strong>.</p>
+                                                </blockquote>
+
+                                                <p>But the usage depends on the context.</p>
+
+                                                <p>If your text is somehow related to science, don't call spider an "insect". Spiders &amp; insects are <a href="https://en.wikipedia.org/wiki/Arthropod" rel="nofollow">"arthropods"</a> (not "arthropod<strong>e</strong>s"), together with worms they are "invertebrates".</p>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250285" title="short permalink to this answer" class="short-link" id="link-post-250285">share</a><span class="lsep">|</span><a href="/posts/250285/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+                                                        <td class="post-signature" align="right">
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    <a href="/posts/250285/revisions" title="show all edits to this post">edited <span title="2015-06-06 07:23:15Z" class="relativetime">Jun 6 '15 at 7:23</span></a>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+
+                                                                </div>
+                                                                <div class="user-details">
+
+                                                                    <div class="-flair">
+
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-03 23:42:31Z" class="relativetime">Jun 3 '15 at 23:42</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/123571/nick-volynkin">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://i.stack.imgur.com/Zt5Ll.jpg?s=32&amp;g=1" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/123571/nick-volynkin">Nick Volynkin</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">237</span><span title="1 silver badge"><span class="badge2"></span><span class="badgecount">1</span></span><span title="8 bronze badges"><span class="badge3"></span><span class="badgecount">8</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250285" class="comments ">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="1" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                        <tr id="comment-544707" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">I believe, in English, it is "arthropod" and "arthropods" (no e after the d). From <i>Saunders Comprehensive Veterinary Dictionary</i>: <i>arthropod</i> -- an individual of the phylum Arthropoda.</span> –
+                                                                    <a href="/users/18655/jlg" title="20,128 reputation" class="comment-user">JLG</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544707_250285"><span title="2015-06-04 13:50:04Z" class="relativetime-clean">Jun 4 '15 at 13:50</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544716" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">1</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@JLG yes, you are right. I'll edit my answer.</span> –
+                                                                    <a href="/users/123571/nick-volynkin" title="237 reputation" class="comment-user">Nick Volynkin</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544716_250285"><span title="2015-06-04 13:54:23Z" class="relativetime-clean">Jun 4 '15 at 13:54</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-546022" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">The problem with "invertebrate" is that it's far too broad, as your passage makes clear.</span> –
+                                                                    <a href="/users/120823/jason-melan%c3%a7on" title="430 reputation" class="comment-user">Jason Melançon</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment546022_250285"><span title="2015-06-06 22:15:02Z" class="relativetime-clean">Jun 6 '15 at 22:15</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-546023" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@JasonMelançon it could be specified with adjectives, like "small invertebrates", "land invertebrates". But I avoided offering variants, as I do not have the proper feeling of language and cannot say if one is good or bad. Not a native speaker, alas.</span> –
+                                                                    <a href="/users/123571/nick-volynkin" title="237 reputation" class="comment-user">Nick Volynkin</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment546023_250285"><span title="2015-06-06 22:18:36Z" class="relativetime-clean">Jun 6 '15 at 22:18</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-546026" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@JasonMelançon also, there's little information on the context. The accepted answer is "minibeasts". As I feel, it is only appropriate for a fairy-tale or some cartoon. But the OP found it acceptable for their context.</span> –
+                                                                    <a href="/users/123571/nick-volynkin" title="237 reputation" class="comment-user">Nick Volynkin</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment546026_250285"><span title="2015-06-06 22:22:51Z" class="relativetime-clean">Jun 6 '15 at 22:22</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250285" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link  dno" title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”."></a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link " title="expand to show all comments on this post" href="#" onclick="">show <b>1</b> more comment</a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250265"></a>
+                        <div id="answer-250265" class="answer" data-answerid="250265" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250265" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">5</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p>"Vermin" or "pests" can be any small creature, usually with a negative connotation, but including things as large as rats or even opossums. "Creepy-crawlies" is good but very informal. But as for "bug" -- scientifically, only a small subset of insects are bugs. But the word has expanded, and can now also mean an infection, or a computer glitch. I would argue that as long as the context doesn't imply you mean only insects, "bug" isn't actually wrong in informal English.</p>
+
+                                                <p>(Scientifically, both worms and insects are invertebrates -- creatures without an internal spine -- which then includes spiders and even coral.)</p>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250265" title="short permalink to this answer" class="short-link" id="link-post-250265">share</a><span class="lsep">|</span><a href="/posts/250265/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-03 20:58:44Z" class="relativetime">Jun 3 '15 at 20:58</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/113411/vynce">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/6cb16a7a9af0cfbe5ad85848024b4cfa?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/113411/vynce">Vynce</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">215</span><span title="1 silver badge"><span class="badge2"></span><span class="badgecount">1</span></span><span title="4 bronze badges"><span class="badge3"></span><span class="badgecount">4</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250265" class="comments ">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="0" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                        <tr id="comment-544507" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">Hi Vince. Good answer. +1. But I suggest you to make it better by providing some attribution; and maybe improve the formatting a little. Thanks.</span> –
+                                                                    <a href="/users/77339/tushar-raj" title="16,459 reputation" class="comment-user owner">Tushar Raj</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544507_250265"><span title="2015-06-04 06:28:21Z" class="relativetime-clean">Jun 4 '15 at 6:28</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544555" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">1</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">"scientifically, only a small subset of insects are bugs. But the word has expanded" -- well, the scientists contracted the meaning for scientific purposes by using an existing English word with a new jargon meaning. Civilians ignored this contraction, and also expanded it further with new meanings.</span> –
+                                                                    <a href="/users/62732/steve-jessop" title="1,726 reputation" class="comment-user">Steve Jessop</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544555_250265"><span title="2015-06-04 09:00:48Z" class="relativetime-clean">Jun 4 '15 at 9:00</span></a>
+                                                                    </span>
+                                                                    <span class="edited-yes" title="this comment was edited 3 times"></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544560" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">c.f: "mathematically, a group is a monoid with inverses. But the word has expanded. I would argue that calling the Beatles a group, or a "pop group", isn't actually wrong in informal English" ;-)</span> –
+                                                                    <a href="/users/62732/steve-jessop" title="1,726 reputation" class="comment-user">Steve Jessop</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544560_250265"><span title="2015-06-04 09:05:22Z" class="relativetime-clean">Jun 4 '15 at 9:05</span></a>
+                                                                    </span>
+                                                                    <span class="edited-yes" title="this comment was edited 2 times"></span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-545022" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">Steve: perhaps.  My biology friends insist that it originally meant a subset of insects and has diverged; <a href="http://www.etymonline.com/index.php?term=bug" rel="nofollow noreferrer">etymonline.com/index.php?term=bug</a> seems to disagree. The argument still stands, though.</span> –
+                                                                    <a href="/users/113411/vynce" title="215 reputation" class="comment-user">Vynce</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment545022_250265"><span title="2015-06-04 22:27:57Z" class="relativetime-clean">Jun 4 '15 at 22:27</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250265" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link disabled-link " title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”.">add a comment</a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link dno" title="expand to show all comments on this post" href="#" onclick=""></a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250281"></a>
+                        <div id="answer-250281" class="answer" data-answerid="250281" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250281" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">4</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p><strong><a href="http://en.wikipedia.org/wiki/Minibeast" rel="nofollow">Minibeast</a></strong> - this term is commonly used (at least in the UK) by charities and other groups which involve children in outdoor activities learning about nature. See also Cbeebies <a href="http://www.bbc.co.uk/cbeebies/shows/mini-beast-adventure-with-jess" rel="nofollow"><em>Minibeasts with Jess</em></a></p>
+
+                                                <p>The UK organisation <a href="https://www.buglife.org.uk/bugs-and-habitats/all-about-bugs" rel="nofollow">Buglife</a> works to protect ALL invertebrates regardless of size or number of legs, and uses the term <em>bug</em> to encompass all of these.</p>
+
+                                                <blockquote>
+                                                    <p>Invertebrates are animals without backbones and make up the great majority of animal life, with 40,000 species in Britain alone and many millions on Earth.</p>
+                                                </blockquote>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250281" title="short permalink to this answer" class="short-link" id="link-post-250281">share</a><span class="lsep">|</span><a href="/posts/250281/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-03 23:19:53Z" class="relativetime">Jun 3 '15 at 23:19</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/33153/mynamite">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://i.stack.imgur.com/6uP5m.jpg?s=32&amp;g=1" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/33153/mynamite">Mynamite</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">6,022</span><span title="1 gold badge"><span class="badge1"></span><span class="badgecount">1</span></span><span title="12 silver badges"><span class="badge2"></span><span class="badgecount">12</span></span><span title="29 bronze badges"><span class="badge3"></span><span class="badgecount">29</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250281" class="comments  dno">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="0" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+                                                        <tr>
+                                                            <td></td>
+                                                            <td></td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250281" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link disabled-link " title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”.">add a comment</a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link dno" title="expand to show all comments on this post" href="#" onclick=""></a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250602"></a>
+                        <div id="answer-250602" class="answer" data-answerid="250602" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250602" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">3</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p>I would say that in the Swedish language the word "kryp" have this meaning. Small creatures that is not built like us mammals, birds and fish. Non vegetable things that move around, but do not have a skeleton. (Or we just can't tell.)</p>
+
+                                                <p>A direct translation to English would be "crawl". But "crawlers" would perhaps correspond more closely to how it is perceived. Yes, it comes from the verb crawl, even if many of them can jump, fly and swim. But it is usually when they crawl on our bodies we notice them.</p>
+
+                                                <p>The word often have a negative association to it, but not necessary.</p>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250602" title="short permalink to this answer" class="short-link" id="link-post-250602">share</a><span class="lsep">|</span><a href="/posts/250602/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-05 13:06:44Z" class="relativetime">Jun 5 '15 at 13:06</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/124155/henriko">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/004664ea648043a0be46ae6830aabbbf?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/124155/henriko">henriko</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">31</span><span title="1 bronze badge"><span class="badge3"></span><span class="badgecount">1</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250602" class="comments ">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="0" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                        <tr id="comment-545360" class="comment ">
+                                                            <td class="comment-actions">
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                                <span title="number of 'useful comment' votes received" class="cool">2</span>
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy"><i>But it is usually when they crawl on our bodies we notice them</i> You sold me. +1 for the information, even though the term is probably unusable in English.</span> –
+                                                                    <a href="/users/77339/tushar-raj" title="16,459 reputation" class="comment-user owner">Tushar Raj</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment545360_250602"><span title="2015-06-05 13:09:01Z" class="relativetime-clean">Jun 5 '15 at 13:09</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250602" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link disabled-link " title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”.">add a comment</a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link dno" title="expand to show all comments on this post" href="#" onclick=""></a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250344"></a>
+                        <div id="answer-250344" class="answer" data-answerid="250344" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250344" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">0</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p>In french, it is common to see products to kill calling them <em>"<strong>indésirables</strong>"</em> or <em>"<strong>nuisibles</strong>"</em>.</p>
+
+                                                <p>You can translate to get :</p>
+
+                                                <blockquote>
+                                                    <p><strong>undesirable</strong>, unwanted, unwelcome, <strong>pest</strong></p>
+                                                </blockquote>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250344" title="short permalink to this answer" class="short-link" id="link-post-250344">share</a><span class="lsep">|</span><a href="/posts/250344/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+                                                        <td class="post-signature" align="right">
+                                                            <div class="user-info ">
+                                                                <div class="user-action-time">
+                                                                    <a href="/posts/250344/revisions" title="show all edits to this post">edited <span title="2015-06-04 08:03:19Z" class="relativetime">Jun 4 '15 at 8:03</span></a>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+
+                                                                </div>
+                                                                <div class="user-details">
+
+                                                                    <div class="-flair">
+
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info user-hover">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-04 07:58:01Z" class="relativetime">Jun 4 '15 at 7:58</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/114385/yohann-v">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/f07296aec63655764d1c31be663dfe5e?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/114385/yohann-v">Yohann V.</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">1,401</span><span title="1 gold badge"><span class="badge1"></span><span class="badgecount">1</span></span><span title="2 silver badges"><span class="badge2"></span><span class="badgecount">2</span></span><span title="17 bronze badges"><span class="badge3"></span><span class="badgecount">17</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250344" class="comments ">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="0" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+
+
+                                                        <tr id="comment-544748" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">"Undesirable" could be interpreted as referring to people.</span> –
+                                                                    <a href="/users/97531/kevin" title="1,890 reputation" class="comment-user">Kevin</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544748_250344"><span title="2015-06-04 14:35:53Z" class="relativetime-clean">Jun 4 '15 at 14:35</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544752" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">@Kevin You are totally right, but since I don't know where this word will be used, <i>context</i> can be leading to insect like reference... or not.</span> –
+                                                                    <a href="/users/114385/yohann-v" title="1,401 reputation" class="comment-user">Yohann V.</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544752_250344"><span title="2015-06-04 14:39:03Z" class="relativetime-clean">Jun 4 '15 at 14:39</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr id="comment-544787" class="comment ">
+                                                            <td>
+                                                                <table>
+                                                                    <tbody>
+                                                                        <tr>
+                                                                            <td class=" comment-score">
+                                                                            
+                                                                            </td>
+                                                                            <td>
+                                                                            
+                                                                            </td>
+                                                                        </tr>
+                                                                    </tbody>
+                                                                </table>
+                                                            </td>
+                                                            <td class="comment-text">
+                                                                <div style="display: block;" class="comment-body">
+                                                                    <span class="comment-copy">+1 for nuisibles!</span> –
+                                                                    <a href="/users/77339/tushar-raj" title="16,459 reputation" class="comment-user owner">Tushar Raj</a>
+                                                                    <span class="comment-date" dir="ltr"><a class="comment-link" href="#comment544787_250344"><span title="2015-06-04 15:09:32Z" class="relativetime-clean">Jun 4 '15 at 15:09</span></a>
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250344" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link disabled-link " title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”.">add a comment</a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link dno" title="expand to show all comments on this post" href="#" onclick=""></a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+
+                        <a name="250846"></a>
+                        <div id="answer-250846" class="answer" data-answerid="250846" itemscope="" itemtype="http://schema.org/Answer">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td class="votecell">
+
+
+                                            <div class="vote">
+                                                <input name="_id_" value="250846" type="hidden" />
+                                                <a class="vote-up-off" title="This answer is useful">up vote</a>
+                                                <span itemprop="upvoteCount" class="vote-count-post ">0</span>
+                                                <a class="vote-down-off" title="This answer is not useful">down vote</a>
+
+
+
+
+                                            </div>
+
+                                        </td>
+
+
+
+                                        <td class="answercell">
+                                            <div class="post-text" itemprop="text">
+                                                <p><strong>Wug</strong> is a portmanteau of <em>worm</em> and <em>bug</em>. It's not very common though, and might need to be explained.</p>
+
+                                                <p>A Google search for <a href="https://www.google.co.il/webhp?sourceid=chrome-instant&amp;ion=1&amp;espv=2&amp;es_th=1&amp;ie=UTF-8#q=wug%20worm%20bug" rel="nofollow"><code>wug worm bug</code></a> reveals hundreds of results, many from books on taxonomy. I couldn't just search for <code>wug</code> because it has other meanings as well.</p>
+
+                                                <p>This is either very informal or very formal -- i can't quite tell. :P</p>
+                                            </div>
+                                            <table class="fw">
+                                                <tbody>
+                                                    <tr>
+                                                        <td class="vt">
+                                                            <div class="post-menu"><a href="/a/250846" title="short permalink to this answer" class="short-link" id="link-post-250846">share</a><span class="lsep">|</span><a href="/posts/250846/edit" class="suggest-edit-post" title="">improve this answer</a></div>
+                                                        </td>
+
+
+
+                                                        <td class="post-signature" align="right">
+
+
+                                                            <div class="user-info user-hover">
+                                                                <div class="user-action-time">
+                                                                    answered <span title="2015-06-06 21:54:02Z" class="relativetime">Jun 6 '15 at 21:54</span>
+                                                                </div>
+                                                                <div class="user-gravatar32">
+                                                                    <a href="/users/73553/scimonster">
+                                                                        <div class="gravatar-wrapper-32"><img src="https://www.gravatar.com/avatar/40119dd76422b3d9c696051014ae6ff3?s=32&amp;d=identicon&amp;r=PG" alt="" height="32" width="32" /></div>
+                                                                    </a>
+                                                                </div>
+                                                                <div class="user-details">
+                                                                    <a href="/users/73553/scimonster">Scimonster</a>
+                                                                    <div class="-flair">
+                                                                        <span class="reputation-score" title="reputation score " dir="ltr">1,102</span><span title="1 gold badge"><span class="badge1"></span><span class="badgecount">1</span></span><span title="5 silver badges"><span class="badge2"></span><span class="badgecount">5</span></span><span title="22 bronze badges"><span class="badge3"></span><span class="badgecount">22</span></span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+
+                                    <tr>
+                                        <td class="votecell"></td>
+                                        <td>
+                                            <div id="comments-250846" class="comments  dno">
+                                                <table>
+                                                    <tbody data-remaining-comments-count="0" data-canpost="false" data-cansee="true" data-comments-unavailable="false" data-addlink-disabled="true">
+
+                                                        <tr>
+                                                            <td></td>
+                                                            <td></td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                            <div id="comments-link-250846" data-rep="50" data-anon="true">
+
+                                                <a class="js-add-link comments-link disabled-link " title="Use comments to ask for more information or suggest improvements. Avoid comments like “+1” or “thanks”.">add a comment</a><span class="js-link-separator dno"> | </span>
+                                                <a class="js-show-link comments-link dno" title="expand to show all comments on this post" href="#" onclick=""></a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <a name="new-answer"></a>
+                        <form id="post-form" action="/questions/250245/answer/submit" method="post" class="post-form">
+                            <input id="post-id" value="250245" type="hidden" />
+                            <input id="qualityBanWarningShown" name="qualityBanWarningShown" value="false" type="hidden" />
+                            <input name="referrer" value="" type="hidden" />
+                            <h2 class="space">Your Answer</h2>
+
+
+
+
+                            <script>
+                                StackExchange.ready(function() {
+                                    initTagRenderer("".split(" "), "".split(" "));
+
+                                    StackExchange.using("externalEditor", function() {
+                                        // Have to fire editor after snippets, if snippets enabled
+                                        if (StackExchange.settings.snippets.snippetsEnabled) {
+                                            StackExchange.using("snippets", function() {
+                                                createEditor();
+                                            });
+                                        } else {
+                                            createEditor();
+                                        }
+                                    });
+
+                                    function createEditor() {
+                                        prepareEditor({
+                                            heartbeatType: 'answer',
+                                            convertImagesToLinks: false,
+                                            reputationToPostImages: null,
+                                            bindNavPrevention: true,
+                                            postfix: "",
+                                            noCode: true,
+                                            onDemand: true,
+                                            discardSelector: ".discard-answer",
+                                            immediatelyShowMarkdownHelp: true
+                                        });
+
+
+                                    }
+                                });
+                            </script>
+
+
+                            <div id="post-editor" class="post-editor js-post-editor">
+
+                                <div style="position: relative;">
+                                    <div class="wmd-container">
+                                        <div id="wmd-button-bar" class="wmd-button-bar">
+                                            <ul id="wmd-button-row" class="wmd-button-row">
+                                                <li id="wmd-bold-button" class="wmd-button" style="left: 0px;"><span style="background-position: 0px -20px;"></span></li>
+                                                <li id="wmd-italic-button" class="wmd-button" style="left: 25px;"><span style="background-position: -20px -20px;"></span></li>
+                                                <li id="wmd-spacer1" class="wmd-spacer" style="left: 50px;"><span style="background-position: -40px -20px;"></span></li>
+                                                <li id="wmd-link-button" class="wmd-button" style="left: 75px;"><span style="background-position: -40px -20px;"></span></li>
+                                                <li id="wmd-quote-button" class="wmd-button" style="left: 100px;"><span style="background-position: -60px -20px;"></span></li>
+                                                <li id="wmd-code-button" class="wmd-button" style="left: 125px;"><span style="background-position: -80px -20px;"></span></li>
+                                                <li id="wmd-image-button" class="wmd-button" style="left: 150px;"><span style="background-position: -100px -20px;"></span></li>
+                                                <li id="wmd-spacer2" class="wmd-spacer" style="left: 175px;"><span style="background-position: -120px -20px;"></span></li>
+                                                <li id="wmd-olist-button" class="wmd-button" style="left: 200px;"><span style="background-position: -120px -20px;"></span></li>
+                                                <li id="wmd-ulist-button" class="wmd-button" style="left: 225px;"><span style="background-position: -140px -20px;"></span></li>
+                                                <li id="wmd-heading-button" class="wmd-button" style="left: 250px;"><span style="background-position: -160px -20px;"></span></li>
+                                                <li id="wmd-hr-button" class="wmd-button" style="left: 275px;"><span style="background-position: -180px -20px;"></span></li>
+                                                <li id="wmd-spacer3" class="wmd-spacer" style="left: 300px;"><span style="background-position: -200px -20px;"></span></li>
+                                                <li id="wmd-undo-button" class="wmd-button" style="left: 325px;"><span style="background-position: -200px -20px;"></span></li>
+                                                <li id="wmd-redo-button" class="wmd-button" style="left: 350px;"><span style="background-position: -220px -20px;"></span></li>
+                                            </ul>
+                                        </div>
+                                        <textarea id="wmd-input" class="wmd-input" name="post-text" cols="92" rows="15" tabindex="101" data-min-length=""></textarea>
+                                    </div>
+                                </div>
+
+                                <div class="fl" style="margin-top: 8px; height:24px;"> </div>
+                                <div id="draft-saved" class="draft-saved community-option fl" style="margin-top: 8px; height:24px; display:none;">draft saved</div>
+
+                                <div id="draft-discarded" class="draft-discarded community-option fl" style="margin-top: 8px; height:24px; display:none;">draft discarded</div>
+
+
+
+                                <div id="wmd-preview" class="wmd-preview"></div>
+                                <div></div>
+                                <div class="edit-block">
+                                    <input id="fkey" name="fkey" value="bb931690941949cbbfdc4a6f840da0f8" type="hidden" />
+                                    <input id="author" name="author" type="text" />
+                                </div>
+
+
+
+                            </div>
+                            <div style="position: relative;">
+
+                                <div class="form-item new-post-login">
+
+                                    <div class="new-login-form">
+                                        <div class="new-login-left">
+                                            <h3>Sign up or <a id="login-link" href="/users/login?ssrc=question_page&amp;returnurl=http%3a%2f%2fenglish.stackexchange.com%2fquestions%2f250245%2fa-hypernym-for-insects-worms-and-the-like%23new-answer">log in</a></h3>
+                                            <script>
+                                                StackExchange.ready(function() {
+                                                    StackExchange.helpers.onClickDraftSave('#login-link');
+                                                });
+                                            </script>
+                                            <div class="preferred-login google-login">
+                                                <p><span class="icon"></span><span>Sign up using Google</span></p>
+                                            </div>
+                                            <div class="preferred-login facebook-login">
+                                                <p><span class="icon"></span><span>Sign up using Facebook</span></p>
+                                            </div>
+                                            <div class="preferred-login stackexchange-login">
+                                                <p><span class="icon"></span><span>Sign up using Email and Password</span></p>
+                                            </div>
+                                        </div>
+                                        <input name="manual-openid" class="manual-openid" type="hidden" />
+                                        <input name="use-facebook" class="use-facebook" value="false" type="hidden" />
+                                        <input name="use-google" class="use-google" value="false" type="hidden" />
+                                        <input class="submit-openid" value="Submit" style="display:none" type="button" />
+                                        <div class="new-login-right">
+                                            <h3>Post as a guest</h3>
+                                            <div class="form-item">
+                                                <table>
+                                                    <tbody>
+                                                        <tr>
+                                                            <td class="vm">
+                                                                <div>
+                                                                    <label for="display-name">Name</label>
+                                                                    <input id="display-name" name="display-name" size="30" maxlength="30" value="" tabindex="105" type="text" />
+                                                                </div>
+                                                                <div>
+                                                                    <label for="m-address">Email</label>
+                                                                    <input id="m-address" name="m-address" size="30" maxlength="100" value="" tabindex="106" placeholder="required, but never shown" type="email" />
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                        </div>
+                                    </div>
+                                </div>
+                                <script>
+                                    StackExchange.ready(
+                                        function() {
+                                            StackExchange.openid.initPostLogin('.new-post-login', 'http%3a%2f%2fenglish.stackexchange.com%2fquestions%2f250245%2fa-hypernym-for-insects-worms-and-the-like%23new-answer', 'question_page');
+                                        }
+                                    );
+                                </script>
+                                <noscript>
+                        &lt;h3&gt;Post as a guest&lt;/h3&gt;
+    &lt;div class="form-item"&gt;
+        &lt;table&gt;
+        &lt;tr&gt;
+                    &lt;td class="vm"&gt;
+                &lt;div&gt;
+                    &lt;label for="display-name"&gt;Name&lt;/label&gt;
+                    &lt;input id="display-name" name="display-name" type="text" size="30" maxlength="30" value="" tabindex="105"&gt;
+                &lt;/div&gt;
+                &lt;div&gt;
+                    &lt;label for="m-address"&gt;Email&lt;/label&gt;
+                    &lt;input id="m-address" name="m-address" type="email" size="30" maxlength="100" value="" tabindex="106" placeholder="required, but never shown" /&gt;
+                &lt;/div&gt;
+            &lt;/td&gt;
+        &lt;/tr&gt;
+        &lt;/table&gt;
+    &lt;/div&gt;
+
+            </noscript>
+
+                            </div>
+
+                            <div class="form-submit cbt">
+                                <input id="submit-button" value="Post Your Answer" tabindex="110" type="submit" />
+                                <a href="#" class="btn-clear discard-answer dno">discard</a>
+
+                                <p class="privacy-policy-agreement">
+                                    By posting your answer, you agree to the <a href="http://stackexchange.com/legal/privacy-policy" name="privacy" target="_blank">privacy policy</a> and <a href="http://stackexchange.com/legal/terms-of-service" name="tos" target="_blank">terms of service</a>.</p>
+                                <input name="legalLinksShown" value="1" type="hidden" /> </div>
+                        </form>
+
+
+
+                        <h2 class="bottom-notice" data-loc="1">
+                            Not the answer you're looking for? Browse other questions tagged <a href="/questions/tagged/single-word-requests" class="post-tag" title="show questions tagged 'single-word-requests'" rel="tag">single-word-requests</a> <a href="/questions/tagged/hypernyms" class="post-tag" title="show questions tagged 'hypernyms'" rel="tag">hypernyms</a> <a href="/questions/tagged/nuance" class="post-tag" title="show questions tagged 'nuance'" rel="tag">nuance</a> or <a href="/questions/ask">ask your own question</a>. </h2>
+                    </div>
+                </div>
+                <div id="sidebar" class="show-votes">
+                    <div class="module question-stats">
+                        <table id="qinfo">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <p class="label-key">asked</p>
+                                    </td>
+                                    <td style="padding-left: 10px">
+                                        <p class="label-key" title="2015-06-03 19:33:46Z"><b>1 year ago</b></p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <p class="label-key">viewed</p>
+                                    </td>
+
+                                    <td style="padding-left: 10px">
+                                        <p class="label-key">
+                                            <b>6327 times</b>
+                                        </p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <p class="label-key">active</p>
+                                    </td>
+                                    <td style="padding-left: 10px">
+                                        <p class="label-key"><b><a href="?lastactivity" class="lastactivity-link" title="2015-06-06 21:54:02Z">1 year ago</a></b></p>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="module community-bulletin" data-tracker="cb=1">
+                        <div class="related">
+                            <div class="bulletin-title">
+                                Blog
+                            </div>
+                            <hr />
+                            <div class="spacer">
+                                <div class="bulletin-item-type">
+                                    <a href="https://stackoverflow.blog/2017/03/06/stack-overflow-podcast-103-grandma/?cb=1" class="question-hyperlink">
+                                        <div class="favicon favicon-stackexchangemeta" title="Meta Stack Exchange"></div>
+                                    </a>
+                                </div>
+                                <div class="bulletin-item-content">
+                                    <a href="https://stackoverflow.blog/2017/03/06/stack-overflow-podcast-103-grandma/?cb=1" class="question-hyperlink">Podcast #103: Grandma, is that you?</a>
+                                </div>
+                                <br class="cbt" />
+                            </div>
+                        </div>
+                    </div>
+                    <div style="margin-bottom: 10px;">
+
+
+                        <script>
+                            StackExchange.ready(function() {
+                                StackExchange.newsletterAd.init();
+                            });
+                        </script>
+
+                        <div id="newsletter-ad">
+                            <p id="newsletter-ad-header">Get the <b>weekly newsletter!</b> In it, you'll get:</p>
+                            <ul>
+                                <li>The week's top questions and answers</li>
+                                <li>Important community announcements</li>
+                                <li>Questions that need answers</li>
+                            </ul>
+                            <div id="newsletter-signup-container"><input id="newsletter-signup" value="Sign up for the newsletter" type="button" /></div>
+                            <p id="newsletter-preview-container">see an <a href="http://stackexchange.com/newsletters/newsletter?site=english.stackexchange.com" id="newsletter-preview">example newsletter</a></p>
+                            <div class="dno">
+
+                                <p class="privacy-policy-agreement">
+                                    By subscribing, you agree to the <a href="http://stackexchange.com/legal/privacy-policy" name="privacy" target="_blank">privacy policy</a> and <a href="http://stackexchange.com/legal/terms-of-service" name="tos" target="_blank">terms of service</a>.</p>
+                                <input name="legalLinksShown" value="1" type="hidden" />
+                            </div>
+                        </div>
+
+                    </div>
+                    <style type="text/css">
+                        .ads {
+                            margin-left: 60px;
+                        }
+                        
+                        .ad-container {
+                            width: 300px;
+                            height: 250px;
+                            margin-right: 20px;
+                            margin-bottom: 20px;
+                        }
+                        
+                        .ad-container .ad {
+                            height: 250px;
+                        }
+                        
+                        .ad-container .footer-container {
+                            overflow: hidden;
+                            height: 30px;
+                            position: relative;
+                            top: -30px;
+                        }
+                        
+                        .ad-container .footer-container .footer {
+                            font-family: Arial, Helvetic, Sans-Serif;
+                            font-size: 12px;
+                            text-align: center;
+                            padding-top: 9px;
+                            background-color: #000;
+                            color: #EFF;
+                            opacity: 0.9;
+                            filter: alpha(opacity=90);
+                            top: 30px;
+                            height: 30px;
+                            position: relative;
+                        }
+                        
+                        .ad-container a:hover {
+                            text-decoration: underline;
+                        }
+                        
+                        #adzerk2 {
+                            height: 250px;
+                        }
+                    </style>
+                    <script>
+                        StackExchange.ready(function() {
+                            $(".ad-container").hover(
+                                function() {
+                                    $(".ad-container .footer-container .footer").stop(true, true).animate({
+                                        top: "0px"
+                                    }, "fast");
+                                },
+                                function() {
+                                    $(".ad-container .footer-container .footer").animate({
+                                        top: "30px"
+                                    }, "fast");
+                                });
+                        });
+                    </script>
+                    <div class="ad-container">
+                        <div class="ad">
+                            <a href="http://meta.english.stackexchange.com/ads/ct/10006?url=https%3a%2f%2flatin.stackexchange.com%2f&amp;s=0f59166bcd89c8e08c572510b3916e6ad5d1b243a5334f05ac8cced0f1b86bf1" rel="nofollow" target="_blank"><img src="https://i.stack.imgur.com/BeN5I.png" alt="Explore the roots of English at the Latin Stack Exchange" title="Explore the roots of English at the Latin Stack Exchange" height="250" width="300" /></a>
+                        </div>
+                        <div class="footer-container">
+                            <div class="footer">
+                                16 votes · <a href="http://meta.english.stackexchange.com/questions/10004#10006" title="click to comment on this ad" target="_blank">comment</a> · <a href="http://meta.english.stackexchange.com/ads/display/10004" target="_blank">stats</a>
+                            </div>
+                        </div>
+                    </div>
+
+
+                    <div class="module sidebar-linked">
+                        <h4 id="h-linked">Linked</h4>
+                        <div class="linked" data-tracker="lq=1">
+
+                            <div class="spacer">
+                                <a href="http://english.stackexchange.com/q/166006?lq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">5</div>
+                                </a>
+                                <a href="http://english.stackexchange.com/questions/166006/origin-of-minibeasts?noredirect=1&amp;lq=1" class="question-hyperlink">Origin of “minibeasts”?</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="module sidebar-related">
+                        <h4 id="h-related">Related</h4>
+                        <div class="related js-gps-related-questions" data-tracker="rq=1">
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/23031?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">8</div>
+                                </a><a href="http://english.stackexchange.com/questions/23031/is-there-a-hypernym-for-order-confirmation-quotation-and-invoice?rq=1" class="question-hyperlink">Is there a hypernym for “order confirmation”, “quotation” and “invoice”?</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/84652?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">2</div>
+                                </a><a href="http://english.stackexchange.com/questions/84652/hypernym-for-various-parts-of-a-plant?rq=1" class="question-hyperlink">Hypernym for various parts of a plant</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/85714?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes default">3</div>
+                                </a><a href="http://english.stackexchange.com/questions/85714/hypernym-for-coalition-and-opposition?rq=1" class="question-hyperlink">Hypernym for “coalition” and “opposition”</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/152153?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">2</div>
+                                </a><a href="http://english.stackexchange.com/questions/152153/hypernym-for-something-like-a-blanket-sheet-to-cover-oneself-for-keeping-warm?rq=1" class="question-hyperlink">Hypernym for something like a blanket/sheet to cover oneself for keeping warm</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/185591?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">0</div>
+                                </a><a href="http://english.stackexchange.com/questions/185591/hypernyms-for-directions?rq=1" class="question-hyperlink">Hypernyms for directions</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/204186?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes default">1</div>
+                                </a><a href="http://english.stackexchange.com/questions/204186/hypernym-for-parallel-and-antiparallel?rq=1" class="question-hyperlink">Hypernym for 'parallel' and 'antiparallel'</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/211670?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">1</div>
+                                </a><a href="http://english.stackexchange.com/questions/211670/hypernym-for-scientist-and-engineer?rq=1" class="question-hyperlink">Hypernym for “scientist” and “engineer”</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/248812?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">23</div>
+                                </a><a href="http://english.stackexchange.com/questions/248812/hypernym-for-bark-meow-roar?rq=1" class="question-hyperlink">Hypernym for “bark”, “meow”, “roar”</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/269048?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">2</div>
+                                </a><a href="http://english.stackexchange.com/questions/269048/hypernym-for-driver-and-passenger?rq=1" class="question-hyperlink">Hypernym for “driver” and “passenger”</a></div>
+                            <div class="spacer js-gps-track">
+                                <a href="http://english.stackexchange.com/q/273678?rq=1" title="Vote score (upvotes - downvotes)">
+                                    <div class="answer-votes answered-accepted default">0</div>
+                                </a><a href="http://english.stackexchange.com/questions/273678/hypernym-for-pluralise-and-singularise?rq=1" class="question-hyperlink">Hypernym for pluralise and singularise</a></div>
+                        </div>
+                    </div>
+
+                    <div id="hot-network-questions" class="module tex2jax_ignore">
+                        <h4>
+                            <a href="http://stackexchange.com/questions?tab=hot" class="js-gps-track" data-gps-track="posts_hot_network.click({ item_type:1, location:11 })">
+            Hot Network Questions
+        </a>
+                        </h4>
+                        <ul>
+                            <li>
+                                <div class="favicon favicon-codereview" title="Code Review Stack Exchange"></div><a href="http://codereview.stackexchange.com/questions/157208/find-a-value-in-a-container" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:196 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Find a Value in a Container
+                </a>
+
+                            </li>
+                            <li>
+                                <div class="favicon favicon-music" title="Music: Practice &amp; Theory Stack Exchange"></div><a href="http://music.stackexchange.com/questions/54143/why-do-people-with-perfect-pitch-perceive-tunes-not-in-440hz-out-of-tune" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:240 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Why do people with perfect pitch perceive tunes not in 440hz out of tune
+                </a>
+
+                            </li>
+                            <li>
+                                <div class="favicon favicon-chess" title="Chess Stack Exchange"></div><a href="http://chess.stackexchange.com/questions/16854/strategic-implications-in-this-puzzle-by-s-polgar-p-truong" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:435 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Strategic implications in this puzzle by S. Polgar/P. Truong
+                </a>
+
+                            </li>
+                            <li>
+                                <div class="favicon favicon-politics" title="Politics Stack Exchange"></div><a href="http://politics.stackexchange.com/questions/16143/is-there-anything-that-functionally-prevents-a-us-president-from-switching-parti" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:475 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Is there anything that functionally prevents a US President from switching parties?
+                </a>
+
+                            </li>
+                            <li>
+                                <div class="favicon favicon-worldbuilding" title="Worldbuilding Stack Exchange"></div><a href="http://worldbuilding.stackexchange.com/questions/72958/how-can-a-horror-from-beyond-reason-reliably-communicate-with-mortals" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:579 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    How can a Horror from Beyond Reason reliably communicate with mortals?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-codegolf" title="Programming Puzzles &amp; Code Golf Stack Exchange"></div><a href="http://codegolf.stackexchange.com/questions/112152/construct-the-natural-numbers-with-sets" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:200 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Construct the natural numbers with sets
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-worldbuilding" title="Worldbuilding Stack Exchange"></div><a href="http://worldbuilding.stackexchange.com/questions/73232/would-a-civilization-on-a-planet-with-no-natural-uranium-235-need-to-first-achie" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:579 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Would a civilization on a planet with no natural Uranium-235 NEED to first achieve fusion before it can build nukes?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-superuser" title="Super User"></div><a href="http://superuser.com/questions/1185792/does-a-usb-keyboard-only-send-signals-or-does-it-also-receive-them-from-the-com" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:3 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Does a USB keyboard only send signals, or does it also receive them from the computer?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-stats" title="Cross Validated"></div><a href="http://stats.stackexchange.com/questions/265871/can-i-trust-a-significant-result-of-a-t-test-if-the-sample-size-is-small" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:65 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Can I trust a significant result of a t-test if the sample size is small?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-ux" title="User Experience Stack Exchange"></div><a href="http://ux.stackexchange.com/questions/105654/are-there-any-guidelines-concerning-the-use-of-alt-ctrl-and-shift-keys" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:102 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Are there any guidelines concerning the use of Alt, Ctrl and Shift keys?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-aviation" title="Aviation Stack Exchange"></div><a href="http://aviation.stackexchange.com/questions/36096/could-the-v-22-osprey-be-used-as-a-close-air-support-platform" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:528 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Could the V-22 Osprey be used as a close air support platform?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-tex" title="TeX - LaTeX Stack Exchange"></div><a href="http://tex.stackexchange.com/questions/357383/meaning-of-and-in-latex-syntax" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:85 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Meaning of {} and [] in LaTeX syntax?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-workplace" title="The Workplace Stack Exchange"></div><a href="http://workplace.stackexchange.com/questions/86320/is-using-an-informal-version-of-my-name-in-professional-contexts-unprofessional" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:423 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Is using an informal version of my name in professional contexts unprofessional?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-politics" title="Politics Stack Exchange"></div><a href="http://politics.stackexchange.com/questions/16151/what-are-the-differences-between-trumps-old-travel-ban-and-the-new-one" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:475 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    What are the differences between Trump's old travel ban and the new one?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-puzzling" title="Puzzling Stack Exchange"></div><a href="http://puzzling.stackexchange.com/questions/49827/another-matchstick-cotton-swab-puzzle" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:559 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Another Matchstick (cotton swab) puzzle
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-literature" title="Literature Stack Exchange"></div><a href="http://literature.stackexchange.com/questions/1962/does-snape-talk-in-code" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:668 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Does Snape talk in code?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-academia" title="Academia Stack Exchange"></div><a href="http://academia.stackexchange.com/questions/86124/how-do-i-know-how-well-i-am-progressing-in-my-phd" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:415 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    How do I know how well I am progressing in my PhD?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-writers" title="Writers Stack Exchange"></div><a href="http://writers.stackexchange.com/questions/27070/should-you-avoid-offensive-hyperbole" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:166 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Should you avoid offensive hyperbole?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-gaming" title="Arqade"></div><a href="http://gaming.stackexchange.com/questions/302427/how-can-i-reliably-catch-fish-without-drowning" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:41 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    How can I reliably catch fish without drowning?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-superuser" title="Super User"></div><a href="http://superuser.com/questions/1186303/how-can-a-processor-be-made-faster-with-a-software-update" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:3 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    How can a processor be made faster with a "software" update?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-scifi" title="Science Fiction &amp; Fantasy Stack Exchange"></div><a href="http://scifi.stackexchange.com/questions/154107/story-about-astronauts-who-set-off-an-alien-warning-beacon-on-the-moon-or-mars" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:186 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Story about astronauts who set off an alien warning beacon on the moon (or Mars?)
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-math" title="Mathematics Stack Exchange"></div><a href="http://math.stackexchange.com/questions/2176971/a-union-of-two-subgroups" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:69 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    a union of two subgroups
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-scifi" title="Science Fiction &amp; Fantasy Stack Exchange"></div><a href="http://scifi.stackexchange.com/questions/154035/in-star-trek-why-do-federation-starfleet-ships-always-seem-to-delay-returning" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:186 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    In Star Trek, why do Federation / Starfleet ships always seem to delay returning fire until it's almost too late?
+                </a>
+
+                            </li>
+                            <li class="dno js-hidden" style="display: list-item;">
+                                <div class="favicon favicon-codereview" title="Code Review Stack Exchange"></div><a href="http://codereview.stackexchange.com/questions/157122/show-time-in-format-yyyy-mm-ddthhmmss-sss" class="js-gps-track" data-gps-track="site.switch({ item_type:11, target_site:196 }); posts_hot_network.click({ item_type:2, location:11 })">
+                    Show time in format yyyy-MM-ddThh:mm:ss.SSS
+                </a>
+
+                            </li>
+                        </ul>
+
+
+                    </div>
+                </div>
+
+                <div id="feed-link">
+                    <div id="feed-link-text">
+                        <a href="/feeds/question/250245" title="feed of this question and its answers">
+                            <span class="feed-icon"></span>question feed
+                        </a>
+                    </div>
+                </div>
+                <script>
+                    StackExchange.ready(function() {
+                        $.get('/posts/250245/ivc/edbc');
+                    });
+                </script>
+                <noscript>
+    &lt;div&gt;&lt;img src="/posts/250245/ivc/edbc" class="dno" alt="" width="0" height="0"&gt;&lt;/div&gt;
+</noscript></div>
+
+
+        </div>
+    </div>
+    <div id="footer" class="categories">
+        <div class="footerwrap">
+            <div id="footer-menu">
+                <div class="top-footer-links">
+                    <a href="http://stackoverflow.com/company/about">about us</a>
+                    <a href="/tour">tour</a>
+                    <a href="/help">help</a>
+                    <a href="http://stackoverflow.blog?blb=1">blog</a>
+                    <a href="http://chat.stackexchange.com?tab=site&amp;host=english.stackexchange.com">chat</a>
+                    <a href="https://data.stackexchange.com">data</a>
+                    <a href="http://stackexchange.com/legal">legal</a>
+                    <a href="http://stackexchange.com/legal/privacy-policy">privacy policy</a>
+                    <a href="http://stackoverflow.com/company/work-here">work here</a>
+                    <a href="http://stackexchange.com/mediakit">advertising info</a>
+
+                    <a onclick='StackExchange.switchMobile("on")'>mobile</a>
+                    <b><a href="/contact">contact us</a></b>
+                    <b><a href="http://meta.english.stackexchange.com">feedback</a></b>
+
+                </div>
+                <div id="footer-sites">
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th colspan="3">
+                                    Technology
+                                </th>
+                                <th>
+                                    Life / Arts
+                                </th>
+                                <th>
+                                    Culture / Recreation
+                                </th>
+                                <th>
+                                    Science
+                                </th>
+                                <th>
+                                    Other
+                                </th>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <ol>
+                                        <li><a href="//stackoverflow.com" title="professional and enthusiast programmers">Stack Overflow</a></li>
+                                        <li><a href="//serverfault.com" title="system and network administrators">Server Fault</a></li>
+                                        <li><a href="//superuser.com" title="computer enthusiasts and power users">Super User</a></li>
+                                        <li><a href="//webapps.stackexchange.com" title="power users of web applications">Web Applications</a></li>
+                                        <li><a href="//askubuntu.com" title="Ubuntu users and developers">Ask Ubuntu</a></li>
+                                        <li><a href="//webmasters.stackexchange.com" title="pro webmasters">Webmasters</a></li>
+                                        <li><a href="//gamedev.stackexchange.com" title="professional and independent game developers">Game Development</a></li>
+                                        <li><a href="//tex.stackexchange.com" title="users of TeX, LaTeX, ConTeXt, and related typesetting systems">TeX - LaTeX</a></li>
+                                        <li><a href="//softwareengineering.stackexchange.com" title="professionals, academics, and students working within the systems development life cycle who care about creating, delivering, and maintaining software responsibly">Software Engineering</a></li>
+                                        <li><a href="//unix.stackexchange.com" title="users of Linux, FreeBSD and other Un*x-like operating systems">Unix &amp; Linux</a></li>
+                                        <li><a href="//apple.stackexchange.com" title="power users of Apple hardware and software">Ask Different (Apple)</a></li>
+                                        <li><a href="//wordpress.stackexchange.com" title="WordPress developers and administrators">WordPress Development</a></li>
+                                    </ol>
+                                </td>
+                                <td>
+                                    <ol>
+                                        <li><a href="//gis.stackexchange.com" title="cartographers, geographers and GIS professionals">Geographic Information Systems</a></li>
+                                        <li><a href="//electronics.stackexchange.com" title="electronics and electrical engineering professionals, students, and enthusiasts">Electrical Engineering</a></li>
+                                        <li><a href="//android.stackexchange.com" title="enthusiasts and power users of the Android operating system">Android Enthusiasts</a></li>
+                                        <li><a href="//security.stackexchange.com" title="information security professionals">Information Security</a></li>
+                                        <li><a href="//dba.stackexchange.com" title="database professionals who wish to improve their database skills and learn from others in the community">Database Administrators</a></li>
+                                        <li><a href="//drupal.stackexchange.com" title="Drupal developers and administrators">Drupal Answers</a></li>
+                                        <li><a href="//sharepoint.stackexchange.com" title="SharePoint enthusiasts">SharePoint</a></li>
+                                        <li><a href="//ux.stackexchange.com" title="user experience researchers and experts">User Experience</a></li>
+                                        <li><a href="//mathematica.stackexchange.com" title="users of Wolfram Mathematica">Mathematica</a></li>
+                                        <li><a href="//salesforce.stackexchange.com" title="Salesforce administrators, implementation experts, developers and anybody in-between">Salesforce</a></li>
+                                        <li><a href="//expressionengine.stackexchange.com" title="administrators, end users, developers and designers for ExpressionEngine® CMS">ExpressionEngine® Answers</a></li>
+                                        <li><a href="//crypto.stackexchange.com" title="software developers, mathematicians and others interested in cryptography">Cryptography</a></li>
+                                    </ol>
+                                </td>
+                                <td>
+                                    <ol>
+                                        <li><a href="//codereview.stackexchange.com" title="peer programmer code reviews">Code Review</a></li>
+                                        <li><a href="//magento.stackexchange.com" title="users of the Magento e-Commerce platform">Magento</a></li>
+                                        <li><a href="//dsp.stackexchange.com" title="practitioners of the art and science of signal, image and video processing">Signal Processing</a></li>
+                                        <li><a href="//raspberrypi.stackexchange.com" title="users and developers of hardware and software for Raspberry Pi">Raspberry Pi</a></li>
+                                        <li><a href="//codegolf.stackexchange.com" title="programming puzzle enthusiasts and code golfers">Programming Puzzles &amp; Code Golf</a></li>
+
+                                        <li>
+                                            <a href="http://stackexchange.com/sites#technology" class="more">
+                                more (7)
+                            </a>
+                                        </li>
+                                    </ol>
+                                </td>
+                                <td>
+                                    <ol>
+                                        <li><a href="//photo.stackexchange.com" title="professional, enthusiast and amateur photographers">Photography</a></li>
+                                        <li><a href="//scifi.stackexchange.com" title="science fiction and fantasy enthusiasts">Science Fiction &amp; Fantasy</a></li>
+                                        <li><a href="//graphicdesign.stackexchange.com" title="Graphic Design professionals, students, and enthusiasts">Graphic Design</a></li>
+                                        <li><a href="//movies.stackexchange.com" title="movie and tv enthusiasts">Movies &amp; TV</a></li>
+                                        <li><a href="//music.stackexchange.com" title="musicians, students, and enthusiasts">Music: Practice &amp; Theory</a></li>
+                                        <li><a href="//cooking.stackexchange.com" title="professional and amateur chefs">Seasoned Advice (cooking)</a></li>
+                                        <li><a href="//diy.stackexchange.com" title="contractors and serious DIYers">Home Improvement</a></li>
+                                        <li><a href="//money.stackexchange.com" title="people who want to be financially literate">Personal Finance &amp; Money</a></li>
+                                        <li><a href="//academia.stackexchange.com" title="academics and those enrolled in higher education">Academia</a></li>
+
+                                        <li>
+                                            <a href="http://stackexchange.com/sites#lifearts" class="more">
+                                more (8)
+                            </a>
+                                        </li>
+                                    </ol>
+                                </td>
+                                <td>
+                                    <ol>
+                                        <li><a href="//english.stackexchange.com" title="linguists, etymologists, and serious English language enthusiasts">English Language &amp; Usage</a></li>
+                                        <li><a href="//skeptics.stackexchange.com" title="scientific skepticism">Skeptics</a></li>
+                                        <li><a href="//judaism.stackexchange.com" title="those who base their lives on Jewish law and tradition and anyone interested in learning more">Mi Yodeya (Judaism)</a></li>
+                                        <li><a href="//travel.stackexchange.com" title="road warriors and seasoned travelers">Travel</a></li>
+                                        <li><a href="//christianity.stackexchange.com" title="committed Christians, experts in Christianity and those interested in learning more">Christianity</a></li>
+                                        <li><a href="//ell.stackexchange.com" title="speakers of other languages learning English">English Language Learners</a></li>
+                                        <li><a href="//japanese.stackexchange.com" title="students, teachers, and linguists wanting to discuss the finer points of the Japanese language">Japanese Language</a></li>
+                                        <li><a href="//gaming.stackexchange.com" title="passionate videogamers on all platforms">Arqade (gaming)</a></li>
+                                        <li><a href="//bicycles.stackexchange.com" title="people who build and repair bicycles, people who train cycling, or commute on bicycles">Bicycles</a></li>
+                                        <li><a href="//rpg.stackexchange.com" title="gamemasters and players of tabletop, paper-and-pencil role-playing games">Role-playing Games</a></li>
+                                        <li><a href="//anime.stackexchange.com" title="anime and manga fans">Anime &amp; Manga</a></li>
+                                        <li><a href="//mechanics.stackexchange.com" title="mechanics and DIY enthusiast owners of cars, trucks, and motorcycles">Motor Vehicle Maintenance &amp; Repair</a></li>
+
+                                        <li>
+                                            <a href="http://stackexchange.com/sites#culturerecreation" class="more">
+                                more (17)
+                            </a>
+                                        </li>
+                                    </ol>
+                                </td>
+                                <td>
+                                    <ol>
+                                        <li><a href="//mathoverflow.net" title="professional mathematicians">MathOverflow</a></li>
+                                        <li><a href="//math.stackexchange.com" title="people studying math at any level and professionals in related fields">Mathematics</a></li>
+                                        <li><a href="//stats.stackexchange.com" title="people interested in statistics, machine learning, data analysis, data mining, and data visualization">Cross Validated (stats)</a></li>
+                                        <li><a href="//cstheory.stackexchange.com" title="theoretical computer scientists and researchers in related fields">Theoretical Computer Science</a></li>
+                                        <li><a href="//physics.stackexchange.com" title="active researchers, academics and students of physics">Physics</a></li>
+                                        <li><a href="//chemistry.stackexchange.com" title="scientists, academics, teachers and students">Chemistry</a></li>
+                                        <li><a href="//biology.stackexchange.com" title="biology researchers, academics, and students">Biology</a></li>
+                                        <li><a href="//cs.stackexchange.com" title="students, researchers and practitioners of computer science">Computer Science</a></li>
+                                        <li><a href="//philosophy.stackexchange.com" title="those interested in the study of the fundamental nature of knowledge, reality, and existence">Philosophy</a></li>
+
+                                        <li>
+                                            <a href="http://stackexchange.com/sites#science" class="more">
+                                more (3)
+                            </a>
+                                        </li>
+                                    </ol>
+                                </td>
+                                <td>
+                                    <ol>
+                                        <li><a href="//meta.stackexchange.com" title="meta-discussion of the Stack Exchange family of Q&amp;A websites">Meta Stack Exchange</a></li>
+                                        <li><a href="//stackapps.com" title="apps, scripts, and development with the Stack Exchange API">Stack Apps</a></li>
+                                        <li><a href="//area51.stackexchange.com" title="proposing new sites in the Stack Exchange network">Area 51</a></li>
+                                        <li><a href="https://www.stackoverflowbusiness.com/talent">Stack Overflow Talent</a></li>
+
+                                    </ol>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div id="copyright">
+                site design / logo © 2017 Stack Exchange Inc; user contributions licensed under <a href="https://creativecommons.org/licenses/by-sa/3.0/" rel="license">cc by-sa 3.0</a> with <a href="http://blog.stackoverflow.com/2009/06/attribution-required/" rel="license">attribution required</a>
+            </div>
+            <div id="svnrev">
+                rev 2017.3.7.25334
+            </div>
+        </div>
+    </div>
+    <noscript>
+        &lt;div id="noscript-warning"&gt;English Language &amp;amp; Usage Stack Exchange works best with JavaScript enabled&lt;img src="https://pixel.quantserve.com/pixel/p-c1rF4kxgLUzNc.gif" alt="" class="dno"&gt;&lt;/div&gt;
+    </noscript>
+
+    <script>
+        (function(i, s, o, g, r, a, m) {
+            i['GoogleAnalyticsObject'] = r;
+            i[r] = i[r] || function() {
+                (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * new Date();
+            a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0];
+            a.async = 1;
+            a.src = g;
+            m.parentNode.insertBefore(a, m);
+        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+        ga('create', 'UA-5620270-24', {
+            'cookieDomain': 'stackexchange.com'
+        });
+        ga('set', 'dimension2', '|single-word-requests|hypernyms|nuance|');
+        ga('send', 'pageview');
+        var _qevents = _qevents || [],
+            _comscore = _comscore || [];
+        (function() {
+            var ssl = 'https:' == document.location.protocol,
+                s = document.getElementsByTagName('script')[0],
+                qc = document.createElement('script');
+            qc.async = true;
+            qc.src = (ssl ? 'https://secure' : 'http://edge') + '.quantserve.com/quant.js';
+            s.parentNode.insertBefore(qc, s);
+            _qevents.push({
+                qacct: "p-c1rF4kxgLUzNc"
+            });
+            var sc = document.createElement('script');
+            sc.async = true;
+            sc.src = (ssl ? 'https://sb' : 'http://b') + '.scorecardresearch.com/beacon.js';
+            s.parentNode.insertBefore(sc, s);
+            _comscore.push({
+                c1: "2",
+                c2: "17440561"
+            });
+        })();
+    </script>
+
+
+    <script type="text/javascript">
+        (function(appendChild) {
+            Node.prototype.appendChild = function() {
+                var parent = this;
+                var newNode = arguments[0];
+                if (parent.nodeName === 'HEAD' &
+                    amp; & amp; newNode &
+                    amp; & amp; newNode.nodeName === 'SCRIPT' &
+                    amp; & amp; newNode.src) {
+
+                    window.setTimeout(function() {
+                        var result = newNode.src.match(/^https:\/\/maps\.googleapis\.com\/maps\/api\/place\/js\/(\w+)Service\./i) || [];
+                        var service = result[1];
+                        if (service) {
+                            if (service === 'Autocompletion') service = 2;
+                            else if (service === 'Place') service = 1;
+                            else service = 0;
+                            StackExchange.using('gps', function() {
+                                StackExchange.gps.track('google_maps_places_api.call', {
+                                    service: service
+                                });
+                            });
+                        }
+                    }, 0);
+                }
+                return appendChild.apply(this, arguments);
+            };
+        })(Node.prototype.appendChild);
+    </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Fixes #232.

Try to select more items from `topCandidates` might be related with document content array to get the question and answers sections. But it causes some test failures. Continue to figure out that...
