### PR TITLE
update JSDOM example for node

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ var JSDOM = require('jsdom').JSDOM;
 var doc = new JSDOM("<body>Here's a bunch of text</body>", {
   url: "https://www.example.com/the-page-i-got-the-source-from",
 });
-let reader = new Readability(doc);
+let reader = new Readability(doc.window.document);
 let article = reader.parse();
 ```
 


### PR DESCRIPTION
throws error "First argument to Readability constructor should be a document object" unless you reference the JSDOM `document` object instead of the `window` object per https://github.com/jsdom/jsdom/blob/master/README.md#basic-usage