### PR TITLE
[Docs] Fixed JSDOM usage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Until [#346](https://github.com/mozilla/readability/issues/346) is fixed, if you
 ...
 var dom = new JSDOM(html, OPTIONS);
 Node = dom.window.Node;
-var article = new Readability(uri, dom).parse();
+var article = new Readability(uri, dom.window.document).parse();
 ```
 
 ### Optional


### PR DESCRIPTION
As described in https://github.com/mozilla/readability/issues/414#issue-279172404, we need to pass JSDOM's `.window.document` property to Readability. Otherwise, it will fail with `TypeError: Cannot read property 'firstElementChild' of undefined`.