### PR TITLE
Make unused URI object optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,14 @@ Please make sure to run [eslint](http://eslint.org/) against any proposed change
 
 ## Usage
 
-To parse a document, you must create a new `Readability` object from a URI object and a document object, and then call `parse()`. Here's an example:
+To parse a document, you must create a new `Readability` object from a document object, and then call `parse()`. Here's an example:
 
 ```javascript
-var loc = document.location;
-var uri = {
-  spec: loc.href,
-  host: loc.host,
-  prePath: loc.protocol + "//" + loc.host,
-  scheme: loc.protocol.substr(0, loc.protocol.indexOf(":")),
-  pathBase: loc.protocol + "//" + loc.host + loc.pathname.substr(0, loc.pathname.lastIndexOf("/") + 1)
-};
-var article = new Readability(uri, document).parse();
+var article = new Readability(document).parse();
 ```
 
 This `article` object will contain the following properties:
 
-* `uri`: original `uri` object that was passed to constructor
 * `title`: article title
 * `content`: HTML string of processed article content
 * `length`: length of article, in characters
@@ -42,15 +33,6 @@ This `article` object will contain the following properties:
 
 If you're using Readability on the web, you will likely be able to use a `document` reference from elsewhere (e.g. fetched via XMLHttpRequest, in a same-origin `<iframe>` you have access to, etc.). Otherwise, you would need to construct such an object using a DOM parser such as [jsdom](https://github.com/tmpvar/jsdom). While this repository contains a parser of its own (`JSDOMParser`), that is restricted to reading XML-compatible markup and therefore we do not recommend it for general use.
 
-Until [#346](https://github.com/mozilla/readability/issues/346) is fixed, if you're using `jsdom` and `node` (rather than running in a browser), you will need to also ensure a global `Node` object is available for `Readability` to use, e.g. like so:
-
-```javascript
-...
-var dom = new JSDOM(html, OPTIONS);
-Node = dom.window.Node;
-var article = new Readability(uri, dom.window.document).parse();
-```
-
 ### Optional
 
 Readability's `parse()` works by modifying the DOM. This removes some elements in the web page. You could avoid this by passing the clone of the `document` object while creating a `Readability` object.
@@ -58,7 +40,7 @@ Readability's `parse()` works by modifying the DOM. This removes some elements i
 
 ```
 var documentClone = document.cloneNode(true); 
-var article = new Readability(uri, documentClone).parse();   
+var article = new Readability(documentClone).parse();
 ```
 
 ## Tests

--- a/Readability.js
+++ b/Readability.js
@@ -22,14 +22,17 @@
 
 /**
  * Public constructor.
- * @param {Object}       uri     The URI descriptor object.
  * @param {HTMLDocument} doc     The document to parse.
  * @param {Object}       options The options object.
  */
-function Readability(uri, doc, options) {
+function Readability(doc, options) {
+  // In some older versions, people passed a URI object as the first argument. Cope:
+  if (doc && !doc.documentElement && doc.spec) {
+    doc = options;
+    options = arguments[2];
+  }
   options = options || {};
 
-  this._uri = uri;
   this._doc = doc;
   this._articleTitle = null;
   this._articleByline = null;
@@ -1748,7 +1751,6 @@ Readability.prototype = {
 
     var textContent = articleContent.textContent;
     return {
-      uri: this._uri,
       title: this._articleTitle,
       byline: metadata.byline || this._articleByline,
       dir: this._articleDir,

--- a/benchmarks/benchmarks.js
+++ b/benchmarks/benchmarks.js
@@ -42,17 +42,10 @@ suite("Readability test page perf", function () {
   set("iterations", 1);
   set("type", "static");
 
-  var uri = {
-    spec: "http://fakehost/test/page.html",
-    host: "fakehost",
-    prePath: "http://fakehost",
-    scheme: "http",
-    pathBase: "http://fakehost/test"
-  };
   testPages.forEach(function(testPage) {
     var doc = new JSDOMParser().parse(testPage.source);
     bench(testPage.dir + " readability perf", function() {
-      new Readability(uri, doc).parse();
+      new Readability(doc).parse();
     });
   });
 });
@@ -61,17 +54,10 @@ suite("isProbablyReaderable perf", function () {
   set("iterations", 1);
   set("type", "static");
 
-  var uri = {
-    spec: "http://fakehost/test/page.html",
-    host: "fakehost",
-    prePath: "http://fakehost",
-    scheme: "http",
-    pathBase: "http://fakehost/test"
-  };
   testPages.forEach(function(testPage) {
     var doc = new JSDOMParser().parse(testPage.source);
     bench(testPage.dir + " readability perf", function() {
-      new Readability(uri, doc).isProbablyReaderable();
+      new Readability(doc).isProbablyReaderable();
     });
   });
 });

--- a/test/generate-testcase.js
+++ b/test/generate-testcase.js
@@ -100,19 +100,13 @@ function onResponseReceived(source) {
 }
 
 function runReadability(source, destPath, metadataDestPath) {
-  var uri = {
-    spec: "http://fakehost/test/page.html",
-    host: "fakehost",
-    prePath: "http://fakehost",
-    scheme: "http",
-    pathBase: "http://fakehost/test/"
-  };
-  var doc = new JSDOMParser().parse(source, uri.spec);
+  var uri = "http://fakehost/test/page.html";
+  var doc = new JSDOMParser().parse(source, uri);
   var myReader, result, readerable;
   try {
     // We pass `caption` as a class to check that passing in extra classes works,
     // given that it appears in some of the test documents.
-    myReader = new Readability(uri, doc, { classesToPreserve: ["caption"] });
+    myReader = new Readability(doc, { classesToPreserve: ["caption"] });
     result = myReader.parse();
   } catch (ex) {
     console.error(ex);
@@ -126,7 +120,7 @@ function runReadability(source, destPath, metadataDestPath) {
         ProcessExternalResources: false
       }
     });
-    myReader = new Readability(uri, jsdomDoc);
+    myReader = new Readability(jsdomDoc);
     readerable = myReader.isProbablyReaderable();
   } catch (ex) {
     console.error(ex);
@@ -144,7 +138,6 @@ function runReadability(source, destPath, metadataDestPath) {
     }
 
     // Delete the result data we don't care about checking.
-    delete result.uri;
     delete result.content;
     delete result.textContent;
     delete result.length;


### PR DESCRIPTION
The URI object isn't actually used anywhere in the code, other than to be [passed back unmodified to the caller](https://github.com/mozilla/readability/blob/master/Readability.js#L1751), so it seems to make sense to be able to call the constructor without it?