### PR TITLE
Check for a document in either of the first two arguments (fixes #444 and #441)

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -26,10 +26,12 @@
  * @param {Object}       options The options object.
  */
 function Readability(doc, options) {
-  // In some older versions, people passed a URI object as the first argument. Cope:
-  if (doc && !doc.documentElement && doc.spec) {
+  // In some older versions, people passed a URI as the first argument. Cope:
+  if (options && options.documentElement) {
     doc = options;
     options = arguments[2];
+  } else if (!doc || !doc.documentElement) {
+    throw new Error("First argument to Readability constructor should be a document object.");
   }
   options = options || {};
 

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -190,19 +190,20 @@ function removeCommentNodesRecursively(node) {
 
 describe("Readability API", function() {
   describe("#constructor", function() {
+    var doc = new JSDOMParser().parse("<html><div>yo</div></html>");
     it("should accept a debug option", function() {
-      expect(new Readability({})._debug).eql(false);
-      expect(new Readability({}, {debug: true})._debug).eql(true);
+      expect(new Readability(doc)._debug).eql(false);
+      expect(new Readability(doc, {debug: true})._debug).eql(true);
     });
 
     it("should accept a nbTopCandidates option", function() {
-      expect(new Readability({})._nbTopCandidates).eql(5);
-      expect(new Readability({}, {nbTopCandidates: 42})._nbTopCandidates).eql(42);
+      expect(new Readability(doc)._nbTopCandidates).eql(5);
+      expect(new Readability(doc, {nbTopCandidates: 42})._nbTopCandidates).eql(42);
     });
 
     it("should accept a maxElemsToParse option", function() {
-      expect(new Readability({})._maxElemsToParse).eql(0);
-      expect(new Readability({}, {maxElemsToParse: 42})._maxElemsToParse).eql(42);
+      expect(new Readability(doc)._maxElemsToParse).eql(0);
+      expect(new Readability(doc, {maxElemsToParse: 42})._maxElemsToParse).eql(42);
     });
   });
 


### PR DESCRIPTION
This should fix #444, I believe. @davidar and/or @bittlingmayer, can you have a look if this makes sense to you? Thanks!