### PR TITLE
Avoid setAttribute errors from invalid attributes, fixes #392

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -535,7 +535,16 @@ Readability.prototype = {
       replacement.readability = node.readability;
 
     for (var i = 0; i < node.attributes.length; i++) {
-      replacement.setAttribute(node.attributes[i].name, node.attributes[i].value);
+      try {
+        replacement.setAttribute(node.attributes[i].name, node.attributes[i].value);
+      } catch (ex) {
+        /* it's possible for setAttribute() to throw if the attribute name
+         * isn't a valid XML Name. Such attributes can however be parsed from
+         * source in HTML docs, see https://github.com/whatwg/html/issues/4275,
+         * so we can hit them here and then throw. We don't care about such
+         * attributes so we ignore them.
+         */
+      }
     }
     return replacement;
   },


### PR DESCRIPTION
The original markup that trips these exceptions is things that look like `<table width="90% border="0>` which gets you an attribute with name `0`; passing that (or something with a "." or other invalid characters) to `setAttribute` can throw an exception, which we should catch.