### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/*.html linguist-detectable=false


### PR DESCRIPTION
This ignores HTML (test data) so the repository is considered to use JavaScript instead of HTML on GitHub.

(Note that this won't display on my fork, since it must be pushed to the `master` branch to be effective.)