### PR TITLE
Added npmignore for test and benchmarks resources

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+/benchmarks/
+/test/


### PR DESCRIPTION
Added a `.npmignore` file to this repository, excluding `test` and `benchmarks` from the distribution tarball, where no test and benchmark files are needed. 

The distribution tarball shrinks from 2.7MB down to 30,4KB by excluding 297 files, totalling 16.9MB before compression. This is also the space it saves in the `node_modules` directory of every project depending on this library.

