### PR TITLE
Match headings on trimmed strings to avoid whitespace causing mismatches (Fixes #452)

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -383,8 +383,9 @@ Readability.prototype = {
         doc.getElementsByTagName('h1'),
         doc.getElementsByTagName('h2')
       );
+      var trimmedTitle = curTitle.trim();
       var match = this._someNode(headings, function(heading) {
-        return heading.textContent === curTitle;
+        return heading.textContent.trim() === trimmedTitle;
       });
 
       // If we don't, let's extract the title out of the original title string.

--- a/test/test-pages/engadget/expected-metadata.json
+++ b/test/test-pages/engadget/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "A console that keeps up with gaming PCs",
+  "title": "Xbox One X review: A console that keeps up with gaming PCs",
   "byline": null,
   "dir": null,
   "excerpt": "The Xbox One X is the ultimate video game system. It sports more horsepower than any system ever. And it plays more titles in native 4K than Sony's PlayStation...",

--- a/test/test-pages/engadget/expected.html
+++ b/test/test-pages/engadget/expected.html
@@ -44,7 +44,7 @@
                                                         <div data-behavior="lightbox_trigger" data-engadget-slideshow-id="803271" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142088,&quot;index&quot;:0}" data-eng-mn="93511844">
                                                             <p><a href="#" data-index="0" data-engadget-slide-id="7142088" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142088,&quot;index&quot;:0}">
                                                                 <img src="https://o.aolcdn.com/images/dims?thumbnail=980%2C653&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F208%2F8%2FS7142088%2Fslug%2Fl%2Fxbox-one-x-review-gallery-1-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=9bb08b52e12de8e4060f863a52c613489529818d"/>
-                                                            </a> </p>
+                                                            </a></p>
                                                         </div>
                                                     </section>
                                                 </div>
@@ -171,7 +171,7 @@
                                                             <div data-behavior="lightbox_trigger" data-engadget-slideshow-id="803330" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142924}" data-eng-mn="93511844">
                                                                 <p><a href="#" data-index="0" data-engadget-slide-id="7142924" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142924}">
                                                                     <img src="https://o.aolcdn.com/images/dims?thumbnail=980%2C653&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F292%2F4%2FS7142924%2Fslug%2Fl%2Fxbox-one-x-screenshot-gallery-2-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=38c95635c7aad58a8a48038e05589f5cf35b1e28"/>
-                                                                </a> </p>
+                                                                </a></p>
                                                             </div>
                                                         </section>
                                                     </div>

--- a/test/test-pages/telegraph/expected-metadata.json
+++ b/test/test-pages/telegraph/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Robert Mugabe and wife Grace 'insisting he finishes his term', as priest steps in to mediate",
+  "title": "Zimbabwe coup: Robert Mugabe and wife Grace 'insisting he finishes his term', as priest steps in to mediate",
   "byline": null,
   "dir": null,
   "excerpt": "Zimbabwe President Robert Mugabe, his wife Grace and two key figures from her G40 political faction are under house arrest at Mugabe's &quot;Blue House&quot; compound in Harare and are insisting the 93 year-old finishes his presidential term, a source said.",

--- a/test/test-pages/telegraph/expected.html
+++ b/test/test-pages/telegraph/expected.html
@@ -2,71 +2,44 @@
     <div>
         <div>
             <div>
-                <p><span>Z</span>imbabwe President <a
-                        href="http://www.telegraph.co.uk/news/2017/11/17/zimbabwes-ruling-party-drafting-motion-fire-robert-mugabe-sunday/">Robert
-                    Mugabe</a>, his wife Grace and two key figures from her G40 political faction are under house arrest
-                    at Mugabe's "Blue House" compound in Harare and are insisting the 93 year-old finishes his
-                    presidential term, a source said.</p>
-                <p>The G40 figures are cabinet ministers Jonathan Moyo and Saviour Kasukuwere, who fled to the compound
-                    after their homes were attacked by troops in Tuesday night's coup, the source, who said he had
-                    spoken to people inside the compound, told Reuters.</p>
-                <p>Mr Mugabe is resisting mediation by a Catholic priest to allow the former guerrilla a graceful exit
-                    after the military takeover.</p>
-                <p>The priest, Fidelis Mukonori, is acting as a middle-man between Mr Mugabe and the generals, <a
-                        href="http://www.telegraph.co.uk/news/2017/11/15/zimbabwe-crisis-have-spent-long-careful-really-change/">who
-                    seized power in a targeted operation against "criminals" in his entourage</a>, a senior political
-                    source told Reuters.</p>
-                <p>The source could not provide details of the talks, which appear to be aimed at a smooth and bloodless
-                    transition after the departure of Mr Mugabe, who has led Zimbabwe since independence in 1980.</p>
-                <p>Mr Mugabe, still seen by many Africans as a liberation hero, is reviled in the West as a despot whose
-                    disastrous handling of the economy and willingness to resort to violence to maintain power destroyed
-                    one of Africa's most promising states.</p>
+                <p><span>Z</span>imbabwe President <a href="http://www.telegraph.co.uk/news/2017/11/17/zimbabwes-ruling-party-drafting-motion-fire-robert-mugabe-sunday/">Robert Mugabe</a>, his wife Grace and two key figures from her G40 political faction are under house arrest at Mugabe's "Blue House" compound in Harare and are insisting the 93 year-old finishes his presidential term, a source said.</p>
+                <p>The G40 figures are cabinet ministers Jonathan Moyo and Saviour Kasukuwere, who fled to the compound after their homes were attacked by troops in Tuesday night's coup, the source, who said he had spoken to people inside the compound, told Reuters.</p>
+                <p>Mr Mugabe is resisting mediation by a Catholic priest to allow the former guerrilla a graceful exit after the military takeover.</p>
+                <p>The priest, Fidelis Mukonori, is acting as a middle-man between Mr Mugabe and the generals, <a href="http://www.telegraph.co.uk/news/2017/11/15/zimbabwe-crisis-have-spent-long-careful-really-change/">who seized power in a targeted operation against "criminals" in his entourage</a>, a senior political source told Reuters.</p>
+                <p>The source could not provide details of the talks, which appear to be aimed at a smooth and bloodless transition after the departure of Mr Mugabe, who has led Zimbabwe since independence in 1980.</p>
+                <p>Mr Mugabe, still seen by many Africans as a liberation hero, is reviled in the West as a despot whose disastrous handling of the economy and willingness to resort to violence to maintain power destroyed one of Africa's most promising states.</p>
             </div>
         </div>
     </div>
     <div>
         <div>
-            <p><span>Z</span>imbabwean intelligence reports seen by Reuters suggest that former security chief Emmerson
-                Mnangagwa, who was ousted as vice-president this month, has been mapping out a post-Mugabe vision with
-                the military and opposition for more than a year.</p>
+            <p><span>Z</span>imbabwean intelligence reports seen by Reuters suggest that former security chief Emmerson Mnangagwa, who was ousted as vice-president this month, has been mapping out a post-Mugabe vision with the military and opposition for more than a year.</p>
         </div>
     </div>
     <div>
         <div>
             <div>
-                <p><span>F</span>uelling speculation that Mnangagwa's plan might be rolling into action, opposition
-                    leader Morgan Tsvangirai, who has been receiving cancer treatment in Britain and South Africa,
-                    returned to Harare late on Wednesday, his spokesman said.</p>
-                <p>South Africa said Mr Mugabe had told President Jacob Zuma by telephone on Wednesday that he was
-                    confined to his home but was otherwise fine and the military said it was keeping him and his family,
-                    including wife Grace, safe.</p>
+                <p><span>F</span>uelling speculation that Mnangagwa's plan might be rolling into action, opposition leader Morgan Tsvangirai, who has been receiving cancer treatment in Britain and South Africa, returned to Harare late on Wednesday, his spokesman said.</p>
+                <p>South Africa said Mr Mugabe had told President Jacob Zuma by telephone on Wednesday that he was confined to his home but was otherwise fine and the military said it was keeping him and his family, including wife Grace, safe.</p>
             </div>
         </div>
     </div>
     <div>
         <div>
             <div>
-                <p><span>D</span>espite the lingering admiration for Mr Mugabe, there is little public affection for
-                    52-year-old Grace, a former government typist who started having an affair with Mr Mugabe in the
-                    early 1990s as his first wife, Sally, was dying of kidney disease.</p>
-                <p>Dubbed "DisGrace" or "Gucci Grace" on account of her reputed love of shopping, she enjoyed a meteoric
-                    rise through the ranks of Mugabe's ruling Zanu-PF in the last two years, culminating in Mnangagwa's
-                    removal a week ago - a move seen as clearing the way for her to succeed her husband.</p>
+                <p><span>D</span>espite the lingering admiration for Mr Mugabe, there is little public affection for 52-year-old Grace, a former government typist who started having an affair with Mr Mugabe in the early 1990s as his first wife, Sally, was dying of kidney disease.</p>
+                <p>Dubbed "DisGrace" or "Gucci Grace" on account of her reputed love of shopping, she enjoyed a meteoric rise through the ranks of Mugabe's ruling Zanu-PF in the last two years, culminating in Mnangagwa's removal a week ago - a move seen as clearing the way for her to succeed her husband.</p>
             </div>
         </div>
     </div>
     <div>
         <div>
-            <p><span>I</span>n contrast to the high political drama unfolding behind closed doors, the streets of the
-                capital remained calm, with people going about their daily business, albeit under the watch of soldiers
-                on armoured vehicles at strategic locations.</p>
+            <p><span>I</span>n contrast to the high political drama unfolding behind closed doors, the streets of the capital remained calm, with people going about their daily business, albeit under the watch of soldiers on armoured vehicles at strategic locations.</p>
         </div>
     </div>
     <div>
         <div>
-            <p><span>W</span>hatever the final outcome, the events could signal a once-in-a-generation change for the
-                former British colony, a regional breadbasket reduced to destitution by economic policies Mr Mugabe's
-                critics have long blamed on him.</p>
+            <p><span>W</span>hatever the final outcome, the events could signal a once-in-a-generation change for the former British colony, a regional breadbasket reduced to destitution by economic policies Mr Mugabe's critics have long blamed on him.</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
@msujaws this should be fairly easy to review. The HTML changes are just because `generate-testcase.js` changes some formatting to how the HTML used to be.

The reason we have all this code is to deal with cases where the title is something like "New York Times - Some title", so we remove the generic website name stuff. This code then looks to see if the prefix might actually just be a legit part of the title by checking headings inside the page for the same title. As noted in #452 this fixes the engadget title, but as you can see here it also improves the telegraph testcase, so it seems plausible it'll affect a good number of articles.