### PR TITLE
Fix issues with finding nytimes content caused by in-article ads

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -111,7 +111,7 @@ Readability.prototype = {
   // All of the regular expressions in use within readability.
   // Defined up here so we don't instantiate them repeatedly in loops.
   REGEXPS: {
-    unlikelyCandidates: /banner|breadcrumbs|combx|comment|community|cover-wrap|disqus|extra|foot|header|legends|menu|related|remark|replies|rss|shoutbox|sidebar|skyscraper|social|sponsor|supplemental|ad-break|agegate|pagination|pager|popup|yom-remote/i,
+    unlikelyCandidates: /-ad-|banner|breadcrumbs|combx|comment|community|cover-wrap|disqus|extra|foot|header|legends|menu|related|remark|replies|rss|shoutbox|sidebar|skyscraper|social|sponsor|supplemental|ad-break|agegate|pagination|pager|popup|yom-remote/i,
     okMaybeItsACandidate: /and|article|body|column|main|shadow/i,
     positive: /article|body|content|entry|hentry|h-entry|main|page|pagination|post|text|blog|story/i,
     negative: /hidden|^hid$| hid$| hid |^hid |banner|combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|tool|widget/i,


### PR DESCRIPTION
First reported in https://bugzilla.mozilla.org/show_bug.cgi?id=1472749 .

The articles on the NYTimes website have changed the ids and classes of their in-article ads. As a result, the fix in https://github.com/mozilla/readability/pull/337 is no longer sufficient. This adds the `-ad-` class substring to the list of things that make unlikely candidates. In my testing, this is sufficient to make the article load correctly.

The "real" fix here would be to do a better job of removing some of the arbitrary levels of nesting and/or more aggressively include the `article` and `main` nodes that the NYT website uses. However, these changes are also more risky and require substantially more work, so as a stop-gap I'd like to land this and get it into Firefox 62.