### PR TITLE
Strip XML namespaces from tag names to deal with broken serializations

### DIFF
--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -611,6 +611,13 @@
   };
 
   var Element = function (tag) {
+    // We use this to find the closing tag.
+    this._matchingTag = tag;
+    // We're explicitly a non-namespace aware parser, we just pretend it's all HTML.
+    var lastColonIndex = tag.lastIndexOf(":");
+    if (lastColonIndex != -1) {
+      tag = tag.substring(lastColonIndex + 1);
+    }
     this.attributes = [];
     this.childNodes = [];
     this.children = [];
@@ -1118,7 +1125,7 @@
       // If this isn't a void Element, read its child nodes
       if (!closed) {
         this.readChildren(node);
-        var closingTag = "</" + localName + ">";
+        var closingTag = "</" + node._matchingTag + ">";
         if (!this.match(closingTag)) {
           this.error("expected '" + closingTag + "' and got " + this.html.substr(this.currentChar, closingTag.length));
           return null;

--- a/test/test-jsdomparser.js
+++ b/test/test-jsdomparser.js
@@ -320,3 +320,19 @@ describe("baseURI parsing", function() {
     checkBase("//absolute/path", "http://absolute/path");
   });
 });
+
+describe("namespace workarounds", function() {
+  it("should handle random namespace information in the serialized DOM", function() {
+    var html = "<a0:html><a0:body><a0:DIV><a0:svG><a0:clippath/></a0:svG></a0:DIV></a0:body></a0:html>";
+    var doc = new JSDOMParser().parse(html);
+    var div = doc.getElementsByTagName("div")[0];
+    expect(div.tagName).eql("DIV");
+    expect(div.localName).eql("div");
+    expect(div.firstChild.tagName).eql("SVG");
+    expect(div.firstChild.localName).eql("svg");
+    expect(div.firstChild.firstChild.tagName).eql("CLIPPATH");
+    expect(div.firstChild.firstChild.localName).eql("clippath");
+    expect(doc.documentElement).eql(doc.firstChild);
+    expect(doc.body).eql(doc.documentElement.firstChild);
+  });
+});


### PR DESCRIPTION
Per discussion with @bzbarsky on IRC re https://bugzilla.mozilla.org/show_bug.cgi?id=1394941 , this seems like the simplest solution to the issue we're facing there. The `XMLSerializer` does the right thing per the spec, even if it's... confusing. And JSDOMParser can cope relatively easily, so let's just do that.

@msujaws , can you doublecheck this looks OK to you? I added some minor unit tests. :-)