### PR TITLE
Fix issue #400: Fall back to the original title if there are too many words before the colon

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -375,8 +375,13 @@ Readability.prototype = {
         curTitle = origTitle.substring(origTitle.lastIndexOf(':') + 1);
 
         // If the title is now too short, try the first colon instead:
-        if (wordCount(curTitle) < 3)
+        if (wordCount(curTitle) < 3) {
           curTitle = origTitle.substring(origTitle.indexOf(':') + 1);
+          // But if we have too many words before the colon there's something weird
+          // with the titles and the H tags so let's just use the original title instead
+        } else if (wordCount(origTitle.substr(0, origTitle.indexOf(':'))) > 5) {
+          curTitle = origTitle;
+        }
       }
     } else if (curTitle.length > 150 || curTitle.length < 15) {
       var hOnes = doc.getElementsByTagName('h1');

--- a/test/test-pages/title-and-h1-discrepancy/expected-metadata.json
+++ b/test/test-pages/title-and-h1-discrepancy/expected-metadata.json
@@ -1,0 +1,6 @@
+{
+  "title": "This is a long title with a colon: Hello there",
+  "byline": null,
+  "excerpt": "Lorem\n        ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non\n        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  "readerable": false
+}

--- a/test/test-pages/title-and-h1-discrepancy/expected.html
+++ b/test/test-pages/title-and-h1-discrepancy/expected.html
@@ -1,0 +1,21 @@
+<div id="readability-page-1" class="page"><article>
+
+    <p>
+        Lorem
+        ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem
+        ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+</article></div>

--- a/test/test-pages/title-and-h1-discrepancy/source.html
+++ b/test/test-pages/title-and-h1-discrepancy/source.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>This is a long title with a colon: Hello there</title>
+</head>
+<body>
+<article>
+    <h1>This is a long title with a colon: But the final text here is different</h1>
+    <div>
+        Lorem
+        ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </div>
+    <div>
+        Lorem
+        ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </div>
+</article>
+</body>
+</html>


### PR DESCRIPTION
Hi,

This fixes issue #400.

In [the example provided](https://www.ndtv.com/india-news/surgical-strikes-a-message-to-pakistan-more-if-necessary-army-chief-general-bipin-rawat-1755007), the `<title>` tag says "Surgical Strikes A Message To Pakistan, More If Necessary: **Army Chief General Bipin Rawat**" and the `<h1>` says "Surgical Strikes A Message To Pakistan, More If Necessary: **Army Chief**". Since Readability considers the colon as a hierarchical separator (and no H node matches exactly the title), the resulting title is "Army Chief General Bipin Rawat"

This patch checks the length of the discarded text before the colon. If there are more than 5 words, it assumes something weird is happening with the title and falls back to the original title that comes from the `<title>`  tag.

I also added a test case for this.

Let me know if you have any questions.