### PR TITLE
Remove general part of title when viewing websites with hierarchical titles

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -314,11 +314,11 @@ Readability.prototype = {
         curTitle = origTitle = this._getInnerText(doc.getElementsByTagName('title')[0]);
     } catch (e) {/* ignore exceptions setting the title. */}
 
-    if (curTitle.match(/ [\|\-] /)) {
-      curTitle = origTitle.replace(/(.*)[\|\-] .*/gi, '$1');
+    if (curTitle.match(/ [\|\-\\\/>»] /)) {
+      curTitle = origTitle.replace(/(.*)[\|\-\\\/>»] .*/gi, '$1');
 
       if (curTitle.split(' ').length < 3)
-        curTitle = origTitle.replace(/[^\|\-]*[\|\-](.*)/gi, '$1');
+        curTitle = origTitle.replace(/[^\|\-\\\/>»]*[\|\-\\\/>»](.*)/gi, '$1');
     } else if (curTitle.indexOf(': ') !== -1) {
       // Check if we have an heading containing this exact string, so we
       // could assume it's the full title.
@@ -346,8 +346,9 @@ Readability.prototype = {
     }
 
     curTitle = curTitle.trim();
-
-    if (curTitle.split(' ').length <= 4)
+    var curTitleLen = curTitle.split(' ').length;
+    if (curTitleLen <=4 && ( !origTitle.match(/ [\\\/>»] /)
+        || curTitleLen != origTitle.replace(/[\|\-\\\/>» ]+/g," ").split(' ').length -1))
       curTitle = origTitle;
 
     return curTitle;

--- a/Readability.js
+++ b/Readability.js
@@ -348,7 +348,7 @@ Readability.prototype = {
     curTitle = curTitle.trim();
     var curTitleLen = curTitle.split(' ').length;
     if (curTitleLen <=4 && ( !origTitle.match(/ [\\\/>»] /)
-        || curTitleLen != origTitle.replace(/[\|\-\\\/>» ]+/g," ").split(' ').length -1))
+        || curTitleLen != origTitle.replace(/[\|\-\\\/>» ]+/g, " ").split(' ').length -1))
       curTitle = origTitle;
 
     return curTitle;

--- a/Readability.js
+++ b/Readability.js
@@ -346,9 +346,9 @@ Readability.prototype = {
     }
 
     curTitle = curTitle.trim();
-    var curTitleLen = curTitle.split(' ').length;
-    if (curTitleLen <=4 && (!/ [\\\/>»] /.test(origTitle)
-        || curTitleLen != origTitle.replace(/[\|\-\\\/>» ]+/g, " ").split(' ').length -1))
+    var curTitleWordCount = curTitle.split(' ').length;
+    if (curTitleWordCount <= 4 && (!/ [\\\/>»] /.test(origTitle)
+        || curTitleWordCount != origTitle.replace(/[\|\-\\\/>» ]+/g, " ").split(' ').length -1))
       curTitle = origTitle;
 
     return curTitle;

--- a/Readability.js
+++ b/Readability.js
@@ -347,7 +347,7 @@ Readability.prototype = {
 
     curTitle = curTitle.trim();
     var curTitleLen = curTitle.split(' ').length;
-    if (curTitleLen <=4 && ( !origTitle.match(/ [\\\/>»] /)
+    if (curTitleLen <=4 && (!/ [\\\/>»] /.test(origTitle)
         || curTitleLen != origTitle.replace(/[\|\-\\\/>» ]+/g, " ").split(' ').length -1))
       curTitle = origTitle;
 


### PR DESCRIPTION
I mainly use readability to convert web blogs with hierarchical article titles:
e.g. "Story A > Chapter 1" -> "Chapter 1"
into continuous text (which I then feed into a Text2Speech engine)
Therefore it's kind of annoying if the domain/story name always repeats itself in the title.

In case anyone else considers this useful I thought I just create a pull request if not, that's ok too.