### PR TITLE
Recognize more iframe video embed video services

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -119,7 +119,7 @@ Readability.prototype = {
     byline: /byline|author|dateline|writtenby|p-author/i,
     replaceFonts: /<(\/?)font[^>]*>/gi,
     normalize: /\s{2,}/g,
-    videos: /\/\/(www\.)?(dailymotion|youtube|youtube-nocookie|player\.vimeo)\.com/i,
+    videos: /\/\/(www\.)?((dailymotion|youtube|youtube-nocookie|player\.vimeo|v\.qq)\.com|(archive|upload\.wikimedia)\.org|player\.twitch\.tv)/i,
     nextLink: /(next|weiter|continue|>([^\|]|$)|»([^\|]|$))/i,
     prevLink: /(prev|earl|old|new|<|«)/i,
     whitespace: /^\s*$/,


### PR DESCRIPTION
Added:

* TenCent QQ Video, Alexa Rank 8
* Twitch clips and streams, Alexa Rank 33
* Internet Archive, Alexa Rank 265
* Wikimedia, Alexa Rank 347


[List of even more services](https://en.wikipedia.org/wiki/List_of_video_hosting_services) including some popular omissions: Facebook, VKontakte (Russia), Flickr, and Naver (South Korea). I’ve not got an account with these services so I can’t test their embeds properly.