### PR TITLE
Elements that have no .style (e.g. MathML) are probably visible

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1701,7 +1701,7 @@ Readability.prototype = {
   },
 
   _isProbablyVisible: function(node) {
-    return node.style.display != "none" && !node.hasAttribute("hidden");
+    return (!node.style || node.style.display != "none") && !node.hasAttribute("hidden");
   },
 
   /**


### PR DESCRIPTION
Fixes #493. 

P.S. Seems a couple of tests are failing but not related to these changes.