### PR TITLE
Fix embedded videos got removed

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1661,10 +1661,27 @@ Readability.prototype = {
         var input = node.getElementsByTagName("input").length;
 
         var embedCount = 0;
-        var embeds = node.getElementsByTagName("embed");
+        var videoCount = 0;
+        var embeds = this._concatNodeLists(
+          node.getElementsByTagName("object"),
+          node.getElementsByTagName("embed"),
+          node.getElementsByTagName("iframe"));
+
         for (var ei = 0, il = embeds.length; ei < il; ei += 1) {
-          if (!this.REGEXPS.videos.test(embeds[ei].src))
+          var attributeValues = [].map.call(node.attributes, function(attr) {
+            return attr.value;
+          }).join("|");
+
+          if (this.REGEXPS.videos.test(attributeValues) || this.REGEXPS.videos.test(node.innerHTML)) {
+            videoCount += 1;
+          } else {
             embedCount += 1;
+          }
+        }
+
+        // If contains video, don't delete this node
+        if (videoCount > 0) {
+          return false;
         }
 
         var linkDensity = this._getLinkDensity(node);

--- a/Readability.js
+++ b/Readability.js
@@ -1482,17 +1482,17 @@ Readability.prototype = {
     this._removeNodes(e.getElementsByTagName(tag), function(element) {
       // Allow youtube and vimeo videos through as people usually want to see those.
       if (isEmbed) {
-        var attributeValues = [].map.call(element.attributes, function(attr) {
-          return attr.value;
-        }).join("|");
-
         // First, check the elements attributes to see if any of them contain youtube or vimeo
-        if (this.REGEXPS.videos.test(attributeValues))
-          return false;
+        for (var i = 0; i < element.attributes.length || 0; i++) {
+          if (this.REGEXPS.videos.test(element.attributes[i].value)) {
+            return false;
+          }
+        }
 
-        // Then check the elements inside this element for the same.
-        if (this.REGEXPS.videos.test(element.innerHTML))
+        // For embed with <object> tag, check inner HTML as well.
+        if (element.tagName === "object" && this.REGEXPS.videos.test(element.innerHTML)) {
           return false;
+        }
       }
 
       return true;
@@ -1661,27 +1661,25 @@ Readability.prototype = {
         var input = node.getElementsByTagName("input").length;
 
         var embedCount = 0;
-        var videoCount = 0;
         var embeds = this._concatNodeLists(
           node.getElementsByTagName("object"),
           node.getElementsByTagName("embed"),
           node.getElementsByTagName("iframe"));
 
-        for (var ei = 0, il = embeds.length; ei < il; ei += 1) {
-          var attributeValues = [].map.call(node.attributes, function(attr) {
-            return attr.value;
-          }).join("|");
-
-          if (this.REGEXPS.videos.test(attributeValues) || this.REGEXPS.videos.test(node.innerHTML)) {
-            videoCount += 1;
-          } else {
-            embedCount += 1;
+        for (var i = 0; i < embeds.length; i++) {
+          // If this embed has attribute that matches video regex, don't delete it.
+          for (var j = 0; j < embeds[i].attributes.length || 0; j++) {
+            if (this.REGEXPS.videos.test(embeds[i].attributes[j].value)) {
+              return false;
+            }
           }
-        }
 
-        // If contains video, don't delete this node
-        if (videoCount > 0) {
-          return false;
+          // For embed with <object> tag, check inner HTML as well.
+          if (embeds[i].tagName === "object" && this.REGEXPS.videos.test(embeds[i].innerHTML)) {
+            return false;
+          }
+
+          embedCount++;
         }
 
         var linkDensity = this._getLinkDensity(node);

--- a/Readability.js
+++ b/Readability.js
@@ -1483,7 +1483,7 @@ Readability.prototype = {
       // Allow youtube and vimeo videos through as people usually want to see those.
       if (isEmbed) {
         // First, check the elements attributes to see if any of them contain youtube or vimeo
-        for (var i = 0; i < element.attributes.length || 0; i++) {
+        for (var i = 0; i < element.attributes.length; i++) {
           if (this.REGEXPS.videos.test(element.attributes[i].value)) {
             return false;
           }
@@ -1668,7 +1668,7 @@ Readability.prototype = {
 
         for (var i = 0; i < embeds.length; i++) {
           // If this embed has attribute that matches video regex, don't delete it.
-          for (var j = 0; j < embeds[i].attributes.length || 0; j++) {
+          for (var j = 0; j < embeds[i].attributes.length; j++) {
             if (this.REGEXPS.videos.test(embeds[i].attributes[j].value)) {
               return false;
             }

--- a/test/test-pages/videos-1/expected-metadata.json
+++ b/test/test-pages/videos-1/expected-metadata.json
@@ -1,0 +1,8 @@
+{
+  "title": "The 21 best movies of 2017",
+  "byline": "By Alissa Wilkinson@alissamarie\n                                 Updated Jul 24, 2018, 2:15pm EDT",
+  "dir": null,
+  "excerpt": "How to watch the greatest movies of the year, from Lady Bird and Dunkirk to Get Out and The Big Sick.",
+  "siteName": "Vox",
+  "readerable": true
+}

--- a/test/test-pages/videos-1/expected.html
+++ b/test/test-pages/videos-1/expected.html
@@ -1,0 +1,229 @@
+<div id="readability-page-1" class="page">
+    <div>
+        <p id="oFNvY2"> In the introduction to her review anthology <em>For Keeps: 30 Years at the Movies</em>, the legendary film critic Pauline Kael wrote, “I’m frequently asked why I don’t write my memoirs. I think I have.” She meant what most movie critics realize at some point: that reading your past reviews and revisiting the lists of films you liked most during the year reveals not just something about a particular year in cinema, but something about you as well. </p>
+        <p id="49aoQQ"> That’s the feeling I get constructing my list of the best films of 2017, a year that overflowed with great films in every genre, from horror and romantic comedy to documentary and arthouse drama. Some of the films on my list have commonalities — ghosts, meditations on memory and interpersonal connection, and women who refuse to behave — but mostly they underscore just how vibrant cinema remains as an art form, even in the midst of massive cultural shifts in the industry and beyond. And it is a keen reminder to me of all the 2017 conversations I’ve had around and at the movies — and the ways I will never be the same. </p>
+        <p id="dC0oTJ"> Here are my top 21 films of 2017 and how to watch them at home, with 14 honorable mentions. </p>
+        <h3 id="jDDW9T"> 21) <a href="https://www.vox.com/culture/2017/12/12/16765308/last-jedi-star-wars-review-rey-carrie-fisher-poe-finn-kylo-ren"><em>Star Wars: The Last Jedi</em></a>
+        </h3>
+        <div id="x5htN5">
+            <p>
+                <iframe src="https://www.youtube.com/embed/Q0CbN8sfihY?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="WdtoaT"> I am as shocked as anyone that a <em>Star Wars</em> movie found its way onto my list — but I was bowled over by <em>The Last Jedi</em>, which may be one of the series’ best. In the hands of writer-director <a href="https://www.vox.com/culture/2017/12/13/16761916/rian-johnson-star-wars-last-jedi-looper-brick-brothers-bloom-fly-breaking-bad">Rian Johnson</a> (who will also oversee <a href="https://www.theverge.com/2017/11/9/16630902/star-wars-new-trilogy-rian-johnson-disney-lucasfilm">a new <em>Star Wars</em> trilogy</a>), <em>The Last Jedi</em> is beautiful to look at and keeps its eye on the relationships between characters and how they communicate with one another, in addition to the bigger galactic story. The same characters are back, but they seem infused with new life, and the galaxy with a new kind of hope. The movie’s best details are in the strong bonds that develop between characters, and I left the film with the realization that for the first time in my life, I loved a <em>Star Wars</em> movie. Now I understand the magic. </p>
+        <p id="m6vJQd"> Star Wars: The Last Jedi <em>is currently</em> <a href="https://www.netflix.com/watch/80192018?source=35"><em>streaming on Netflix</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=fgPqJgZepxM"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=fgPqJgZepxM"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="3XHosO"> 20) <a href="https://www.vox.com/2017/10/6/16434046/faces-places-review-agnes-varda-jr"><em>Faces Places</em></a>
+        </h3>
+        <div id="FZOPyv">
+            <p>
+                <iframe src="https://www.youtube.com/embed/KKbjnLpxv70?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="zP5jCd"> The unusual documentary <a href="https://www.vox.com/2017/10/6/16434046/faces-places-review-agnes-varda-jr"><em>Faces Places</em></a> (in French, <em>Visages Villages</em>) turns on the friendship between the accomplished street artist JR and legendary film director Agnès Varda, whose work was central to the development of the French New Wave movement. The pair (whose difference in age is 55 years) met after years of admiring each other’s work and decided to create a documentary portrait of France — by making a number of actual portraits. The film chronicles a leg of the "Inside Outside Project," a roving art initiative in which JR makes enormous portraits of people he meets and pastes them onto buildings and walls. In the film, Varda joins him, and as they talk to people around the country, they grow in their understanding of themselves and of each other. The development of their friendship, which is both affectionate and mutually sharpening, forms <em>Faces Places</em>’ emotional center. </p>
+        <p id="yIfUci"> Faces Places <em>is currently</em> <a href="https://www.netflix.com/watch/80194288?source=35"><em>streaming on Netflix</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=WuB9Fl8nrzM"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=WuB9Fl8nrzM"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="R0KXNO"> 19) <a href="https://www.vox.com/summer-movies/2017/8/8/16107088/ingrid-goes-west-review-aubrey-plaza-elizabeth-olsen"><em>Ingrid Goes West</em></a>
+        </h3>
+        <div id="94aRXv">
+            <p>
+                <iframe src="https://www.youtube.com/embed/xP4vD1tWbPU?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="d2ZAUw">
+            <a href="https://www.vox.com/summer-movies/2017/8/8/16107088/ingrid-goes-west-review-aubrey-plaza-elizabeth-olsen"><em>Ingrid Goes West</em></a> is a twisted and <a href="https://www.vox.com/culture/2017/8/9/16107140/matt-spicer-interview-ingrid-goes-west-dark-comedy-aubrey-plaza-sundance?utm_campaign=vox&amp;utm_content=chorus&amp;utm_medium=social&amp;utm_source=twitter">dark comedy</a> — part addiction narrative, part stalker story — and yet it’s set in a world that’s almost pathologically cheery: the glossy, sunny, nourishing, superfood- and superlative-loving universe of Instagram celebrity. But despite <em>Ingrid Goes West</em>’s spot-on take on that world, the best thing about the film is that it refuses to traffic in lazy buzzwords and easy skewering, particularly at the expense of young women. Instead, the movie conveys that behind every Instagram image and meltdown is a real person, with real insecurities, real feelings, and real problems. And it recognizes that living a life performed in public can be its own kind of self-deluding prison. </p>
+        <p id="oGMXK4"> Ingrid Goes West <em>is currently</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.hulu.com%2Fwatch%2F1205749" rel="nofollow noopener" target="_blank"><em>streaming on Hulu</em></a> <em>and available to digitally rent on</em> <a href="https://www.youtube.com/watch?v=c2O7KouP5CM"><em>YouTube</em></a> <em>and</em> <a href="https://play.google.com/store/movies/details?id=c2O7KouP5CM"><em>Google Play</em></a><em>.</em>
+        </p>
+        <h3 id="qfZ4Iv"> 18) <a href="https://www.vox.com/summer-movies/2017/7/14/15955888/review-lady-macbeth-florence-pugh"><em>Lady Macbeth</em></a>
+        </h3>
+        <div id="0ZWzkX">
+            <p>
+                <iframe src="https://www.youtube.com/embed/2Z0N8ULhuUA?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="Ii1QS5">
+            <a href="https://www.vox.com/summer-movies/2017/7/14/15955888/review-lady-macbeth-florence-pugh"><em>Lady Macbeth</em></a> is no placid costume drama. Adapted from an 1865 Russian novella by Nikolai Leskov, the movie follows Katherine (the astounding Florence Pugh), a woman in the Lady Macbeth line characterized by a potent cocktail of very few scruples and a lot of determination. She's a chilling avatar for the ways that class and privilege — both obvious and hidden — insulate some people from the consequences of their actions while damning others. <em>Lady Macbeth</em> is also a dazzling directorial debut from William Oldroyd, a thrilling combination of sex, murder, intrigue, and power plays. It’s visually stunning, each frame composed so carefully and deliberately that the wildness and danger roiling just below the surface feels even more frightening. Each scene ratchets up the tension to an explosive, chilling end. </p>
+        <p id="e2nBAO"> Lady Macbeth <em>is currently streaming on</em> <a href="https://play.hbogo.com/feature/urn:hbo:feature:GWrEd3wdB_LiWwwEAAAIk?camp=Search&amp;play=true"><em>HBO Go</em></a> <em>and</em> <a href="https://play.hbonow.com/feature/urn:hbo:feature:GWrEd3wdB_LiWwwEAAAIk?camp=Search&amp;play=true"><em>HBO Now</em></a><em>, and it is available to digitally rent on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB074HJGH3F%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F891310" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=l8vAACgcUCo"><em>YouTube</em></a><em>,</em> <a href="https://play.google.com/store/movies/details?id=l8vAACgcUCo"><em>iTunes</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=l8vAACgcUCo"><em>Google Play</em></a><em>.</em>
+        </p>
+        <h3 id="JhEBod"> 17) <em>BPM (Beats Per Minute)</em>
+        </h3>
+        <div id="t3derk">
+            <p>
+                <iframe src="https://www.youtube.com/embed/2fhO2A4SL24?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="DEyp0A">
+            <em>BPM (Beats Per Minute)</em> is a remarkably tender and stirring story of the Paris chapter of ACT UP, an AIDS activism group, and the young people who found themselves caught in the crosshairs of the AIDS crisis in the early 1990s. The film follows both the group's actions and the individual members’ shifting relationships to one another — enemies becoming friends, friends becoming lovers, lovers becoming caretakers — as well as their struggles with the disease wracking their community. As an account of the period, it’s riveting; as an exploration of life and love set at the urgent intersection of the political and the personal, it’s devastating. </p>
+        <p id="8vBdkS"> BPM (Beats Per Minute) <em>is currently</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.hulu.com%2Fwatch%2F1258801" rel="nofollow noopener" target="_blank"><em>streaming on Hulu</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=xrjoEWj6gLg"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=xrjoEWj6gLg"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="jocryI"> 16) <a href="https://www.vox.com/summer-movies/2017/6/21/15837678/big-sick-review-kumail-nanjiani-emily-gordon-zoe-kazan-islam"><em>The Big Sick</em></a>
+        </h3>
+        <div id="ZRFycn">
+            <p>
+                <iframe src="https://www.youtube.com/embed/PJmpSMRQhhs?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="DqZc5Q"> Few 2017 movies could top the charm and tenderness of <a href="https://www.vox.com/summer-movies/2017/6/21/15837678/big-sick-review-kumail-nanjiani-emily-gordon-zoe-kazan-islam"><em>The Big Sick</em></a>, which hits all the right romantic comedy notes with one unusual distinction: It feels like real life. That’s probably because <em>The Big Sick</em> is written by <a href="https://www.vox.com/2017/11/22/16687092/the-big-sick-kumail-nanjiani-emily-gordon-real-story">real-life married couple</a> Emily V. Gordon and <em>Silicon Valley</em>'s Kumail Nanjiani, and based on their real-life romance. <em>The Big Sick</em> — which stars Nanjiani as a version of himself, alongside Zoe Kazan as Emily — is funny and sweet while not backing away from matters that romantic comedies don’t usually touch on, like serious illness, struggles in long-term marriages, and religion. As it tells the couple’s story, which takes a serious turn when Emily falls ill with a mysterious infection and her parents (played by Holly Hunter and Ray Romano) come to town, it becomes a funny and wise story about real love. </p>
+        <p id="Wgpjgu"> The Big Sick <em>is currently</em> <em>streaming on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FBig-Sick-Kumail-Nanjiani%2Fdp%2FB07193L7RD%2Fref%3Dsr_1_1%3Fie%3DUTF8%26qid%3D1532454848" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a> <em>and available to digitally rent on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fthe-big-sick%2Fid1246483301" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F865258" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB071HFCYDH%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=WUX0wW2OMkA"><em>YouTube</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=WUX0wW2OMkA"><em>Google Play</em></a><em>.</em>
+        </p>
+        <h3 id="dFyVjw"> 15) <a href="https://www.vox.com/culture/2017/9/10/16277234/mother-review-aronofsky-lawrence-bardem-tiff"><em>Mother!</em></a>
+        </h3>
+        <div id="kUMpyj">
+            <p>
+                <iframe src="https://www.youtube.com/embed/XpICoc65uh0?rel=0&amp;amp;start=17" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="LA1s4n"> There’s so much pulsing beneath <a href="https://www.vox.com/culture/2017/9/10/16277234/mother-review-aronofsky-lawrence-bardem-tiff">the surface of <em>Mother!</em></a> that it’s hard to grab on to just one theme as what it “means.” It’s full-on apocalyptic fiction, and like all stories of apocalypse, it’s intended to draw back the veil on reality and show us what’s really beneath. And this movie gets wild: If its gleeful cracking apart of traditional theologies doesn’t get you (there’s a lot of Catholic folk imagery here, complete with an Ash Wednesday-like mud smearing on the foreheads of the faithful), its bonkers scenes of chaos probably will. <em>Mother!</em> is a movie designed to provoke fury, ecstasy, madness, catharsis, and more than a little awe. Watching it, and then participating in the flurry of arguments and discussions unpacking it, was among my best moviegoing experiences of 2017. </p>
+        <p id="mxI0Kb"> Mother! <em>is available to digitally purchase on</em> <a href="https://play.google.com/store/movies/details?id=F9p9HlSbIuU"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=F9p9HlSbIuU"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="PL5PTS"> 14) <a href="https://www.vox.com/culture/2017/7/7/15925272/ghost-story-review-rooney-mara-casey-affleck"><em>A Ghost Story</em></a>
+        </h3>
+        <div id="76I1cH">
+            <p>
+                <iframe src="https://www.youtube.com/embed/0Vb0F_CN83E?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="JWA6Pb"> Director <a href="https://www.vox.com/summer-movies/2017/7/13/15960236/david-lowery-ghost-story-interview">David Lowery</a> filmed <a href="https://www.vox.com/culture/2017/7/7/15925272/ghost-story-review-rooney-mara-casey-affleck"><em>A Ghost Story</em></a> in secret, then premiered it at the Sundance Film Festival to critical acclaim. The movie starts out being about a grieving widow (Rooney Mara) trying to live through the pain of losing her beloved husband, but it soon shifts focus to the ghost of her husband (Casey Affleck, covered in a sheet), evolving into a compelling rumination on the nature of time, memory, history, and the universe. Bathed in warm humor and wistful longing, it's a film that stays with you long after it’s over, a lingering reminder of the inextricable link between love and place. </p>
+        <p id="9CatN2"> A Ghost Story <em>is available to digitally rent on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fa-ghost-story%2Fid1252853654%3Fat%3D1001l6hu%26ct%3Dgca_organic_movie-title_1252853654" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F875682" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB075K4YG8P%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://play.google.com/store/movies/details?id=cGUoTWQIcP0"><em>Google Play</em></a><em>, and</em> <a href="https://www.youtube.com/watch?v=cGUoTWQIcP0"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="rRIM9r"> 13) <a href="https://www.vox.com/2017/10/24/16523642/square-review-ruben-ostlund-claes-bang-elisabeth-moss"><em>The Square</em></a>
+        </h3>
+        <div id="z1g0Cs">
+            <p>
+                <iframe src="https://www.youtube.com/embed/EUzRjRv0Ib0?rel=0" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="NavzzU"> Winner of the Palme d’Or at the 2017 Cannes Film Festival, <a href="https://www.vox.com/2017/10/24/16523642/square-review-ruben-ostlund-claes-bang-elisabeth-moss"><em>The Square</em></a> is a hilariously needling comedy about the contemporary art world, as well as the kind of idealistic liberalism that is tough to maintain in the face of real problems. The outstanding Claes Bang stars as Christian, a curator whose cluelessness leads him into some outlandishly rough spots, with Elisabeth Moss in a too-short but brilliant part as an American journalist who won’t let him get away with his shenanigans. It’s a heady film with a lot of ideas ricocheting around — and a <em>lot</em> of uncomfortable satire — but if you (like me) are the sort of viewer who loves that stuff, its sly jabs at the veneer of civilization that keeps the social contract intact are intoxicating. </p>
+        <p id="2iTOd5"> The Square <em>is currently</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.hulu.com%2Fwatch%2F1228556" rel="nofollow noopener" target="_blank"><em>streaming on Hulu</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=OaD-B0aK9aw"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=OaD-B0aK9aw"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="Px2hT6"> 12) <a href="https://www.vox.com/culture/2017/7/17/15984026/dunkirk-review-nolan-rylance-hardy-styles-spoilers"><em>Dunkirk</em></a>
+        </h3>
+        <div id="TDSYe7">
+            <p>
+                <iframe src="https://www.youtube.com/embed/F-eMt3SrfFU?rel=0&amp;amp;start=24" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="MLatLf">
+            <a href="https://www.vox.com/culture/2017/7/17/15984026/dunkirk-review-nolan-rylance-hardy-styles-spoilers"><em>Dunkirk</em></a>, a true cinematic achievement from acclaimed director Christopher Nolan, backs off conventional notions of narrative and chronology as much as possible, while leaning headfirst into everything else that makes a movie a visceral work of art aimed at the senses: the images, the sounds, the scale, the swelling vibrations of it all. You can’t smell the sea spray, but your brain may trick you into thinking you can. Nolan’s camera pushes the edges of the screen as far as it can as <em>Dunkirk</em> engulfs the audience in something that feels like a lot more than a war movie. It’s a symphony for the brave and broken, and it resolves in a major key — but one with an undercurrent of sorrow, and of sober warning. Courage in the face of danger is not just for characters in movies. </p>
+        <p id="cmMBuS"> Dunkirk <em>is currently streaming on</em> <a href="https://play.hbogo.com/feature/urn:hbo:feature:GWqvX7wxdtyl0YAEAAAFv?camp=Search&amp;play=true"><em>HBO Go</em></a> <em>and</em> <a href="https://play.hbonow.com/feature/urn:hbo:feature:GWqvX7wxdtyl0YAEAAAFv?camp=Search&amp;play=true"><em>HBO Now</em></a><em>, and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=yOJhvgczBNk"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=yOJhvgczBNk"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="CPlXz5"> 11) <em>Rat Film</em>
+        </h3>
+        <div id="s6q4gj">
+            <p>
+                <iframe src="https://www.youtube.com/embed/f-kpMAKc0l4?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="GFFO6D">
+            <em>Rat Film</em> is about rats, yes — and rat poison experts and rat hunters and people who keep rats as pets. But it’s also about the history of eugenics, dubious science, <a href="https://en.wikipedia.org/wiki/Redlining">“redlining,”</a> and segregated housing in Baltimore. All these pieces come together to form one big essay, where the meaning of each vignette only becomes clearer in light of the whole. It’s a fast-paced, no-holds-barred exploration of a damning history, and it accrues meaning as the images, sounds, and text pile up. </p>
+        <p id="HkeUxt"> Rat Film <em>is available to digitally rent on</em> <a href="https://www.youtube.com/watch?v=ZZlweN7XXJ4"><em>YouTube</em></a> <em>and</em> <a href="https://play.google.com/store/movies/details?id=ZZlweN7XXJ4"><em>Google Play</em></a><em>.</em>
+        </p>
+        <h3 id="Qgio0l"> 10) <a href="https://www.vox.com/culture/2017/4/13/15243556/quiet-passion-review-emily-dickinson-passover-easter"><em>A Quiet Passion</em></a>
+        </h3>
+        <div id="Ya6IEK">
+            <p>
+                <iframe src="https://www.youtube.com/embed/T3SyPbUTEeU?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="EO0XbC">
+            <a href="https://www.vox.com/culture/2017/4/13/15243556/quiet-passion-review-emily-dickinson-passover-easter"><em>A Quiet Passion</em></a> is technically a biographical film about Emily Dickinson, but it transcends its genre to become something more like poetry. It’s a perplexing and challenging film, crafted without the traditional guardrails that guide most biographical movies — dates, times, major accomplishments, and so on. Time slips away in the film almost imperceptibly, and the narrative arc doesn’t yield easily to the viewer. Cynthia Nixon plays Emily Dickinson, whose poetry and life is a perfect match for the signature style of director Terence Davies: rich in detail, deeply enigmatic, and weighed down with a kind of sparkling, joy-tinged sorrow. <em>A Quiet Passion</em> is a portrait, both visual and narrative, of the kind of saint most modern people can understand: one who is certain of her uncertainty, and yearning to walk the path on which her passion and longing meet. </p>
+        <p id="YuHQ0h"> A Quiet Passion <em>is currently streaming on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB072FP21C5%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a> <em>and available to digitally rent or purchase on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fa-quiet-passion%2Fid1238938795" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F859491" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB072FP21C5%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=de0ELdfPGik"><em>YouTube</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=de0ELdfPGik"><em>Google Play</em></a><em>.</em>
+        </p>
+        <h3 id="7dz2o3"> 9) <em>Columbus</em>
+        </h3>
+        <div id="ZfQfEI">
+            <p>
+                <iframe src="https://www.youtube.com/embed/r3dcnV6Z9Zs?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="pM0BdD">
+            <em>Columbus</em> is a stunner of a debut from video essayist turned director Kogonada. Haley Lu Richardson stars as Casey, a young woman living in Columbus, Indiana, who cares for her mother, works at a library, and harbors a passion for architecture. (Columbus is a mecca for modernist architecture scholars and enthusiasts.) When a visiting architecture scholar falls into a coma in Columbus, his estranged son Jin (John Cho) arrives to wait for him and strikes up a friendship with Casey, who starts to show him her favorite buildings. The two begin to unlock something in each other that’s hard to define but life-changing for both. <em>Columbus</em> is beautiful and subtle, letting us feel how the places we build and the people we let near us move and mold us. </p>
+        <p id="P7j9oY"> Columbus <em>is currently</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.hulu.com%2Fwatch%2F1185842" rel="nofollow noopener" target="_blank"><em>streaming on Hulu</em></a> <em>and available to rent on</em> <a href="https://play.google.com/store/movies/details?id=I-j0IqPQaYU"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=I-j0IqPQaYU"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="wkyPUl"> 8) <a href="https://www.vox.com/culture/2017/5/31/15706424/florida-project-review-cannes-sean-baker"><em>The Florida Project</em></a>
+        </h3>
+        <div id="RLHf4Z">
+            <p>
+                <iframe src="https://www.youtube.com/embed/WwQ-NH1rRT4?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="J6kOkz"> Sean Baker’s <a href="https://www.vox.com/culture/2017/5/31/15706424/florida-project-review-cannes-sean-baker"><em>The Florida Project</em></a> unfolds at first like a series of sketches about the characters who live in a purple-painted, $35-a-night motel called the Magic Castle down the street from Disney World. The film is held together by the hysterical antics of a kid named Moonee and her pack of young friends, as well as long-suffering hotel manager Bobby (a splendid, warm Willem Dafoe), who tries to put up with it all while keeping some kind of order. But as <em>The Florida Project</em> goes on, a narrative starts to form, one that chronicles with heartbreaking attention the sort of dilemmas that face poor parents and their children in America, and the broken systems that try to cope with impossible situations. </p>
+        <p id="xG8Q8C"> The Florida Project <em>is currently streaming on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FFlorida-Project-Willem-Dafoe%2Fdp%2FB0764MS7GQ%2Fref%3Dsr_1_2%3Fs%3Dinstant-video%26ie%3DUTF8%26qid%3D1532455499%26sr%3D1-2%26keywords%3Dthe%2Bflorida%2Bproject" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a> <em>and available to digitally rent on</em> <a href="https://www.youtube.com/watch?v=MLsXQdPAlws"><em>YouTube</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2Fdetails%2Ftitle%2F922802" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=MLsXQdPAlws"><em>Google Play</em></a><em>.</em>
+        </p>
+        <h3 id="rLGNAf"> 7) <a href="https://www.vox.com/2017/11/21/16552862/call-me-by-your-name-review-timothee-chalamet-armie-hammer"><em>Call Me</em> <em>b</em><em>y Your Name</em></a>
+        </h3>
+        <div id="xGksjG">
+            <p>
+                <iframe src="https://www.youtube.com/embed/Z9AYPxH5NTM?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="KyeOGQ"> Luca Guadagnino’s gorgeous film <a href="https://www.vox.com/2017/11/21/16552862/call-me-by-your-name-review-timothee-chalamet-armie-hammer"><em>Call Me</em> <em>b</em><em>y Your Name</em></a> adapts André Aciman’s <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FCall-Me-Your-Name-Novel%2Fdp%2F031242678X" rel="nofollow noopener" target="_blank">2007 novel</a> about a precocious 17-year-old named Elio (Timothée Chalamet), who falls in lust and love with his father’s 24-year-old graduate student Oliver (Armie Hammer). It’s remarkable for how it turns literature into pure cinema, all emotion and image and heady sensation. Set in 1983 in Northern Italy, <em>Call Me</em> <em>b</em><em>y Your Name</em> is less about coming out than coming of age, but it also captures a particular sort of love that’s equal parts passion and torment, a kind of irrational heart fire that opens a gate into something longer-lasting. The film is a lush, heady experience for the body, but it’s also an arousal for the soul. </p>
+        <p id="VA1se2">
+            <em>Call Me By Your Name</em> is available to digitally purchase on <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FCall-Your-Name-Armie-Hammer%2Fdp%2FB0791VJLVB%2Fref%3Dsr_1_2%3Fs%3Dinstant-video%26ie%3DUTF8%26qid%3D1532455686%26sr%3D1-2%26keywords%3Dcall%2Bme%2Bby%2Byour%2Bname" rel="nofollow noopener" target="_blank">Amazon,</a> <a href="https://www.youtube.com/watch?v=48o3YYnEUQ4">YouTube</a>, and <a href="https://play.google.com/store/movies/details?id=48o3YYnEUQ4">Google Play</a>. </p>
+        <h3 id="h6Biwc"> 6) <em>Personal Shopper</em>
+        </h3>
+        <div id="NSQg2p">
+            <p>
+                <iframe src="https://www.youtube.com/embed/xC8AjoqpBAY?rel=0&amp;amp;start=15" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="pofJH9"> In her second collaboration with French director <a href="http://www.imdb.com/name/nm0000801/?ref_=fn_al_nm_1">Olivier Assayas</a>, Kristen Stewart plays a personal shopper to a wealthy socialite, with a sideline as an amateur ghost hunter who’s searching for her dead twin brother. <em>Personal Shopper</em> is deeper than it seems at first blush, a meditation on grief and an exploration of “between” places — on the fringes of wealth, and in the space between life and death. Some souls are linked in a way that can’t be shaken, and whether or not there’s an afterlife doesn’t change the fact that we see and sense them everywhere. (<em>Personal Shopper</em> also has one of the most tense extended scenes involving text messaging ever seen onscreen.) </p>
+        <p id="8hmlTU"> Personal Shopper <em>is currently</em> <a href="https://www.showtime.com/#/movie/3436534"><em>streaming on Showtime</em></a> <em>and available to rent on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F871777" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=-BgiO6uDH7I"><em>YouTube</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB072YWLGT2%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fpersonal-shopper%2Fid1241184797" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=-BgiO6uDH7I"><em>Google Play</em></a><em>.</em>
+        </p>
+        <h3 id="0RkMKy"> 5) <em>Princess Cyd</em>
+        </h3>
+        <div id="7Tj1H6">
+            <p>
+                <iframe src="https://www.youtube.com/embed/sr64EJfnJwE?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="2tSIHW"> Stephen Cone is a master of small, carefully realized filmmaking; his earlier films such as <em>The Wise Kids</em> and <em>Henry Gamble’s Birthday Party</em> combine an unusual level of empathy for his characters with an unusual combination of interests: love, desire, sexual awakenings, and religion. <em>Princess Cyd</em> is his most accomplished film yet, about a young woman named Cyd (<a href="http://www.imdb.com/name/nm6570557/?ref_=tt_cl_t2">Jessie Pinnick</a>) who finds herself attracted to Katie (<a href="http://www.imdb.com/name/nm5154548/?ref_=tt_cl_t3">Malic White</a>), a barista, while visiting her Aunt Miranda (<a href="http://www.imdb.com/name/nm2050642/?ref_=tt_cl_t1">Rebecca Spence</a>, playing a character modeled on the author Marilynne Robinson) in Chicago. As she works through her own sexual awakening with Katie, Cyd unwinds some of the ways Miranda’s life has gotten too safe. They provoke each other while forming a bond and being prodded toward a bigger understanding of the world. It is a graceful and honest film, and it feels like a modest miracle. </p>
+        <p id="HDD90m"> Princess Cyd <em>is currently</em> <a href="https://www.netflix.com/watch/80201497?source=35"><em>streaming on Netflix</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=sy8otjxDw8w"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=sy8otjxDw8w"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="ADtiAV"> 4) <a href="https://www.vox.com/culture/2017/2/24/14698632/get-out-review-jordan-peele"><em>Get Out</em></a>
+        </h3>
+        <div id="swjmhh">
+            <p>
+                <iframe src="https://www.youtube.com/embed/sRfnevzM9kQ?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="h1ighb"> Racism is sinister, frightening, and deadly. But <a href="https://www.vox.com/culture/2017/2/24/14698632/get-out-review-jordan-peele"><em>Get Out</em></a> (a stunning directorial debut from <em>Key &amp; Peele</em>'s Jordan Peele) isn’t about the blatantly, obviously scary kind of racism — burning crosses and lynchings and snarling hate. Instead, it’s interested in showing how the parts of racism that try to be aggressively unscary are just as horrifying, and it’s interested in making us feel that horror in a visceral, bodily way. In the tradition of the best classic social thrillers, <em>Get Out</em> takes a topic that is often approached cerebrally — casual racism — and turns it into something you feel in your tummy. And it does it with a wicked sense of humor. </p>
+        <p id="2ef6GU"> Get Out <em>is currently streaming on</em> <a href="https://play.hbogo.com/feature/urn:hbo:feature:GWbhJDwNIacPCwgEAAAG5?camp=Search&amp;play=true"><em>HBO Go</em></a> <em>and</em> <a href="https://play.hbonow.com/feature/urn:hbo:feature:GWbhJDwNIacPCwgEAAAG5?camp=Search&amp;play=true"><em>HBO Now</em></a><em>, and is available to digitally rent on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fget-out%2Fid1202441786" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>,</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB06Y1H48K7%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://play.google.com/store/movies/details?id=YfLSryEaAfw"><em>Google Play</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=YfLSryEaAfw"><em>YouTube</em></a><em>, and</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F832496%2FGet-Out" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>.</em>
+        </p>
+        <h3 id="TQbjNr"> 3) <em>The Work</em>
+        </h3>
+        <div id="GYqgVe">
+            <p>
+                <iframe src="https://www.youtube.com/embed/h8OVXG2GhpQ?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="3Uotb3">
+            <em>The Work</em> is an outstanding, astonishing accomplishment and a viewing experience that will leave you shaken (but in a good way). At Folsom Prison in California, incarcerated men regularly participate in group therapy, and each year other men from the “outside” apply to participate in an intense four-day period of group therapy alongside Folsom’s inmates. <em>The Work</em> spends almost all of its time inside the room where that therapy happens, observing the strong, visceral, and sometimes violent emotions the men feel as they expose the hurt and raw nerves that have shaped how they encounter the world. Watching is not always easy, but by letting us peek in, the film invites viewers to become part of the experience — as if we, too, are being asked to let go. </p>
+        <p id="qjxiQW"> The Work <em>is</em> <a href="https://www.topic.com/the-work"><em>streaming on Topic.com</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=iddt4sVZTvI"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=iddt4sVZTvI"><em>YouTube</em></a><em>.</em>
+        </p>
+        <h3 id="kUrRP6"> 2) <em>Ex Libris</em>
+        </h3>
+        <div id="Lb1IzW">
+            <p>
+                <iframe src="https://www.youtube.com/embed/YzKrlOFZBD8?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="rGpjUU"> Frederick Wiseman is one of the towering giants of nonfiction film, a keen observer of American institutions — ranging from prisons to dance companies to welfare offices — for the past half-century. <em>Ex Libris</em> is his mesmerizing look at the New York Public Library and the many functions it fills, which go far beyond housing books. Wiseman works in the observational mode, which means his films contain no captions, dates, or talking-head interviews: We just see what his camera captured, which in this case includes community meetings, benefit dinners, after-school programs, readings with authors and scholars (including Richard Dawkins and Ta-Nehisi Coates), and NYPL patrons going about their business in the library’s branches all over the city. The result is almost hypnotic and, perhaps surprisingly, deeply moving. It makes a case for having faith in the public institutions where ordinary people work — away from the limelight, without trying to score political points — in order to make our communities truly better. </p>
+        <p id="40B8Wq"> Ex Libris <em>will air on PBS in the fall and then be available to cardholders in many library systems across the country via</em> <a href="https://www.kanopy.com/"><em>Kanopy</em></a><em>.</em>
+        </p>
+        <h3 id="QJNuyl"> 1) <a href="https://www.vox.com/2017/11/2/16552860/lady-bird-review-saoirse-ronan-greta-gerwig"><em>Lady Bird</em></a>
+        </h3>
+        <div id="mgxqrA">
+            <p>
+                <iframe src="https://www.youtube.com/embed/cNi_HC839Wo?rel=0&amp;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+            </p>
+        </div>
+        <p id="z8uM1l">
+            <em>Lady Bird</em> topped my list almost instantly, and only rose in my estimation on repeated viewings. For many who saw it (including me), it felt like a movie made not just for but <em>about</em> me. <em>Lady Bird</em> is a masterful, exquisite coming-of-age comedy starring the great Saoirse Ronan as Christine — or “Lady Bird,” as she’s re-christened herself — and it’s as funny, smart, and filled with yearning as its heroine. Writer-director Greta Gerwig made the film as an act of love, not just toward her hometown of Sacramento but also toward girlhood, and toward the feeling of always being on the outside of wherever real life is happening. <em>Lady Bird</em> is the rare movie that manages to be affectionate, entertaining, hilarious, witty, and confident. And one line from it struck me as the guiding principle of many of the year’s best films: “Don’t you think they are the same thing? Love, and attention?” </p>
+        <p id="jqSCLV"> Lady Bird <em>is currently streaming on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FLady-Bird-Saoirse-Ronan%2Fdp%2FB07734STRN%2Fref%3Dsr_1_3%3Fs%3Dinstant-video%26ie%3DUTF8%26qid%3D1532455686" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a> <em>and available to digitally rent on</em> <a href="https://go.redirectingat.com/?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FLady-Bird-Saoirse-Ronan%2Fdp%2FB07734STRN%2Fref%3Dsr_1_3%3Fs%3Dinstant-video%26ie%3DUTF8%26qid%3D1532455686" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://play.google.com/store/movies/details?id=yBIPcwJ03V4"><em>Google Play</em></a><em>, and</em> <a href="https://www.youtube.com/watch?v=yBIPcwJ03V4"><em>YouTube</em></a><em>.</em>
+        </p>
+        <p id="EVymKt">
+            <strong>Honorable mentions:</strong> <em>Marjorie Prime</em>, <em>Phantom Thread</em>, <a href="https://www.vox.com/culture/2017/4/28/15437008/casting-jonbenet-kitty-green-interview-netflix"><em>Casting JonBenet</em></a>, <a href="https://www.vox.com/2017/12/6/16682926/the-post-review-spieberg-streep-hanks-pentagon-nixon"><em>The Post</em></a>, <a href="https://www.vox.com/culture/2017/9/12/16288080/shape-of-water-del-toro-review-tiff"><em>The Shape of Water</em></a>, <a href="https://www.vox.com/summer-movies/2017/8/17/16150634/logan-lucky-review-soderbergh-tatum-driver-craig"><em>Logan Lucky</em></a>, <a href="https://www.vox.com/culture/2017/9/14/16301552/i-tonya-harding-kerrigan-review-tiff"><em>I, Tonya</em></a>, <a href="https://www.vox.com/culture/2017/4/13/15243584/lost-city-of-z-review-james-gray-charlie-hunnam-robert-pattinson"><em>The Lost City of Z</em></a>, <em>Graduation</em>, <em>Spettacolo</em>, <em>Loveless</em>, <em>Restless Creature: Wendy Whelan</em>, <em>In Transit</em>, <a href="https://www.vox.com/culture/2017/6/29/15844952/reagan-show-review"><em>The Reagan Show</em></a>
+        </p>
+    </div>
+</div>

--- a/test/test-pages/videos-1/source.html
+++ b/test/test-pages/videos-1/source.html
@@ -1,0 +1,1319 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>
+            How to watch the 21 best films of 2017 - Vox
+        </title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <meta name="apple-mobile-web-app-title" content="Vox" />
+        <script type="text/javascript" src="https://optimize-stats.voxmedia.com/loader.min.js?key=beb6b278a131e3b9"></script>
+        <meta property="article:publisher" content="https://www.facebook.com/Vox" />
+        <meta property="author" content="Alissa Wilkinson" />
+        <meta property="article:author" content="http://facebook.com/alissawilkinson" />
+        <meta property="article:published_time" content="2017-12-15T08:50:02-05:00" />
+        <meta property="article:modified_time" content="2018-07-24T14:15:58-04:00" />
+        <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bookitalic.woff2" as="font" type="font/woff2" crossorigin="" />
+        <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-book.woff2" as="font" type="font/woff2" crossorigin="" />
+        <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bolditalic.woff2" as="font" type="font/woff2" crossorigin="" />
+        <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bold.woff2" as="font" type="font/woff2" crossorigin="" />
+        <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/harriet_text_regular_italic.woff2" as="font" type="font/woff2" crossorigin="" />
+        <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/harriet_display_black.woff2" as="font" type="font/woff2" crossorigin="" />
+        <meta id="chorus-fonts" data-cid="site/font_loader-1551300229_5055_12234" data-cdata="{&quot;version&quot;:&quot;9f8ee6f3bdedf804934bcc0183d202bf&quot;,&quot;fonts_catalog&quot;:[{&quot;slug&quot;:&quot;vox-balto&quot;,&quot;family&quot;:&quot;Balto&quot;,&quot;weight&quot;:&quot;400&quot;,&quot;style&quot;:&quot;italic&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bookitalic.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bookitalic.woff&quot;},{&quot;slug&quot;:&quot;vox-balto&quot;,&quot;family&quot;:&quot;Balto&quot;,&quot;weight&quot;:&quot;400&quot;,&quot;style&quot;:&quot;normal&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-book.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-book.woff&quot;},{&quot;slug&quot;:&quot;vox-balto&quot;,&quot;family&quot;:&quot;Balto&quot;,&quot;weight&quot;:&quot;600&quot;,&quot;style&quot;:&quot;italic&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bolditalic.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bolditalic.woff&quot;},{&quot;slug&quot;:&quot;vox-balto&quot;,&quot;family&quot;:&quot;Balto&quot;,&quot;weight&quot;:&quot;700&quot;,&quot;style&quot;:&quot;normal&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bold.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/baltoweb-bold.woff&quot;},{&quot;slug&quot;:&quot;vox-harriet&quot;,&quot;family&quot;:&quot;Harriet&quot;,&quot;weight&quot;:&quot;400&quot;,&quot;style&quot;:&quot;italic&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/harriet_text_regular_italic.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/harriet_text_regular_italic.woff&quot;},{&quot;slug&quot;:&quot;vox-harriet-black&quot;,&quot;family&quot;:&quot;HarrietDisplayBlack&quot;,&quot;weight&quot;:&quot;400&quot;,&quot;style&quot;:&quot;italic&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/harriet_display_black.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/vox/webfonts/harriet_display_black.woff&quot;}],&quot;font_stylesheets&quot;:[&quot;https://fonts.voxmedia.com/unison/stylesheets/vox.0e5fbdb944cfd2ebf347dcc8f8246d7b.css&quot;],&quot;font_tracker_stylesheets&quot;:[],&quot;typekit_ids&quot;:[],&quot;headline_balance_div_classes&quot;:&quot;.c-page-title,.c-entry-summary,.c-entry-box__title,.c-entry-box--compact__title,.c-entry-box--compact__dek,.c-rock-list__entry-title&quot;,&quot;headline_balance_fraction&quot;:0.5}" />
+        <script>
+        <![CDATA[
+        var chorusInitQueue=[],volume_embed_host="https://volume.vox-cdn.com";var Chorus=Chorus||{};Chorus.windowLoaded=!1,Chorus.AddScript=function(t,e){var o=document.createElement("script");o.async=!0,o.type="text/javascript",o.src=t,"function"==typeof e&&(o.onload=e);var a=document.getElementsByTagName("script")[0];return a.parentNode.insertBefore(o,a),o},Chorus.ready=function(t){"loading"!=document.readyState?t():document.addEventListener?document.addEventListener("DOMContentLoaded",t):document.attachEvent("onreadystatechange",function(){"loading"!=document.readyState&&t()})},Chorus.OnLoad=function(t){if(Chorus.windowLoaded=!0)return void t();var e=window.onload;"function"!=typeof window.onload?window.onload=t:window.onload=function(){e(),t()}},Chorus.OnLoad(function(){Chorus.windowLoaded=!0});var dataLayer=dataLayer||[];Chorus.OnLoad(function(){var t;void 0!==navigator.doNotTrack?t=navigator.doNotTrack:void 0!==window.doNotTrack?t=window.doNotTrack:void 0!==navigator.msDoNotTrack&&(t=navigator.msDoNotTrack),t=void 0!==t?/1|yes|true/.test(String(t).toLowerCase())?"true":"false":"undefined";var e={DNT:t};dataLayer.push(e)});var VoxMediaFontLoader=function(t){function e(t,e){var o=window.performance;if(o&&o.mark&&o.measure){var a=t.toLocaleLowerCase().replace(/\W+/g,"_")+(e?"_"+e:"");o.mark(a),o.measure(a+"_time","navigationStart",a)}}function o(){s.classList.add(c),e("fonts_success")}function a(){s.classList.add(c),e("fonts_fail")}function n(t){var o=[t.family,t.style,t.weight,"loaded"].join(" ");e(o)}function r(t){var e=u.font_stylesheets||[];t&&(e=e.filter(function(e){return!e.match(t)})),e.forEach(i)}function i(e){var o=t.createElement("link");o.href=e,o.rel="stylesheet",o.media="all",f.parentNode.insertBefore(o,f)}function d(e){var o,a=t,n=a.documentElement,r=setTimeout(function(){n.className=n.className.replace(/\bwf-loading\b/g,"")+" wf-inactive"},e.scriptTimeout),i=a.createElement("script"),d=!1,c=a.getElementsByTagName("script")[0];n.className+=" wf-loading",i.src="https://use.typekit.net/"+e.kitId+".js",i.async=!0,i.onload=i.onreadystatechange=function(){if(o=this.readyState,!(d||o&&"complete"!=o&&"loaded"!=o)){d=!0,clearTimeout(r);try{Typekit.load(e)}catch(t){}}},c.parentNode.insertBefore(i,c)}var c="fonts-loaded",s=t.documentElement,f=t.getElementById("chorus-fonts");if(f){var u=JSON.parse(f.getAttribute("data-cdata"));t.fonts?(r("voxmedia.com"),u.fonts_catalog.forEach(function(e){if(e.woff2_url||e.woff_url){var o=[e.woff2_url,e.woff_url].filter(function(t){return t}).map(function(t){return"url("+t+")"}).join(", "),a=new FontFace(e.family,o,{weight:e.weight,style:e.style});t.fonts.add(a),a.load().then(n)}}),t.fonts.ready.then(o,a)):r(),u.typekit_ids.forEach(function(t){d({kitId:t,scriptTimeout:3e3,async:!0})}),u.font_tracker_stylesheets.forEach(i)}};VoxMediaFontLoader(document);
+        ]]>
+        </script>
+        <script class="kxint" type="text/javascript">
+        //<![CDATA[
+        window.Krux||((Krux=function(){Krux.q.push(arguments);}).q=[]);
+        (function(){
+        function retrieve(e){var r,o="kxvoxmedia_"+e;return window.localStorage?window.localStorage[o]||"":navigator.cookieEnabled?(r=document.cookie.match(o+"=([^;]*)"),r&&unescape(r[1])||""):""}Krux.user=retrieve("user"),Krux.segments=retrieve("segs")&&retrieve("segs").split(",")||[];
+        })();
+        //]]>
+        </script>
+        <script>
+        <![CDATA[
+        dataLayer = [{"Network":"vox","Community":"vox","GA Primary ID":"UA-48698701-1","GA CrossDomains":"vox.com","Content ID":"16515179","Story Word Count":3472,"Entry Groups":"front-page:movies:culture:awards-season:2017-in-review","Hidden Groups":"Category—Evergreen","Author":"Alissa Wilkinson","Last Time Updated":"2018-07-24 14:16","Hour of Update":"14","Publish Date":"2017-12-15 08:50","Hour of Publish":"08","Demand Post":"no","All Chorus Categories":"vox:vox:front-page:movies:culture:awards-season:2017-in-review:Category—Evergreen","Content Type":"article","chartbeat_domain":"vox.com","chartbeat_zone":"172968584/vox/vox.com/2017-in-review","chartbeat_authors":"Alissa Wilkinson","Logged in Status":"Logged Out"}];
+        ]]>
+        </script><!-- Google Tag Manager -->
+
+        <script>
+        <![CDATA[
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-W8JKW6');
+        ]]>
+        </script><!-- End Google Tag Manager -->
+
+        <script>
+        <![CDATA[
+        var concertAdsQueue = concertAdsQueue || [];
+
+        CONCERT_ADS_CONFIG = {"production":true,"slug":"/172968584/vox/vox.com/2017-in-review","dfpVariables":{"network":["vox"],"affiliation":["general"],"unison":[true],"entry_id":[16515179],"entry_type":["article"],"entry_slug":["2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch"],"entry_author":["Alissa Wilkinson"],"entry_group":["front-page","movies","culture","awards-season","2017-in-review","category-evergreen"],"hub_page":["culture","2017-in-review"],"page_type":["interior_page"],"keywords":"how to watch the best films of vox"},"isUnison":true,"is_unison":true,"prebid":{"enabled":false,"timeout":1000,"defaultConfig":{"openx":{"delDomain":"sbnationbidder-d.openx.net"},"rubicon":{"accountId":7470,"position":"btf"},"rubiconLite":{"accountId":18288,"siteId":193902,"sizes":[213,270,271,272],"position":"btf"},"consumable":{"networkId":9969,"siteId":1039096}},"prelude":{"trustx":{"uid":2663}},"reskin":{"trustx":{"uid":2664}},"desktop_leaderboard_variable":{"trustx":{"uid":2665}},"medium_rectangle_variable":{"trustx":{"uid":2666}},"btf_medium_rectangle_variable":{"trustx":{"uid":2668}},"desktop_article_medrec_dynamic":{"trustx":{"uid":2669}},"btf_leaderboard_variable":{"trustx":{"uid":2670}},"native_ad_latest":{"trustx":{"uid":2671}},"native_ad_ymal_link":{"trustx":{"uid":2672}},"mobile_leaderboard":{"trustx":{"uid":2673}},"mobile_article_body":{"trustx":{"uid":2674}},"native_ad_mobile":{"trustx":{"uid":2675}},"mobile_article_body_med_rec_dynamic":{"trustx":{"uid":2676}},"mobile_footer":{"trustx":{"uid":2677}},"tablet_leaderboard":{"trustx":{"uid":2678}},"tablet_medium_rectangle":{"trustx":{"uid":2679}},"tablet_btf_leaderboard":{"trustx":{"uid":2680}},"native_ad_content_link":{"trustx":{"uid":2681}},"hub_river_leaderboard":{"trustx":{"uid":2682}},"hub_river_med_rec":{"trustx":{"uid":2684}},"mobile_med_rec_athena":{"trustx":{"uid":2685}}},"slots":[{"name":"editorially_placed_athena_mobile","className":"m-ad__editorially_placed_athena","prebidName":"editorially_placed_athena","selector":".m-ad.m-ad__editorial-athena-placement","sizes":[[1030,590],[325,508],[325,203],[325,236],[325,204]],"holdSize":[300,500],"filters":{"viewportWidth":{"max":727}}},{"name":"editorially_placed_athena_desktop","className":"m-ad__editorially_placed_athena","prebidName":"editorially_placed_athena","selector":".m-ad.m-ad__editorial-athena-placement","sizes":[[1030,590],{"size":[1060,610],"filters":{"containerWidth":{"min":1060}}},{"size":[620,366],"filters":{"containerWidth":{"max":1059}}},{"size":[1060,619],"filters":{"containerWidth":{"min":1060}}},{"size":[1060,694],"filters":{"containerWidth":{"min":1060}}}],"holdSize":[728,295],"filters":{"viewportWidth":{"min":728}}},{"name":"editorially_placed_leaderboard","selector":".m-ad.m-ad__editorial-leaderboard-placement","sizes":[[728,90]],"holdSize":[728,90],"filters":{"viewportWidth":{"min":728}}},{"name":"native_quicklistings","selector":".l-hub-page .river-segment-0 .c-compact-river__entry:nth-child(2), .l-hub-page .river-segment-0 .c-compact-river__entry:nth-child(6), .l-hub-page .river-segment-0 .c-compact-river__entry:nth-child(8), .l-hub-page .river-segment-0 .c-compact-river__entry:nth-child(10)","sizes":["fluid"],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"matchDomain":{"domains":"curbed.com, atlanta.curbed.com, austin.curbed.com, boston.curbed.com, chicago.curbed.com, detroit.curbed.com, hamptons.curbed.com, la.curbed.com, miami.curbed.com, nola.curbed.com, ny.curbed.com, philly.curbed.com, sf.curbed.com, seattle.curbed.com, dc.curbed.com"}}},{"name":"native_quicklistings_article","selector":".l-segment .l-segment .c-compact-river__entry","sizes":["fluid"],"maxSlots":1,"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"insertion":"after","filters":{"matchDomain":{"domains":"curbed.com, atlanta.curbed.com, austin.curbed.com, boston.curbed.com, chicago.curbed.com, detroit.curbed.com, hamptons.curbed.com, la.curbed.com, miami.curbed.com, nola.curbed.com, ny.curbed.com, philly.curbed.com, sf.curbed.com, seattle.curbed.com, dc.curbed.com"}}},{"name":"prelude","selector":".l-root","sizes":[[1400,600]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"allowSiblings":true,"filters":{"viewportWidth":{"min":881},"deviceType":"desktop"}},{"name":"reskin","selector":".l-root","sizes":[[2,2]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"min":1280},"hideIfPresent":{"selector":".l-feature, .c-maps-hub"}}},{"name":"desktop_leaderboard_variable","selector":".l-header","sizes":[[728,90],[970,250],[970,90],[1020,90]],"holdSize":[728,90],"insertion":"after","filters":{"viewportWidth":{"min":881},"hideIfPresent":{"selector":".l-feature"}}},{"name":"tablet_leaderboard","selector":".l-header","sizes":[[728,90]],"holdSize":[728,90],"insertion":"after","filters":{"viewportWidth":{"min":729,"max":880}}},{"name":"mobile_leaderboard_hub","className":"m-ad__mobile_leaderboard","prebidName":"mobile_leaderboard","selector":".l-hub-page .l-header","sizes":[[320,50],[300,250]],"holdSize":[300,250],"insertion":"after","maxSlots":1,"filters":{"viewportWidth":{"max":728}}},{"name":"mobile_leaderboard_group","className":"m-ad__mobile_leaderboard","prebidName":"mobile_leaderboard","selector":".l-group-page .l-header","sizes":[[320,50]],"holdSize":[320,50],"insertion":"after","maxSlots":1,"filters":{"viewportWidth":{"max":728}}},{"name":"package_cover_ad","selector":".c-package-subnav","sizes":[[728,90],[970,250],[970,90],[1020,90],[1030,590],{"size":[1060,610],"filters":{"containerWidth":{"min":1060}}},{"size":[620,366],"filters":{"containerWidth":{"max":1059}}},{"size":[1060,619],"filters":{"containerWidth":{"min":1060}}},{"size":[1060,694],"filters":{"containerWidth":{"min":1060}}}],"holdSize":[728,90],"insertion":"after","filters":{"viewportWidth":{"min":729}}},{"name":"package_cover_ad_mobile","selector":".c-package-subnav","sizes":[[320,50],[300,250],[1030,590],[325,508],[325,203],[325,236],[325,204],[1020,90]],"holdSize":[320,50],"insertion":"after","filters":{"viewportWidth":{"max":729}}},{"name":"btf_leaderboard_variable","selector":".c-footer","sizes":[[728,90],[1020,90]],"holdSize":[728,90],"filters":{"viewportWidth":{"min":881}}},{"name":"tablet_btf_leaderboard","selector":".c-footer","sizes":[[728,90]],"holdSize":[728,90],"filters":{"viewportWidth":{"min":729,"max":888}}},{"name":"mobile_footer","selector":"body:not(.entry_layout_unison_package_landing) .c-footer","sizes":[[320,50],[300,250],[325,203],[325,236],[325,204]],"holdSize":[300,250],"filters":{"viewportWidth":{"min":0,"max":728}}},{"name":"package_mobile_footer","selector":".entry_layout_unison_package_landing .c-footer","sizes":[[320,50],[300,250],[1030,590],[325,508],[325,203],[325,236],[325,204]],"holdSize":[300,250],"filters":{"viewportWidth":{"min":0,"max":728}}},{"name":"mobile_feature_body","className":"m-ad__mobile_article_body_med_rec_dynamic","prebidName":"mobile_article_body_med_rec_dynamic","selector":".l-feature .c-entry-content \u003e p + p","sizes":[[300,250],[325,508],[325,203],[325,236],[325,204],[320,50],[1030,590]],"previewHoldSize":[300,250],"maxSlots":1,"filters":{"spacing":{"before":150},"viewportWidth":{"max":779}}},{"name":"desktop_feature_body","selector":".l-feature .c-entry-content \u003e p + p + p","sizes":[[728,90],[620,366],[1030,590]],"previewHoldSize":[728,90],"maxSlots":1,"insertion":"after","filters":{"avoidFloats":true,"viewportWidth":{"min":780},"hideIfPresent":{"selector":".c-buying-guide"}}},{"name":"desktop_feature_body_dynamic","className":"m-ad__desktop_feature_body","prebidName":"desktop_feature_body","selector":".l-feature .c-entry-content \u003e p + p","sizes":[[728,90],[300,250],[620,366],[1030,590]],"previewHoldSize":[728,90],"maxSlots":3,"filters":{"avoidFloats":true,"spacing":{"before":1500},"paragraphHeight":{"above":200},"viewportWidth":{"min":780},"hideIfPresent":{"selector":".c-buying-guide"}}},{"name":"athena_features_mobile","className":"m-ad__athena_features","prebidName":"athena_features","selector":".l-feature .c-entry-content \u003e p + p","sizes":[[1030,590],[325,508],[300,250],[300,265],[325,203],[325,236],[325,204]],"previewHoldSize":[300,250],"maxSlots":1,"filters":{"avoidFloats":true,"paragraphHeight":{"above":200},"viewportWidth":{"max":779},"spacing":{"before":1500}}},{"name":"athena_features_dynamic_mobile","className":"m-ad__athena_features_dynamic","prebidName":"athena_features_dynamic","selector":".l-feature .c-entry-content \u003e p + p","sizes":[[1030,590],[325,508],[300,250],[300,265],[325,203],[325,236],[325,204]],"previewHoldSize":[300,250],"maxSlots":2,"filters":{"avoidFloats":true,"paragraphHeight":{"above":200},"viewportWidth":{"max":779},"spacing":{"before":1500}}},{"name":"athena_features_desktop","className":"m-ad__athena_features","prebidName":"athena_features","selector":".l-feature .c-entry-content \u003e p + p","sizes":[[1030,590],[620,366],[620,371],[620,415]],"previewHoldSize":[726,415],"maxSlots":3,"filters":{"paragraphHeight":{"above":200},"avoidFloats":true,"viewportWidth":{"min":779},"spacing":{"before":2000}}},{"name":"mobile_leaderboard","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[320,50],[300,250]],"holdSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"max":728}}},{"name":"desktop_article_body","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p, .l-article .c-entry-content \u003e p + p","sizes":[[1030,590],[620,366],[620,371],[620,415],{"size":[728,90],"filters":{"containerWidth":{"min":700}}}],"previewHoldSize":[726,415],"maxSlots":1,"filters":{"avoidFloats":true,"spacing":{"before":750,"after":450},"containerWidth":{"min":620}}},{"name":"mobile_article_body","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[1030,590],[325,508],[300,250],[300,265],[325,203],[325,236],[325,204]],"previewHoldSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"max":728},"spacing":{"before":600}}},{"name":"native_ad_mobile","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[1030,590],[325,508],[300,250],[300,265],[325,203],[325,236],[325,204]],"previewHoldSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"max":728},"spacing":{"before":600}}},{"name":"mobile_article_body_med_rec_dynamic","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[300,250],[1030,590],[325,508],[325,203],[325,236],[325,204]],"previewHoldSize":[300,250],"filters":{"viewportWidth":{"max":728},"spacing":{"before":900}}},{"name":"desktop_article_medrec_dynamic","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p, .l-article .c-entry-content \u003e p + p","sizes":[[300,250]],"holdSize":[300,250],"filters":{"paragraphHeight":{"above":150,"below":250},"viewportWidth":{"min":729},"avoidFloats":true,"spacing":{"before":1500,"after":750}}},{"name":"medium_rectangle_variable","selector":".l-col__sidebar:not(.c-sports-blog-directory__filter) \u003e div:first-of-type, .l-article-sidebar \u003e *:first-child","sizes":[[300,250],[300,600]],"holdSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"min":881},"hideIfPresent":{"selector":".l-full-archives"},"elementHeight":{"selector":".l-article-body-segment .l-col__main, .l-main-content \u003e .l-col__main","min":2001}}},{"name":"medium_rectangle_short","selector":".l-col__sidebar:not(.c-sports-blog-directory__filter) \u003e div:first-of-type, .l-article-sidebar \u003e *:first-child","sizes":[[300,250]],"holdSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"min":881},"hideIfPresent":{"selector":".l-full-archives"},"elementHeight":{"selector":".l-article-body-segment .l-col__main, .l-main-content \u003e .l-col__main","max":2000}}},{"name":"btf_medium_rectangle_variable_article","className":"m-ad__btf_medium_rectangle_variable","prebidName":"btf_medium_rectangle_variable","selector":"body[data-entry-id] .l-col__sidebar:not(.c-sports-blog-directory__filter) \u003e div:last-of-type","sticky":true,"sizes":[[300,250],{"size":[300,600],"filters":{"viewportHeight":{"min":600}}}],"holdSize":[300,250],"insertion":"after","maxSlots":1,"filters":{"viewportWidth":{"min":881}}},{"name":"btf_medium_rectangle_variable_hub","className":"m-ad__btf_medium_rectangle_variable","prebidName":"btf_medium_rectangle_variable","selector":".l-hub-page .river-segment-1 .l-col__sidebar \u003e div:last-of-type, .l-hub-page .river-segment-0 .l-col__sidebar \u003e div:last-of-type, .l-group-page .river-segment-0 .l-col__sidebar \u003e div:last-of-type","sizes":[[300,250]],"holdSize":[300,250],"insertion":"after","maxSlots":2,"filters":{"viewportWidth":{"min":881},"hideIfPresent":{"selector":".l-full-archives"}}},{"name":"in_map_legacy","className":"m-ad__in_map","prebidName":"in_map","selector":".c-mapstack__ad","sizes":[[300,250]],"previewHoldSize":[300,250]},{"name":"in_map","selector":".c-mapstack__card--ad","sizes":[[300,250],[1030,590],[620,366],[620,371],[620,415]],"previewHoldSize":[300,250],"insertion":"after"},{"name":"mapstack_sponsorship","className":"m-ad__mapstack_sponsorship","selector":".c-mapstack__content","insertion":"before","maxSlots":1,"sizes":[[200,40]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"athena_hub","className":"m-ad__athena","prebidName":"athena","selector":".l-hub-page .river-segment-0, .l-group-page .river-segment-0","sizes":[[1030,590],{"size":[1060,610],"filters":{"containerWidth":{"min":1060}}},{"size":[620,366],"filters":{"containerWidth":{"max":1059}}},{"size":[1060,619],"filters":{"containerWidth":{"min":1060}}},{"size":[1060,694],"filters":{"containerWidth":{"min":1060}}}],"holdSize":[728,295],"maxSlots":1,"insertion":"after","filters":{"viewportWidth":{"min":728}}},{"name":"athena_article","className":"m-ad__athena","prebidName":"athena","selector":".l-article-body-segment","sizes":[[1030,590],[728,90],{"size":[1060,610],"filters":{"containerWidth":{"min":1060}}},{"size":[620,366],"filters":{"containerWidth":{"max":1059}}},{"size":[970,250],"filters":{"viewportWidth":{"min":970}}},{"size":[620,371],"filters":{"containerWidth":{"max":1059}}},{"size":[620,415],"filters":{"containerWidth":{"max":1059}}}],"holdSize":[728,295],"maxSlots":1,"insertion":"after","filters":{"viewportWidth":{"min":728}}},{"name":"hub_river_leaderboard","selector":".l-hub-page .c-compact-river__entry, .l-group-page .c-compact-river__entry","sizes":[[728,90],[1030,590],[620,366]],"holdSize":[728,90],"filters":{"spacing":{"before":700,"after":500,"exceptSlot":"native_quicklistings"},"containerWidth":{"min":728}}},{"name":"mobile_med_rec_athena","selector":".l-hub-page .river-segment-0","sizes":[[300,250],[1030,590],[325,508],[300,265],[325,203],[325,236],[325,204]],"holdSize":[300,250],"maxSlots":1,"insertion":"after","filters":{"viewportWidth":{"max":728}}},{"name":"hub_river_med_rec","selector":".l-hub-wrapper .c-compact-river__entry, .l-group-page .c-compact-river__entry","sizes":[[300,250],[1030,590]],"customSizes":[{"placement":1,"sizes":[[1030,590]]}],"holdSize":[300,250],"filters":{"spacing":{"before":600,"after":400},"viewportWidth":{"max":728}}},{"name":"gift_guide_leaderboard_variable_desktop","className":"m-ad__desktop_article_body","prebidName":"desktop_article_body","selector":".l-feature .c-buying-guide","sizes":[[1030,590],[620,366],[728,90],[620,371],[620,415]],"previewHoldSize":[726,415],"maxSlots":1,"filters":{"viewportWidth":{"min":728}}},{"name":"gift_guide_leaderboard_mobile","className":"m-ad__mobile_leaderboard","prebidName":"mobile_leaderboard","selector":".l-feature .c-buying-guide","sizes":[[320,50],[300,250],[1030,590]],"holdSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"max":728}}},{"name":"storystream_top_leaderboard_desktop","className":"m-ad__hub_river_leaderboard","prebidName":"hub_river_leaderboard","selector":".l-main-content \u003e .c-entry-group-labels--stream","sizes":[[728,90]],"holdSize":[728,90],"maxSlots":1,"filters":{"viewportWidth":{"min":880}}},{"name":"storystream_bottom_leaderboard_variable_desktop","className":"m-ad__desktop_article_body","prebidName":"desktop_article_body","selector":".c-entry-group-labels--stream ~ .c-entry-update-bar","sizes":[[1030,590],[620,366],[620,371],[620,415],[728,90]],"previewHoldSize":[726,415],"maxSlots":1,"filters":{"avoidFloats":true,"containerWidth":{"min":729}}},{"name":"storystream_river_leaderboard_variable_desktop","className":"m-ad__hub_river_leaderboard","prebidName":"hub_river_leaderboard","selector":".c-stream-list .c-stream-list__entry:nth-of-type(6n) .c-entry-box--stream-item","sizes":[[1030,590],[620,366],[620,371],[620,415],[728,90]],"previewHoldSize":[726,415],"insertion":"after","filters":{"viewportWidth":{"min":729}}},{"name":"storystream_top_leaderboard_mobile","className":"m-ad__hub_river_leaderboard","prebidName":"hub_river_leaderboard","selector":".l-main-content \u003e .c-entry-group-labels--stream","sizes":[[320,50]],"holdSize":[320,50],"maxSlots":1,"filters":{"viewportWidth":{"max":728}}},{"name":"storystream_bottom_leaderboard_variable_mobile","className":"m-ad__mobile_article_body_med_rec_dynamic","prebidName":"mobile_article_body_med_rec_dynamic","selector":".c-entry-group-labels--stream ~ .c-entry-update-bar","sizes":[[320,50],[300,250],[1030,590],[325,508],[325,203],[325,236],[325,204]],"previewHoldSize":[300,250],"maxSlots":1,"filters":{"containerWidth":{"max":728}}},{"name":"storystream_river_leaderboard_variable_mobile","className":"m-ad__mobile_article_body_med_rec_dynamic","prebidName":"mobile_article_body_med_rec_dynamic","selector":".c-stream-list .c-stream-list__entry:nth-of-type(6n) .c-entry-box--stream-item","sizes":[[320,50],[300,250]],"customSizes":[{"placement":2,"sizes":[[320,50],[300,250],[1030,590],[325,508],[325,203],[325,236],[325,204]]}],"previewHoldSize":[300,250],"insertion":"after","filters":{"viewportWidth":{"max":728}}},{"name":"site_sponsorship_logo_white","selector":".site_sponsorship_logo.site_sponsorship_logo-white","sizes":[[26,1]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"min":601}}},{"name":"site_sponsorship_logo_color","selector":".site_sponsorship_logo:not(.site_sponsorship_logo-white), .c-tab-bar__sponsorship","sizes":[[26,2]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"min":601}}},{"name":"site_sponsorship_logo_mobile_white","selector":".site_sponsorship_logo_mobile.site_sponsorship_logo-white","sizes":[[26,3]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"max":600}}},{"name":"site_sponsorship_logo_mobile_color","selector":".site_sponsorship_logo_mobile:not(.site_sponsorship_logo-white), .c-tab-bar__sponsorship","sizes":[[26,4]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"max":600}}},{"name":"native_ad_latest","selector":".dynamic-native-ad-native_ad_latest","sizes":[[300,100]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_video","selector":".dynamic-native-ad-native_ad_video","sizes":[[200,200]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_ymal_link","selector":".dynamic-native-ad-native_ad_ymal_link","sizes":[[1200,100]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_linkset_link","selector":".dynamic-native-ad-native_ad_linkset_link","sizes":[[1200,100]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_content_link","selector":".dynamic-native-ad-native_ad_content_link","sizes":[[650,150]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_module","selector":".c-related-list","sizes":["fluid"],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"maxSlots":1},{"name":"branded_content_feedback_form","selector":".branded_content_feedback_form","sizes":[[300,200]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"maxSlots":1},{"name":"article_sponsorship","className":"m-ad__article_sponsorship","selector":"body.entry_layout_unison_main .c-entry-hero--feature .c-entry-hero__content .c-byline, body.entry_layout_unison_main div.c-entry-hero:not(.c-entry-hero--feature)","insertion":"after","maxSlots":1,"sizes":[[200,40]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"hub_sponsorship","className":"m-ad__hub_sponsorship","selector":".c-hub-title__inner","insertion":"after","maxSlots":1,"sizes":[[200,40]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"failsafe_article_med_rec_athena_mobile","className":"m-ad__mobile_med_rec_athena","prebidName":"mobile_med_rec_athena","selector":"body:not(.entry_template_stream):not(.entry_template_package_landing) .c-entry-content \u003e *:last-child","sizes":[[300,250],[1030,590],[325,508],[300,265],[325,203],[325,236],[325,204]],"holdSize":[300,250],"maxSlots":1,"insertion":"after","filters":{"viewportWidth":{"max":728},"spacing":{"before":600},"hideIfPresent":{"selector":".c-entry-content .m-ad","count":2}}}],"adConfigurationUrl":"https://concertads-configs.vox-cdn.com/sbn/vox/config.json"};
+        ]]>
+        </script>
+        <link href="https://www.vox.com/style/community/441/a623a9b794a00fd0f8dd38707abe8547/chorus.css" data-chorus-theme="chorus" rel="stylesheet" media="all" />
+        <meta name="style-tools" content="https://www.vox.com/style/community/441/70ae1812f16cb0c331c92973ff144d2c/tools.css" />
+        <script class="kxct" data-id="JImdKGAx" data-timing="async" data-version="1.9" type="text/javascript" src="https://cdn.krxd.net/controltag?confid=JImdKGAx" async="async"></script>
+        <script src="https://cdn.vox-cdn.com/packs/concert_ads-7bf774bff743c7c1754a.js" async="async" integrity="sha256-4dNLiLp3y7pWVI7g4NovGrh4zlj6JGUJjVgkw2174l4= sha384-xOqsESSDXn9YorwH4hcmLmfu0z4zZIooD902iAqx+FznU7KPYSm+aaFSLyVLhsZT" crossorigin="anonymous"></script>
+        <script src="https://c.amazon-adsystem.com/aax2/apstag.js" async="async"></script>
+        <script src="https://www.googletagservices.com/tag/js/gpt.js" async="async"></script>
+        <script src="https://cdn.concert.io/lib/concert-concierge.2.3.5.min.js" async="async"></script>
+        <script src="https://sejs.moatads.com/voxprebidheader841653991752/yi.js" async="async"></script>
+        <meta name="p:domain_verify" content="d4410485bd6277c2bf2ce0f277819dc6" />
+        <meta name="msvalidate.01" content="D385D0326A3AE144205C298DB34B4E94" />
+        <meta name="ahrefs-site-verification" content="1e57a609922037a3fbdc1c22efd7334113f174f15608f37e1b8538a7b4ce64c3" />
+        <meta name="description" content="It was an extraordinary year for movies." />
+        <link rel="canonical" href="https://www.vox.com/2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch" />
+        <meta property="og:description" content="How to watch the greatest movies of the year, from Lady Bird and Dunkirk to Get Out and The Big Sick." />
+        <meta property="fb:app_id" content="549923288395304" />
+        <meta property="og:image" content="https://cdn.vox-cdn.com/thumbor/7WyjCLC7n6i1IG2eJB06qi1o7kQ=/0x148:2300x1352/fit-in/1200x630/cdn.vox-cdn.com/uploads/chorus_asset/file/9871033/Movies_end_of_year_2017.jpg" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:site_name" content="Vox" />
+        <meta property="og:title" content="The 21 best movies of 2017" />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://www.vox.com/2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:url" content="https://www.vox.com/2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch" />
+        <meta name="twitter:title" content="The 21 best movies of 2017" />
+        <meta name="twitter:description" content="How to watch the greatest movies of the year, from Lady Bird and Dunkirk to Get Out and The Big Sick." />
+        <meta name="twitter:image" content="https://cdn.vox-cdn.com/thumbor/sFp0spZtjdLgZplwyh3Eb_98Ej0=/0x175:2300x1325/fit-in/1200x600/cdn.vox-cdn.com/uploads/chorus_asset/file/9871033/Movies_end_of_year_2017.jpg" />
+        <meta name="twitter:site" content="voxdotcom" />
+        <meta name="sailthru.title" content="The 21 best movies of 2017" />
+        <meta name="sailthru.tags" content="general,vox" />
+        <meta name="sailthru.date" content="2018-07-24" />
+        <meta name="sailthru.description" content="It was an extraordinary year for movies." />
+        <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/community_logos/52517/voxv.png" sizes="32x32" />
+        <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/uploads/hub/sbnu_logo_minimal/441/touch_icon_iphone_retina_1000_yellow.755.png" sizes="192x192" />
+        <link rel="apple-touch-icon" href="https://cdn.vox-cdn.com/uploads/hub/sbnu_logo_minimal/441/touch_icon_iphone_retina_1000_yellow.755.png" sizes="180x180" />
+        <meta name="msapplication-TileImage" content="https://cdn.vox-cdn.com/uploads/hub/sbnu_logo_minimal/441/touch_icon_ipad_retina_1000_yellow.755.png" />
+        <meta name="msapplication-TileColor" content="#4f7177" />
+        <meta name="theme-color" content="" />
+        <meta data-chorus-version="c783e43305ce80adb5ec31a186ab9723a92ef2c7" />
+        <link rel="amphtml" href="https://www.vox.com/platform/amp/2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch" />
+        <link rel="alternate" type="application/rss+xml" title="Vox" href="/rss/index.xml" />
+        <script type="application/ld+json">
+        <![CDATA[
+        {"@context":"http://schema.org","@type":"NewsArticle","mainEntityOfPage":"https://www.vox.com/2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch","headline":"How to watch the 21 best films of 2017","description":"It was an extraordinary year for movies.","speakable":{"@type":"SpeakableSpecification","xpath":["/html/head/title","/html/head/meta[@name='description']/@content"]},"datePublished":"2017-12-15T08:50:02-05:00","dateModified":"2018-07-24T14:15:58-04:00","author":{"@type":"Person","name":"Alissa Wilkinson"},"publisher":{"@type":"Organization","name":"Vox","logo":{"@type":"ImageObject","url":"https://cdn.vox-cdn.com/uploads/chorus_asset/file/13668548/google_amp.0.png","width":600,"height":60}},"image":[{"@type":"ImageObject","url":"https://cdn.vox-cdn.com/thumbor/TSO6Uy4UkB9DOZWUxOU1Kks5dzo=/1400x1400/filters:format(jpeg)/cdn.vox-cdn.com/uploads/chorus_asset/file/9871033/Movies_end_of_year_2017.jpg","width":1400,"height":1400},{"@type":"ImageObject","url":"https://cdn.vox-cdn.com/thumbor/-_58CyCjSLS36byYJ3jyjvy4Akg=/1400x1050/filters:format(jpeg)/cdn.vox-cdn.com/uploads/chorus_asset/file/9871033/Movies_end_of_year_2017.jpg","width":1400,"height":1050},{"@type":"ImageObject","url":"https://cdn.vox-cdn.com/thumbor/WvgnZiNPS0Pomau4kVrKvRcmHog=/1400x788/filters:format(jpeg)/cdn.vox-cdn.com/uploads/chorus_asset/file/9871033/Movies_end_of_year_2017.jpg","width":1400,"height":788}]}
+        ]]>
+        </script>
+        <meta name="outbrainsection" content="awards-season" />
+        <style id="custom-entry-styles" type="text/css"></style>
+    </head><!--[if lte IE 9]><body class="ie9"><![endif]-->
+    <!--[if gte IE 10]><body class="ie"><![endif]-->
+    <body class="entry_key_unison_standard entry_layout_unison_main entry_template_standard" data-entry-id="16515179">
+        <!-- Google Tag Manager (noscript) -->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W8JKW6" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
+         <svg width="0" height="0" style="position:absolute;display:none;">
+        <symbol viewbox="90 0 689 645" id="icon-clock" xmlns="http://www.w3.org/2000/svg">
+            <title>
+                clock
+            </title>
+            <path d="M489.1 322.5c0 15-5.4 27.9-16 38.6-10.7 10.7-23.6 16-38.6 16-23.7 0-40.3-10.9-49.9-32.8h-125c-6.4 0-11.6-2.1-15.7-6.1-4-4.1-6.1-9.3-6.1-15.7 0-6.4 2.1-11.6 6.1-15.7 4.1-4.1 9.4-6.1 15.8-6.1h125c5.9-13.2 15.3-22.5 28-28V125.8c0-6.4 2.1-11.6 6.1-15.7 4.1-4.1 9.3-6.1 15.7-6.1 6.4 0 11.6 2 15.7 6.1s6.1 9.3 6.1 15.7v146.8c21.9 9.5 32.9 26.1 32.8 49.9zm-54.6-306c84.2 0 156.3 29.9 216.2 89.8 59.9 59.9 89.8 131.9 89.8 216.2s-29.9 156.3-89.8 216.2c-59.9 59.9-131.9 89.8-216.2 89.8s-156.3-29.9-216.2-89.8c-59.9-59.9-89.8-131.9-89.8-216.2s29.9-156.3 89.8-216.2c59.9-59.9 132-89.8 216.2-89.8zm0 546.4c66.5 0 123.2-23.4 170.1-70.4 46.9-46.9 70.4-103.6 70.4-170.1s-23.4-123.2-70.4-170.1C557.7 105.5 501 82.1 434.5 82.1s-123.2 23.4-170.1 70.4C217.5 199.4 194 256.1 194 322.6s23.4 123.2 70.4 170.1c46.9 46.8 103.6 70.2 170.1 70.2z"></path>
+        </symbol>
+        <symbol viewbox="0 0 1000 1000" id="icon-close" xmlns="http://www.w3.org/2000/svg">
+            <path d="M638.6 500l322.7-322.7c38.3-38.3 38.3-100.3 0-138.6S861 .4 822.7 38.7L500 361.4 177.3 38.7C139 .4 77 .4 38.7 38.7S.4 139 38.7 177.3L361.4 500 38.7 822.7C.4 861 .4 923 38.7 961.3 57.9 980.4 82.9 990 108 990s50.1-9.6 69.3-28.7L500 638.6l322.7 322.7c19.1 19.1 44.2 28.7 69.3 28.7 25.1 0 50.1-9.6 69.3-28.7 38.3-38.3 38.3-100.3 0-138.6L638.6 500z"></path>
+        </symbol>
+        <symbol viewbox="0 0 14 14" id="icon-close-map" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" d="M13.074 12.27L7.698 6.958l5.376-5.312-.896-.896-5.312 5.376L1.554.75l-.896.864 5.376 5.312L.658 12.27l.896.896L6.898 7.79l5.312 5.376z"></path>
+        </symbol>
+        <symbol viewbox="0 0 18 17" id="icon-comment" xmlns="http://www.w3.org/2000/svg">
+            <path d="M15.667 6.654c0 3.532-3.432 6.397-7.667 6.397-.945 0-1.85-.14-2.686-.4l-4.406 2.1 1.725-3.52c-1.42-1.16-2.3-2.78-2.3-4.56C.333 3.12 3.765.257 8 .257c4.235 0 7.667 2.863 7.667 6.4z"></path>
+        </symbol>
+        <symbol viewbox="-135.7 744.2 1008.1 429.7" id="icon-down" xmlns="http://www.w3.org/2000/svg">
+            <path d="M872.3 788.5c0 12.1-5.1 25.2-18.2 35.3l-446 335c-12.1 10.1-28.3 15.2-40.4 15.2-15.2 0-28.3-5.1-40.4-15.2l-446.1-335c-18.2-15.2-22.2-40.4-10.1-60.5s40.4-22.2 58.5-10.1l439.1 330.9 435.9-331c18.2-15.2 45.4-10.1 58.5 10.1 7.2 8.1 9.2 15.1 9.2 25.3"></path>
+        </symbol>
+        <symbol viewbox="0 0 50.062 37.479" id="icon-email" xmlns="http://www.w3.org/2000/svg">
+            <path d="M25.085 21.866L.082 3.114A3.114 3.114 0 0 1 3.207-.012H46.96a3.113 3.113 0 0 1 3.126 3.126l-25 18.752zm0 5.613L50.087 8.726v25.64a3.113 3.113 0 0 1-3.125 3.125H3.208a3.113 3.113 0 0 1-3.125-3.125V8.727L25.085 27.48z" class="afshape-1"></path>
+        </symbol>
+        <symbol viewbox="0 0 21.406 43.754" id="icon-facebook" xmlns="http://www.w3.org/2000/svg">
+            <path d="M5.43 43.754v-20.53H0V15.83h5.43V9.518C5.43 4.558 8.635 0 16.024 0c2.99 0 5.204.286 5.204.286l-.175 6.903s-2.257-.03-4.72-.03c-2.663 0-3.09 1.23-3.09 3.26v5.4h8.022l-.35 7.39h-7.672v20.53H5.43z"></path>
+        </symbol>
+        <symbol viewbox="0 0 140 200" id="icon-foursquare" xmlns="http://www.w3.org/2000/svg">
+            <path d="M114.697 27.581l-4.278 22.294c-.511 2.41-3.545 4.945-6.358 4.945h-39.7c-4.467 0-7.664 3.045-7.664 7.508v4.86c0 4.467 3.216 7.632 7.686 7.632h33.681c3.154 0 6.25 3.459 5.568 6.826-.685 3.373-3.886 20.08-4.271 21.924-.387 1.846-2.5 5-6.25 5H65.618c-5.007 0-6.521.654-9.87 4.818-3.353 4.166-33.477 40.342-33.477 40.342-.305.35-.603.249-.603-.134V27.25c0-2.85 2.478-6.194 6.194-6.194h81.78c3.01 0 5.822 2.829 5.055 6.525m3.59 87.418c1.137-4.602 13.899-69.93 18.16-90.656M120.716 0H18.809C4.745 0 .61 10.575.61 17.235v161.916c0 7.503 4.032 10.285 6.296 11.203 2.267.919 8.519 1.692 12.266-2.632 0 0 48.111-55.826 48.938-56.652 1.25-1.25 1.25-1.25 2.5-1.25h31.127c13.08 0 15.183-9.327 16.549-14.821 1.137-4.602 13.899-69.93 18.16-90.656C139.699 8.526 135.681 0 120.716 0"></path>
+        </symbol>
+        <symbol viewbox="-295 387 20 20" id="icon-full-screen" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#ccc" d="M-275 387.7c0-.2-.1-.4-.2-.5-.1-.1-.3-.2-.5-.2h-5.5c-.4 0-.7.3-.7.7 0 .4.4.8.6 1l1.4 1.4-3.9 3.9 1.9 1.9 3.9-3.9 1.4 1.4c.3.3.6.6 1 .6s.7-.3.7-.7l-.1-5.6zm-13.1 10.5l-3.9 4-1.4-1.4c-.3-.3-.6-.6-1-.6s-.6.3-.6.6v5.4c0 .2.1.4.2.5.1.1.3.2.5.2h5.4c.4 0 .6-.3.6-.6 0-.4-.4-.8-.6-.9l-1.4-1.4 4-3.9-1.8-1.9z"></path>
+        </symbol>
+        <symbol viewbox="-295 387 20 20" id="icon-full-screen-exit" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#ccc" d="M-293.2 406.9l3.9-4 1.4 1.4c.3.3.6.6 1 .6s.6-.3.6-.6v-5.4c0-.2-.1-.4-.2-.5-.1-.1-.3-.2-.5-.2h-5.4c-.4 0-.6.3-.6.6 0 .4.4.8.6.9l1.4 1.4-4 3.9 1.8 1.9zM-276.91 387.05l-3.9 4-1.4-1.4c-.3-.3-.6-.6-1-.6s-.6.3-.6.6v5.4c0 .2.1.4.2.5.1.1.3.2.5.2h5.4c.4 0 .6-.3.6-.6 0-.4-.4-.8-.6-.9l-1.4-1.4 4-3.9-1.8-1.9z"></path>
+        </symbol>
+        <symbol viewbox="0 0 39.605 39.633" id="icon-google-plus" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12.488 37.682c-4.69 0-8.08-2.97-8.08-6.537 0-3.496 3.976-6.51 8.667-6.46a10.21 10.21 0 0 1 3.04.488c2.547 1.77 4.6 2.876 5.117 4.894.096.41.15.83.15 1.26 0 3.567-2.3 6.355-8.894 6.355m1.233-21.46c-3.14-.093-6.14-2.982-6.68-7.116-.54-4.136 1.57-7.3 4.72-7.206 3.15.094 5.84 3.486 6.39 7.62.55 4.136-1.27 6.797-4.41 6.703m6.75 6.457c-1.08-.813-3.44-2.478-3.44-3.596 0-1.31.38-1.955 2.35-3.495 2.03-1.58 3.46-3.67 3.46-6.25 0-2.82-1.15-5.37-3.31-6.61h3.06L25.2 0H13.51C7.584 0 2.644 4.37 2.644 9.18c0 4.912 3.246 8.83 8.82 8.83.388 0 .764-.02 1.133-.048-.36.694-.62 1.467-.62 2.277 0 1.36.75 2.14 1.68 3.04-.702 0-1.38.02-2.12.02C4.75 23.3 0 27.97 0 32.46c0 4.412 5.726 7.173 12.513 7.173 7.737 0 12.495-4.39 12.495-8.8 0-3.54-.764-5.32-4.536-8.15M31.52.54v5.388h-5.388v2.695h5.39v5.39h2.694v-5.39h5.39V5.928h-5.39V.538"></path>
+        </symbol>
+        <symbol viewbox="0 0 105.4 105.7" class="alinline-svg" id="icon-grid" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#ccc" d="M0 0h47.7v47.7H0z" class="alshape-1"></path>
+            <path fill="#ccc" d="M57.7 0h47.7v47.7H57.7z" class="alshape-2"></path>
+            <path fill="#ccc" d="M0 58h47.7v47.7H0z" class="alshape-3"></path>
+            <path fill="#ccc" d="M57.7 58h47.7v47.7H57.7z" class="alshape-4"></path>
+        </symbol>
+        <symbol viewbox="0 0 64.37 40.34" id="icon-hamburger" xmlns="http://www.w3.org/2000/svg">
+            <path class="amcls-1" d="M0 30h64.37v10.34H0zm0-15h64.37v10.34H0zM0 0h64.37v10.34H0z"></path>
+        </symbol>
+        <symbol viewbox="0 0 671.78668 671.78668" id="icon-instagram" xmlns="http://www.w3.org/2000/svg">
+            <g transform="matrix(.13333 0 0 -.13333 0 671.787)">
+                <path d="M2519.21 5038.41c-684.18 0-769.97-2.9-1038.67-15.16-268.14-12.23-451.27-54.82-611.513-117.09-165.66-64.38-306.148-150.52-446.203-290.57-140.051-140.05-226.191-280.55-290.57-446.21-62.273-160.24-104.86-343.37-117.098-611.51C2.898 3289.17 0 3203.38 0 2519.2c0-684.17 2.898-769.96 15.156-1038.66 12.239-268.14 54.825-451.27 117.098-611.509 64.379-165.66 150.519-306.152 290.57-446.211 140.055-140.05 280.543-226.191 446.203-290.57C1029.27 69.98 1212.4 27.39 1480.54 15.16 1749.24 2.902 1835.03 0 2519.21 0c684.17 0 769.96 2.902 1038.66 15.16 268.14 12.23 451.27 54.82 611.51 117.09 165.66 64.379 306.15 150.52 446.21 290.57 140.05 140.059 226.19 280.551 290.57 446.211 62.27 160.239 104.86 343.369 117.09 611.509 12.26 268.7 15.16 354.49 15.16 1038.66 0 684.18-2.9 769.97-15.16 1038.67-12.23 268.14-54.82 451.27-117.09 611.51-64.38 165.66-150.52 306.16-290.57 446.21-140.06 140.05-280.55 226.19-446.21 290.57-160.24 62.27-343.37 104.86-611.51 117.09-268.7 12.26-354.49 15.16-1038.66 15.16zm0-453.91c672.65 0 752.33-2.57 1017.97-14.69 245.62-11.2 379.01-52.24 467.78-86.74 117.59-45.7 201.51-100.29 289.66-188.44 88.16-88.16 142.75-172.08 188.45-289.67 34.5-88.77 75.54-222.16 86.74-467.78 12.12-265.64 14.69-345.32 14.69-1017.98 0-672.65-2.57-752.33-14.69-1017.97-11.2-245.62-52.24-379.01-86.74-467.78-45.7-117.591-100.29-201.509-188.45-289.661-88.15-88.16-172.07-142.75-289.66-188.449-88.77-34.5-222.16-75.539-467.78-86.738-265.6-12.122-345.27-14.692-1017.97-14.692-672.71 0-752.37 2.57-1017.98 14.692-245.62 11.199-379.01 52.238-467.78 86.738-117.591 45.699-201.509 100.289-289.661 188.449-88.152 88.152-142.75 172.07-188.449 289.661-34.5 88.77-75.535 222.16-86.742 467.78-12.121 265.64-14.688 345.32-14.688 1017.97 0 672.66 2.567 752.34 14.688 1017.98 11.207 245.62 52.242 379.01 86.742 467.78 45.699 117.59 100.293 201.51 188.445 289.66 88.156 88.16 172.074 142.75 289.665 188.45 88.77 34.5 222.16 75.54 467.78 86.74 265.64 12.12 345.32 14.69 1017.98 14.69"></path>
+                <path d="M2519.21 1679.47c-463.78 0-839.74 375.96-839.74 839.73 0 463.78 375.96 839.74 839.74 839.74 463.77 0 839.73-375.96 839.73-839.74 0-463.77-375.96-839.73-839.73-839.73zm0 2133.38c-714.47 0-1293.65-579.18-1293.65-1293.65 0-714.46 579.18-1293.64 1293.65-1293.64 714.46 0 1293.64 579.18 1293.64 1293.64 0 714.47-579.18 1293.65-1293.64 1293.65M4166.27 3863.96c0-166.96-135.35-302.3-302.31-302.3-166.95 0-302.3 135.34-302.3 302.3s135.35 302.31 302.3 302.31c166.96 0 302.31-135.35 302.31-302.31"></path>
+            </g>
+        </symbol>
+        <symbol viewbox="-27.7 455.1 337.2 791.1" id="icon-left" xmlns="http://www.w3.org/2000/svg">
+            <path fill="inherit" d="M274.8 1246.2c-9.5 0-19.8-4-27.7-14.3l-262.9-350c-7.9-9.5-11.9-22.2-11.9-31.7 0-11.9 4-22.2 11.9-31.7l262.9-350.1c11.9-14.3 31.7-17.4 47.5-7.9 15.8 9.5 17.4 31.7 7.9 45.9L42.8 851l259.8 342.1c11.9 14.3 7.9 35.6-7.9 45.9-6.4 5.6-11.9 7.2-19.9 7.2"></path>
+        </symbol>
+        <symbol viewbox="0 0 18 18" id="icon-link" xmlns="http://www.w3.org/2000/svg">
+            <g opacity=".4">
+                <path d="M10.546 13.732l.623-.623a.957.957 0 0 0 .121-.137c.263-.273.48-.582.65-.905a4.44 4.44 0 0 0 .46-2.733 3.766 3.766 0 0 0-.158-.692 3.61 3.61 0 0 0-.244-.604 4.355 4.355 0 0 0-.877-1.245 4.35 4.35 0 0 0-1.245-.876l-1.14 1.14c-.08.08-.146.163-.204.256a2.735 2.735 0 0 1 2.07 2.07c.044.21.066.426.06.644a2.601 2.601 0 0 1-.765 1.81l-.69.689-.513.513-.485.485-1.237 1.237c-1.037 1.037-2.737 1.024-3.79-.029-1.052-1.052-1.064-2.753-.028-3.789L4.39 9.706a5.663 5.663 0 0 1-.208-2.338L1.881 9.67c-1.73 1.73-1.709 4.56.048 6.316 1.757 1.757 4.586 1.778 6.316.048l2.302-2.302z"></path>
+                <path d="M7.339 7.802a2.54 2.54 0 0 1 .1-.668c.114-.42.339-.814.665-1.14l.693-.694.51-.51.48-.48 1.242-1.241c1.036-1.036 2.736-1.024 3.789.029 1.052 1.052 1.064 2.753.029 3.789l-1.241 1.24c.233.76.302 1.556.211 2.335l2.303-2.303c1.73-1.73 1.708-4.558-.049-6.315C14.314.087 11.485.066 9.756 1.796L7.453 4.098l-.623.623a.934.934 0 0 0-.121.138 3.904 3.904 0 0 0-.645.9 4.39 4.39 0 0 0-.46 2.733c.028.244.08.472.153.696.065.206.142.41.245.604.209.452.503.87.877 1.244.373.374.791.668 1.244.878l1.14-1.141a1.38 1.38 0 0 0 .204-.256 2.68 2.68 0 0 1-1.335-.734 2.685 2.685 0 0 1-.793-1.98z"></path>
+            </g>
+        </symbol>
+        <symbol viewbox="0 0 16 16" id="icon-linkedin" xmlns="http://www.w3.org/2000/svg">
+            <path d="M.2 15.876h3.394V5.222H.2v10.654zM1.997 0C.8 0 0 .836 0 1.88s.8 1.88 1.997 1.88 1.997-.836 1.997-1.88C3.794.836 2.994 0 1.997 0zm9.985 4.804c-1.798 0-2.596 1.045-2.996 1.88V5.222H5.392c.2 1.045 0 10.862 0 10.862h3.395V9.818c0-.21 0-.627.2-.836.2-.626.798-1.253 1.796-1.253 1.2 0 1.798 1.04 1.798 2.5v5.64h3.4V9.82c0-3.342-1.79-5.014-3.99-5.014z"></path>
+        </symbol>
+        <symbol viewbox="0 0 35.4 51" id="icon-map-marker" xmlns="http://www.w3.org/2000/svg">
+            <path d="M18 51.733c11.8-15.9 17.7-27.1 17.7-33.5 0-9.7-7.9-17.5-17.7-17.5S.3 8.533.3 18.233c0 6.4 5.9 17.6 17.7 33.5z"></path>
+            <circle r="8" cy="18" cx="18" fill="#fff"></circle>
+        </symbol>
+        <symbol viewbox="-375 489.5 37.2 30.3" id="icon-menu" xmlns="http://www.w3.org/2000/svg">
+            <title>
+                menu
+            </title>
+            <path d="M-367 489.5h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4zm8 12.8h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4zm8 13.7h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4z"></path>
+        </symbol>
+        <symbol viewbox="0 0 179 96" id="icon-more" xmlns="http://www.w3.org/2000/svg">
+            <title>
+                more-arrow
+            </title>
+            <path d="M178.86 47.677L129.776 0v34.313H0v26.625h116.296v.103h13.48v34.31l49.084-47.67"></path>
+        </symbol>
+        <symbol viewbox="0 0 50.062 37.479" id="icon-newsletter_signup" xmlns="http://www.w3.org/2000/svg">
+            <path d="M25.085 21.866L.082 3.114A3.114 3.114 0 0 1 3.207-.012H46.96a3.113 3.113 0 0 1 3.126 3.126l-25 18.752zm0 5.613L50.087 8.726v25.64a3.113 3.113 0 0 1-3.125 3.125H3.208a3.113 3.113 0 0 1-3.125-3.125V8.727L25.085 27.48z" class="aushape-1"></path>
+        </symbol>
+        <symbol viewbox="0 0 832 512" id="icon-norgie-down" xmlns="http://www.w3.org/2000/svg">
+            <path d="M15.244 98.497L379.433 495.43c20.249 22.24 53.137 22.23 73.373-.021.51-.608.71-1.47 1.25-2.077L817.152 98.259c20.233-22.224 20.223-58.326-.028-80.54-.202-.1-.531-.202-.735-.404C807.065 6.732 793.993-.005 779.353 0L52.923.208C38.073.212 24.903 7.286 15.43 18.18l-.2-.227c-20.314 22.325-20.304 58.33.023 80.543h-.008z"></path>
+        </symbol>
+        <symbol viewbox="0 0 512 832.328" id="icon-norgie-right" xmlns="http://www.w3.org/2000/svg">
+            <path d="M98.278 817.088l397.038-364.076c22.245-20.243 22.245-53.13 0-73.373-.608-.51-1.47-.71-2.077-1.25L98.27 15.18c-22.218-20.24-58.32-20.24-80.54.005-.1.202-.202.53-.404.734C6.74 25.24 0 38.31 0 52.95v726.43c0 14.85 7.07 28.022 17.963 37.5l-.228.2c22.32 20.32 58.324 20.32 80.543 0z"></path>
+        </symbol>
+        <symbol viewbox="0 0 47.3 34.3" id="icon-opentable" xmlns="http://www.w3.org/2000/svg">
+            <path d="M30.1 0C20.7 0 13 7.7 13 17.2s7.7 17.2 17.2 17.2 17.2-7.7 17.2-17.2C47.3 7.7 39.6 0 30.1 0zm0 21.5c-2.4 0-4.3-1.9-4.3-4.3s1.9-4.3 4.3-4.3 4.3 1.9 4.3 4.3c0 2.3-1.9 4.3-4.3 4.3zM0 17.2c0 2.4 1.9 4.3 4.3 4.3s4.3-1.9 4.3-4.3-1.9-4.3-4.3-4.3S0 14.8 0 17.2"></path>
+        </symbol>
+        <symbol viewbox="0 0 12 12" id="icon-pencil" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1.3 8.4c0 .1 0 .1 0 0L0 11.6c0 .1 0 .2.1.3 0 .1.1.1.1.1h.1l3.1-1.2s.1 0 .1-.1l6.2-6.2-2.2-2.3-6.2 6.2zm10.5-7L10.6.2c-.3-.3-.8-.3-1.1 0L8.2 1.5l2.2 2.2 1.3-1.3c.4-.2.4-.7.1-1z"></path>
+        </symbol>
+        <symbol viewbox="0 0 60.7 93.3" id="icon-pin" xmlns="http://www.w3.org/2000/svg">
+            <path d="M57.2 34.6c0 4.8-1.3 9.3-3.5 13.2L31.8 87.5c-.3.5-.9.8-1.5.8-.7 0-1.2-.4-1.5-.8L6.9 47.7c-2.2-3.8-3.5-8.4-3.5-13.2 0-14.8 12-26.9 26.9-26.9 14.9.1 26.9 12.1 26.9 27zm-16.8 0c0-5.6-4.5-10.1-10.1-10.1S20.2 29 20.2 34.6s4.5 10.1 10.1 10.1 10.1-4.5 10.1-10.1z" xmlns="http://www.w3.org/2000/svg"></path>
+        </symbol>
+        <symbol viewbox="-285 377 40 40" id="icon-pinterest" xmlns="http://www.w3.org/2000/svg">
+            <path d="M-265 377.1c-10.9 0-19.7 8.9-19.7 19.8 0 8.1 4.9 15 11.8 18.1-.1-1.4 0-3 .3-4.5.4-1.6 2.5-10.8 2.5-10.8s-.6-1.3-.6-3.1c0-2.9 1.7-5.1 3.8-5.1 1.8 0 2.7 1.3 2.7 3 0 1.8-1.2 4.5-1.7 7-.5 2.1 1 3.8 3.1 3.8 3.7 0 6.3-4.8 6.3-10.5 0-4.3-2.9-7.6-8.2-7.6-6 0-9.7 4.5-9.7 9.5 0 1.7.5 2.9 1.3 3.9.4.4.4.6.3 1.1l-.4 1.6c-.1.5-.5.7-1 .5-2.8-1.1-4-4.1-4-7.5 0-5.6 4.7-12.3 14.1-12.3 7.5 0 12.5 5.5 12.5 11.3 0 7.7-4.3 13.5-10.7 13.5-2.1 0-4.1-1.2-4.8-2.5 0 0-1.1 4.5-1.4 5.4-.4 1.5-1.2 3-2 4.2 1.8.5 3.7.8 5.6.8 10.9 0 19.7-8.8 19.7-19.7 0-11-8.9-19.9-19.8-19.9z"></path>
+        </symbol>
+        <symbol viewbox="-230 372 50 50" id="icon-play" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#999" d="M-214 376l25.6 21.1L-214 418v-42z"></path>
+        </symbol>
+        <symbol viewbox="0 0 17 17" id="icon-rec" xmlns="http://www.w3.org/2000/svg">
+            <path d="M7.544.405l2.305 4.64 5.15.743L11.27 9.4l.88 5.1-4.61-2.407-4.6 2.407.88-5.1L.087 5.79l5.153-.744L7.545.404z"></path>
+        </symbol>
+        <symbol viewbox="0 0 450 386" id="icon-refresh" xmlns="http://www.w3.org/2000/svg">
+            <path d="M352.629 288.14l96-111.9h-64.7c-2.3-27.9-10.5-54-23.5-77.3-27.4-49.2-75.8-85.1-133-95.6-.7-.1-1.5-.3-2.2-.4-.5-.1-.9-.2-1.4-.2-10.1-1.7-20.6-2.6-31.2-2.6h-.4c-90.9.2-167 63.6-186.7 148.6v.1c-.3 1.1-.5 2.2-.7 3.3-.1.5-.2.9-.3 1.4-.1.7-.3 1.4-.4 2.1-.2.9-.3 1.7-.5 2.6-.1.4-.1.7-.2 1.1l-.6 3.6v.2c-1 6.3-1.6 12.7-1.9 19.1v.8c-.1 1.4-.1 2.7-.2 4.1 0 1.6-.1 3.3-.1 5 0 1.7 0 3.3.1 5 0 1.4.1 2.7.2 4.1v.9c.3 6.5 1 12.9 1.9 19.1v.2l.6 3.6c.1.4.1.7.2 1.1.2.9.3 1.8.5 2.6.1.7.3 1.4.4 2.1.1.5.2 1 .3 1.4.2 1.1.5 2.2.7 3.2v.1c19.7 85 96.1 148.4 187.1 148.6 42.9-.1 83.1-14.2 116.9-40.7l7.5-5.9-43.2-46.2-6.2 4.6c-22.1 16.3-47.5 24.2-75 24.2-70.6 0-128-57-128-128s57.4-128 128-128c66.4 0 122.8 46.6 129.5 112h-73.5l104 112z" xmlns:bx="https://boxy-svg.com" bx:origin="0.5 0.5"></path>
+        </symbol>
+        <symbol viewbox="-27.7 455.1 337.2 791.1" id="icon-right" xmlns="http://www.w3.org/2000/svg">
+            <path fill="inherit" d="M6.9 455.1c9.5 0 19.8 4 27.7 14.3l262.9 350.1c7.9 9.5 11.9 22.2 11.9 31.7 0 11.9-4 22.2-11.9 31.7l-262.8 350c-11.9 14.3-31.7 17.4-47.5 7.9-15.8-9.5-17.4-31.7-7.9-45.9L239 850.3-20.8 508.2c-11.9-14.3-7.9-35.6 7.9-45.9 6.4-5.6 11.9-7.2 19.8-7.2"></path>
+        </symbol>
+        <symbol viewbox="0 0 1000 1000" preserveaspectratio="xMinYMin meet" id="icon-rss" xmlns="http://www.w3.org/2000/svg">
+            <path d="M0 866q0-55 39-94t94-39 94 39 39 94q0 56-39 94.5T133 999t-94-39-39-94zm0-335V340q179 0 331 88.5T571.5 669t88.5 331H468q0-194-137-331Q193 531 0 531zm0-339V0q203 0 388 79.5T707 293t213.5 319 79.5 388H808q0-164-64-314T571.5 428t-258-172T0 192z"></path>
+        </symbol>
+        <symbol viewbox="373.3 133.3 533.3 533.3" id="icon-search" xmlns="http://www.w3.org/2000/svg">
+            <path d="M754.7 468.7l-22.3-22.3c24.3-33.3 37.5-73.4 37.7-114.7 0-109.5-88.8-198.3-198.3-198.3s-198.3 88.8-198.3 198.3S462.1 530 571.7 530c41.2-.2 81.3-13.4 114.7-37.7l22.3 22.3 152.7 152 45.3-45.3-152-152.6zm-183 0c-75.8 0-137.3-61.5-137.3-137.3S495.8 194 571.7 194 709 255.5 709 331.3c.2 75.7-61 137.1-136.7 137.3-.2.1-.4.1-.6.1z"></path>
+        </symbol>
+        <symbol viewbox="206 29.9 642.1 681.3" id="icon-settings" xmlns="http://www.w3.org/2000/svg">
+            <path d="M843 467.2c4.8 3.2 6.3 9.5 4 15-13.5 41.2-36.4 79.2-64.2 111.7-4 4.8-9.5 6.3-15 4l-81.6-28.5c-20.6 16.6-43.6 30.1-67.3 39.6l-16.6 84.7c-.8 5.5-5.5 10.3-11.1 11.1-21.4 4-42.8 6.3-64.2 6.3-22.2 0-43.6-2.4-64.2-6.3-5.5-.8-10.3-5.5-11.1-11.1L435.2 609c-24.6-9.5-48.3-23-67.3-39.6l-81.6 28.5c-5.5 2.4-11.1.8-15-4-28.5-32.5-51.5-70.5-64.2-111.7-2.4-5.5-.8-11.9 4-15l64.9-57c-2.4-12.7-3.2-26.1-3.2-39.6s.8-26.9 3.2-39.6l-65-57c-4.8-3.2-6.3-9.5-4-15 13.5-41.2 36.4-79.2 64.2-111.7 4-4.8 9.5-6.3 15-4l81.6 28.5c19.8-16.6 43.6-30.1 67.3-39.6l16.6-84.7c.8-5.5 5.5-10.3 11.1-11.1 42.8-8.7 86.3-8.7 129.1 0 5.5.8 10.3 5.5 11.1 11.1l15 85.5c24.6 9.5 47.5 23 67.3 39.6l81.6-28.5c5.5-2.4 11.1-.8 15 4 28.5 32.5 51.5 70.5 64.2 111.7 2.4 5.5.8 11.9-4 15l-65.7 57c2.4 12.7 3.2 26.1 3.2 39.6s-.8 26.9-3.2 39.6l66.6 56.2zm-190-95.8c0-69.7-57.8-127.5-127.5-127.5-70.5 0-127.5 57-127.5 127.5s57 127.5 127.5 127.5S653 441.9 653 371.4z"></path>
+        </symbol>
+        <symbol viewbox="0 0 16 16" id="icon-snapchat" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8.155.48c.662 0 2.903.185 3.96 2.552.354.797.27 2.15.2 3.237l-.002.04c-.008.12-.015.23-.02.34.05.03.135.06.268.06.2-.01.44-.08.69-.2.11-.06.23-.07.31-.07.12 0 .24.02.34.06.3.1.49.32.49.56.01.3-.26.56-.81.78-.06.02-.14.05-.23.08-.3.09-.76.24-.89.54-.06.15-.04.35.08.58l.01.01c.04.09 1.02 2.32 3.2 2.68.17.03.29.18.28.34 0 .05-.01.1-.03.15-.16.38-.85.66-2.1.85-.04.06-.08.25-.11.38-.02.12-.05.24-.09.37-.05.18-.18.27-.37.27h-.02c-.09 0-.21-.02-.36-.05-.24-.05-.51-.09-.85-.09-.2 0-.4.01-.61.05-.4.07-.75.31-1.15.59-.57.4-1.22.86-2.2.86-.04 0-.08-.01-.12-.01h-.1c-.98 0-1.62-.45-2.19-.86-.4-.28-.74-.52-1.14-.59-.21-.03-.42-.05-.62-.05-.36 0-.64.06-.85.1-.14.03-.26.05-.36.05-.25 0-.35-.15-.39-.28-.04-.13-.06-.26-.09-.38s-.07-.33-.11-.38C.89 12.9.2 12.62.04 12.23a.413.413 0 0 1-.036-.15.332.332 0 0 1 .28-.34c2.18-.36 3.16-2.59 3.2-2.684l.01-.02c.12-.23.15-.43.08-.58-.13-.29-.59-.44-.89-.54-.08-.02-.16-.05-.23-.08-.74-.29-.84-.62-.8-.85.06-.32.45-.53.78-.53.097 0 .18.02.256.05.28.13.527.2.737.2a.63.63 0 0 0 .31-.07l-.03-.38c-.065-1.086-.15-2.438.205-3.23C4.94.67 7.175.49 7.835.49l.28-.01h.04z"></path>
+        </symbol>
+        <symbol viewbox="0 0 17 17" id="icon-star" xmlns="http://www.w3.org/2000/svg">
+            <path d="M7.544.405l2.305 4.64 5.15.743L11.27 9.4l.88 5.1-4.61-2.407-4.6 2.407.88-5.1L.087 5.79l5.153-.744L7.545.404z"></path>
+        </symbol>
+        <symbol viewbox="19.3 54.3 26.9 33.7" id="icon-thumb-down" xmlns="http://www.w3.org/2000/svg">
+            <title>
+                no
+            </title>
+            <path d="M19.3 84.4c0-4.8 0-9.4.1-14 0-.4 1-1 1.6-1.2 4.2-1.1 7.7-3.2 9.6-7.3.7-1.6.9-3.4 1.5-5 .4-.9 1.2-1.7 1.8-2.5.7.8 2 1.6 2.1 2.5.2 2.2 0 4.5-.2 6.8-.1.9-.4 1.8-.6 3h5.1c1.2 0 2.4 0 3.5.2 1.9.3 2.4 1.3 2.2 3.2-.1 1.2.1 2.4.1 3.6 0 1 0 1.9-.1 2.9-.1 1.1 0 2.2-.3 3.1-1 2.6-2.1 5.2-3.4 7.6-.3.6-1.8.7-2.7.7-2.4.1-4.8.2-7.2 0-1.4-.1-2.9-.5-4-1.3-2.2-1.7-4.4-2.3-7.1-2.1-.6-.1-1.2-.2-2-.2z"></path>
+        </symbol>
+        <symbol viewbox="19.3 54.3 26.9 33.7" id="icon-thumb-up" xmlns="http://www.w3.org/2000/svg">
+            <title>
+                yes
+            </title>
+            <path d="M19.3 84.4c0-4.8 0-9.4.1-14 0-.4 1-1 1.6-1.2 4.2-1.1 7.7-3.2 9.6-7.3.7-1.6.9-3.4 1.5-5 .4-.9 1.2-1.7 1.8-2.5.7.8 2 1.6 2.1 2.5.2 2.2 0 4.5-.2 6.8-.1.9-.4 1.8-.6 3h5.1c1.2 0 2.4 0 3.5.2 1.9.3 2.4 1.3 2.2 3.2-.1 1.2.1 2.4.1 3.6 0 1 0 1.9-.1 2.9-.1 1.1 0 2.2-.3 3.1-1 2.6-2.1 5.2-3.4 7.6-.3.6-1.8.7-2.7.7-2.4.1-4.8.2-7.2 0-1.4-.1-2.9-.5-4-1.3-2.2-1.7-4.4-2.3-7.1-2.1-.6-.1-1.2-.2-2-.2z"></path>
+        </symbol>
+        <symbol viewbox="0 0 60.7 93.3" id="icon-topics" xmlns="http://www.w3.org/2000/svg">
+            <g xmlns="http://www.w3.org/2000/svg">
+                <path d="M2.5 21.5h55.2v11.8H2.5zM2.5 42.1h55.2v11.8H2.5zM2.5 64.3h55.2v11.8H2.5z"></path>
+            </g>
+        </symbol>
+        <symbol viewbox="0 0 87 60" id="icon-trending" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1.906 46.826c2.213 1.787 5.466 1.46 7.262-.743v-.006l5.26-6.45 8.378 11.286a5.171 5.171 0 0 0 4.827 2.035 5.128 5.128 0 0 0 4.124-3.215l7.96-20.208L51.26 56.577a5.155 5.155 0 0 0 4.754 3.13c.097 0 .19 0 .286-.007a5.172 5.172 0 0 0 4.66-3.667l10.98-36.787 4.854 9.902c1.234 2.552 4.33 3.613 6.89 2.37 2.56-1.234 3.636-4.314 2.386-6.86L75.42 2.888a5.15 5.15 0 0 0-5.067-2.87 5.135 5.135 0 0 0-4.52 3.653L55.146 39.42 44.28 13.93a5.142 5.142 0 0 0-4.827-3.127 5.157 5.157 0 0 0-4.73 3.263L25.56 37.343l-6.79-9.148a5.197 5.197 0 0 0-4.033-2.08 5.139 5.139 0 0 0-4.124 1.897L1.153 39.6a5.125 5.125 0 0 0 .753 7.226" fill-rule="evenodd"></path>
+        </symbol>
+        <symbol viewbox="0 0 23.62 41.098" id="icon-tumblr" xmlns="http://www.w3.org/2000/svg">
+            <path d="M21.643 32.826c-.764.364-2.226.682-3.316.71-3.29.088-3.927-2.31-3.955-4.052V16.69h8.252v-6.22h-8.222V0h-6.02c-.1 0-.272.087-.296.307C7.734 3.512 6.234 9.135 0 11.382v5.31h4.16V30.12c0 4.595 3.39 11.126 12.343 10.974 3.02-.053 6.375-1.318 7.117-2.408l-1.977-5.86z"></path>
+        </symbol>
+        <symbol viewbox="0 0 44.71 36.327" id="icon-twitter" xmlns="http://www.w3.org/2000/svg">
+            <path d="M44.71 4.295c-1.656.724-3.415 1.242-5.278 1.45A9.146 9.146 0 0 0 43.468.673a18.75 18.75 0 0 1-5.796 2.225C35.965 1.138 33.584 0 30.945 0a9.145 9.145 0 0 0-9.16 9.16c0 .724.052 1.448.208 2.12-7.607-.413-14.335-3.88-18.888-9.417-.777 1.345-1.242 2.742-1.242 4.45 0 3.157 1.604 5.95 4.088 7.607a9.376 9.376 0 0 1-4.14-1.138v.103c0 4.45 3.16 8.176 7.35 9.004-.77.2-1.6.31-2.43.31-.57 0-1.14-.06-1.71-.16 1.14 3.62 4.56 6.31 8.54 6.36-3.1 2.48-7.09 4.34-11.38 4.34-.72 0-1.45-.05-2.17-.16 4.04 2.59 8.9 3.72 14.08 3.72 16.87 0 26.08-13.97 26.08-26.08V9.05c1.76-1.294 3.32-2.9 4.56-4.76"></path>
+        </symbol>
+        <symbol viewbox="-235.8 423.2 35.7 21.3" id="icon-up" xmlns="http://www.w3.org/2000/svg">
+            <path fill="none" d="M-200.5 444.2L-218 424l-17.5 20.2"></path>
+        </symbol>
+        <symbol viewbox="373.3 133.3 533.3 533.3" id="icon-user" xmlns="http://www.w3.org/2000/svg">
+            <path d="M640 400c73.6 0 133.3-59.7 133.3-133.3S713.6 133.3 640 133.3 506.7 193 506.7 266.7 566.4 400 640 400zm0 66.7c-89 0-266.7 44.7-266.7 133.3v66.7h533.3V600c.1-88.7-177.6-133.3-266.6-133.3z"></path>
+        </symbol>
+        <symbol viewbox="0 0 1146 1000" id="icon-vimeo" xmlns="http://www.w3.org/2000/svg">
+            <path d="M0 272q55-65 110-116t95.5-77.5 72.5-43T326 14l17-4q12-2 24-2 19 0 35 6 26 10 42.5 34.5t29 55 21.5 72 15 77.5 13.5 79.5T538 403q32 125 51.5 177.5T631 633q24 0 66.5-55.5T791 426q26-48 26-91 0-13-2-23-9-52-51-65-11-4-24-4-35 0-83 26 22-130 134-209Q876 0 965 0q12 0 24 1 102 8 139 90 18 38 18 88 0 29-6 61-18 102-69.5 208t-113 187.5-132.5 155-123.5 117T611 976q-42 24-78.5 24T463 979t-56-48-38-57q-18-38-97.5-298.5T175 295q-1-2-4-4t-13.5-4.5-24 0-36.5 14T47 333z"></path>
+        </symbol>
+        <symbol viewbox="0 0 86.965 87.642" id="icon-whatsapp" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M44.038 13.007c-16.58 0-30.02 13.44-30.02 30.02a29.883 29.883 0 0 0 4.307 15.503l-5.418 16.106 16.62-5.32a29.915 29.915 0 0 0 14.512 3.733c16.58 0 30.02-13.45 30.02-30.03C74.06 26.44 60.61 13 44.03 13zm0 55.013a24.85 24.85 0 0 1-13.75-4.132l-9.604 3.074 3.122-9.28a24.858 24.858 0 0 1-4.76-14.653c0-13.79 11.212-25 24.993-25 13.78 0 24.99 11.21 24.99 24.99 0 13.78-11.22 24.99-25 24.99zm14.075-18.17c-.753-.412-4.45-2.407-5.143-2.69-.693-.28-1.2-.427-1.74.32s-2.072 2.418-2.538 2.913c-.467.495-.916.54-1.668.128-.752-.41-3.19-1.31-6.02-4.03-2.202-2.11-3.646-4.68-4.065-5.46-.42-.78-.01-1.18.39-1.55.35-.33.8-.86 1.2-1.3.4-.43.54-.74.81-1.25.27-.5.16-.95-.02-1.34s-1.57-4.22-2.15-5.77c-.58-1.56-1.23-1.32-1.68-1.34-.45-.01-.96-.1-1.47-.12-.51-.02-1.35.14-2.08.89-.73.74-2.78 2.52-2.92 6.29-.14 3.77 2.47 7.52 2.83 8.04.36.53 4.98 8.7 12.66 12.06 7.67 3.36 7.71 2.34 9.12 2.26 1.41-.07 4.6-1.68 5.31-3.45.7-1.76.76-3.3.58-3.62-.18-.32-.68-.54-1.43-.95z"></path>
+        </symbol>
+        <symbol viewbox="130.35156 177.43359 300 300" overflow="visible" id="icon-yahoo" xmlns="http://www.w3.org/2000/svg">
+            <path d="M420.926 272.27c-5.2.514-26.85 5.365-34.13 6.925-7.79 2.073-78.983 57.075-83.66 70.58-1.036 4.674-1.556 11.866-1.556 18.624l-.52 10.91c-.002 7.79 2.162 20.35 3.198 27.1 4.68 1.04 38.555.13 44.79 1.17l-.768 13.97c-6.09-.45-49.106-.34-73.68-.34-12.475 0-52.576 1.37-64.897 1l2.33-13.29c6.755-.53 34.728 1.2 40.878-5.29 3.06-3.22 2.09-6.67 2.09-25.38v-8.83c0-4.16 0-11.96-1.04-19.24-2.59-7.8-65.3-86.09-81.41-98.56-4.68-1.56-33.99-4.49-41.26-6.05l-.36-11.97c3.63-1.82 36.22.44 67.85-.73 20.79-.77 68.22 0 74.07.7l-1.5 10.55c-6.23 1.56-36.26 2.14-44.06 4.21 20.27 30.14 52.31 68.94 62.71 84.01 5.72-8.31 55.96-42.87 57.51-54.82-7.79-1.57-33.6-5.28-37.76-5.28l-2.47-13.61c7.08-1.11 44.28 0 62.78 0 15.96 0 50.07 0 59.76.79l-8.86 12.81"></path>
+        </symbol>
+        <symbol viewbox="0 0 462 325" id="icon-youtube" xmlns="http://www.w3.org/2000/svg">
+            <path d="M234.28 1.691c-53.492 0-132.53 3.24-156.188 4.031C52.396 8.02 42.884 9.366 28.811 21.41 7.368 40.48 2.28 77.954 2.28 135.285v54.562c0 65.439 8.69 98.684 23 110.844 16.517 14.17 27.407 15.302 38.406 17 4.27.646 34.49 6 168.594 6 83.626 0 155.507-3.95 162.937-4.906 11.945-1.508 29.104-3.696 42.063-18.094 19.183-21.803 23-57.999 23-110.437V126.69c0-33.943-1.891-81.916-23-102-15.991-13.536-21.848-17.367-54.938-19.031-9.358-.462-91.02-3.969-148.062-3.969zm-49.5 97l123.5 63.75-123.5 64.25v-128z"></path>
+        </symbol></svg>
+        <div class="l-root l-reskin">
+            <div class="l-header">
+                <div class="chorus-emc__content" data-emc-slug="UnisonCustomNavCell" data-emc-bucket="441::">
+                    <header class="c-global-header" data-cid="site/global_header" role="banner" data-analytics-placement="navigation">
+                        <div class="l-wrapper">
+                            <div class="c-global-header__logo">
+                                <a href="/" tabindex="1" id="chorus-brand" data-analytics-link="home"><span class="c-global-header__logo-large"><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 242 121">
+                                <path fill="#444745" d="M110.674 3.528h3.474L114.564 2H71.63l-.418 1.528h6.253c5.418 0 9.726 3.75 9.726 11.255 0 4.168-1.8 9.587-4.72 16.118L54.82 92.32l-6.81-79.756c-.556-6.252 2.5-9.03 9.59-9.03h4.027L62.042 2H1.6l-.557 1.528h3.89c4.725 0 6.532 2.918 7.087 8.615l10.7 103.1h25.427l42.518-90.038c6.392-13.48 13.2-21.677 20.01-21.677zm-5.002 112.27c-3.89 0-6.253-1.25-6.253-7.642 0-8.06 2.91-23.76 6.11-38.072.41 6.67 5 13.2 11.81 13.2 1.67 0 3.06-.138 4.44-.417-6.26 27.236-8.76 32.932-16.12 32.932zm121.024-54.19c8.06 0 13.2-6.67 13.2-14.173 0-6.392-4.585-11.116-11.115-11.116-11.81 0-17.36 9.31-27.09 26.53-2.08-10.7-6.94-24.73-19.45-24.73-14.03 0-30.15 20.01-45.02 32.37-6.67 5.56-14.17 9.17-20.15 9.17-6.11 0-9.72-6.26-9.72-17.23 4.31-17.93 6.67-22.65 13.34-22.65 4.59 0 6.53 2.64 6.53 8.06 0 5.69-1.25 15.42-3.75 27.51 6.67-2.09 16.68-10.42 25.01-19.45-4.44-10.56-13.89-17.79-27.65-17.79-25.42 0-47.66 22.78-47.66 48.35 0 17.65 12.51 30.984 32.1 30.984 32.38 0 45.86-28.066 45.86-47.52 0-2.78-.14-4.86-.42-7.364C155.717 57.14 162.108 52 167.388 52c5.975 0 10.7 15.007 15.423 37.657-4.17 4.58-8.34 13.474-10.42 15.002-.836-8.06-6.115-13.06-13.2-13.06-7.92 0-13.48 7.5-13.48 13.893 0 7.226 5 11.95 11.53 11.95 13.76 0 17.65-13.062 26.265-24.595 2.64 12.363 8.754 24.59 19.313 24.59 12.506 0 24.178-10.7 30.15-18.34l-1.11-1.81c-3.89 3.753-7.642 6.254-11.95 6.254-7.78 0-13.34-16.81-17.645-37.1 2.5-3.47 6.53-12.225 9.31-15.28 1.95 3.612 5.978 10.42 15.15 10.42z"></path></svg></span> <span class="c-global-header__logo-small"><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 242 121">
+                                <path fill="#444745" d="M110.674 3.528h3.474L114.564 2H71.63l-.418 1.528h6.253c5.418 0 9.726 3.75 9.726 11.255 0 4.168-1.8 9.587-4.72 16.118L54.82 92.32l-6.81-79.756c-.556-6.252 2.5-9.03 9.59-9.03h4.027L62.042 2H1.6l-.557 1.528h3.89c4.725 0 6.532 2.918 7.087 8.615l10.7 103.1h25.427l42.518-90.038c6.392-13.48 13.2-21.677 20.01-21.677zm-5.002 112.27c-3.89 0-6.253-1.25-6.253-7.642 0-8.06 2.91-23.76 6.11-38.072.41 6.67 5 13.2 11.81 13.2 1.67 0 3.06-.138 4.44-.417-6.26 27.236-8.76 32.932-16.12 32.932zm121.024-54.19c8.06 0 13.2-6.67 13.2-14.173 0-6.392-4.585-11.116-11.115-11.116-11.81 0-17.36 9.31-27.09 26.53-2.08-10.7-6.94-24.73-19.45-24.73-14.03 0-30.15 20.01-45.02 32.37-6.67 5.56-14.17 9.17-20.15 9.17-6.11 0-9.72-6.26-9.72-17.23 4.31-17.93 6.67-22.65 13.34-22.65 4.59 0 6.53 2.64 6.53 8.06 0 5.69-1.25 15.42-3.75 27.51 6.67-2.09 16.68-10.42 25.01-19.45-4.44-10.56-13.89-17.79-27.65-17.79-25.42 0-47.66 22.78-47.66 48.35 0 17.65 12.51 30.984 32.1 30.984 32.38 0 45.86-28.066 45.86-47.52 0-2.78-.14-4.86-.42-7.364C155.717 57.14 162.108 52 167.388 52c5.975 0 10.7 15.007 15.423 37.657-4.17 4.58-8.34 13.474-10.42 15.002-.836-8.06-6.115-13.06-13.2-13.06-7.92 0-13.48 7.5-13.48 13.893 0 7.226 5 11.95 11.53 11.95 13.76 0 17.65-13.062 26.265-24.595 2.64 12.363 8.754 24.59 19.313 24.59 12.506 0 24.178-10.7 30.15-18.34l-1.11-1.81c-3.89 3.753-7.642 6.254-11.95 6.254-7.78 0-13.34-16.81-17.645-37.1 2.5-3.47 6.53-12.225 9.31-15.28 1.95 3.612 5.978 10.42 15.15 10.42z"></path></svg></span></a>
+                            </div>
+                            <ul class="c-global-header__social">
+                                <li>
+                                    <a href="https://twitter.com/voxdotcom" class="twitter"><svg class="p-svg-icon">
+                                    <use xlink:href="#icon-twitter"></use></svg></a>
+                                </li>
+                                <li>
+                                    <a href="https://www.facebook.com/Vox" class="facebook"><svg class="p-svg-icon">
+                                    <use xlink:href="#icon-facebook"></use></svg></a>
+                                </li>
+                                <li>
+                                    <a href="http://bit.ly/voxyoutube" class="youtube"><svg class="p-svg-icon">
+                                    <use xlink:href="#icon-youtube"></use></svg></a>
+                                </li>
+                                <li>
+                                    <a href="/rss/index.xml" class="rss"><svg class="p-svg-icon">
+                                    <use xlink:href="#icon-rss"></use></svg></a>
+                                </li>
+                            </ul>
+                            <div class="c-global-header__actions">
+                                <div class="c-global-header__login">
+                                    <a class="c-global-header__login-icon" href="https://auth.voxmedia.com/login?return_to=https%3A%2F%2Fwww.vox.com%2F" data-ui="icon" tabindex="2"><svg class="c-global-header__login-svg">
+                                    <use xlink:href="#icon-user"></use></svg> <span class="u-hidden-text">Log In or Sign Up</span></a>
+                                    <ul class="c-global-header__login-menu" data-ui="menu">
+                                        <li class="c-global-header__login-menu-item">
+                                            <a href="https://auth.voxmedia.com/login?return_to=https%3A%2F%2Fwww.vox.com%2F" data-ui-signin="login" tabindex="3" data-analytics-link="login">Log In</a>
+                                        </li>
+                                        <li class="c-global-header__login-menu-item">
+                                            <a href="https://auth.voxmedia.com/signup?return_to=https%3A%2F%2Fwww.vox.com%2F" data-ui-signin="signup" tabindex="4" data-analytics-link="signup">Sign Up</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                                <div class="c-global-header__search">
+                                    <button type="submit" class="c-global-header__search-trigger" tabindex="5"><svg class="c-global-header__login-svg">
+                                    <use xlink:href="#icon-search"></use></svg></button>
+                                </div>
+                            </div>
+                            <nav class="c-global-header__links">
+                                <ul>
+                                    <li class="c-global-header__link is-pinned" data-nav-item-id="future-perfect">
+                                        <a href="https://www.vox.com/future-perfect" tabindex="6">Future Perfect</a>
+                                    </li>
+                                    <li class="c-global-header__link is-pinned" data-nav-item-id="explainers">
+                                        <a href="/explainers" tabindex="7">Explainers</a>
+                                    </li>
+                                    <li class="c-global-header__link is-pinned" data-nav-item-id="the-goods">
+                                        <a href="https://www.vox.com/the-goods" tabindex="8">The Goods</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="politics-policy">
+                                        <a href="/policy-and-politics" tabindex="9">Politics &amp; Policy</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="culture">
+                                        <a href="/culture" tabindex="10">Culture</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="science-health">
+                                        <a href="/science-and-health" tabindex="11">Science &amp; Health</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="world">
+                                        <a href="/world" tabindex="12">World</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="identities">
+                                        <a href="/identities" tabindex="13">Identities</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="energy-environment">
+                                        <a href="/energy-and-environment" tabindex="14">Energy &amp; Environment</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="technology">
+                                        <a href="/technology" tabindex="15">Technology</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="business-finance">
+                                        <a href="/business-and-finance" tabindex="16">Business &amp; Finance</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="first-person">
+                                        <a href="/first-person" tabindex="17">First Person</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="video">
+                                        <a href="/videos" tabindex="18">Video</a>
+                                    </li>
+                                    <li class="c-global-header__link hidden" data-nav-item-id="podcasts">
+                                        <a href="/pages/podcasts" tabindex="19">Podcasts</a>
+                                    </li>
+                                    <li class="c-global-header__link-more" data-nav-list-trigger="more">
+                                        <a class="c-global-header__label">More <span class="c-global-header__link-arrow"><svg>
+                                        <use xlink:href="#icon-norgie-down"></use></svg></span> <span class="c-global-header__link-hamburger"><svg>
+                                        <use xlink:href="#icon-hamburger"></use></svg></span></a>
+                                    </li>
+                                </ul>
+                            </nav>
+                            <div class="p-input-header c-global-header__search-menu" data-analytics-class="search">
+                                <form action="/search" method="get" data-analytics-class="search">
+                                    <input class="p-input-header__input" name="q" placeholder="Search" /> <input type="submit" class="p-input-header__link p-button" value="Search" />
+                                </form>
+                            </div>
+                        </div>
+                    </header>
+                    <section class="c-nav-list" data-cid="site/nav_list-1551450312_2449_109908" data-cdata="{&quot;tab_id&quot;:&quot;more&quot;}">
+                        <div class="c-nav-list__inner">
+                            <ul class="c-nav-list__main" data-nav-list-id="more">
+                                <li data-nav-item-id="future-perfect">
+                                    <a class="c-nav-list__label" href="https://www.vox.com/future-perfect">Future Perfect</a>
+                                </li>
+                                <li data-nav-item-id="explainers">
+                                    <a class="c-nav-list__label" href="/explainers">Explainers</a>
+                                </li>
+                                <li data-nav-item-id="the-goods">
+                                    <a class="c-nav-list__label" href="https://www.vox.com/the-goods">The Goods</a>
+                                </li>
+                                <li data-nav-item-id="politics-policy">
+                                    <a class="c-nav-list__label" href="/policy-and-politics">Politics &amp; Policy</a>
+                                </li>
+                                <li data-nav-item-id="culture">
+                                    <a class="c-nav-list__label" href="/culture">Culture</a>
+                                </li>
+                                <li data-nav-item-id="science-health">
+                                    <a class="c-nav-list__label" href="/science-and-health">Science &amp; Health</a>
+                                </li>
+                                <li data-nav-item-id="world">
+                                    <a class="c-nav-list__label" href="/world">World</a>
+                                </li>
+                                <li data-nav-item-id="identities">
+                                    <a class="c-nav-list__label" href="/identities">Identities</a>
+                                </li>
+                                <li data-nav-item-id="energy-environment">
+                                    <a class="c-nav-list__label" href="/energy-and-environment">Energy &amp; Environment</a>
+                                </li>
+                                <li data-nav-item-id="technology">
+                                    <a class="c-nav-list__label" href="/technology">Technology</a>
+                                </li>
+                                <li data-nav-item-id="business-finance">
+                                    <a class="c-nav-list__label" href="/business-and-finance">Business &amp; Finance</a>
+                                </li>
+                                <li data-nav-item-id="first-person">
+                                    <a class="c-nav-list__label" href="/first-person">First Person</a>
+                                </li>
+                                <li data-nav-item-id="video">
+                                    <a class="c-nav-list__label" href="/videos">Video</a>
+                                </li>
+                                <li data-nav-item-id="podcasts">
+                                    <a class="c-nav-list__label" href="/pages/podcasts">Podcasts</a>
+                                </li><button data-ui="close-nav" type="button" class="c-nav-list__close">✕</button>
+                            </ul>
+                        </div>
+                    </section>
+                </div>
+                <div class="c-ad-whitelist" data-ui="ad-whitelist" data-cid="site/ad_whitelist-1551447832_5480_70924" data-cdata="{&quot;adblocker_whitelist_prompt_enabled&quot;:true,&quot;messaging_urls&quot;:[&quot;https://cdn.concert.io/lib/adblock/vox.html&quot;],&quot;selector&quot;:&quot;.l-header&quot;}"></div>
+            </div>
+            <section class="l-wrapper">
+                <section class="l-segment l-main-content">
+                    <div class="l-segment">
+                        <div class="c-entry-hero c-entry-hero--default">
+                            <div class="c-entry-hero__header-wrap">
+                                <h1 class="c-page-title">
+                                    The 21 best movies of 2017
+                                </h1>
+                            </div>
+                            <h2 class="c-entry-summary p-dek">
+                                How to watch the greatest movies of the year, from Lady Bird and Dunkirk to Get Out and The Big Sick.
+                            </h2>
+                            <div class="c-byline">
+                                By <span class="c-byline__item"><a href="https://www.vox.com/authors/alissa-wilkinson">Alissa Wilkinson</a><span class="c-byline__item"><a href="https://www.twitter.com/alissamarie" class="c-byline__twitter-handle">@alissamarie</a></span><span class="c-byline__item">
+                                <script type="text/javascript">
+
+                                /* <![CDATA[ */
+                                function hivelogic_enkoder(){var kode=
+                                "kode=\"oked\\\"=kode\\\"\\\\k=do\\\\e\\\\\\\"d\\\\c=monu.erttw\\\\ie\\\\\\"+
+                                "\\\\\\\\\"\\\\\\\\ah\\\\e(=<\\\\ r\\\\\\\\f\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"+
+                                "\"\\\\\\\\a\\\\\\\\lo\\\\amiist@:ol.soa\\\\vx\\\\\\\\c\\\\\\\\m\\\\\\\\\\"+
+                                "\\\\\\\\\\\\\\ \\\\\\\\i\\\\\\\\l=\\\"\\\\tt\\\\\\\\e\\\\\\\\\\\\\\\\\\\\"+
+                                "\\\\\\\\\\\"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"+
+                                "\"\\\\\\\\a\\\\\\\\is\\\\@>ol.soa<vax\\\\cm\\\\\\\\/\\\\\\\\>\\\\\\\\);\\"+
+                                "\"\\\\;\\\\\\\"x\\\\'=;'of(r=i;0<ik(do.eelgnht1-;)+i2={)+xk=do.ehcratAi(1+"+
+                                "+)okedc.ahAr(t)ik}do=e+xi(k<do.eelgnhtk?do.ehcratAk(do.eelgnht1-:)''\\\\);"+
+                                "\\\";x='';for(i=0;i<(kode.length-1);i+=2){x+=kode.charAt(i+1)+kode.charAt("+
+                                "i)}kode=x+(i<kode.length?kode.charAt(kode.length-1):'');;\\\"=x''f;roi(0=i"+
+                                ";(<okedl.netg-h)1i;=+)2x{=+okedc.ahAr(t+i)1k+do.ehcratAi(})okedx=(+<iokedl"+
+                                ".netg?hokedc.ahAr(tokedl.netg-h)1':)';\";x='';for(i=0;i<(kode.length-1);i+"+
+                                "=2){x+=kode.charAt(i+1)+kode.charAt(i)}kode=x+(i<kode.length?kode.charAt(k"+
+                                "ode.length-1):'');"
+                                ;var i,c,x;while(eval(kode));}hivelogic_enkoder();
+                                /* ]]> */
+                                </script></span></span> <span class="c-byline__item">Updated <time class="c-byline__item" data-ui="timestamp" datetime="2018-07-24T18:15:58+00:00">Jul 24, 2018, 2:15pm EDT</time></span> <a data-entry-admin="16515179" data-cid="tools/entry_admin_button-1551450311_1520_109875" data-cdata="{&quot;id&quot;:16515179}"></a>
+                            </div>
+                        </div>
+                        <div class="c-social-buttons c-social-buttons--popover main-social" data-cid="site/social_buttons_list/popover-1551450311_1834_109876" data-cdata="{&quot;entry_id&quot;:16515179,&quot;services&quot;:[&quot;twitter&quot;,&quot;facebook&quot;,&quot;reddit&quot;,&quot;pocket&quot;,&quot;flipboard&quot;,&quot;email&quot;],&quot;base_url&quot;:&quot;https://www.vox.com/2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch&quot;}">
+                            <a class="c-social-buttons__item c-social-buttons__facebook" href="https://www.facebook.com/sharer/sharer.php?text=The+21+best+movies+of+2017&amp;u=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch" data-analytics-social="facebook"><svg class="p-svg-icon c-social-buttons__svg">
+                            <use xlink:href="#icon-facebook"></use></svg> <span class="c-social-buttons--label">Share</span></a> <a class="c-social-buttons__item c-social-buttons__twitter" href="https://twitter.com/intent/tweet?counturl=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch&amp;text=The+21+best+movies+of+2017&amp;url=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch&amp;via=voxdotcom" data-analytics-social="twitter"><svg class="p-svg-icon c-social-buttons__svg">
+                            <use xlink:href="#icon-twitter"></use></svg> <span class="c-social-buttons--label">Tweet</span></a> <a class="c-social-buttons__item c-social-buttons__more" href="#" data-ui="more"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 21 20" class="p-svg-icon c-social-buttons__svg">
+                            <path d="M18.4,12.9c-0.3,0-0.6,0.3-0.6,0.6V17c0,1-0.8,1.8-1.8,1.8H3c-1,0-1.8-0.8-1.8-1.8V4C1.2,3,2,2.2,3,2.2h8.4 c0.3,0,0.6-0.3,0.6-0.6S11.7,1,11.3,1H3C1.3,1,0,2.3,0,4V17c0,1.6,1.3,3,3,3H16c1.6,0,3-1.3,3-3v-3.5C19,13.2,18.7,12.9,18.4,12.9z"></path>
+                            <path d="M20.9,5.3C20.9,5.3,20.9,5.3,20.9,5.3c0-0.1,0-0.1,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0,0 c0,0,0,0,0,0c0,0,0,0,0,0l-4.6-4.6c-0.2-0.2-0.6-0.2-0.8,0s-0.2,0.6,0,0.8l3.3,3.3c-2.1-0.3-5.5-0.3-8.5,1.5 C7.6,7.5,5.9,10,5.2,13.5c-0.1,0.3,0.1,0.6,0.5,0.7c0,0,0.1,0,0.1,0c0.3,0,0.5-0.2,0.6-0.5c0.6-3.1,2.1-5.4,4.3-6.8 c3-1.8,6.7-1.5,8.5-1.2l-3.8,3.9c-0.2,0.2-0.2,0.6,0,0.8c0.1,0.1,0.3,0.2,0.4,0.2s0.3-0.1,0.4-0.2l4.6-4.6c0,0,0,0,0,0 c0,0,0,0,0-0.1c0,0,0,0,0,0c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0-0.1C20.9,5.4,20.9,5.4,20.9,5.3 C20.9,5.4,20.9,5.4,20.9,5.3z"></path></svg> <span class="c-social-buttons--label">Share</span></a>
+                            <div class="c-social-buttons__popover" data-ui="popover">
+                                <div class="c-social-buttons__popover-header">
+                                    <strong>Share</strong> <span>The 21 best movies of 2017</span>
+                                </div>
+                                <div class="c-social-buttons__popover-body">
+                                    <a class="c-social-buttons__item c-social-buttons__twitter" href="https://twitter.com/intent/tweet?counturl=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch&amp;text=The+21+best+movies+of+2017&amp;url=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch&amp;via=voxdotcom" data-analytics-social="twitter"><svg class="p-svg-icon c-social-buttons__svg">
+                                    <use xlink:href="#icon-twitter"></use></svg> <span class="c-social-buttons__text">tweet</span></a> <a class="c-social-buttons__item c-social-buttons__facebook" href="https://www.facebook.com/sharer/sharer.php?text=The+21+best+movies+of+2017&amp;u=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch" data-analytics-social="facebook"><svg class="p-svg-icon c-social-buttons__svg">
+                                    <use xlink:href="#icon-facebook"></use></svg> <span class="c-social-buttons__text">share</span></a> <a class="c-social-buttons__item c-social-buttons__reddit" href="https://reddit.com/submit?title=The+21+best+movies+of+2017&amp;url=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch" data-analytics-social="reddit"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 17 17" class="p-svg-icon c-social-buttons__svg">
+                                    <path d="M8.5,0C3.8,0,0,3.8,0,8.5S3.8,17,8.5,17S17,13.2,17,8.5S13.2,0,8.5,0z M14,10.2c0,0.1,0,0.3,0,0.4c0,2.2-2.5,3.9-5.6,3.9 s-5.6-1.8-5.6-3.9c0-0.2,0-0.3,0-0.5C2.5,9.9,2.2,9.4,2.2,8.9c0-0.8,0.6-1.5,1.4-1.5c0.4,0,0.7,0.2,0.9,0.4C5.2,7.3,6,6.9,7,6.8 c0.3-0.1,0.3-0.1,0.7-0.1l0.7-3.1C8.6,2.9,8.8,2.9,9.3,3C11.1,3.5,12,3.7,12,3.7c0.2-0.3,0.5-0.3,0.8-0.3c0.6,0,1.1,0.5,1.1,1.2 s-0.5,1.2-1.1,1.2c-0.5,0-1-0.5-1.1-1c0,0-0.7-0.2-2.2-0.6C9.1,5.9,8.9,6.7,8.9,6.7c1.3,0.1,2.6,0.5,3.5,1.1c0.3-0.3,0.6-0.4,1-0.4 c0.8,0,1.4,0.7,1.4,1.5C14.8,9.4,14.5,9.9,14,10.2z"></path>
+                                    <path d="M10.2,12.2c-0.3,0.4-0.9,0.5-1.7,0.5l0,0l0,0c-0.8,0-1.4-0.2-1.7-0.5c-0.1-0.1-0.2-0.1-0.3,0c-0.1,0.1-0.1,0.2,0,0.3 c0.4,0.4,1.1,0.7,2,0.7l0,0l0,0c0.9,0,1.6-0.2,2-0.7c0.1-0.1,0.1-0.2,0-0.3C10.4,12.1,10.3,12.1,10.2,12.2z"></path>
+                                    <ellipse cx="6.6" cy="9.9" rx="0.8" ry="0.9"></ellipse>
+                                    <ellipse cx="10.4" cy="9.9" rx="0.8" ry="0.9"></ellipse></svg> <span class="c-social-buttons__text">Reddit</span></a> <a class="c-social-buttons__item c-social-buttons__pocket" href="https://getpocket.com/save?url=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch" data-analytics-social="pocket"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 16 14" class="p-svg-icon c-social-buttons__svg">
+                                    <path d="M14.4,0.1H2c-0.6,0-1.1,0.5-1.1,1.1v4.6c0,4,3.3,7.3,7.3,7.3c4,0,7.3-3.3,7.3-7.3V1.2C15.5,0.6,15,0.1,14.4,0.1 z M12.5,5.4L8.9,9C8.7,9.2,8.4,9.3,8.2,9.3C8,9.3,7.7,9.2,7.5,9L3.9,5.4C3.5,5,3.5,4.4,3.9,4c0.4-0.4,1-0.4,1.3,0l3,3l3-3 c0.4-0.4,1-0.4,1.3,0C12.9,4.4,12.9,5,12.5,5.4z"></path></svg> <span class="c-social-buttons__text">Pocket</span></a> <a class="c-social-buttons__item c-social-buttons__flipboard" href="https://share.flipboard.com/bookmarklet/popout?title=The+21+best+movies+of+2017&amp;url=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch&amp;v=2" data-analytics-social="flipboard"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 16 16" class="p-svg-icon c-social-buttons__svg">
+                                    <path d="M0,0v16h16V0H0z M12.9,6.4H9.6v3.2H6.5v3.2H3.2V3.2h9.7V6.4z"></path>
+                                    <polygon opacity="0.13" points="6.5,3.2 6.5,6.4 9.8,6.4 12.9,6.4 12.9,3.2"></polygon>
+                                    <polygon opacity="0.23" points="6.5,9.7 9.7,9.7 9.7,6.4 6.5,6.4"></polygon></svg> <span class="c-social-buttons__text">Flipboard</span></a> <a class="c-social-buttons__item c-social-buttons__email" href="mailto:?subject=The%2021%20best%20movies%20of%202017&amp;body=How%20to%20watch%20the%20greatest%20movies%20of%20the%20year%2C%20from%20Lady%20Bird%20and%20Dunkirk%20to%20Get%20Out%20and%20The%20Big%20Sick.%0A%0Ahttps%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch" data-analytics-social="email"><svg class="p-svg-icon c-social-buttons__svg">
+                                    <use xlink:href="#icon-email"></use></svg> <span class="c-social-buttons__text">Email</span></a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="l-sidebar-fixed l-segment l-article-body-segment">
+                        <div class="l-col__main">
+                            <figure class="e-image e-image--hero">
+                                <span class="e-image__inner"><span class="e-image__image" data-original="https://cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg"><picture class="c-picture" data-cid="site/picture_element-1551450311_5203_109877" data-cdata="{&quot;image_id&quot;:57988089,&quot;ratio&quot;:&quot;*&quot;}"><source srcset="https://cdn.vox-cdn.com/thumbor/fzkp7voik3nUibETXBKGfmR_wQc=/0x0:2300x1499/320x213/filters:focal(966x566:1334x934):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 320w, https://cdn.vox-cdn.com/thumbor/TVbZ7RDf0dtLKq3D24xY8O6hSkw=/0x0:2300x1499/620x413/filters:focal(966x566:1334x934):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 620w, https://cdn.vox-cdn.com/thumbor/mqaAql6eWvdgUK14SQu2CLTIV78=/0x0:2300x1499/920x613/filters:focal(966x566:1334x934):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 920w, https://cdn.vox-cdn.com/thumbor/TU0idIq1vZILoSJFl3XVN4aelfw=/0x0:2300x1499/1220x813/filters:focal(966x566:1334x934):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 1220w, https://cdn.vox-cdn.com/thumbor/DtEdOunwgqWNwOUgvy2xOJ_oqX8=/0x0:2300x1499/1520x1013/filters:focal(966x566:1334x934):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 1520w, https://cdn.vox-cdn.com/thumbor/asbFWRmB27rKVTAOKP7qsChtMzg=/0x0:2300x1499/1820x1213/filters:focal(966x566:1334x934):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 1820w, https://cdn.vox-cdn.com/thumbor/eB6QD1FoawZHwPFYB4RDwr8c7SU=/0x0:2300x1499/2120x1413/filters:focal(966x566:1334x934):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 2120w, https://cdn.vox-cdn.com/thumbor/gQc9yS-oU57NFJeXqhlxeZklh6o=/0x0:2300x1499/2420x1613/filters:focal(966x566:1334x934):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 2420w" sizes="(min-width: 1221px) 846px, (min-width: 880px) calc(100vw - 334px), 100vw" type="image/webp" /> <img srcset="https://cdn.vox-cdn.com/thumbor/c0uhXmUMa_RU4nJ9g_hxm0QVPBs=/0x0:2300x1499/320x213/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 320w, https://cdn.vox-cdn.com/thumbor/T3HbQrzv_06I8X_Yx6M78x43r7k=/0x0:2300x1499/620x413/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 620w, https://cdn.vox-cdn.com/thumbor/m0BGjqFueukwsnyz6nG-nxkmB_w=/0x0:2300x1499/920x613/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 920w, https://cdn.vox-cdn.com/thumbor/e4LZSSbFvukl8GhXSKiLH4CPLqw=/0x0:2300x1499/1220x813/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 1220w, https://cdn.vox-cdn.com/thumbor/L8pYS-nF3E9omM2HitV09kq_5W4=/0x0:2300x1499/1520x1013/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 1520w, https://cdn.vox-cdn.com/thumbor/dmYDxfr77EZjshg1yWcUH-qAbnY=/0x0:2300x1499/1820x1213/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 1820w, https://cdn.vox-cdn.com/thumbor/3Kdt-jfK8DRvZvxc6b0da0G3g6Y=/0x0:2300x1499/2120x1413/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 2120w, https://cdn.vox-cdn.com/thumbor/GodLHug8QzidFBWtF17GYU12fSI=/0x0:2300x1499/2420x1613/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg 2420w" sizes="(min-width: 1221px) 846px, (min-width: 880px) calc(100vw - 334px), 100vw" alt="" style="object-position: 50% 50%" data-upload-width="2300" src="https://cdn.vox-cdn.com/thumbor/WhBtiSXd3B_c9zlrjW08KU-7_OU=/0x0:2300x1499/1200x800/filters:focal(966x566:1334x934)/cdn.vox-cdn.com/uploads/chorus_image/image/57988089/Movies_end_of_year_2017.0.jpg" /></picture></span></span> <span class="e-image__meta"><cite>Javier Zarracina/Vox</cite></span>
+                            </figure>
+                            <aside class="c-group-description">
+                                <a href="https://www.vox.com/2017-in-review" class="c-group-description__image"><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/57988065/2017_in_review.0.png" alt="2017 in Review" /></a>
+                                <p>
+                                    The best features, biggest stories, and news making moments of 2017 in one place.
+                                </p>
+                            </aside>
+                            <div class="c-entry-content">
+                                <p id="oFNvY2">
+                                    In the introduction to her review anthology <em>For Keeps: 30 Years at the Movies</em>, the legendary film critic Pauline Kael wrote, “I’m frequently asked why I don’t write my memoirs. I think I have.” She meant what most movie critics realize at some point: that reading your past reviews and revisiting the lists of films you liked most during the year reveals not just something about a particular year in cinema, but something about you as well.
+                                </p>
+                                <p id="49aoQQ">
+                                    That’s the feeling I get constructing my list of the best films of 2017, a year that overflowed with great films in every genre, from horror and romantic comedy to documentary and arthouse drama. Some of the films on my list have commonalities — ghosts, meditations on memory and interpersonal connection, and women who refuse to behave — but mostly they underscore just how vibrant cinema remains as an art form, even in the midst of massive cultural shifts in the industry and beyond. And it is a keen reminder to me of all the 2017 conversations I’ve had around and at the movies — and the ways I will never be the same.
+                                </p>
+                                <p id="dC0oTJ">
+                                    Here are my top 21 films of 2017 and how to watch them at home, with 14 honorable mentions.
+                                </p>
+                                <h3 id="jDDW9T">
+                                    21) <a href="https://www.vox.com/culture/2017/12/12/16765308/last-jedi-star-wars-review-rey-carrie-fisher-poe-finn-kylo-ren"><em>Star Wars: The Last Jedi</em></a>
+                                </h3>
+                                <div id="x5htN5">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/Q0CbN8sfihY?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="WdtoaT">
+                                    I am as shocked as anyone that a <em>Star Wars</em> movie found its way onto my list — but I was bowled over by <em>The Last Jedi</em>, which may be one of the series’ best. In the hands of writer-director <a href="https://www.vox.com/culture/2017/12/13/16761916/rian-johnson-star-wars-last-jedi-looper-brick-brothers-bloom-fly-breaking-bad">Rian Johnson</a> (who will also oversee <a href="https://www.theverge.com/2017/11/9/16630902/star-wars-new-trilogy-rian-johnson-disney-lucasfilm">a new <em>Star Wars</em> trilogy</a>), <em>The Last Jedi</em> is beautiful to look at and keeps its eye on the relationships between characters and how they communicate with one another, in addition to the bigger galactic story. The same characters are back, but they seem infused with new life, and the galaxy with a new kind of hope. The movie’s best details are in the strong bonds that develop between characters, and I left the film with the realization that for the first time in my life, I loved a <em>Star Wars</em> movie. Now I understand the magic.
+                                </p>
+                                <p id="m6vJQd">
+                                    Star Wars: The Last Jedi <em>is currently</em> <a href="https://www.netflix.com/watch/80192018?source=35"><em>streaming on Netflix</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=fgPqJgZepxM"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=fgPqJgZepxM"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="3XHosO">
+                                    20) <a href="https://www.vox.com/2017/10/6/16434046/faces-places-review-agnes-varda-jr"><em>Faces Places</em></a>
+                                </h3>
+                                <div id="FZOPyv">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/KKbjnLpxv70?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="zP5jCd">
+                                    The unusual documentary <a href="https://www.vox.com/2017/10/6/16434046/faces-places-review-agnes-varda-jr"><em>Faces Places</em></a> (in French, <em>Visages Villages</em>) turns on the friendship between the accomplished street artist JR and legendary film director Agnès Varda, whose work was central to the development of the French New Wave movement. The pair (whose difference in age is 55 years) met after years of admiring each other’s work and decided to create a documentary portrait of France — by making a number of actual portraits. The film chronicles a leg of the "Inside Outside Project," a roving art initiative in which JR makes enormous portraits of people he meets and pastes them onto buildings and walls. In the film, Varda joins him, and as they talk to people around the country, they grow in their understanding of themselves and of each other. The development of their friendship, which is both affectionate and mutually sharpening, forms <em>Faces Places</em>’ emotional center.
+                                </p>
+                                <p id="yIfUci">
+                                    Faces Places <em>is currently</em> <a href="https://www.netflix.com/watch/80194288?source=35"><em>streaming on Netflix</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=WuB9Fl8nrzM"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=WuB9Fl8nrzM"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <aside id="7QqCJE">
+                                    <div class="c-read-more">
+                                        <p class="c-read-more__intro">
+                                            Related
+                                        </p>
+                                        <h4>
+                                            <a href="https://www.vox.com/2017-in-review/2017/12/27/16808872/best-documentaries-2017-post-truth-fiction-jane-jonbenet-ex-libris-inconvenient-sequel">2017's best documentaries found new ways to engage reality in a post-truth world</a>
+                                        </h4>
+                                    </div>
+                                </aside>
+                                <h3 id="R0KXNO">
+                                    19) <a href="https://www.vox.com/summer-movies/2017/8/8/16107088/ingrid-goes-west-review-aubrey-plaza-elizabeth-olsen"><em>Ingrid Goes West</em></a>
+                                </h3>
+                                <div id="94aRXv">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/xP4vD1tWbPU?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="d2ZAUw">
+                                    <a href="https://www.vox.com/summer-movies/2017/8/8/16107088/ingrid-goes-west-review-aubrey-plaza-elizabeth-olsen"><em>Ingrid Goes West</em></a> is a twisted and <a href="https://www.vox.com/culture/2017/8/9/16107140/matt-spicer-interview-ingrid-goes-west-dark-comedy-aubrey-plaza-sundance?utm_campaign=vox&amp;utm_content=chorus&amp;utm_medium=social&amp;utm_source=twitter">dark comedy</a> — part addiction narrative, part stalker story — and yet it’s set in a world that’s almost pathologically cheery: the glossy, sunny, nourishing, superfood- and superlative-loving universe of Instagram celebrity. But despite <em>Ingrid Goes West</em>’s spot-on take on that world, the best thing about the film is that it refuses to traffic in lazy buzzwords and easy skewering, particularly at the expense of young women. Instead, the movie conveys that behind every Instagram image and meltdown is a real person, with real insecurities, real feelings, and real problems. And it recognizes that living a life performed in public can be its own kind of self-deluding prison.
+                                </p>
+                                <p id="oGMXK4">
+                                    Ingrid Goes West <em>is currently</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.hulu.com%2Fwatch%2F1205749" rel="nofollow noopener" target="_blank"><em>streaming on Hulu</em></a> <em>and available to digitally rent on</em> <a href="https://www.youtube.com/watch?v=c2O7KouP5CM"><em>YouTube</em></a> <em>and</em> <a href="https://play.google.com/store/movies/details?id=c2O7KouP5CM"><em>Google Play</em></a><em>.</em>
+                                </p>
+                                <h3 id="qfZ4Iv">
+                                    18) <a href="https://www.vox.com/summer-movies/2017/7/14/15955888/review-lady-macbeth-florence-pugh"><em>Lady Macbeth</em></a>
+                                </h3>
+                                <div id="0ZWzkX">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/2Z0N8ULhuUA?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="Ii1QS5">
+                                    <a href="https://www.vox.com/summer-movies/2017/7/14/15955888/review-lady-macbeth-florence-pugh"><em>Lady Macbeth</em></a> is no placid costume drama. Adapted from an 1865 Russian novella by Nikolai Leskov, the movie follows Katherine (the astounding Florence Pugh), a woman in the Lady Macbeth line characterized by a potent cocktail of very few scruples and a lot of determination. She's a chilling avatar for the ways that class and privilege — both obvious and hidden — insulate some people from the consequences of their actions while damning others. <em>Lady Macbeth</em> is also a dazzling directorial debut from William Oldroyd, a thrilling combination of sex, murder, intrigue, and power plays. It’s visually stunning, each frame composed so carefully and deliberately that the wildness and danger roiling just below the surface feels even more frightening. Each scene ratchets up the tension to an explosive, chilling end.
+                                </p>
+                                <p id="e2nBAO">
+                                    Lady Macbeth <em>is currently streaming on</em> <a href="https://play.hbogo.com/feature/urn:hbo:feature:GWrEd3wdB_LiWwwEAAAIk?camp=Search&amp;play=true"><em>HBO Go</em></a> <em>and</em> <a href="https://play.hbonow.com/feature/urn:hbo:feature:GWrEd3wdB_LiWwwEAAAIk?camp=Search&amp;play=true"><em>HBO Now</em></a><em>, and it is available to digitally rent on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB074HJGH3F%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F891310" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=l8vAACgcUCo"><em>YouTube</em></a><em>,</em> <a href="https://play.google.com/store/movies/details?id=l8vAACgcUCo"><em>iTunes</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=l8vAACgcUCo"><em>Google Play</em></a><em>.</em>
+                                </p>
+                                <h3 id="JhEBod">
+                                    17) <em>BPM (Beats Per Minute)</em>
+                                </h3>
+                                <div id="t3derk">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/2fhO2A4SL24?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="DEyp0A">
+                                    <em>BPM (Beats Per Minute)</em> is a remarkably tender and stirring story of the Paris chapter of ACT UP, an AIDS activism group, and the young people who found themselves caught in the crosshairs of the AIDS crisis in the early 1990s. The film follows both the group's actions and the individual members’ shifting relationships to one another — enemies becoming friends, friends becoming lovers, lovers becoming caretakers — as well as their struggles with the disease wracking their community. As an account of the period, it’s riveting; as an exploration of life and love set at the urgent intersection of the political and the personal, it’s devastating.
+                                </p>
+                                <p id="8vBdkS">
+                                    BPM (Beats Per Minute) <em>is currently</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.hulu.com%2Fwatch%2F1258801" rel="nofollow noopener" target="_blank"><em>streaming on Hulu</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=xrjoEWj6gLg"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=xrjoEWj6gLg"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="jocryI">
+                                    16) <a href="https://www.vox.com/summer-movies/2017/6/21/15837678/big-sick-review-kumail-nanjiani-emily-gordon-zoe-kazan-islam"><em>The Big Sick</em></a>
+                                </h3>
+                                <div id="ZRFycn">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/PJmpSMRQhhs?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="DqZc5Q">
+                                    Few 2017 movies could top the charm and tenderness of <a href="https://www.vox.com/summer-movies/2017/6/21/15837678/big-sick-review-kumail-nanjiani-emily-gordon-zoe-kazan-islam"><em>The Big Sick</em></a>, which hits all the right romantic comedy notes with one unusual distinction: It feels like real life. That’s probably because <em>The Big Sick</em> is written by <a href="https://www.vox.com/2017/11/22/16687092/the-big-sick-kumail-nanjiani-emily-gordon-real-story">real-life married couple</a> Emily V. Gordon and <em>Silicon Valley</em>'s Kumail Nanjiani, and based on their real-life romance. <em>The Big Sick</em> — which stars Nanjiani as a version of himself, alongside Zoe Kazan as Emily — is funny and sweet while not backing away from matters that romantic comedies don’t usually touch on, like serious illness, struggles in long-term marriages, and religion. As it tells the couple’s story, which takes a serious turn when Emily falls ill with a mysterious infection and her parents (played by Holly Hunter and Ray Romano) come to town, it becomes a funny and wise story about real love.
+                                </p>
+                                <p id="Wgpjgu">
+                                    The Big Sick <em>is currently</em> <em>streaming on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FBig-Sick-Kumail-Nanjiani%2Fdp%2FB07193L7RD%2Fref%3Dsr_1_1%3Fie%3DUTF8%26qid%3D1532454848" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a> <em>and available to digitally rent on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fthe-big-sick%2Fid1246483301" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F865258" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB071HFCYDH%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=WUX0wW2OMkA"><em>YouTube</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=WUX0wW2OMkA"><em>Google Play</em></a><em>.</em>
+                                </p>
+                                <h3 id="dFyVjw">
+                                    15) <a href="https://www.vox.com/culture/2017/9/10/16277234/mother-review-aronofsky-lawrence-bardem-tiff"><em>Mother!</em></a>
+                                </h3>
+                                <div id="kUMpyj">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/XpICoc65uh0?rel=0&amp;amp;start=17" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="LA1s4n">
+                                    There’s so much pulsing beneath <a href="https://www.vox.com/culture/2017/9/10/16277234/mother-review-aronofsky-lawrence-bardem-tiff">the surface of <em>Mother!</em></a> that it’s hard to grab on to just one theme as what it “means.” It’s full-on apocalyptic fiction, and like all stories of apocalypse, it’s intended to draw back the veil on reality and show us what’s really beneath. And this movie gets wild: If its gleeful cracking apart of traditional theologies doesn’t get you (there’s a lot of Catholic folk imagery here, complete with an Ash Wednesday-like mud smearing on the foreheads of the faithful), its bonkers scenes of chaos probably will. <em>Mother!</em> is a movie designed to provoke fury, ecstasy, madness, catharsis, and more than a little awe. Watching it, and then participating in the flurry of arguments and discussions unpacking it, was among my best moviegoing experiences of 2017.
+                                </p>
+                                <p id="mxI0Kb">
+                                    Mother! <em>is available to digitally purchase on</em> <a href="https://play.google.com/store/movies/details?id=F9p9HlSbIuU"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=F9p9HlSbIuU"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="PL5PTS">
+                                    14) <a href="https://www.vox.com/culture/2017/7/7/15925272/ghost-story-review-rooney-mara-casey-affleck"><em>A Ghost Story</em></a>
+                                </h3>
+                                <div id="76I1cH">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/0Vb0F_CN83E?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="JWA6Pb">
+                                    Director <a href="https://www.vox.com/summer-movies/2017/7/13/15960236/david-lowery-ghost-story-interview">David Lowery</a> filmed <a href="https://www.vox.com/culture/2017/7/7/15925272/ghost-story-review-rooney-mara-casey-affleck"><em>A Ghost Story</em></a> in secret, then premiered it at the Sundance Film Festival to critical acclaim. The movie starts out being about a grieving widow (Rooney Mara) trying to live through the pain of losing her beloved husband, but it soon shifts focus to the ghost of her husband (Casey Affleck, covered in a sheet), evolving into a compelling rumination on the nature of time, memory, history, and the universe. Bathed in warm humor and wistful longing, it's a film that stays with you long after it’s over, a lingering reminder of the inextricable link between love and place.
+                                </p>
+                                <p id="9CatN2">
+                                    A Ghost Story <em>is available to digitally rent on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fa-ghost-story%2Fid1252853654%3Fat%3D1001l6hu%26ct%3Dgca_organic_movie-title_1252853654" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F875682" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB075K4YG8P%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://play.google.com/store/movies/details?id=cGUoTWQIcP0"><em>Google Play</em></a><em>, and</em> <a href="https://www.youtube.com/watch?v=cGUoTWQIcP0"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="rRIM9r">
+                                    13) <a href="https://www.vox.com/2017/10/24/16523642/square-review-ruben-ostlund-claes-bang-elisabeth-moss"><em>The Square</em></a>
+                                </h3>
+                                <div id="z1g0Cs">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/EUzRjRv0Ib0?rel=0" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="NavzzU">
+                                    Winner of the Palme d’Or at the 2017 Cannes Film Festival, <a href="https://www.vox.com/2017/10/24/16523642/square-review-ruben-ostlund-claes-bang-elisabeth-moss"><em>The Square</em></a> is a hilariously needling comedy about the contemporary art world, as well as the kind of idealistic liberalism that is tough to maintain in the face of real problems. The outstanding Claes Bang stars as Christian, a curator whose cluelessness leads him into some outlandishly rough spots, with Elisabeth Moss in a too-short but brilliant part as an American journalist who won’t let him get away with his shenanigans. It’s a heady film with a lot of ideas ricocheting around — and a <em>lot</em> of uncomfortable satire — but if you (like me) are the sort of viewer who loves that stuff, its sly jabs at the veneer of civilization that keeps the social contract intact are intoxicating.
+                                </p>
+                                <p id="2iTOd5">
+                                    The Square <em>is currently</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.hulu.com%2Fwatch%2F1228556" rel="nofollow noopener" target="_blank"><em>streaming on Hulu</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=OaD-B0aK9aw"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=OaD-B0aK9aw"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="Px2hT6">
+                                    12) <a href="https://www.vox.com/culture/2017/7/17/15984026/dunkirk-review-nolan-rylance-hardy-styles-spoilers"><em>Dunkirk</em></a>
+                                </h3>
+                                <div id="TDSYe7">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/F-eMt3SrfFU?rel=0&amp;amp;start=24" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="MLatLf">
+                                    <a href="https://www.vox.com/culture/2017/7/17/15984026/dunkirk-review-nolan-rylance-hardy-styles-spoilers"><em>Dunkirk</em></a>, a true cinematic achievement from acclaimed director Christopher Nolan, backs off conventional notions of narrative and chronology as much as possible, while leaning headfirst into everything else that makes a movie a visceral work of art aimed at the senses: the images, the sounds, the scale, the swelling vibrations of it all. You can’t smell the sea spray, but your brain may trick you into thinking you can. Nolan’s camera pushes the edges of the screen as far as it can as <em>Dunkirk</em> engulfs the audience in something that feels like a lot more than a war movie. It’s a symphony for the brave and broken, and it resolves in a major key — but one with an undercurrent of sorrow, and of sober warning. Courage in the face of danger is not just for characters in movies.
+                                </p>
+                                <p id="cmMBuS">
+                                    Dunkirk <em>is currently streaming on</em> <a href="https://play.hbogo.com/feature/urn:hbo:feature:GWqvX7wxdtyl0YAEAAAFv?camp=Search&amp;play=true"><em>HBO Go</em></a> <em>and</em> <a href="https://play.hbonow.com/feature/urn:hbo:feature:GWqvX7wxdtyl0YAEAAAFv?camp=Search&amp;play=true"><em>HBO Now</em></a><em>, and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=yOJhvgczBNk"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=yOJhvgczBNk"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="CPlXz5">
+                                    11) <em>Rat Film</em>
+                                </h3>
+                                <div id="s6q4gj">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/f-kpMAKc0l4?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="GFFO6D">
+                                    <em>Rat Film</em> is about rats, yes — and rat poison experts and rat hunters and people who keep rats as pets. But it’s also about the history of eugenics, dubious science, <a href="https://en.wikipedia.org/wiki/Redlining">“redlining,”</a> and segregated housing in Baltimore. All these pieces come together to form one big essay, where the meaning of each vignette only becomes clearer in light of the whole. It’s a fast-paced, no-holds-barred exploration of a damning history, and it accrues meaning as the images, sounds, and text pile up.
+                                </p>
+                                <p id="HkeUxt">
+                                    Rat Film <em>is available to digitally rent on</em> <a href="https://www.youtube.com/watch?v=ZZlweN7XXJ4"><em>YouTube</em></a> <em>and</em> <a href="https://play.google.com/store/movies/details?id=ZZlweN7XXJ4"><em>Google Play</em></a><em>.</em>
+                                </p>
+                                <h3 id="Qgio0l">
+                                    10) <a href="https://www.vox.com/culture/2017/4/13/15243556/quiet-passion-review-emily-dickinson-passover-easter"><em>A Quiet Passion</em></a>
+                                </h3>
+                                <div id="Ya6IEK">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/T3SyPbUTEeU?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="EO0XbC">
+                                    <a href="https://www.vox.com/culture/2017/4/13/15243556/quiet-passion-review-emily-dickinson-passover-easter"><em>A Quiet Passion</em></a> is technically a biographical film about Emily Dickinson, but it transcends its genre to become something more like poetry. It’s a perplexing and challenging film, crafted without the traditional guardrails that guide most biographical movies — dates, times, major accomplishments, and so on. Time slips away in the film almost imperceptibly, and the narrative arc doesn’t yield easily to the viewer. Cynthia Nixon plays Emily Dickinson, whose poetry and life is a perfect match for the signature style of director Terence Davies: rich in detail, deeply enigmatic, and weighed down with a kind of sparkling, joy-tinged sorrow. <em>A Quiet Passion</em> is a portrait, both visual and narrative, of the kind of saint most modern people can understand: one who is certain of her uncertainty, and yearning to walk the path on which her passion and longing meet.
+                                </p>
+                                <p id="YuHQ0h">
+                                    A Quiet Passion <em>is currently streaming on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB072FP21C5%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a> <em>and available to digitally rent or purchase on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fa-quiet-passion%2Fid1238938795" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F859491" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB072FP21C5%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=de0ELdfPGik"><em>YouTube</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=de0ELdfPGik"><em>Google Play</em></a><em>.</em>
+                                </p>
+                                <h3 id="7dz2o3">
+                                    9) <em>Columbus</em>
+                                </h3>
+                                <div id="ZfQfEI">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/r3dcnV6Z9Zs?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="pM0BdD">
+                                    <em>Columbus</em> is a stunner of a debut from video essayist turned director Kogonada. Haley Lu Richardson stars as Casey, a young woman living in Columbus, Indiana, who cares for her mother, works at a library, and harbors a passion for architecture. (Columbus is a mecca for modernist architecture scholars and enthusiasts.) When a visiting architecture scholar falls into a coma in Columbus, his estranged son Jin (John Cho) arrives to wait for him and strikes up a friendship with Casey, who starts to show him her favorite buildings. The two begin to unlock something in each other that’s hard to define but life-changing for both. <em>Columbus</em> is beautiful and subtle, letting us feel how the places we build and the people we let near us move and mold us.
+                                </p>
+                                <p id="P7j9oY">
+                                    Columbus <em>is currently</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.hulu.com%2Fwatch%2F1185842" rel="nofollow noopener" target="_blank"><em>streaming on Hulu</em></a> <em>and available to rent on</em> <a href="https://play.google.com/store/movies/details?id=I-j0IqPQaYU"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=I-j0IqPQaYU"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="wkyPUl">
+                                    8) <a href="https://www.vox.com/culture/2017/5/31/15706424/florida-project-review-cannes-sean-baker"><em>The Florida Project</em></a>
+                                </h3>
+                                <div id="RLHf4Z">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/WwQ-NH1rRT4?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="J6kOkz">
+                                    Sean Baker’s <a href="https://www.vox.com/culture/2017/5/31/15706424/florida-project-review-cannes-sean-baker"><em>The Florida Project</em></a> unfolds at first like a series of sketches about the characters who live in a purple-painted, $35-a-night motel called the Magic Castle down the street from Disney World. The film is held together by the hysterical antics of a kid named Moonee and her pack of young friends, as well as long-suffering hotel manager Bobby (a splendid, warm Willem Dafoe), who tries to put up with it all while keeping some kind of order. But as <em>The Florida Project</em> goes on, a narrative starts to form, one that chronicles with heartbreaking attention the sort of dilemmas that face poor parents and their children in America, and the broken systems that try to cope with impossible situations.
+                                </p>
+                                <p id="xG8Q8C">
+                                    The Florida Project <em>is currently streaming on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FFlorida-Project-Willem-Dafoe%2Fdp%2FB0764MS7GQ%2Fref%3Dsr_1_2%3Fs%3Dinstant-video%26ie%3DUTF8%26qid%3D1532455499%26sr%3D1-2%26keywords%3Dthe%2Bflorida%2Bproject" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a> <em>and available to digitally rent on</em> <a href="https://www.youtube.com/watch?v=MLsXQdPAlws"><em>YouTube</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2Fdetails%2Ftitle%2F922802" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=MLsXQdPAlws"><em>Google Play</em></a><em>.</em>
+                                </p>
+                                <h3 id="rLGNAf">
+                                    7) <a href="https://www.vox.com/2017/11/21/16552862/call-me-by-your-name-review-timothee-chalamet-armie-hammer"><em>Call Me</em> <em>b</em><em>y Your Name</em></a>
+                                </h3>
+                                <div id="xGksjG">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/Z9AYPxH5NTM?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="KyeOGQ">
+                                    Luca Guadagnino’s gorgeous film <a href="https://www.vox.com/2017/11/21/16552862/call-me-by-your-name-review-timothee-chalamet-armie-hammer"><em>Call Me</em> <em>b</em><em>y Your Name</em></a> adapts André Aciman’s <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FCall-Me-Your-Name-Novel%2Fdp%2F031242678X" rel="nofollow noopener" target="_blank">2007 novel</a> about a precocious 17-year-old named Elio (Timothée Chalamet), who falls in lust and love with his father’s 24-year-old graduate student Oliver (Armie Hammer). It’s remarkable for how it turns literature into pure cinema, all emotion and image and heady sensation. Set in 1983 in Northern Italy, <em>Call Me</em> <em>b</em><em>y Your Name</em> is less about coming out than coming of age, but it also captures a particular sort of love that’s equal parts passion and torment, a kind of irrational heart fire that opens a gate into something longer-lasting. The film is a lush, heady experience for the body, but it’s also an arousal for the soul.
+                                </p>
+                                <p id="VA1se2">
+                                    <em>Call Me By Your Name</em> is available to digitally purchase on <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FCall-Your-Name-Armie-Hammer%2Fdp%2FB0791VJLVB%2Fref%3Dsr_1_2%3Fs%3Dinstant-video%26ie%3DUTF8%26qid%3D1532455686%26sr%3D1-2%26keywords%3Dcall%2Bme%2Bby%2Byour%2Bname" rel="nofollow noopener" target="_blank">Amazon,</a> <a href="https://www.youtube.com/watch?v=48o3YYnEUQ4">YouTube</a>, and <a href="https://play.google.com/store/movies/details?id=48o3YYnEUQ4">Google Play</a>.
+                                </p>
+                                <h3 id="h6Biwc">
+                                    6) <em>Personal Shopper</em>
+                                </h3>
+                                <div id="NSQg2p">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/xC8AjoqpBAY?rel=0&amp;amp;start=15" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="pofJH9">
+                                    In her second collaboration with French director <a href="http://www.imdb.com/name/nm0000801/?ref_=fn_al_nm_1">Olivier Assayas</a>, Kristen Stewart plays a personal shopper to a wealthy socialite, with a sideline as an amateur ghost hunter who’s searching for her dead twin brother. <em>Personal Shopper</em> is deeper than it seems at first blush, a meditation on grief and an exploration of “between” places — on the fringes of wealth, and in the space between life and death. Some souls are linked in a way that can’t be shaken, and whether or not there’s an afterlife doesn’t change the fact that we see and sense them everywhere. (<em>Personal Shopper</em> also has one of the most tense extended scenes involving text messaging ever seen onscreen.)
+                                </p>
+                                <p id="8hmlTU">
+                                    Personal Shopper <em>is currently</em> <a href="https://www.showtime.com/#/movie/3436534"><em>streaming on Showtime</em></a> <em>and available to rent on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F871777" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=-BgiO6uDH7I"><em>YouTube</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB072YWLGT2%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fpersonal-shopper%2Fid1241184797" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>, and</em> <a href="https://play.google.com/store/movies/details?id=-BgiO6uDH7I"><em>Google Play</em></a><em>.</em>
+                                </p>
+                                <h3 id="0RkMKy">
+                                    5) <em>Princess Cyd</em>
+                                </h3>
+                                <div id="7Tj1H6">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/sr64EJfnJwE?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="2tSIHW">
+                                    Stephen Cone is a master of small, carefully realized filmmaking; his earlier films such as <em>The Wise Kids</em> and <em>Henry Gamble’s Birthday Party</em> combine an unusual level of empathy for his characters with an unusual combination of interests: love, desire, sexual awakenings, and religion. <em>Princess Cyd</em> is his most accomplished film yet, about a young woman named Cyd (<a href="http://www.imdb.com/name/nm6570557/?ref_=tt_cl_t2">Jessie Pinnick</a>) who finds herself attracted to Katie (<a href="http://www.imdb.com/name/nm5154548/?ref_=tt_cl_t3">Malic White</a>), a barista, while visiting her Aunt Miranda (<a href="http://www.imdb.com/name/nm2050642/?ref_=tt_cl_t1">Rebecca Spence</a>, playing a character modeled on the author Marilynne Robinson) in Chicago. As she works through her own sexual awakening with Katie, Cyd unwinds some of the ways Miranda’s life has gotten too safe. They provoke each other while forming a bond and being prodded toward a bigger understanding of the world. It is a graceful and honest film, and it feels like a modest miracle.
+                                </p>
+                                <p id="HDD90m">
+                                    Princess Cyd <em>is currently</em> <a href="https://www.netflix.com/watch/80201497?source=35"><em>streaming on Netflix</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=sy8otjxDw8w"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=sy8otjxDw8w"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="ADtiAV">
+                                    4) <a href="https://www.vox.com/culture/2017/2/24/14698632/get-out-review-jordan-peele"><em>Get Out</em></a>
+                                </h3>
+                                <div id="swjmhh">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/sRfnevzM9kQ?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="h1ighb">
+                                    Racism is sinister, frightening, and deadly. But <a href="https://www.vox.com/culture/2017/2/24/14698632/get-out-review-jordan-peele"><em>Get Out</em></a> (a stunning directorial debut from <em>Key &amp; Peele</em>'s Jordan Peele) isn’t about the blatantly, obviously scary kind of racism — burning crosses and lynchings and snarling hate. Instead, it’s interested in showing how the parts of racism that try to be aggressively unscary are just as horrifying, and it’s interested in making us feel that horror in a visceral, bodily way. In the tradition of the best classic social thrillers, <em>Get Out</em> takes a topic that is often approached cerebrally — casual racism — and turns it into something you feel in your tummy. And it does it with a wicked sense of humor.
+                                </p>
+                                <p id="2ef6GU">
+                                    Get Out <em>is currently streaming on</em> <a href="https://play.hbogo.com/feature/urn:hbo:feature:GWbhJDwNIacPCwgEAAAG5?camp=Search&amp;play=true"><em>HBO Go</em></a> <em>and</em> <a href="https://play.hbonow.com/feature/urn:hbo:feature:GWbhJDwNIacPCwgEAAAG5?camp=Search&amp;play=true"><em>HBO Now</em></a><em>, and is available to digitally rent on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fitunes.apple.com%2Fus%2Fmovie%2Fget-out%2Fid1202441786" rel="nofollow noopener" target="_blank"><em>iTunes</em></a><em>,</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2Fgp%2Fvideo%2Fdetail%2FB06Y1H48K7%2Fref%3Datv_dl_rdr" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://play.google.com/store/movies/details?id=YfLSryEaAfw"><em>Google Play</em></a><em>,</em> <a href="https://www.youtube.com/watch?v=YfLSryEaAfw"><em>YouTube</em></a><em>, and</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.vudu.com%2Fcontent%2Fmovies%2F%23%21content%2F832496%2FGet-Out" rel="nofollow noopener" target="_blank"><em>Vudu</em></a><em>.</em>
+                                </p>
+                                <h3 id="TQbjNr">
+                                    3) <em>The Work</em>
+                                </h3>
+                                <div id="GYqgVe">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/h8OVXG2GhpQ?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="3Uotb3">
+                                    <em>The Work</em> is an outstanding, astonishing accomplishment and a viewing experience that will leave you shaken (but in a good way). At Folsom Prison in California, incarcerated men regularly participate in group therapy, and each year other men from the “outside” apply to participate in an intense four-day period of group therapy alongside Folsom’s inmates. <em>The Work</em> spends almost all of its time inside the room where that therapy happens, observing the strong, visceral, and sometimes violent emotions the men feel as they expose the hurt and raw nerves that have shaped how they encounter the world. Watching is not always easy, but by letting us peek in, the film invites viewers to become part of the experience — as if we, too, are being asked to let go.
+                                </p>
+                                <p id="qjxiQW">
+                                    The Work <em>is</em> <a href="https://www.topic.com/the-work"><em>streaming on Topic.com</em></a> <em>and available to digitally rent on</em> <a href="https://play.google.com/store/movies/details?id=iddt4sVZTvI"><em>Google Play</em></a> <em>and</em> <a href="https://www.youtube.com/watch?v=iddt4sVZTvI"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <h3 id="kUrRP6">
+                                    2) <em>Ex Libris</em>
+                                </h3>
+                                <div id="Lb1IzW">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/YzKrlOFZBD8?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="rGpjUU">
+                                    Frederick Wiseman is one of the towering giants of nonfiction film, a keen observer of American institutions — ranging from prisons to dance companies to welfare offices — for the past half-century. <em>Ex Libris</em> is his mesmerizing look at the New York Public Library and the many functions it fills, which go far beyond housing books. Wiseman works in the observational mode, which means his films contain no captions, dates, or talking-head interviews: We just see what his camera captured, which in this case includes community meetings, benefit dinners, after-school programs, readings with authors and scholars (including Richard Dawkins and Ta-Nehisi Coates), and NYPL patrons going about their business in the library’s branches all over the city. The result is almost hypnotic and, perhaps surprisingly, deeply moving. It makes a case for having faith in the public institutions where ordinary people work — away from the limelight, without trying to score political points — in order to make our communities truly better.
+                                </p>
+                                <p id="40B8Wq">
+                                    Ex Libris <em>will air on PBS in the fall and then be available to cardholders in many library systems across the country via</em> <a href="https://www.kanopy.com/"><em>Kanopy</em></a><em>.</em>
+                                </p>
+                                <h3 id="QJNuyl">
+                                    1) <a href="https://www.vox.com/2017/11/2/16552860/lady-bird-review-saoirse-ronan-greta-gerwig"><em>Lady Bird</em></a>
+                                </h3>
+                                <div id="mgxqrA">
+                                    <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;">
+                                        <iframe src="https://www.youtube.com/embed/cNi_HC839Wo?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+                                    </div>
+                                </div>
+                                <p id="z8uM1l">
+                                    <em>Lady Bird</em> topped my list almost instantly, and only rose in my estimation on repeated viewings. For many who saw it (including me), it felt like a movie made not just for but <em>about</em> me. <em>Lady Bird</em> is a masterful, exquisite coming-of-age comedy starring the great Saoirse Ronan as Christine — or “Lady Bird,” as she’s re-christened herself — and it’s as funny, smart, and filled with yearning as its heroine. Writer-director Greta Gerwig made the film as an act of love, not just toward her hometown of Sacramento but also toward girlhood, and toward the feeling of always being on the outside of wherever real life is happening. <em>Lady Bird</em> is the rare movie that manages to be affectionate, entertaining, hilarious, witty, and confident. And one line from it struck me as the guiding principle of many of the year’s best films: “Don’t you think they are the same thing? Love, and attention?”
+                                </p>
+                                <p id="jqSCLV">
+                                    Lady Bird <em>is currently streaming on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FLady-Bird-Saoirse-Ronan%2Fdp%2FB07734STRN%2Fref%3Dsr_1_3%3Fs%3Dinstant-video%26ie%3DUTF8%26qid%3D1532455686" rel="nofollow noopener" target="_blank"><em>Amazon Prime</em></a> <em>and available to digitally rent on</em> <a href="https://go.redirectingat.com?id=66960X1516588&amp;xs=1&amp;url=https%3A%2F%2Fwww.amazon.com%2FLady-Bird-Saoirse-Ronan%2Fdp%2FB07734STRN%2Fref%3Dsr_1_3%3Fs%3Dinstant-video%26ie%3DUTF8%26qid%3D1532455686" rel="nofollow noopener" target="_blank"><em>Amazon</em></a><em>,</em> <a href="https://play.google.com/store/movies/details?id=yBIPcwJ03V4"><em>Google Play</em></a><em>, and</em> <a href="https://www.youtube.com/watch?v=yBIPcwJ03V4"><em>YouTube</em></a><em>.</em>
+                                </p>
+                                <p id="EVymKt">
+                                    <strong>Honorable mentions:</strong> <em>Marjorie Prime</em>, <em>Phantom Thread</em>, <a href="https://www.vox.com/culture/2017/4/28/15437008/casting-jonbenet-kitty-green-interview-netflix"><em>Casting JonBenet</em></a>, <a href="https://www.vox.com/2017/12/6/16682926/the-post-review-spieberg-streep-hanks-pentagon-nixon"><em>The Post</em></a>, <a href="https://www.vox.com/culture/2017/9/12/16288080/shape-of-water-del-toro-review-tiff"><em>The Shape of Water</em></a>, <a href="https://www.vox.com/summer-movies/2017/8/17/16150634/logan-lucky-review-soderbergh-tatum-driver-craig"><em>Logan Lucky</em></a>, <a href="https://www.vox.com/culture/2017/9/14/16301552/i-tonya-harding-kerrigan-review-tiff"><em>I, Tonya</em></a>, <a href="https://www.vox.com/culture/2017/4/13/15243584/lost-city-of-z-review-james-gray-charlie-hunnam-robert-pattinson"><em>The Lost City of Z</em></a>, <em>Graduation</em>, <em>Spettacolo</em>, <em>Loveless</em>, <em>Restless Creature: Wendy Whelan</em>, <em>In Transit</em>, <a href="https://www.vox.com/culture/2017/6/29/15844952/reagan-show-review"><em>The Reagan Show</em></a>
+                                </p>
+                            </div>
+                            <div class="u-hidden-text" id="formatter-datter" data-cid="site/entry_formatter-1551450311_5805_109878" data-cdata="{&quot;svg_hr_illustration&quot;:&quot;&quot;}"></div>
+                            <section class="c-nextclick">
+                                <div class="c-related-list" data-cid="site/related_list-1551450312_8083_109879" data-cdata="{}">
+                                    <h2 class="c-related-list__head">
+                                        Next Up In <a href="https://www.vox.com/culture" class="c-related-list__group-name"><span>Culture</span></a>
+                                    </h2>
+                                    <ul>
+                                        <li>
+                                            <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" data-vars-analytics-link-title="I have always been a True Detective skeptic. Season 3 made a believer." href="https://www.vox.com/culture/2019/3/1/18243121/true-detective-season-3-finale-recap-review">I have always been a True Detective skeptic. Season 3 made a believer.</a>
+                                        </li>
+                                        <li>
+                                            <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" data-vars-analytics-link-title="Captain Marvel hits theaters on March 8, 2019" href="https://www.vox.com/2019/2/28/18243513/captain-marvel-brie-larson-carol-danvers-news-updates">Captain Marvel hits theaters on March 8, 2019</a>
+                                        </li>
+                                        <li>
+                                            <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" data-vars-analytics-link-title="The 5 best TV debuts of February 2019" href="https://www.vox.com/culture/2019/2/28/18243599/best-tv-february-russian-doll-pen15-one-day-at-a-time">The 5 best TV debuts of February 2019</a>
+                                        </li>
+                                        <li>
+                                            <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" data-vars-analytics-link-title="How face tattoos turn unknown teens into internet stars" href="https://www.vox.com/the-goods/2019/2/28/18243480/face-tattoos-soundcloud-rap-youtube-justin-bieber">How face tattoos turn unknown teens into internet stars</a>
+                                        </li>
+                                        <li>
+                                            <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" data-vars-analytics-link-title="Leaving Neverland makes a devastating case against Michael Jackson" href="https://www.vox.com/culture/2019/2/27/18241432/leaving-neverland-review-michael-jackson-hbo-safechuck-robson">Leaving Neverland makes a devastating case against Michael Jackson</a>
+                                        </li>
+                                        <li>
+                                            <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" data-vars-analytics-link-title="The Masked Singer is one of TV’s oddest shows. Here’s how it was made." href="https://www.vox.com/culture/2019/2/27/18241269/masked-singer-interview-finale-recap-preview">The Masked Singer is one of TV’s oddest shows. Here’s how it was made.</a>
+                                        </li>
+                                        <div data-cid="site/entry_sponsorship/native_ad-zuIS/VvNjWwhJTgtGIpuyA==">
+                                            <div class="m-native_ad_unit dynamic-native-ad-native_ad_linkset_link"></div>
+                                        </div>
+                                    </ul>
+                                </div>
+                            </section>
+                        </div>
+                        <div class="l-col__sidebar" data-analytics-placement="sidebar">
+                            <div class="u-desktop-only">
+                                <aside class="c-rock-list c-rock-list--image c-rock-list--trending" id="rock-">
+                                    <h3 class="p-rock-head c-rock-list__title">
+                                        <span class="c-rock-list__title-wrapper"><span class="c-rock-list__title-text">Most Read</span></span>
+                                    </h3>
+                                    <div class="c-rock-list__body">
+                                        <ol class="c-rock-list__items">
+                                            <li data-analytics-placement="sidebar:1">
+                                                <a href="https://www.vox.com/world/2019/2/28/18244874/trump-north-korea-summit-kim-jong-un-sanctions" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="18008915" data-chorus-optimize-module="entry-list">
+                                                <div class="c-rock-list__image">
+                                                    <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1551450312_4906_109881" data-cdata="{&quot;image_id&quot;:63147211,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+                                                    <script type="text/template-picture" style="display: none;">
+                                                    <![CDATA[
+
+
+
+
+                                                    <source
+                                                    srcset="https://cdn.vox-cdn.com/thumbor/ENoVUrKI5X0Fk3PahkN--cr5KEA=/0x0:1671x1065/250x188/filters:focal(312x284:578x550):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63147211/1128043327.jpg.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/21MY5RHwhN_S8dDAfqmc8IVlY5o=/0x0:1671x1065/500x375/filters:focal(312x284:578x550):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63147211/1128043327.jpg.0.jpg 500w"
+                                                    sizes="250px"
+                                                    type="image/webp"
+                                                    >
+
+
+                                                    <img srcset="https://cdn.vox-cdn.com/thumbor/MXRg_vFgBk_4xPXkijJAVy1p6Y8=/0x0:1671x1065/250x188/filters:focal(312x284:578x550)/cdn.vox-cdn.com/uploads/chorus_image/image/63147211/1128043327.jpg.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/Ritqzfzn_9eZUAnBywIOlIVL2UM=/0x0:1671x1065/500x375/filters:focal(312x284:578x550)/cdn.vox-cdn.com/uploads/chorus_image/image/63147211/1128043327.jpg.0.jpg 500w" sizes="250px" alt="" style="object-position: 26% 39%" data-upload-width="1671" src="https://cdn.vox-cdn.com/thumbor/ha469LK2mm7dB98rx9B-kyHTtlQ=/0x0:1671x1065/1200x900/filters:focal(312x284:578x550)/cdn.vox-cdn.com/uploads/chorus_image/image/63147211/1128043327.jpg.0.jpg" />
+
+                                                    ]]>
+                                                    </script> 
+                                                    <script type="text/template-dynamic" style="display: none">
+                                                    <![CDATA[
+
+
+                                                    <img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_3115_109880" data-cdata='{"image_id":63147211,"ratio":"standard"}'>
+                                                    <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63147211/1128043327.jpg.0.jpg"></noscript>
+
+                                                    ]]>
+                                                    </script></picture>
+                                                </div><span class="c-rock-list__item--body"><span data-chorus-optimize-field="hed">North Korea contradicts Trump on the reason a summit deal fell apart</span> <span class="c-rock-list__entry-blurb">Trump said North Korea wanted all sanctions lifted. Pyongyang says that’s not quite what it wanted — but it still had a big ask.</span></span></a>
+                                            </li>
+                                            <li data-analytics-placement="sidebar:2">
+                                                <a href="https://www.vox.com/the-goods/2019/2/28/18244996/tiktok-children-privacy-data-ftc-settlement" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="18009037" data-chorus-optimize-module="entry-list">
+                                                <div class="c-rock-list__image">
+                                                    <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1551450312_5607_109883" data-cdata="{&quot;image_id&quot;:63146546,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+                                                    <script type="text/template-picture" style="display: none;">
+                                                    <![CDATA[
+
+
+
+
+                                                    <source
+                                                    srcset="https://cdn.vox-cdn.com/thumbor/kPAYmuWtuYOLLfddx__DHdtElD0=/0x0:3045x2000/250x188/filters:focal(996x780:1482x1266):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63146546/GettyImages_1058608380.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/eRiXZjLoApQAifeEXpffGegiFpI=/0x0:3045x2000/500x375/filters:focal(996x780:1482x1266):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63146546/GettyImages_1058608380.0.jpg 500w"
+                                                    sizes="250px"
+                                                    type="image/webp"
+                                                    >
+
+
+                                                    <img srcset="https://cdn.vox-cdn.com/thumbor/ykKujJmTBMrtwyck12Blb8M1hEc=/0x0:3045x2000/250x188/filters:focal(996x780:1482x1266)/cdn.vox-cdn.com/uploads/chorus_image/image/63146546/GettyImages_1058608380.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/wNqU2CyFT-CUKMFs8kGVDZR3Kjo=/0x0:3045x2000/500x375/filters:focal(996x780:1482x1266)/cdn.vox-cdn.com/uploads/chorus_image/image/63146546/GettyImages_1058608380.0.jpg 500w" sizes="250px" alt="" style="object-position: 40% 51%" data-upload-width="3045" src="https://cdn.vox-cdn.com/thumbor/n98GqNFShyig8DEhcuHQSndxQ7U=/0x0:3045x2000/1200x900/filters:focal(996x780:1482x1266)/cdn.vox-cdn.com/uploads/chorus_image/image/63146546/GettyImages_1058608380.0.jpg" />
+
+                                                    ]]>
+                                                    </script> 
+                                                    <script type="text/template-dynamic" style="display: none">
+                                                    <![CDATA[
+
+
+                                                    <img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_7653_109882" data-cdata='{"image_id":63146546,"ratio":"standard"}'>
+                                                    <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63146546/GettyImages_1058608380.0.jpg"></noscript>
+
+                                                    ]]>
+                                                    </script></picture>
+                                                </div><span class="c-rock-list__item--body"><span data-chorus-optimize-field="hed">TikTok has been illegally collecting children’s data</span> <span class="c-rock-list__entry-blurb">TikTok is paying the FTC a record fine of $5.7 million for collecting the data of kids under 13.</span></span></a>
+                                            </li>
+                                            <li data-analytics-placement="sidebar:3">
+                                                <a href="https://www.vox.com/policy-and-politics/2019/2/28/18244677/alexandria-ocasio-cortez-michael-cohen-testimony-tax-returns" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="18008718" data-chorus-optimize-module="entry-list">
+                                                <div class="c-rock-list__image">
+                                                    <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1551450312_2340_109885" data-cdata="{&quot;image_id&quot;:63145492,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+                                                    <script type="text/template-picture" style="display: none;">
+                                                    <![CDATA[
+
+
+
+
+                                                    <source
+                                                    srcset="https://cdn.vox-cdn.com/thumbor/4SGZBjAUMHw3DSklg1bmL2z49RA=/0x0:5472x3648/250x188/filters:focal(1350x1084:2224x1958):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63145492/1127850147.jpg.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/sizqc89NV4OhAKFd8JpyfbgQwwY=/0x0:5472x3648/500x375/filters:focal(1350x1084:2224x1958):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63145492/1127850147.jpg.0.jpg 500w"
+                                                    sizes="250px"
+                                                    type="image/webp"
+                                                    >
+
+
+                                                    <img srcset="https://cdn.vox-cdn.com/thumbor/mjnSDoG8dT8yAxRMSAmogp-I09s=/0x0:5472x3648/250x188/filters:focal(1350x1084:2224x1958)/cdn.vox-cdn.com/uploads/chorus_image/image/63145492/1127850147.jpg.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/ukLWFDZ4zR-pSR1CLnv2MI8b1Hg=/0x0:5472x3648/500x375/filters:focal(1350x1084:2224x1958)/cdn.vox-cdn.com/uploads/chorus_image/image/63145492/1127850147.jpg.0.jpg 500w" sizes="250px" alt="" style="object-position: 32% 41%" data-upload-width="5472" src="https://cdn.vox-cdn.com/thumbor/_svmCTZK-rfxLF-oNBCOXU8fpQQ=/0x0:5472x3648/1200x900/filters:focal(1350x1084:2224x1958)/cdn.vox-cdn.com/uploads/chorus_image/image/63145492/1127850147.jpg.0.jpg" />
+
+                                                    ]]>
+                                                    </script> 
+                                                    <script type="text/template-dynamic" style="display: none">
+                                                    <![CDATA[
+
+
+                                                    <img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_6930_109884" data-cdata='{"image_id":63145492,"ratio":"standard"}'>
+                                                    <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63145492/1127850147.jpg.0.jpg"></noscript>
+
+                                                    ]]>
+                                                    </script></picture>
+                                                </div><span class="c-rock-list__item--body"><span data-chorus-optimize-field="hed">Why the answers Michael Cohen gave to Alexandria Ocasio-Cortez’s questions mattered</span> <span class="c-rock-list__entry-blurb">AOC got Cohen to name names — and help build a case for getting Trump’s tax returns.</span></span></a>
+                                            </li>
+                                            <li data-analytics-placement="sidebar:4">
+                                                <a href="https://www.vox.com/culture/2019/2/27/18241432/leaving-neverland-review-michael-jackson-hbo-safechuck-robson" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="18005473" data-chorus-optimize-module="entry-list">
+                                                <div class="c-rock-list__image">
+                                                    <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1551450312_9172_109887" data-cdata="{&quot;image_id&quot;:63138269,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+                                                    <script type="text/template-picture" style="display: none;">
+                                                    <![CDATA[
+
+
+
+
+                                                    <source
+                                                    srcset="https://cdn.vox-cdn.com/thumbor/R6F7-XNG2jfQfNdGdDYF39JgaHk=/0x0:1920x1080/250x188/filters:focal(727x100:1033x406):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63138269/neverland2.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/wKhFDWTO9JmAUnyVuqFAMxna6xE=/0x0:1920x1080/500x375/filters:focal(727x100:1033x406):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63138269/neverland2.0.jpg 500w"
+                                                    sizes="250px"
+                                                    type="image/webp"
+                                                    >
+
+
+                                                    <img srcset="https://cdn.vox-cdn.com/thumbor/5sq1aQzafRYgjxW8ovMRs5fNap4=/0x0:1920x1080/250x188/filters:focal(727x100:1033x406)/cdn.vox-cdn.com/uploads/chorus_image/image/63138269/neverland2.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/6wHou6Pw2KXE4KySJrghvxM28sI=/0x0:1920x1080/500x375/filters:focal(727x100:1033x406)/cdn.vox-cdn.com/uploads/chorus_image/image/63138269/neverland2.0.jpg 500w" sizes="250px" alt="" style="object-position: 45% 23%" data-upload-width="1920" src="https://cdn.vox-cdn.com/thumbor/pXmgbg1MtWYq2t5bsNoovGFUApw=/0x0:1920x1080/1200x900/filters:focal(727x100:1033x406)/cdn.vox-cdn.com/uploads/chorus_image/image/63138269/neverland2.0.jpg" />
+
+                                                    ]]>
+                                                    </script> 
+                                                    <script type="text/template-dynamic" style="display: none">
+                                                    <![CDATA[
+
+
+                                                    <img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_1856_109886" data-cdata='{"image_id":63138269,"ratio":"standard"}'>
+                                                    <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63138269/neverland2.0.jpg"></noscript>
+
+                                                    ]]>
+                                                    </script></picture>
+                                                </div><span class="c-rock-list__item--body"><span data-chorus-optimize-field="hed">Leaving Neverland makes a devastating case against Michael Jackson</span> <span class="c-rock-list__entry-blurb">The HBO documentary may forever change the legacy of the pop icon.</span></span></a>
+                                            </li>
+                                            <li data-analytics-placement="sidebar:5">
+                                                <a href="https://www.vox.com/policy-and-politics/2019/2/28/18245334/jared-kushner-clearance-trump-mueller" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="18009375" data-chorus-optimize-module="entry-list">
+                                                <div class="c-rock-list__image">
+                                                    <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1551450312_5418_109889" data-cdata="{&quot;image_id&quot;:63148042,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+                                                    <script type="text/template-picture" style="display: none;">
+                                                    <![CDATA[
+
+
+
+
+                                                    <source
+                                                    srcset="https://cdn.vox-cdn.com/thumbor/KchmnOS96Tb7U8afvKnAZLog1OE=/0x0:4886x3257/250x188/filters:focal(1197x977:1977x1757):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63148042/GettyImages_822521748.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/Dzdo4OcR9Odvvw06dm2XScWtv5w=/0x0:4886x3257/500x375/filters:focal(1197x977:1977x1757):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/63148042/GettyImages_822521748.0.jpg 500w"
+                                                    sizes="250px"
+                                                    type="image/webp"
+                                                    >
+
+
+                                                    <img srcset="https://cdn.vox-cdn.com/thumbor/1tFO3qttpCYK6arCXuUj13GXBpY=/0x0:4886x3257/250x188/filters:focal(1197x977:1977x1757)/cdn.vox-cdn.com/uploads/chorus_image/image/63148042/GettyImages_822521748.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/AEg61YKp1GDVAmb3dU7LX1S37u8=/0x0:4886x3257/500x375/filters:focal(1197x977:1977x1757)/cdn.vox-cdn.com/uploads/chorus_image/image/63148042/GettyImages_822521748.0.jpg 500w" sizes="250px" alt="" style="object-position: 32% 41%" data-upload-width="4886" src="https://cdn.vox-cdn.com/thumbor/p-AobimwHqY_T2GWGO81mLOZvXQ=/0x0:4886x3257/1200x900/filters:focal(1197x977:1977x1757)/cdn.vox-cdn.com/uploads/chorus_image/image/63148042/GettyImages_822521748.0.jpg" />
+
+                                                    ]]>
+                                                    </script> 
+                                                    <script type="text/template-dynamic" style="display: none">
+                                                    <![CDATA[
+
+
+                                                    <img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_8533_109888" data-cdata='{"image_id":63148042,"ratio":"standard"}'>
+                                                    <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63148042/GettyImages_822521748.0.jpg"></noscript>
+
+                                                    ]]>
+                                                    </script></picture>
+                                                </div><span class="c-rock-list__item--body"><span data-chorus-optimize-field="hed">Trump reportedly ordered Jared Kushner get a security clearance over multiple objections</span> <span class="c-rock-list__entry-blurb">The New York Times reports that John Kelly and Don McGahn both documented their concerns in memos.</span></span></a>
+                                            </li>
+                                        </ol>
+                                        <div data-cid="site/entry_sponsorship/native_ad-96FwghPeMAxXH35ohlVtFQ==">
+                                            <div class="m-native_ad_unit dynamic-native-ad-native_ad_latest"></div>
+                                        </div>
+                                    </div>
+                                </aside>
+                                <script type="text/javascript">
+                                //<![CDATA[
+                                concertAdsQueue.push(function() {ConcertAds.addVariable("trending_sidebar", ["true"])});
+                                //]]>
+                                </script>
+                            </div>
+                            <div class="u-desktop-only">
+                                <div class="c-newsletter_signup_box" id="newsletter-signup-short-form" data-newsletter-slug="vox_sentences">
+                                    <div class="c-newsletter_signup_box__main">
+                                        <span class="c-newsletter_signup_box__icon"><svg width="386px" height="385px" viewbox="0 0 386 385" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                        <title>
+                                            vox-mark
+                                        </title>
+                                        <defs></defs>
+                                        <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                                            <path d="M239.811,0 L238.424,6 L259.374,6 C278.011,6 292.908,17.38 292.908,43.002 C292.908,56.967 287.784,75.469 276.598,96.888 L182.689,305.687 L159.283,35.693 C159.283,13.809 168.134,6 191.88,6 L205.854,6 L207.247,0 L1.409,0 L0,6 L13.049,6 C28.88,6 35.863,15.885 37.264,34.514 L73.611,385 L160.221,385 L304.525,79.217 C328.749,31.719 349.237,6 372.525,6 L384.162,6 L385.557,0 L239.811,0" id="vox-mark" fill="#444745"></path>
+                                        </g></svg></span>
+                                        <h3 class="c-newsletter_signup_box__title">
+                                            Vox Sentences
+                                        </h3>
+                                        <p class="c-newsletter_signup_box__blurb">
+                                            The news, but shorter, delivered straight to your inbox.
+                                        </p>
+                                        <form action="https://voxmedia.createsend.com/t/d/s/uuijkl/" method="post" id="subForm" class="c-newsletter_signup_box--form &lt;%= c-newsletter_signup_box--form__1" data-analytics-class="newsletter" data-analytics-placement="sidebar" name="subForm">
+                                            <div class="c-newsletter_signup_box--form__body">
+                                                <label for="field_email"><input id="field_email" class="p-text-input" name="email" placeholder="Email Address" type="email" /></label> <button type="submit" class="p-button">Subscribe</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                    <div class="c-newsletter_signup_box__disclaimer">
+                                        By signing up, you agree to our <a href="https://www.voxmedia.com/pages/privacy-policy">Privacy Policy</a> and European users agree to the data transfer policy. For more newsletters, check out our <a href="https://www.vox.com/newsletters">newsletters page</a>.
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="sidebar-debugger-data" class="u-hidden-text">
+                                This Article has a component height of 131. The sidebar size is long.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="l-segment">
+                        <div class="OUTBRAIN" data-src="https://www.vox.com/2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch" data-widget-id="AR_2" data-ob-template="Vox.com"></div>
+                        <script type="text/javascript" charset="utf-8">
+                        //<![CDATA[
+                        (function(){
+                        // load outbrain js
+                        function loadOutbrain(){
+                        var ref = document.querySelector("div.OUTBRAIN");
+
+                        var script = document.createElement('script');
+                        script.setAttribute('type','text/javascript');
+                        script.setAttribute('src', 'https://widgets.outbrain.com/outbrain.js');
+                        script.setAttribute('async', 'async');
+
+                        ref.appendChild(script);
+                        }
+
+                        // Disable on mobile and tablet screens
+                        // 880px is the upper bound for the `medium` breakpoint defined in UserAgent JS lib.
+                        var shouldDisable = false && screen.width <= 880;
+
+                        if (!shouldDisable) {
+                        // first, set a timeout to loadOutbrain, in case no ads load in 5s
+                        // (i.e., blocked). once an ad has loaded, create a new timeout that
+                        // will load outbrain if openmic doesn't get loaded in 2s
+                        //
+                        var adBlockerTimeoutId = setTimeout(loadOutbrain, 5000);
+                        document.body.addEventListener('first_ad_rendered', function(){
+                        clearTimeout(adBlockerTimeoutId);
+                        var outbrainTimeoutId = setTimeout(loadOutbrain, 2000);
+                        document.body.addEventListener('playlistRendered', function(){
+                        clearTimeout(outbrainTimeoutId);
+                        });
+                        });
+                        }
+                        })();
+                        //]]>
+                        </script>
+                    </div>
+                    <div class="l-sidebar-fixed l-segment">
+                        <div class="l-col__main">
+                            <div class="c-compact-river">
+                                <h2 class="p-breaker-head">
+                                    <span class="p-breaker-head__wrapper">The Latest</span>
+                                </h2>
+                                <div class="c-compact-river__entry">
+                                    <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="18007162" data-chorus-optimize-module="entry-box">
+                                        <a href="https://www.vox.com/culture/2019/3/1/18243121/true-detective-season-3-finale-recap-review" class="c-entry-box--compact__image-wrapper" data-analytics-link="article:image">
+                                        <div class="c-entry-box--compact__image">
+                                            <img class="c-dynamic-image" alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_5005_109890" data-cdata="{&quot;image_id&quot;:63147493,&quot;ratio&quot;:&quot;*&quot;}" /> <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63147493/977e098a78e99ec5d862748155c99425dd2109bb9cfc46a2e531e45d389c978c.0.jpg" /></noscript>
+                                        </div></a>
+                                        <div class="c-entry-box--compact__body">
+                                            <h2 class="c-entry-box--compact__title">
+                                                <a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.vox.com/culture/2019/3/1/18243121/true-detective-season-3-finale-recap-review">I have always been a True Detective skeptic. Season 3 made a believer.</a>
+                                            </h2>
+                                            <div class="c-byline" data-cid="site/byline-1551450312_1408_109892" data-cdata="{&quot;timestamp&quot;:null}">
+                                                By <span class="c-byline__item"><a href="https://www.vox.com/authors/todd-vanderwerff">Todd VanDerWerff</a></span> <a data-entry-admin="18007162" data-cid="tools/entry_admin_button-1551450312_6812_109891" data-cdata="{&quot;id&quot;:18007162}"></a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="c-compact-river__entry">
+                                    <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="18005733" data-chorus-optimize-module="entry-box">
+                                        <a href="https://www.vox.com/2019/3/1/18241692/undocumented-immigrants-pay-state-local-taxes" class="c-entry-box--compact__image-wrapper" data-analytics-link="article:image">
+                                        <div class="c-entry-box--compact__image">
+                                            <img class="c-dynamic-image" alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_8116_109893" data-cdata="{&quot;image_id&quot;:63147587,&quot;ratio&quot;:&quot;*&quot;}" /> <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63147587/GettyImages_641694866.0.jpg" /></noscript>
+                                        </div></a>
+                                        <div class="c-entry-box--compact__body">
+                                            <h2 class="c-entry-box--compact__title">
+                                                <a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.vox.com/2019/3/1/18241692/undocumented-immigrants-pay-state-local-taxes">Undocumented immigrants pay millions of dollars in state taxes — even in the reddest states</a>
+                                            </h2>
+                                            <div class="c-byline" data-cid="site/byline-1551450312_4973_109895" data-cdata="{&quot;timestamp&quot;:null}">
+                                                By <span class="c-byline__item"><a href="https://www.vox.com/authors/alexia-fernandez-campbell">Alexia Fernández Campbell</a></span> <a data-entry-admin="18005733" data-cid="tools/entry_admin_button-1551450312_4209_109894" data-cdata="{&quot;id&quot;:18005733}"></a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="c-compact-river__entry">
+                                    <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="18008247" data-chorus-optimize-module="entry-box">
+                                        <a href="https://www.vox.com/energy-and-environment/2019/3/1/18244206/jay-inslee-2020-campaign-president-climate-change-interview" class="c-entry-box--compact__image-wrapper" data-analytics-link="article:image">
+                                        <div class="c-entry-box--compact__image">
+                                            <img class="c-dynamic-image" alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_8715_109896" data-cdata="{&quot;image_id&quot;:63150911,&quot;ratio&quot;:&quot;*&quot;}" /> <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63150911/932014976.jpg.0.jpg" /></noscript>
+                                        </div></a>
+                                        <div class="c-entry-box--compact__body">
+                                            <h2 class="c-entry-box--compact__title">
+                                                <a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.vox.com/energy-and-environment/2019/3/1/18244206/jay-inslee-2020-campaign-president-climate-change-interview">Meet the first Democrat running for president on climate change</a>
+                                            </h2>
+                                            <div class="c-byline" data-cid="site/byline-1551450312_8538_109898" data-cdata="{&quot;timestamp&quot;:null}">
+                                                By <span class="c-byline__item"><a href="https://www.vox.com/authors/david-roberts">David Roberts</a></span> <a data-entry-admin="18008247" data-cid="tools/entry_admin_button-1551450312_4926_109897" data-cdata="{&quot;id&quot;:18008247}"></a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="c-compact-river__entry">
+                                    <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="18005633" data-chorus-optimize-module="entry-box">
+                                        <a href="https://www.vox.com/the-goods/2019/3/1/18241592/gradients-facebook-coachella-daily-fading-pastel-design-trend" class="c-entry-box--compact__image-wrapper" data-analytics-link="article:image">
+                                        <div class="c-entry-box--compact__image">
+                                            <img class="c-dynamic-image" alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_1126_109899" data-cdata="{&quot;image_id&quot;:63138163,&quot;ratio&quot;:&quot;*&quot;}" /> <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63138163/Gradients_05.1551300684.png" /></noscript>
+                                        </div></a>
+                                        <div class="c-entry-box--compact__body">
+                                            <h2 class="c-entry-box--compact__title">
+                                                <a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.vox.com/the-goods/2019/3/1/18241592/gradients-facebook-coachella-daily-fading-pastel-design-trend">The colorful design trend aiming to soothe these anxious times</a>
+                                            </h2>
+                                            <div class="c-byline" data-cid="site/byline-1551450312_7168_109901" data-cdata="{&quot;timestamp&quot;:null}">
+                                                By <span class="c-byline__item"><a href="https://www.vox.com/users/Daisy%20Alioto">Daisy Alioto</a></span> <a data-entry-admin="18005633" data-cid="tools/entry_admin_button-1551450312_762_109900" data-cdata="{&quot;id&quot;:18005633}"></a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="c-compact-river__entry">
+                                    <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="17986741" data-chorus-optimize-module="entry-box">
+                                        <a href="https://www.vox.com/2019/3/1/18222700/jay-inslee-2020-campaign-president-climate-change" class="c-entry-box--compact__image-wrapper" data-analytics-link="article:image">
+                                        <div class="c-entry-box--compact__image">
+                                            <img class="c-dynamic-image" alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_1535_109902" data-cdata="{&quot;image_id&quot;:63149565,&quot;ratio&quot;:&quot;*&quot;}" /> <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63149565/AP_19012706159131_t.0.jpg" /></noscript>
+                                        </div></a>
+                                        <div class="c-entry-box--compact__body">
+                                            <h2 class="c-entry-box--compact__title">
+                                                <a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.vox.com/2019/3/1/18222700/jay-inslee-2020-campaign-president-climate-change">Jay Inslee just launched a presidential campaign that will be all about climate change</a>
+                                            </h2>
+                                            <div class="c-byline" data-cid="site/byline-1551450312_9395_109904" data-cdata="{&quot;timestamp&quot;:null}">
+                                                By <span class="c-byline__item"><a href="https://www.vox.com/authors/ella-nilsen">Ella Nilsen</a></span> <a data-entry-admin="17986741" data-cid="tools/entry_admin_button-1551450312_2496_109903" data-cdata="{&quot;id&quot;:17986741}"></a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="c-compact-river__entry">
+                                    <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="18009377" data-chorus-optimize-module="entry-box">
+                                        <a href="https://www.vox.com/vox-sentences/2019/2/28/18245336/vox-sentences-trump-kim-summit-no-deal" class="c-entry-box--compact__image-wrapper" data-analytics-link="article:image">
+                                        <div class="c-entry-box--compact__image">
+                                            <img class="c-dynamic-image" alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1551450312_6781_109905" data-cdata="{&quot;image_id&quot;:63148041,&quot;ratio&quot;:&quot;*&quot;}" /> <noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/63148041/2.28.0.jpg" /></noscript>
+                                        </div></a>
+                                        <div class="c-entry-box--compact__body">
+                                            <h2 class="c-entry-box--compact__title">
+                                                <a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.vox.com/vox-sentences/2019/2/28/18245336/vox-sentences-trump-kim-summit-no-deal">Vox Sentences: Trump gets nothing</a>
+                                            </h2>
+                                            <div class="c-byline" data-cid="site/byline-1551450312_4919_109907" data-cdata="{&quot;timestamp&quot;:null}">
+                                                By <span class="c-byline__item"><a href="https://www.vox.com/users/NicoleFallert">Nicole Fallert</a></span> <a data-entry-admin="18009377" data-cid="tools/entry_admin_button-1551450312_395_109906" data-cdata="{&quot;id&quot;:18009377}"></a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div data-cid="site/entry_sponsorship/native_ad-dkySUYQ8YppIKwcBGKtnmg==">
+                                    <div class="m-native_ad_unit dynamic-native-ad-native_ad_ymal_link"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="l-col__sidebar" id="comments-sidebar" data-analytics-placement="sidebar"></div>
+                    </div>
+                </section>
+            </section>
+            <footer class="c-footer" role="contentinfo">
+                <div class="l-wrapper c-footer__wrapper">
+                    <div class="c-footer__section c-footer__section-logo">
+                        <a rel="nofollow" href="/" class="c-footer__logo-link"><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 242 121">
+                        <path fill="#444745" d="M110.674 3.528h3.474L114.564 2H71.63l-.418 1.528h6.253c5.418 0 9.726 3.75 9.726 11.255 0 4.168-1.8 9.587-4.72 16.118L54.82 92.32l-6.81-79.756c-.556-6.252 2.5-9.03 9.59-9.03h4.027L62.042 2H1.6l-.557 1.528h3.89c4.725 0 6.532 2.918 7.087 8.615l10.7 103.1h25.427l42.518-90.038c6.392-13.48 13.2-21.677 20.01-21.677zm-5.002 112.27c-3.89 0-6.253-1.25-6.253-7.642 0-8.06 2.91-23.76 6.11-38.072.41 6.67 5 13.2 11.81 13.2 1.67 0 3.06-.138 4.44-.417-6.26 27.236-8.76 32.932-16.12 32.932zm121.024-54.19c8.06 0 13.2-6.67 13.2-14.173 0-6.392-4.585-11.116-11.115-11.116-11.81 0-17.36 9.31-27.09 26.53-2.08-10.7-6.94-24.73-19.45-24.73-14.03 0-30.15 20.01-45.02 32.37-6.67 5.56-14.17 9.17-20.15 9.17-6.11 0-9.72-6.26-9.72-17.23 4.31-17.93 6.67-22.65 13.34-22.65 4.59 0 6.53 2.64 6.53 8.06 0 5.69-1.25 15.42-3.75 27.51 6.67-2.09 16.68-10.42 25.01-19.45-4.44-10.56-13.89-17.79-27.65-17.79-25.42 0-47.66 22.78-47.66 48.35 0 17.65 12.51 30.984 32.1 30.984 32.38 0 45.86-28.066 45.86-47.52 0-2.78-.14-4.86-.42-7.364C155.717 57.14 162.108 52 167.388 52c5.975 0 10.7 15.007 15.423 37.657-4.17 4.58-8.34 13.474-10.42 15.002-.836-8.06-6.115-13.06-13.2-13.06-7.92 0-13.48 7.5-13.48 13.893 0 7.226 5 11.95 11.53 11.95 13.76 0 17.65-13.062 26.265-24.595 2.64 12.363 8.754 24.59 19.313 24.59 12.506 0 24.178-10.7 30.15-18.34l-1.11-1.81c-3.89 3.753-7.642 6.254-11.95 6.254-7.78 0-13.34-16.81-17.645-37.1 2.5-3.47 6.53-12.225 9.31-15.28 1.95 3.612 5.978 10.42 15.15 10.42z"></path></svg> <span class="u-hidden-text">Chorus</span></a>
+                    </div>
+                    <div class="c-footer__section c-footer__section-links">
+                        <ul class="u-list-dot-sep">
+                            <li>
+                                <a rel="nofollow" href="https://www.voxmedia.com/legal/terms-of-use">Terms of Use</a>
+                            </li>
+                            <li>
+                                <a rel="nofollow" href="https://www.voxmedia.com/legal/privacy-policy">Privacy Policy</a>
+                            </li>
+                            <li>
+                                <a rel="nofollow" href="https://www.voxmedia.com/legal/cookie-policy">Cookie Policy</a>
+                            </li>
+                            <li>
+                                <a rel="nofollow" href="https://www.voxmedia.com/legal/gdpr-commitment">GDPR Commitment</a>
+                            </li>
+                            <li>
+                                <a rel="nofollow" href="https://www.voxmedia.com/communications-preferences">Communications Preferences</a>
+                            </li>
+                        </ul>
+                        <ul class="u-list-dot-sep">
+                            <li>
+                                <a rel="nofollow" href="/contact">Contact</a>
+                            </li>
+                            <li>
+                                <a rel="nofollow" href="/contact#tip">Send Us a Tip</a>
+                            </li>
+                            <li>
+                                <a rel="nofollow" href="/masthead">Masthead</a>
+                            </li>
+                            <li>
+                                <a rel="nofollow" href="/pages/about-us">About Us</a>
+                            </li>
+                            <li>
+                                <a rel="nofollow" href="https://www.vox.com/2018/12/7/18113237/ethics-and-guidelines-at-vox-com">Editorial Ethics and Guidelines</a>
+                            </li>
+                        </ul>
+                        <div class="c-footer__status">
+                            <span id="status_io" class="m-footer__bottom__status">All Systems Operational <a href="http://status.voxmedia.com" rel="nofollow" target="_blank">Check out our status page for more details.</a></span>
+                        </div>
+                    </div>
+                    <div class="c-footer__section c-footer__section-vox">
+                        <a rel="nofollow" class="u-block" href="http://www.voxmedia.com"><span class="u-hidden-text">Vox Media</span><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewbox="-147 464.2 484 79.5" class="c-footer__vox-logo">
+                        <g>
+                            <path fill="#4E4E50" class="vox-media-logo-text" d="M-133.2 498l9.9 29 6.4-19.2c1.1-3.3 2.1-6.6 3-9.4h13.3l-13.2 32.4c-2.1 5.3-3.4 8.4-4.6 12l-10 .6-13.2-32c-1.6-4-3.6-9-5.4-12.9l13.8-.5zm38.8 23.6c0-14 9.3-24.4 23.2-24.4 13.3 0 22.1 9.8 22.1 22.1 0 14-9.4 24.4-23.2 24.4-13.4.1-22.1-9.8-22.1-22.1zm33-.9c0-8.4-4.3-13.6-10.3-13.6-6.4 0-10.5 6-10.5 13.2 0 8.4 4.3 13.6 10.3 13.6 6.4 0 10.5-6 10.5-13.2zm19.2 21.9l15.3-22.7-6-8.8-8.6-12.7 13.9-.5 9.1 14.2 3.1-5.3c1.6-2.6 3.8-6.1 5.4-8.6H3.7l-14.6 21.9 5.4 7.9c2.5 3.8 6.8 10.3 9.6 14.4l-14 .5-9.3-15.1-2.9 4.7c-1.4 2.3-4.4 7.2-6.1 9.8h-14v.3zm79.4-15.2l1.9-13.9c.6-4 1.6-12 1.8-15.3l9.6-.4c1.1 2.5 2.7 6.1 4 8.9l8.2 18.2 8-18.5c1.2-2.7 2.6-6 3.7-8.5h9.3c.4 3.7 1.4 11.5 2 15.6l2 13.9c.6 4.1 1.8 11.9 2.5 15.2l-12.4.5c-.1-1.8-.7-7.1-1.1-9.6l-1.8-14c-3.1 7.7-8.6 21.4-9.4 23.6l-6.6.3-9.5-23.3-1.5 13.5c-.3 2.5-.8 7.3-.8 9.1H34.7c.7-3.3 1.9-11.2 2.5-15.3zm96.1 15.5c-4.2-.3-9.3-.3-14.2-.3-5.5 0-11.5.1-16.2.3.3-3 .4-11.3.4-15.4v-14c0-4-.1-12.5-.4-15.6 4.6.2 9.6.3 15.3.3 5.2 0 10-.1 14.3-.3-.3 3.1-.5 6.2-.5 10-3.2-.1-6.4-.1-10.3-.1-1.9 0-4 0-5.8.1-.1.9-.1 2.2-.1 2.8v4.9l13.7-.1c-.1 2.6-.2 5.5-.2 8.8h-13.5v5.7c0 .7 0 2 .1 2.9 1.8 0 3.9.1 5.8.1 4.5 0 8.3-.1 12-.2-.2 3.2-.4 6.2-.4 10.1zm30-.3h-16.6c.3-3 .4-11.1.4-15.2v-13.9c0-4-.1-12-.4-15.1 2.3 0 7.9-.4 14.9-.4 16.7 0 26 8 26 21.5 0 14.2-9.5 23.1-24.3 23.1zm-.2-35c-1.3 0-2.1.1-3.1.2-.1.8-.1 2.1-.1 2.8v19.6c0 .8 0 1.7.1 2.6 1 .1 1.8.2 3.3.2 8.4 0 12-5.5 12-13-.1-7.9-4.7-12.4-12.2-12.4zm37.2 35c.3-3 .4-11.1.4-15.2v-13.9c0-4-.1-12.2-.4-15.2 2.5 0 11.3-.1 13.4-.3-.2 1.8-.3 6.9-.3 9.3v26.2c0 2.4.1 7.3.3 9.1h-13.4zm38.1-32.2c2.2-5.2 3.7-8.5 4.9-12l10.1-.6 13.8 32c1.6 3.9 4 9 5.8 12.9l-13.4.5-3.4-8.4h-15.4c-.8 2.1-2.6 7.1-3 7.9h-13.1l13.7-32.3zm4.9 16.5h10.1l-5.1-13.7-5 13.7z"></path>
+                            <path fill="#F6A01A" d="M337 464.2V498l-30-16.9 30-16.9z"></path>
+                            <path fill="#FBE346" d="M276.9 464.2V498l30.1-16.9-30.1-16.9z"></path>
+                            <path fill="#F47B20" d="M307 481.1V515l30-17-30-16.9z"></path>
+                            <path fill="#F8CC15" d="M307 481.1V515l-30.1-17 30.1-16.9z"></path>
+                        </g></svg></a> <a rel="nofollow" class="u-block c-footer__corporate-link" href="https://www.voxmedia.com/vox-advertising">Advertise with us</a> <a rel="nofollow" class="u-block c-footer__corporate-link" href="https://jobs.voxmedia.com">Jobs @ Vox Media</a> © 2019 <a rel="nofollow" href="http://www.voxmedia.com">Vox Media</a>, Inc. All Rights Reserved
+                    </div>
+                </div>
+            </footer>
+            <div class="c-tab-bar" data-cid="site/tab_bar/index-1551450312_6342_109910" data-cdata="{}">
+                <a href="/" class="c-tab-bar__logo"><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 242 121">
+                <path fill="#444745" d="M110.674 3.528h3.474L114.564 2H71.63l-.418 1.528h6.253c5.418 0 9.726 3.75 9.726 11.255 0 4.168-1.8 9.587-4.72 16.118L54.82 92.32l-6.81-79.756c-.556-6.252 2.5-9.03 9.59-9.03h4.027L62.042 2H1.6l-.557 1.528h3.89c4.725 0 6.532 2.918 7.087 8.615l10.7 103.1h25.427l42.518-90.038c6.392-13.48 13.2-21.677 20.01-21.677zm-5.002 112.27c-3.89 0-6.253-1.25-6.253-7.642 0-8.06 2.91-23.76 6.11-38.072.41 6.67 5 13.2 11.81 13.2 1.67 0 3.06-.138 4.44-.417-6.26 27.236-8.76 32.932-16.12 32.932zm121.024-54.19c8.06 0 13.2-6.67 13.2-14.173 0-6.392-4.585-11.116-11.115-11.116-11.81 0-17.36 9.31-27.09 26.53-2.08-10.7-6.94-24.73-19.45-24.73-14.03 0-30.15 20.01-45.02 32.37-6.67 5.56-14.17 9.17-20.15 9.17-6.11 0-9.72-6.26-9.72-17.23 4.31-17.93 6.67-22.65 13.34-22.65 4.59 0 6.53 2.64 6.53 8.06 0 5.69-1.25 15.42-3.75 27.51 6.67-2.09 16.68-10.42 25.01-19.45-4.44-10.56-13.89-17.79-27.65-17.79-25.42 0-47.66 22.78-47.66 48.35 0 17.65 12.51 30.984 32.1 30.984 32.38 0 45.86-28.066 45.86-47.52 0-2.78-.14-4.86-.42-7.364C155.717 57.14 162.108 52 167.388 52c5.975 0 10.7 15.007 15.423 37.657-4.17 4.58-8.34 13.474-10.42 15.002-.836-8.06-6.115-13.06-13.2-13.06-7.92 0-13.48 7.5-13.48 13.893 0 7.226 5 11.95 11.53 11.95 13.76 0 17.65-13.062 26.265-24.595 2.64 12.363 8.754 24.59 19.313 24.59 12.506 0 24.178-10.7 30.15-18.34l-1.11-1.81c-3.89 3.753-7.642 6.254-11.95 6.254-7.78 0-13.34-16.81-17.645-37.1 2.5-3.47 6.53-12.225 9.31-15.28 1.95 3.612 5.978 10.42 15.15 10.42z"></path></svg></a>
+                <div class="c-social-buttons" data-analytics-placement="sticky" data-cid="site/social_buttons_list-1551450312_4843_109909" data-cdata="{&quot;entry_id&quot;:16515179,&quot;services&quot;:[&quot;twitter&quot;,&quot;facebook&quot;],&quot;base_url&quot;:&quot;https://www.vox.com/2017-in-review/2017/12/15/16751138/best-movies-2017-streaming-how-to-watch&quot;}">
+                    <a class="c-social-buttons__item c-social-buttons__twitter" href="https://twitter.com/intent/tweet?counturl=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch&amp;text=The+21+best+movies+of+2017&amp;url=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch&amp;via=voxdotcom" data-analytics-social="twitter"><svg class="p-svg-icon c-social-buttons__svg">
+                    <use xlink:href="#icon-twitter"></use></svg> <span class="c-social-buttons__text">tweet</span></a> <a class="c-social-buttons__item c-social-buttons__facebook" href="https://www.facebook.com/sharer/sharer.php?text=The+21+best+movies+of+2017&amp;u=https%3A%2F%2Fwww.vox.com%2F2017-in-review%2F2017%2F12%2F15%2F16751138%2Fbest-movies-2017-streaming-how-to-watch" data-analytics-social="facebook"><svg class="p-svg-icon c-social-buttons__svg">
+                    <use xlink:href="#icon-facebook"></use></svg> <span class="c-social-buttons__text">share</span></a>
+                </div>
+            </div>
+        </div>
+        <script src="https://cdn.vox-cdn.com/packs/chorus-95d6a425234d55b36191.js" async="async" integrity="sha256-TMEAF0AVhZm0JUpTe84mXXTZONaJ1d9ADjSTEDSDB/U= sha384-mrNz9RuysydpcSWB6AxELlKRb2uOllPXkHY8hr84ggvbgUUlir7CK3R/cWoPnWeO" crossorigin="anonymous"></script> <!-- Phonograph -->
+         
+        <script src="https://phonograph2.voxmedia.com/pickup.js?v=1529075019264" id="phonograph-pickup" async="async" defer="defer"></script> 
+        <script>
+        <![CDATA[
+
+        var phonographEvents = phonographEvents || [];
+        (function() {
+        var continent = document.cookie.match(/_chorus_geoip_continent=([^;]+)/i) || [];
+        var data = { 'Page Title':document.title, 'GA Track Prefix':'t1.', 'geoip_continent': continent[1] };
+        var dataLayer = window.dataLayer || [];
+        dataLayer
+          .filter(function(m) { return !!m['Network'] })
+          .forEach(function(m) {
+            Object.keys(m).forEach(function(k) { data[k] = m[k] });
+          });
+
+        var userid = data['Logged in Status'];
+        data['User ID'] = (typeof userid === 'number') ? userid : null;
+        phonographEvents.push(['pageload', data]);
+        })();
+        ]]>
+        </script> <!-- End Phonograph -->
+    </body>
+</html>

--- a/test/test-pages/videos-2/expected-metadata.json
+++ b/test/test-pages/videos-2/expected-metadata.json
@@ -1,0 +1,8 @@
+{
+  "title": "Screenshot : «Vape Wave», «6 Days», «Alphonse Président»…",
+  "byline": "Par Alexandre Hervaud et Jérémy Piette",
+  "dir": null,
+  "excerpt": "Séries, documentaires, programmes jeunesse… Retrouvez les recommandations de Libération pour savoir quoi regarder sur vos écrans cette semaine. Pour dépasser...",
+  "siteName": "Libération.fr",
+  "readerable": true
+}

--- a/test/test-pages/videos-2/expected.html
+++ b/test/test-pages/videos-2/expected.html
@@ -1,0 +1,75 @@
+<div id="readability-page-1" class="page">
+    <div>
+        <p> Séries, documentaires, programmes jeunesse… Retrouvez les recommandations de&#160;<em>Libération</em>&#160;pour savoir quoi regarder sur vos écrans cette semaine. </p>
+        <h3> Pour dépasser le tabac </h3>
+        <p>
+            <strong><em>Vape Wave</em> (documentaire, 1h28, Planète+)</strong>
+        </p>
+        <p>
+            <iframe width="100%" src="https://www.youtube.com/embed/lGL7RgHn5f0" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+        </p>
+        <p> Pendant quelques jours, le doute a plané&#160;: l’Etat comptait-il vraiment légiférer contre la cigarette dans les films français, que ce soit via une interdiction pure et simple ou via un système de «punition» (coupe des aides CNC, par exemple) pour les longs-métrages qui sentent le mégot&#160;? Si <a href="https://www.liberation.fr/direct/element/agnes-buzyn-assure-quelle-na-jamais-envisage-linterdiction-de-la-cigarette-au-cinema_73855/" target="_blank">le rétropédalage de la ministre Buzyn</a> n’en est pas vraiment un (elle n’avait jamais clairement menacé le septième art), la polémique a le mérite de pointer la (sur)représentation clopesque sur écran. Et si, comme c’est le cas dans la vie quotidienne, on voyait progressivement les cigarettes électroniques remplacer les tiges nicotinées authentiques&#160;? Que ceux qui mettraient en doute le potentiel cinématographique des vapoteuses se ruent sur <a href="http://www.vapewave.net/" target="_blank"><em>Vape Wave</em></a>, documentaire militant signé Jan Kounen, ex-fumeur reconverti à la vape dont les images magnifient les volutes de vapeur recrachée. </p>
+        <p> Si le film du réalisateur de <em>Dobermann</em> et <em>99 Francs</em> part un peu dans tous les sens, il a le mérite de défendre avec une passion contagieuse ce qui semble, de loin, être <a href="https://www.liberation.fr/societe/2015/08/20/une-e-cigarette-tres-frequentable_1366687" target="_blank">le meilleur et plus sain substitut à la clope</a>, n’en déplaise aux mesures restrictives imposées en France <a href="https://www.liberation.fr/france/2017/10/03/la-cigarette-electronique-bannie-de-certains-lieux-publics_1600601" target="_blank">à son égard</a>. Financé en partie via crowdfunding, le documentaire a été présenté par Kounen à travers toute la France lors de projection tenant quasiment de l’évangélisation. Disponible en VOD/DVD, il a été diffusé cette semaine sur la chaîne Planète+, qui le rediffusera les 25/11, 30/11 et 02/12 prochains. <strong>(Alexandre Hervaud)</strong>
+        </p>
+        <h3> Pour écouter parler un génie </h3>
+        <p>
+            <strong><em>Dans la tête d’Alan Moore</em> (websérie documentaire, 8x5min, Arte Creative)</strong>
+        </p>
+        <p>
+            <iframe width="100%" src="https://www.youtube.com/embed/s_rw5fPHz2g" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+        </p>
+        <p> Le week-end dernier, <em>Libération</em> publiait <a href="http://next.liberation.fr/livres/2017/11/17/alan-moore-dernier-barde-avant-la-fin-du-monde_1610854" target="_blank">un portrait de der consacré à l’auteur britannique Alan Moore</a>, connu pour ses BD cultes (<em>V pour Vendetta, Watchmen, From Hell</em>), à l’occasion de la sortie de son deuxième roman, le pavé <em>Jérusalem</em>. En attendant l’imminente sortie d’une version longue de son entretien avec <em>Libé</em>, on pourra se replonger dans les épisodes d’une websérie documentaire d’Arte Creative en 8 épisodes consacré au maître. Brexit, magie, Anonymous font partie des sujets discutés avec le maître au fil de ce programme sobrement intitulé <a href="https://www.arte.tv/fr/videos/RC-014342/dans-la-tete-d-alan-moore/" target="_blank"><em>Dans la tête d’Alan Moore</em></a>. <strong>(A.H.)</strong>
+        </p>
+        <h3> Pour honorer la mémoire d’une icône queer </h3>
+        <p>
+            <strong><em>The Death and Life of Marsha P. Johnson</em> (docu, 1h45, Netflix)</strong>
+        </p>
+        <p>
+            <iframe width="100%" src="https://www.youtube.com/embed/pADsuuPd79E" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+        </p>
+        <p> Marsha, la <em>«Rosa Parks du mouvement LGBTQ»</em>. Marsha <em>«la prostituée, l’actrice et la sainte, modèle d’Andy Warhol»</em> ou encore Marsha l’élaborée, la radicale, <em>«avec ses plumes et ce maquillage qu’elle ne mettait jamais bien»</em>. «Queen Marsha» a été retrouvée morte dans l’Hudson en juillet&#160;1992, alors qu’on la voyait encore parader dans les rues de Greenwich Village quelques jours auparavant. Un choc glaçant. Là où son corps a été repêché puis ingratement déposé, les sans-abri ont constitué le lendemain un mémorial de bouteilles et de plantes qui délimitent les contours de l’absente. </p>
+        <p> Marsha P. Johnson de son nom complet, icône queer, femme transgenre noire américaine et emblème de la lutte pour les droits des LGBTQ avait été l’une des premières à s’engager lors des émeutes de Stonewall à New York, en&#160;1969&#160;: <em>«C’est la révolution. Dieu merci.»</em> Marsha était une fleur souriante au parfum d’espoir. Le documentaire <em>The Death and Life of Marsha P. Johnson</em> du cinéaste David France relate l’enquête de l’activiste Victoria Cruz, membre de l’organisation Anti-Violence Project à New York qui, avant de prendre sa retraite, réclame que lumière soit faite sur la disparition de l’icône […]&#160;<a href="http://next.liberation.fr/cinema/2017/11/17/docu-marsha-p-johnson-unique-en-son-genre_1610846" target="_blank">Lire la suite de la critique de Jérémy Piette sur Libération.fr</a>
+        </p>
+        <h3> Pour Michel Vuilermoz (et rien d’autre) </h3>
+        <p>
+            <strong><em>Alphonse President</em> (série, 10x26, OCS Max)</strong>
+        </p>
+        <p>
+            <iframe width="100%" frameborder="0" src="https://www.dailymotion.com/embed/video/x67iqc9" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+        </p>
+        <p> Un temps baptisée <em>French Touch</em>, la série <em>Alphonse Président</em> est le dernier né des programmes originaux made in OCS. On savait les budgets de la chaîne bien moins généreux que ceux de Canal+ (voire que ceux de France 3 Limousin), et cette série le prouve à nouveau régulièrement, notamment lors d’une scène de conférence de presse alternant plans larges d’une authentique conf' à l’Elysée période François Hollande et plans serrés d’acteurs filmés dans un château des Pays de la Loire où a eu lieu le tournage. Le principal atout (et quel atout) de cette série écrite et réalisée par Nicolas Castro (<em>Des lendemains qui chantent</em>, 2014) réside dans son interprète principal, Michel Vuillermoz. </p>
+        <p> Dans le rôle d’un sénateur ringard devenu par un concours de circonstances président de la République, ce pensionnaire de la Comédie-Française et complice d’Albert Dupontel fait des merveilles, notamment lorsque le scénario lui prête des répliques enflammées typiques de la langue de bois politicienne –&#160;pas étonnant qu’il brasse du vent, son personnage de prof d’histoire retraité s’appelle Alphonse Dumoulin. C’est lorsqu’il n’est plus à l’écran que les choses se gâtent&#160;: si Jean-Michel Lahmi (de la bande d’Edouard Baer) fait le job en grand patron des flics, difficile de croire une seconde à Nabiha Akkari dans le rôle de la Première ministre –&#160;et pas uniquement parce que l’idée d’avoir une femme trentenaire issue de la diversité à Matignon sonne hélas comme un doux rêve en&#160;2017. Si, en matière de fiction politique sérieuse, un <em>Baron Noir</em> n’a pas grand-chose à envier à un <em>House of Cards</em>, côté comique la France est encore loin d’avoir son <em>Veep</em>. Gageons que la génération LREM saura largement inspirer des scénaristes moqueurs. <strong>(A.H.)</strong>
+        </p>
+        <h3> Pour les coulisses d’un tournage dément </h3>
+        <p>
+            <strong><em>Jim &amp; Andy</em> (documentaire, 1h33, Netflix)&#160;</strong>
+        </p>
+        <p>
+            <iframe width="100%" src="https://www.youtube.com/embed/kB15UFO5ebA" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+        </p>
+        <p> A la sortie de <em>Man on the Moon</em> (2000), le magnifique film de Milos Forman consacré à Andy Kaufman –&#160;comique et génie de la performance absurde mort en 1984&#160;–, le cinéaste et les acteurs insistaient dans chaque interview sur l’in­croyable comportement de Jim Carrey pendant le tournage&#160;: il aurait été comme possédé par Kaufman, se prenant pour lui 24&#160;heures sur 24. Certains affirmaient même ne jamais avoir eu l’impression que l’acteur était présent, tant son modèle avait littéralement pris sa place. Nous en avons aujourd’hui la preuve en images car tout cela avait été filmé par Bob Zmuda et Lynne Margulies, l’ancien complice et la veuve de Kaufman. </p>
+        <p> Dans le passionnant <em>Jim &amp; Andy&#160;: the Great Beyond</em>, disponible sur Netflix, Chris Smith a monté ces documents inédits parallèlement à un entretien dans lequel Jim Carrey revient sur cette expérience unique. <a href="http://next.liberation.fr/cinema,58" target="_blank">Lire la suite de la critique de Marcos Uzal sur Liberation.fr</a>
+        </p>
+        <h3> Pour un trip sibérien en totale autarcie </h3>
+        <p>
+            <strong><em>Braguino</em> (documentaire, 50min, Arte)</strong>
+        </p>
+        <p>
+            <iframe width="100%" src="https://www.youtube.com/embed/OIS-P-0-cRk" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+        </p>
+        <p> La querelle peut se trouver derrière toutes les portes, y compris celle de l’exil. On a beau croire avoir tourné le dos à tout, à cette inclination humaine à nourrir sa&#160;propre haine, l’allergie peut regermer fissa sur une&#160;peau qui frissonne à&#160;l’approche de ce voisin que l’on ne comprend pas. Issu&#160;d’une lignée de vieux-croyants orthodoxes russes, Sacha Braguine a pris sa famille sous le bras, loin de toute autre présence humaine en taïga sibérienne. Un autre groupe, les Kiline, a décidé d’en faire de même et de s’installer de l’autre côté de la rivière. Qui est arrivé en premier&#160;? Qui menace l’autre&#160;? L’histoire de l’impossible communauté peut commencer. </p>
+        <p> La lecture d’<em>Ermites dans la taïga</em>&#160;(1992) de Vassili Peskov, authentique récit sur la famille Lykov opérant une migration similaire en&#160;1938, a poussé l’artiste&#160;<a href="http://next.liberation.fr/images/2017/09/29/clement-cogitore-j-essaye-de-raconter-les-terreurs-profondes-de-l-etre-humain_1599854">Clément Cogitore</a>&#160;à&#160;rencontrer les Braguine, puis à se faire témoin de la&#160;bisbille de voisinage en&#160;2016. Il en est revenu avec un nouveau film d’une cinquantaine de minutes&#160;:&#160;<em>Braguino,</em>&#160;soutenu par le prix Le&#160;Bal de la&#160;jeune création avec l’ADAGP.<em>&#160;</em>Le documentaire y frôle son déguisement fictionnel, tant ce qui s’y déroule convoque une dramaturgie comme invoquée par on ne sait quel rituel vaudou […] <a href="http://next.liberation.fr/cinema/2017/10/30/braguino-prises-de-bec-dans-la-taiga_1606859" target="_blank">Lire la suite de la critique de Jérémy Piette sur Liberation.fr</a>, le film diffusé cette semaine sur Arte est visible en intégralité ci-dessus. </p>
+        <h3> Pour un thriller tiré de faits réels </h3>
+        <p>
+            <strong><em>6 Days</em> (film, 1h34, Netflix)</strong>
+        </p>
+        <p>
+            <iframe width="100%" src="https://www.youtube.com/embed/7HthiTi_IcI" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+        </p>
+        <p> Fin avril 1980, l’ambassade d’Iran à Londres a été le théâtre d’une prise d’otages largement médiatisée : une trentaine de personnes ont ainsi été retenues pendant six jours par des soldats iraniens dissidents exigeant la libération de 91 prisonniers. Avec Margaret Thatcher au 10 Downing Street à l’époque, pas question pour l’Angleterre d’avoir l’air mou du genou sur la réponse à apporter à cette crise scrutée par les caméras du monde entier. Le SAS (Special Air Service) est sur le coup : l’opération Nimrod se met en place pour prendre d’assaut l’ambassade. </p>
+        <p> Inspiré par cet épisode, <em>6 Days</em> de&#160;Toa Fraser (<em>The Dead Lands</em>, 2014) est un thriller carré pouvant compter sur l'autorité naturelle de Mark Strong (<em>Kingsman</em>) ici recyclé en flic londonien et sur la néo-badass attitude de Jamie Bell, bien loin du freluquet danseur de <em>Billy Elliot</em> puisqu'on le retrouve ici&#160;en soldat chargé d’organiser l’opération de secours. Attention, la bande-annonce ci-dessus dévoile à peu près l’intégralité des scènes d’action du film. <strong>(A.H.)</strong>
+        </p>
+        <p><span><span><a href="https://www.liberation.fr/auteur/5631-alexandre-hervaud">Alexandre Hervaud</a></span> , <span><a href="https://www.liberation.fr/auteur/17350-jeremy-piette">Jérémy Piette</a></span></span>
+        </p>
+    </div>
+</div>

--- a/test/test-pages/videos-2/source.html
+++ b/test/test-pages/videos-2/source.html
@@ -1,0 +1,2043 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+    <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+        <title>
+            Screenshot&#160;: «Vape Wave», «6&#160;Days», «Alphonse Président»… - Culture / Next
+        </title>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="Séries, documentaires, programmes jeunesse… Retrouvez les recommandations de&#160;Libération&#160;pour savoir quoi regarder sur vos écrans cette semaine. Pour dépasser..." />
+        <meta name="keywords" content="Documentaire, Libération, Netflix, Arte, Marsha P. Johnson, Alan Moore, France, New York, Cinéaste, Thriller, Special Air Service, Acteur, Web-série, Opération Nimrod, Jim Carrey, Winamp, Planète+, Queer, LGBT, Icône, From Hell, Comique, Etty Buzyn, Bande-annonce, Jefferson Starship, Vieux-croyants, Greenwich Village, V pour Vendetta, Michel Vuillermoz, Évangélisation, Sans-abri, Frein de bicyclette, Cigarette, Allergie, États-Unis, Dieu merci!, Londres, Édouard Baer, Clément Cogitore, Margaret Thatcher, Vidéo à la demande, Pays de la Loire, Cinéma, Brasses, Réalisateur, 10 Downing Street, Jérusalem, Orange Cinéhappy, Mégot, Long métrage, Un grand patron, Droits de l'homme, Baron noir, Ermites dans la taïga, DVD, Parfum, Financement participatif, Révolution, Albert Dupontel, Sénat, Andy Kaufman, Autarcie, Royaume-Uni, Famille Lykov, Brexit, Captures d'écran, Jan Kounen, Dobermann, Comédie-Française, Famille, Taïga, Queen, Prise d'otages des Jeux olympiques de Munich, Président de la République, 99 francs, Langue de bois, Miloš Forman, Torture, Watchmen, Anonymous, François Hollande, The Dead Lands, Mark Strong, Jamie Bell, Nabiha Akkari, Jean-Michel Lahmi, France 3 Limousin, Tournage, Élysée, Cigarette électronique, Billy Elliot, Andy Warhol, Vaudou, Des lendemains qui chantent, Prostitution, Angleterre, Rosa Parks, Bob Zmuda, Émeutes de Stonewall, CNC, MtF, Tabac, Michel Serres, Violence, ADAGP, French Touch, Premier ministre, Canal+, Danse, Man on the Moon, The Great Beyond, Veep, House of Cards, Vassili Peskov, actualités, news" />
+        <meta name="apple-itunes-app" content="app-id=371288979" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@libe" />
+        <meta name="twitter:creator" content="@libe" />
+        <meta name="twitter:title" content="Screenshot&#160;: «Vape Wave», «6&#160;Days», «Alphonse Président»…" />
+        <meta name="twitter:description" content="Séries, documentaires, programmes jeunesse… Retrouvez les recommandations de&#160;Libération&#160;pour savoir quoi regarder sur vos écrans cette semaine. Pour dépasser..." />
+        <meta name="twitter:url" content="https://next.liberation.fr/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047" />
+        <meta name="twitter:image" content="https://medias.liberation.fr/photo/1075029-screenshot-alphonse-vape-wave-6-days.jpg?modified_at=1511536242&amp;amp;picto=fb&amp;amp;ratio_x=191&amp;amp;ratio_y=100&amp;amp;width=600" />
+        <meta property="article:section" content="Culture" />
+        <meta property="article:published_time" content="2017-11-24T18:42:20" />
+        <meta property="article:modified_time" content="2017-11-24T18:42:20" />
+        <meta property="article:author" content="https://www.liberation.fr/auteur/5631-alexandre-hervaud" />
+        <meta property="article:author" content="https://www.liberation.fr/auteur/17350-jeremy-piette" />
+        <meta name="news_keywords" content="Documentaire, Libération, Netflix, Arte, Marsha P. Johnson, Alan Moore, France, New York, Cinéaste, Thriller, Special Air Service, Acteur, Web-série, Opération Nimrod, Jim Carrey, Winamp, Planète+, Queer, LGBT, Icône, From Hell, Comique, Etty Buzyn, Bande-annonce, Jefferson Starship, Vieux-croyants, Greenwich Village, V pour Vendetta, Michel Vuillermoz, Évangélisation, Sans-abri, Frein de bicyclette, Cigarette, Allergie, États-Unis, Dieu merci!, Londres, Édouard Baer, Clément Cogitore, Margaret Thatcher, Vidéo à la demande, Pays de la Loire, Cinéma, Brasses, Réalisateur, 10 Downing Street, Jérusalem, Orange Cinéhappy, Mégot, Long métrage, Un grand patron, Droits de l'homme, Baron noir, Ermites dans la taïga, DVD, Parfum, Financement participatif, Révolution, Albert Dupontel, Sénat, Andy Kaufman, Autarcie, Royaume-Uni, Famille Lykov, Brexit, Captures d'écran, Jan Kounen, Dobermann, Comédie-Française, Famille, Taïga, Queen, Prise d'otages des Jeux olympiques de Munich, Président de la République, 99 francs, Langue de bois, Miloš Forman, Torture, Watchmen, Anonymous, François Hollande, The Dead Lands, Mark Strong, Jamie Bell, Nabiha Akkari, Jean-Michel Lahmi, France 3 Limousin, Tournage, Élysée, Cigarette électronique, Billy Elliot, Andy Warhol, Vaudou, Des lendemains qui chantent, Prostitution, Angleterre, Rosa Parks, Bob Zmuda, Émeutes de Stonewall, CNC, MtF, Tabac, Michel Serres, Violence, ADAGP, French Touch, Premier ministre, Canal+, Danse, Man on the Moon, The Great Beyond, Veep, House of Cards, Vassili Peskov" />
+        <meta property="article:tag" content="Documentaire" />
+        <meta property="article:tag" content="Libération" />
+        <meta property="article:tag" content="Netflix" />
+        <meta property="article:tag" content="Arte" />
+        <meta property="article:tag" content="Marsha P. Johnson" />
+        <meta property="article:tag" content="Alan Moore" />
+        <meta property="article:tag" content="France" />
+        <meta property="article:tag" content="New York" />
+        <meta property="article:tag" content="Cinéaste" />
+        <meta property="article:tag" content="Thriller" />
+        <meta property="article:tag" content="Special Air Service" />
+        <meta property="article:tag" content="Acteur" />
+        <meta property="article:tag" content="Web-série" />
+        <meta property="article:tag" content="Opération Nimrod" />
+        <meta property="article:tag" content="Jim Carrey" />
+        <meta property="article:tag" content="Winamp" />
+        <meta property="article:tag" content="Planète+" />
+        <meta property="article:tag" content="Queer" />
+        <meta property="article:tag" content="LGBT" />
+        <meta property="article:tag" content="Icône" />
+        <meta property="article:tag" content="From Hell" />
+        <meta property="article:tag" content="Comique" />
+        <meta property="article:tag" content="Etty Buzyn" />
+        <meta property="article:tag" content="Bande-annonce" />
+        <meta property="article:tag" content="Jefferson Starship" />
+        <meta property="article:tag" content="Vieux-croyants" />
+        <meta property="article:tag" content="Greenwich Village" />
+        <meta property="article:tag" content="V pour Vendetta" />
+        <meta property="article:tag" content="Michel Vuillermoz" />
+        <meta property="article:tag" content="Évangélisation" />
+        <meta property="article:tag" content="Sans-abri" />
+        <meta property="article:tag" content="Frein de bicyclette" />
+        <meta property="article:tag" content="Cigarette" />
+        <meta property="article:tag" content="Allergie" />
+        <meta property="article:tag" content="États-Unis" />
+        <meta property="article:tag" content="Dieu merci!" />
+        <meta property="article:tag" content="Londres" />
+        <meta property="article:tag" content="Édouard Baer" />
+        <meta property="article:tag" content="Clément Cogitore" />
+        <meta property="article:tag" content="Margaret Thatcher" />
+        <meta property="article:tag" content="Vidéo à la demande" />
+        <meta property="article:tag" content="Pays de la Loire" />
+        <meta property="article:tag" content="Cinéma" />
+        <meta property="article:tag" content="Brasses" />
+        <meta property="article:tag" content="Réalisateur" />
+        <meta property="article:tag" content="10 Downing Street" />
+        <meta property="article:tag" content="Jérusalem" />
+        <meta property="article:tag" content="Orange Cinéhappy" />
+        <meta property="article:tag" content="Mégot" />
+        <meta property="article:tag" content="Long métrage" />
+        <meta property="article:tag" content="Un grand patron" />
+        <meta property="article:tag" content="Droits de l'homme" />
+        <meta property="article:tag" content="Baron noir" />
+        <meta property="article:tag" content="Ermites dans la taïga" />
+        <meta property="article:tag" content="DVD" />
+        <meta property="article:tag" content="Parfum" />
+        <meta property="article:tag" content="Financement participatif" />
+        <meta property="article:tag" content="Révolution" />
+        <meta property="article:tag" content="Albert Dupontel" />
+        <meta property="article:tag" content="Sénat" />
+        <meta property="article:tag" content="Andy Kaufman" />
+        <meta property="article:tag" content="Autarcie" />
+        <meta property="article:tag" content="Royaume-Uni" />
+        <meta property="article:tag" content="Famille Lykov" />
+        <meta property="article:tag" content="Brexit" />
+        <meta property="article:tag" content="Captures d'écran" />
+        <meta property="article:tag" content="Jan Kounen" />
+        <meta property="article:tag" content="Dobermann" />
+        <meta property="article:tag" content="Comédie-Française" />
+        <meta property="article:tag" content="Famille" />
+        <meta property="article:tag" content="Taïga" />
+        <meta property="article:tag" content="Queen" />
+        <meta property="article:tag" content="Prise d'otages des Jeux olympiques de Munich" />
+        <meta property="article:tag" content="Président de la République" />
+        <meta property="article:tag" content="99 francs" />
+        <meta property="article:tag" content="Langue de bois" />
+        <meta property="article:tag" content="Miloš Forman" />
+        <meta property="article:tag" content="Torture" />
+        <meta property="article:tag" content="Watchmen" />
+        <meta property="article:tag" content="Anonymous" />
+        <meta property="article:tag" content="François Hollande" />
+        <meta property="article:tag" content="The Dead Lands" />
+        <meta property="article:tag" content="Mark Strong" />
+        <meta property="article:tag" content="Jamie Bell" />
+        <meta property="article:tag" content="Nabiha Akkari" />
+        <meta property="article:tag" content="Jean-Michel Lahmi" />
+        <meta property="article:tag" content="France 3 Limousin" />
+        <meta property="article:tag" content="Tournage" />
+        <meta property="article:tag" content="Élysée" />
+        <meta property="article:tag" content="Cigarette électronique" />
+        <meta property="article:tag" content="Billy Elliot" />
+        <meta property="article:tag" content="Andy Warhol" />
+        <meta property="article:tag" content="Vaudou" />
+        <meta property="article:tag" content="Des lendemains qui chantent" />
+        <meta property="article:tag" content="Prostitution" />
+        <meta property="article:tag" content="Angleterre" />
+        <meta property="article:tag" content="Rosa Parks" />
+        <meta property="article:tag" content="Bob Zmuda" />
+        <meta property="article:tag" content="Émeutes de Stonewall" />
+        <meta property="article:tag" content="CNC" />
+        <meta property="article:tag" content="MtF" />
+        <meta property="article:tag" content="Tabac" />
+        <meta property="article:tag" content="Michel Serres" />
+        <meta property="article:tag" content="Violence" />
+        <meta property="article:tag" content="ADAGP" />
+        <meta property="article:tag" content="French Touch" />
+        <meta property="article:tag" content="Premier ministre" />
+        <meta property="article:tag" content="Canal+" />
+        <meta property="article:tag" content="Danse" />
+        <meta property="article:tag" content="Man on the Moon" />
+        <meta property="article:tag" content="The Great Beyond" />
+        <meta property="article:tag" content="Veep" />
+        <meta property="article:tag" content="House of Cards" />
+        <meta property="article:tag" content="Vassili Peskov" />
+        <link rel="amphtml" href="https://next.liberation.fr/amphtml/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047" />
+        <script type="application/ld+json">
+        <![CDATA[
+        {"publisher": {"url": "https://www.liberation.fr", "logo": {"url": "https://statics.liberation.fr/newnext/images/logo-libe-meta.png", "width": "131", "@type": "ImageObject", "height": "60"}, "@type": "Organization", "name": "Lib\u00e9ration"}, "description": "S\u00e9ries, documentaires, programmes jeunesse\u2026 Retrouvez les recommandations de\u00a0Lib\u00e9ration\u00a0pour savoir quoi regarder sur vos \u00e9crans cette semaine.\nPour d\u00e9passer...", "author": [{"url": "https://www.liberation.fr/auteur/5631-alexandre-hervaud", "@type": "Person", "name": "Alexandre Hervaud"}, {"url": "https://www.liberation.fr/auteur/17350-jeremy-piette", "@type": "Person", "name": "J\u00e9r\u00e9my Piette"}], "headline": "Screenshot\u00a0: \u00abVape Wave\u00bb, \u00ab6\u00a0Days\u00bb, \u00abAlphonse Pr\u00e9sident\u00bb\u2026", "image": {"url": "https://statics.liberation.fr/newnext/images/social-placeholder.jpg", "width": "1000", "@type": "ImageObject", "height": "500"}, "datePublished": "2017-11-24T18:42:20.314667", "keywords": "Documentaire,Lib\u00e9ration,Netflix,Arte,Marsha P. Johnson,Alan Moore,France,New York,Cin\u00e9aste,Thriller,Special Air Service,Acteur,Web-s\u00e9rie,Op\u00e9ration Nimrod,Jim Carrey,Winamp,Plan\u00e8te+,Queer,LGBT,Ic\u00f4ne,From Hell,Comique,Etty Buzyn,Bande-annonce,Jefferson Starship,Vieux-croyants,Greenwich Village,V pour Vendetta,Michel Vuillermoz,\u00c9vang\u00e9lisation,Sans-abri,Frein de bicyclette,Cigarette,Allergie,\u00c9tats-Unis,Dieu merci!,Londres,\u00c9douard Baer,Cl\u00e9ment Cogitore,Margaret Thatcher,Vid\u00e9o \u00e0 la demande,Pays de la Loire,Cin\u00e9ma,Brasses,R\u00e9alisateur,10 Downing Street,J\u00e9rusalem,Orange Cin\u00e9happy,M\u00e9got,Long m\u00e9trage,Un grand patron,Droits de l'homme,Baron noir,Ermites dans la ta\u00efga,DVD,Parfum,Financement participatif,R\u00e9volution,Albert Dupontel,S\u00e9nat,Andy Kaufman,Autarcie,Royaume-Uni,Famille Lykov,Brexit,Captures d'\u00e9cran,Jan Kounen,Dobermann,Com\u00e9die-Fran\u00e7aise,Famille,Ta\u00efga,Queen,Prise d'otages des Jeux olympiques de Munich,Pr\u00e9sident de la R\u00e9publique,99 francs,Langue de bois,Milo\u0161 Forman,Torture,Watchmen,Anonymous,Fran\u00e7ois Hollande,The Dead Lands,Mark Strong,Jamie Bell,Nabiha Akkari,Jean-Michel Lahmi,France 3 Limousin,Tournage,\u00c9lys\u00e9e,Cigarette \u00e9lectronique,Billy Elliot,Andy Warhol,Vaudou,Des lendemains qui chantent,Prostitution,Angleterre,Rosa Parks,Bob Zmuda,\u00c9meutes de Stonewall,CNC,MtF,Tabac,Michel Serres,Violence,ADAGP,French Touch,Premier ministre,Canal+,Danse,Man on the Moon,The Great Beyond,Veep,House of Cards,Vassili Peskov", "@type": "NewsArticle", "mainEntityOfPage": {"@id": "https://next.liberation.fr/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047", "@type": "URL"}, "@context": "http://schema.org", "dateCreated": "2017-11-24T18:42:20.314667", "dateModified": "2017-11-24T18:42:20.314667"}
+        ]]>
+        </script>
+        <meta name="google-site-verification" content="zVHLmJdGBN-aytKJzwnoPQeYRQZLOwePkL6terUtF8U" />
+        <meta property="fb:pages" content="147126052393" />
+        <meta property="og:site_name" content="Libération.fr" />
+        <meta property="og:type" content="article" />
+        <meta property="og:title" content="Screenshot&#160;: «Vape Wave», «6&#160;Days», «Alphonse Président»…" />
+        <meta property="og:image" content="https://medias.liberation.fr/photo/1075029-screenshot-alphonse-vape-wave-6-days.jpg?modified_at=1511536242&amp;amp;picto=fb&amp;amp;ratio_x=191&amp;amp;ratio_y=100&amp;amp;width=600" />
+        <meta property="al:ios:url" content="liberation://article?id=1612047" />
+        <meta property="al:ios:app_store_id" content="336173383" />
+        <meta property="al:ios:app_name" content="Libération" />
+        <meta property="al:android:package" content="com.visuamobile.liberation" />
+        <meta property="al:android:app_name" content="Libération - Toute l'actualité" />
+        <meta property="al:android:url" content="liberation://article?id=1612047" />
+        <meta name="twitter:app:country" content="FR" />
+        <meta name="twitter:app:name:iphone" content="Libération" />
+        <meta name="twitter:app:id:iphone" content="336173383" />
+        <meta name="twitter:app:url:iphone" content="liberation://article?id=1612047" />
+        <meta name="twitter:app:name:ipad" content="Libération" />
+        <meta name="twitter:app:id:ipad" content="336173383" />
+        <meta name="twitter:app:url:ipad" content="liberation://article?id=1612047" />
+        <meta name="twitter:app:name:googleplay" content="Libération - Toute l'actualité" />
+        <meta name="twitter:app:id:googleplay" content="com.visuamobile.liberation" />
+        <meta name="twitter:app:url:googleplay" content="liberation://article?id=1612047" />
+        <meta property="og:url" content="https://next.liberation.fr/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047" />
+        <meta property="og:description" content="Séries, documentaires, programmes jeunesse… Retrouvez les recommandations de&#160;Libération&#160;pour savoir quoi regarder sur vos écrans cette semaine. Pour dépasser..." />
+        <meta property="libe:image" content="https://medias.liberation.fr/photo/1075029-screenshot-alphonse-vape-wave-6-days.jpg?modified_at=1511536242&amp;amp;width=750" />
+        <link rel="canonical" href="https://next.liberation.fr/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047" />
+        <link rel="shortcut icon" href="https://www.liberation.fr/favicon.ico" />
+        <link rel="stylesheet" href="https://statics.liberation.fr/newnext/cache/css/46a524bbe7a5.css" type="text/css" media="all" />
+        <link rel="stylesheet" href="https://statics.liberation.fr/newnext/cache/css/db0902551ea0.css" type="text/css" media="all" />
+        <link rel="dns-prefetch" href="https://medias.liberation.fr" />
+        <link rel="dns-prefetch" href="http://m0.libe.com/" />
+        <link rel="dns-prefetch" href="https://statics.liberation.fr/newnext/" />
+        <link rel="dns-prefetch" href="http://asqliberation.nuggad.net/" />
+        <link rel="dns-prefetch" href="http://logliberation.xiti.com/" />
+        <link rel="dns-prefetch" href="http://www.google-analytics.com/" />
+        <link rel="dns-prefetch" href="http://static.chartbeat.com/" />
+        <link rel="dns-prefetch" href="http://ping.chartbeat.com/" />
+        <link rel="dns-prefetch" href="http://widgets.outbrain.com/" />
+        <link rel="dns-prefetch" href="http://images.outbrain.com/" />
+        <link rel="dns-prefetch" href="http://odb.outbrain.com/" />
+        <link rel="dns-prefetch" href="http://platform.twitter.com/" />
+        <link rel="dns-prefetch" href="http://connect.facebook.net/" />
+        <link rel="dns-prefetch" href="http://www.facebook.com/" />
+        <link rel="dns-prefetch" href="https://www6.smartadserver.com/" />
+        <link rel="dns-prefetch" href="http://ak-ns.sascdn.com/" />
+        <link rel="dns-prefetch" href="http://cdn1.smartadserver.com/" />
+        <link rel="dns-prefetch" href="http://ib.adnxs.com/" />
+        <link rel="dns-prefetch" href="http://cdn.adslvr.com/" />
+        <link rel="dns-prefetch" href="http://d.ligatus.com/" />
+        <link rel="dns-prefetch" href="http://x.ligatus.com/" />
+        <link rel="dns-prefetch" href="http://l.ligatus.com/" />
+        <link rel="dns-prefetch" href="http://cdn.elasticad.net/" />
+        <script type="text/javascript" src="https://statics.liberation.fr/newnext/cache/js/6cc7f5d7edf1.js"></script>
+        <script type="text/javascript" src="https://statics.liberation.fr/newnext/cache/js/ec1d4b0cc5cb.js"></script>
+    </head>
+    <body class="contentmodel next article article-screenshot-vape-wave-6-days-alphonse-president article">
+        <script type="text/javascript" src="https://statics.liberation.fr/newnext/cache/js/47759a0c4465.js"></script> <svg xmlns="http://www.w3.org/2000/svg" style="height: 0; width: 0; position: absolute; visibility: hidden;"> <!-- LAYOUT -->
+        <symbol id="icon-search" viewbox="0 0 21 22">
+            <title>
+                Search
+            </title>
+            <g stroke-width="2" stroke-miterlimit="10" fill="none">
+                <circle cx="8.4" cy="8.5" r="7.1"></circle>
+                <path d="M12.9 13.8l7.1 7.1"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-direct-anim" viewbox="0 0 26 22">
+            <title>
+                Direct
+            </title>
+            <path class="stroke-anim" stroke="#000" stroke-width="2" stroke-miterlimit="10" d="M15.5 8c.7-1 2-2 4-2 3 0 5 2.1 5 5s-2.1 5-5 5c-3.3 0-5-2.1-6.5-5s-3.2-5-6.5-5c-2.9 0-5 2.1-5 5s2 5 5 5c2 0 3.2-.9 4-2" fill="none"></path>
+        </symbol>
+        <symbol id="icon-user" viewbox="0 0 21 22">
+            <title>
+                User
+            </title>
+            <g stroke-width="2" stroke-miterlimit="10" fill="none">
+                <path d="M7.1 12.2c-3.3 1.3-5.6 4.3-5.6 8.3h17.9c0-4-2.3-7-5.6-8.3"></path>
+                <circle cx="10.5" cy="7.1" r="5.6"></circle>
+            </g>
+        </symbol>
+        <symbol id="icon-100" viewbox="0 0 26 22">
+            <title>
+                100
+            </title>
+            <g stroke="#000" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <path d="M14.8 8c0-1.7-1.3-3-3-3s-3 1.3-3 3v6c0 1.7 1.3 3 3 3s3-1.3 3-3v-6zM24.8 8c0-1.7-1.3-3-3-3s-3 1.3-3 3v6c0 1.7 1.3 3 3 3s3-1.3 3-3v-6zM.8 7l2.6-2h.4v13"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-zoom" viewbox="0 0 22 22">
+            <title>
+                Zoom
+            </title>
+            <path fill="#ffffff" d="M9 22v-2h-5.5l6.5-6.5-1.5-1.5-6.5 6.5v-5.5h-2v9zM13 0v2h5.5l-6.5 6.5 1.5 1.5 6.5-6.5v5.5h2v-9z"></path>
+        </symbol>
+        <symbol id="icon-quiz" viewbox="0 0 60 60">
+            <title>
+                Quiz
+            </title>
+            <text transform="translate(23.727 40.574)" fill="#fff" font-family="'Liberation-x2750.00_x1500.00'" font-size="26.585" letter-spacing="2">
+                ?
+            </text>
+            <path stroke="#fff" d="M30 12v-7M21.1 14.5l-3.6-6.2M14.5 21.1l-6.2-3.6M12 30h-7M14.5 38.9l-6.2 3.6M21.1 45.5l-3.6 6.2M30 48v7M38.9 45.5l3.6 6.2M45.5 38.9l6.2 3.6M48 30h7M45.5 21.1l6.2-3.6M38.9 14.5l3.6-6.2"></path>
+        </symbol><!-- LIVE -->
+        <symbol id="icon-diamond" viewbox="0 0 26 11">
+            <title>
+                Libération Diamond
+            </title>
+            <path stroke="#000" stroke-linejoin="round" stroke-miterlimit="10" fill="none" d="M1.1 5.5l11.9-4.4 11.9 4.4-11.9 4.4z"></path>
+        </symbol><!-- EVENEMENT -->
+        <symbol id="icon-clock" viewbox="0 0 18 18">
+            <title>
+                clock
+            </title>
+            <g stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" fill="none">
+                <circle cx="9" cy="9" r="7.5"></circle>
+                <path d="M9 3.9v5.1h2.6"></path>
+            </g>
+        </symbol><!-- RSS -->
+        <symbol id="icon-xml" viewbox="0 0 14.6 14.6">
+            <title>
+                xml
+            </title>
+            <path fill="#fff" d="M0 7.8c1.8 0 3.5.7 4.8 2 1.3 1.3 2 3 2 4.8h2.8c0-5.3-4.3-9.6-9.6-9.6v2.8zm0-5c6.5 0 11.8 5.3 11.8 11.8h2.8c0-8-6.6-14.6-14.6-14.6v2.8zm3.9 9.9c0 1.1-.9 1.9-1.9 1.9-1.1 0-1.9-.9-1.9-1.9 0-1.1.9-1.9 1.9-1.9 1-.1 1.9.8 1.9 1.9z"></path>
+        </symbol>
+        <symbol id="icon-netvibes" viewbox="0 0 14 14">
+            <title>
+                netvibes
+            </title>
+            <g fill="#fff">
+                <path d="M6 0h2v14h-2zM0 6h14v2h-14z"></path>
+            </g>
+        </symbol><!-- CATEGORIES -->
+        <symbol id="icon-live" viewbox="0 0 60 60">
+            <title>
+                live
+            </title>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" d="M33 26c1.3-2 3.1-4 6-4 5 0 8 3.7 8 8s-3 8-8 8c-4.9 0-6.8-3.7-9-8s-4.1-8-9-8c-5.1 0-8 3.7-8 8s2.9 8 8 8c3 0 4.8-2.4 6-4" fill="none"></path>
+        </symbol>
+        <symbol id="icon-anciens-numeros" viewbox="0 0 60 60">
+            <title>
+                anciens-numeros
+            </title>
+            <path fill="#fff" d="M20.2 22.5l7.1-2.5 6.9 2.5-6.9 2.5z"></path>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M15 17h24v32h-24zM20 14v-2h24v32h-2"></path>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M20 29h14v8h-14zM19 41h7M19 44h7M28 41h7M28 44h7"></path>
+        </symbol>
+        <symbol id="icon-data" viewbox="0 0 60 60">
+            <title>
+                data
+            </title>
+            <g stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <circle cx="30" cy="30" r="15.7"></circle>
+                <path d="M30 14v16l-10.6 11.6M18.8 19l11.2 11"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-desintox" viewbox="0 0 60 60">
+            <title>
+                desintox
+            </title>
+            <g stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" fill="none">
+                <circle cx="20.6" cy="40.8" r="6.5"></circle>
+                <path d="M23.4 40.8c0-1.5-1.3-2.8-2.8-2.8M42.4 40.8c0-1.5-1.3-2.8-2.8-2.8M14 41v-14.7c0-3.5 3-6.3 6.5-6.3s6.5 2.8 6.5 6.3v14.7"></path>
+            </g>
+            <g stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" fill="none">
+                <circle cx="39.6" cy="40.8" r="6.5"></circle>
+                <path d="M33 41v-14.7c0-3.5 3-6.3 6.5-6.3s6.5 2.8 6.5 6.3v14.7"></path>
+            </g>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M19 20v-4.2c0-2.1 1.9-3.7 4-3.7s4 1.7 4 3.7v9.2M41 20v-4.2c0-2.1-1.9-3.7-4-3.7s-4 1.7-4 3.7v9.2" fill="none"></path>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" fill="none" d="M27 25h6v11h-6z"></path>
+        </symbol>
+        <symbol id="icon-diapo" viewbox="0 0 60 60">
+            <title>
+                diapo
+            </title>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M11 23h33v21h-33zM11.2 38l7.1-6.2 10 12.2M27.2 42.5l7-6.2 10.1 7.7"></path>
+            <circle fill="#fff" cx="38" cy="29.3" r="3.3"></circle>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M17 20v-3h33v21h-3"></path>
+        </symbol>
+        <symbol id="icon-edito" viewbox="0 0 60 60">
+            <title>
+                edito
+            </title>
+            <g fill="#fff">
+                <path d="M10.2 23h6.5v2.7h-3.7v2.6h3.5v2.6h-3.5v3.1h3.7v2.7h-6.5v-13.7zM18.5 23h3.9c3.1 0 4.1 1.2 4.1 4.5v4.6c0 3.3-1 4.5-4.1 4.5h-3.9v-13.6zm2.8 2.6v8.5h1.1c.9 0 1.3-.4 1.3-2.2v-4c0-1.8-.4-2.2-1.3-2.2h-1.1zM28.4 23h2.9v13.7h-2.9v-13.7zM37.5 25.9v10.8h-2.9v-10.8h-2v-2.9h6.9v2.9h-2zM45.1 36.8c-2.9 0-4.1-1.2-4.1-4.4v-5.2c0-3 1.2-4.3 4.1-4.3 2.9 0 4.1 1.3 4.1 4.3v5.2c0 3.1-1.3 4.4-4.1 4.4zm-.1-11.2c-.9 0-1.3.4-1.3 2v4.5c0 1.6.4 2 1.3 2s1.3-.4 1.3-2v-4.5c0-1.6-.4-2-1.3-2z"></path>
+            </g>
+            <path fill="#fff" d="M11.7 21l2.2-3h2.3l-2.7 3z"></path>
+        </symbol>
+        <symbol id="icon-election-2017" viewbox="0 0 60 60">
+            <title>
+                election-2017
+            </title>
+            <g fill="#fff">
+                <path d="M17.1 49.4c3.9-4.7 4-4.7 4-5.5v-.3c0-.7-.2-1-.9-1-.6 0-.9.3-.9 1.2v.5h-2.3v-.6c0-2.1.9-3 3.2-3 2.2 0 3.1.7 3.1 2.6v.3c0 1.2-.2 1.5-3.4 5.7h3.3v2h-6.2v-1.9zM28 51.4c-2.3 0-3.2-.9-3.2-3.4v-4c0-2.3.9-3.3 3.2-3.3 2.3 0 3.2 1 3.2 3.3v4c0 2.4-1 3.4-3.2 3.4zm0-8.7c-.7 0-1 .3-1 1.5v3.5c0 1.2.3 1.5 1 1.5s1-.3 1-1.5v-3.5c0-1.2-.3-1.5-1-1.5zM33.8 51.3v-8l-1.3.6v-2.1l2.3-1.1h1.2v10.6h-2.2zM38.4 51.3c.3-4.1 1.7-6.5 2.9-8.6h-3.8v-2h6.2v1.6c-1.5 2.7-2.6 4.9-2.9 9h-2.4z"></path>
+            </g>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M24 13h-10v12h32v-12h-6"></path>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M14 25h32v9h-32z"></path>
+            <path fill="#fff" d="M32 21l7-7-7-7-10 10 4 4z"></path>
+        </symbol>
+        <symbol id="icon-election" viewbox="0 0 60 60">
+            <title>
+                election
+            </title>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M20.9 21h-7v12h32v-12h-5"></path>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M13.9 33h32v10h-32z"></path>
+            <path fill="#fff" d="M31.1 29l8.6-7.4-7.4-8.6-12.3 11.1 4.1 4.9z"></path>
+        </symbol>
+        <symbol id="icon-essentiel" viewbox="0 0 60 60">
+            <title>
+                essentiel
+            </title>
+            <g stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <path d="M19 24h-2.5c-3.9 0-6.8 3.1-6.8 7s3 7 6.8 7h26.3c3.9 0 6.8-3.1 6.8-7s-3-7-6.8-7h-18.8M28.2 28.4l-4.4-4.4 4.4-4.4"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-generique" viewbox="0 0 60 60">
+            <title>
+                generique
+            </title>
+            <path fill="#fff" d="M12 30l18-6.6 18 6.6-18 6.6-18-6.6"></path>
+        </symbol>
+        <symbol id="icon-idee" viewbox="0 0 60 60">
+            <title>
+                idee
+            </title>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M41.5 35c-1.8 3.2-6 2.5-5.7 7.3M38.4 46.9c5-3.4-.5-7.9 3.1-11.9M39.4 30.9c2.6-2.9 8.1-1.3 7.3 3.6M31 31.9c0 .9.3 5 5.3 2.2M31 31.9c0-2.3 3.5-2.6 5.7-5.3" fill="none"></path>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M24.6 13c-2.8 1.4-3.9 3.7-3 6" fill="none"></path>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" d="M31 45.3c0 5.6 16 2.6 16-14.4 0-16.9-16-23.3-16-15.5v29.9zM31 45.3c0 5.6-16 2.6-16-14.4 0-16.9 16-23.3 16-15.5v29.9z" fill="none"></path>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M20.2 35.2c5.3-1.3 4.3 3 10.8 3M20.7 35.1c3.9-.7 3.9-1.5 6.5-2M15.6 25.4c-.6 3.5 2.4 5.3 4.4 4.9 2-.4 3.5-1.1 4.6-1.1" fill="none"></path>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M28.3 25.1c-2.6-1.9-2.8-5.3-1.5-7.8M31 31.1c0-5.1-5-9.8-10-6.3" fill="none"></path>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M21.9 40c3.1 1.4 2.8 2.7 5.6 3.7" fill="none"></path>
+            <g stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" fill="none">
+                <path d="M36.1 22.4c-.3-1.8.9-3.1 2.5-3.4M35.9 17.3c-.4 2 .1 3.8.2 5.2"></path>
+            </g>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M44.7 30c-2.2-1.4-4.2-3.4-3.9-6.3" fill="none"></path>
+        </symbol>
+        <symbol id="icon-jo" viewbox="0 0 60 60">
+            <title>
+                jo
+            </title>
+            <g stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <circle cx="44.9" cy="28.1" r="6.1"></circle>
+                <circle cx="37.6" cy="33.9" r="6.1"></circle>
+                <circle cx="23" cy="33.9" r="6.1"></circle>
+                <circle cx="30.3" cy="28.1" r="6.1"></circle>
+                <circle cx="15.7" cy="28.1" r="6.1"></circle>
+            </g>
+        </symbol>
+        <symbol id="icon-next" viewbox="0 0 60 60">
+            <title>
+                next
+            </title>
+            <g fill="#fff">
+                <path d="M15.4 29.6v7.1h-2.6v-13.7h2.5l2.9 7.1v-7.1h2.6v13.7h-2.5l-2.9-7.1zM22.6 23h6.5v2.7h-3.7v2.6h3.5v2.6h-3.5v3.1h3.7v2.7h-6.5v-13.7zM30.9 23h3l1 5.9 1-5.9h3l-1.6 6.8 1.6 6.8h-3l-1.1-6-1.1 6h-3l1.6-6.8-1.4-6.8zM44.9 25.9v10.8h-2.9v-10.8h-2v-2.9h6.9v2.9h-2z"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-portrait" viewbox="0 0 60 60">
+            <title>
+                portrait
+            </title>
+            <path stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M46 30c0-2.4 2-1.7 2-4s-2-1.7-2-4v-7c1-.5 1.8-3.2 0-5s-5.2-1.2-6.1.7c-2.3.4-2.3-1.5-4.7-1.5s-2.9 1.8-5.2 1.8-2.9-1.8-5.2-1.8-2.4 1.9-4.7 1.5c-.9-1.9-4.3-2.5-6.1-.7s-1.2 4.5 0 5v7l-2 4s2 1.6 2 4-2 1.7-2 3.9 2 1.7 2 4v7c-1 .5-1.8 3.2 0 5s5.2 1.2 6.1-.7c2.3-.4 2.3 1.5 4.7 1.5s2.9-1.8 5.2-1.8 2.9 1.8 5.2 1.8 2.4-1.9 4.7-1.5c.9 1.9 4.3 2.5 6.1.7s1.2-4.5 0-5v-7l2-4s-2-1.5-2-3.9z" fill="none"></path>
+            <g stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <path d="M28 24v8h3M22 25h6M32 25h5M24 36c1.8 1.3 3.5 2 6 2 2.3 0 3.3-.9 5-2"></path>
+            </g>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M18 15h24v30h-24z"></path>
+        </symbol>
+        <symbol id="icon-radio" viewbox="0 0 60 60">
+            <title>
+                radio
+            </title>
+            <g stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <path d="M20 22h30v20h-30z"></path>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M29 15.3l17.9 6.7"></path>
+                <circle cx="30" cy="32" r="4.5"></circle>
+                <path d="M38 28h7M38 32h7M38 36h7M7 32h5M11.6 23.2l3.6 3.6M15.2 37.2l-3.6 3.6"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-son" viewbox="0 0 60 60">
+            <title>
+                son
+            </title>
+            <g stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <path d="M22 26h6v8h-6zM28 34l7 5v-18l-7 5z"></path>
+                <circle cx="30" cy="30" r="18"></circle>
+            </g>
+        </symbol>
+        <symbol id="icon-alerte" viewbox="0 0 60 60">
+            <title>
+                alerte
+            </title>
+            <path fill="#fff" d="M25.9 42l2.3-10h-5.3l4.8-14h9.6l-6 10h6.6z"></path>
+        </symbol>
+        <symbol id="icon-top-100" viewbox="0 0 60 60">
+            <title>
+                top-100
+            </title>
+            <g fill="#fff">
+                <path d="M27.2 36.7v-10.4l-1.7.8v-2.7l3-1.4h1.6v13.7h-2.9zM36.4 36.8c-2.9 0-4.1-1.2-4.1-4.4v-5.2c0-3 1.2-4.3 4.1-4.3 2.9 0 4.1 1.3 4.1 4.3v5.2c0 3.1-1.2 4.4-4.1 4.4zm0-11.2c-.9 0-1.3.4-1.3 2v4.6c0 1.6.4 2 1.3 2s1.3-.4 1.3-2v-4.6c0-1.6-.4-2-1.3-2zM46.4 36.8c-2.9 0-4.1-1.2-4.1-4.4v-5.2c0-3 1.2-4.3 4.1-4.3 2.9 0 4.1 1.3 4.1 4.3v5.2c.1 3.1-1.2 4.4-4.1 4.4zm0-11.2c-.9 0-1.3.4-1.3 2v4.6c0 1.6.4 2 1.3 2s1.3-.4 1.3-2v-4.6c0-1.6-.4-2-1.3-2z"></path>
+            </g>
+            <path fill="#fff" d="M22 31l-7-8-7 8h3v5h8v-5z"></path>
+        </symbol>
+        <symbol id="icon-star" viewbox="0 0 20 20">
+            <title>
+                star
+            </title>
+            <path d="M10 2.3l1.9 5.9h6.2l-5 3.6 1.9 5.9-5-3.6-5 3.6 1.9-5.9-5-3.6h6.2z"></path>
+        </symbol>
+        <symbol id="icon-une" viewbox="0 0 60 60">
+            <title>
+                une
+            </title>
+            <path fill="#fff" d="M23.5 16.5l6.5-2.5 6.5 2.5-6.5 2.5z"></path>
+            <path stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none" d="M15 10h30v40h-30zM21 24h18v12h-18zM20 40h9M20 44h9M31 40h9M31 44h9"></path>
+        </symbol>
+        <symbol id="icon-video" viewbox="0 0 60 60">
+            <title>
+                video
+            </title>
+            <path fill="#fff" d="M37.4 30l-11.4-7.9v15.8z"></path>
+            <circle stroke="#fff" stroke-width="2" stroke-miterlimit="10" cx="30.2" cy="30" r="18" fill="none"></circle>
+        </symbol>
+        <symbol id="icon-scroll" viewbox="0 0 16 26">
+            <title>
+                scroll
+            </title>
+            <path stroke="#282828" stroke-width="2" stroke-miterlimit="10" d="M8 24.5c-3.6 0-6.5-2.9-6.5-6.5v-10c0-3.6 2.9-6.5 6.5-6.5s6.5 2.9 6.5 6.5v10c0 3.6-2.9 6.5-6.5 6.5z" fill="none"></path>
+            <circle fill="#2D2D2D" cx="8" cy="6.9" r="1.5"></circle>
+        </symbol>
+        <symbol id="icon-politiques" viewbox="0 0 60 60">
+            <title>
+                politiques
+            </title>
+            <g transform="translate(0.2,-104.59999)">
+                <rect style="fill:none;stroke-width:0.36275697" height="60" width="60" y="104.59999" x="-0.2"></rect>
+                <g transform="matrix(0.36275697,0,0,0.36275697,-0.12744861,104.8902)">
+                    <path style="fill:#ffffff" d="m 93.2,64.4 c -4.1,0 -9.4,-4.5 -10.5,-5.5 L 81.8,58.1 82.2,48 c -2.9,-3.7 -4.6,-8.2 -4.6,-12.7 0,-10.2 7,-18.5 15.5,-18.5 8.5,0 15.5,8.3 15.5,18.5 0,4.5 -1.7,9 -4.6,12.7 l 0.4,10.1 -0.9,0.8 c -0.9,0.9 -6.2,5.5 -10.3,5.5 z m -6.3,-8.5 c 2.1,1.6 4.9,3.5 6.3,3.5 1.3,0 4.2,-1.8 6.2,-3.5 L 99,46.3 99.7,45.5 c 2.5,-2.9 4,-6.6 4,-10.2 0,-7.5 -4.7,-13.5 -10.5,-13.5 -5.8,0 -10.5,6.1 -10.5,13.5 0,3.6 1.5,7.3 4,10.2 l 0.7,0.8 z"></path>
+                    <path style="fill:#ffffff" d="m 104.4,59 c 4.6,1.2 10.7,2.9 13.1,3.7 l 0.2,0.1 c 1,0.3 2.3,0.8 2.6,1.1 0.1,0.1 0.7,0.9 0.9,4.3 0.3,5.6 1.3,21.7 1.8,30.2 H 98.1 L 104.4,59 M 82,59 88.1,98.3 H 63.5 C 64,89.9 65,73.8 65.3,68.1 c 0.2,-3.5 0.8,-4.2 0.9,-4.3 0.2,-0.3 1.5,-0.7 2.6,-1.1 L 69,62.6 C 71.3,62 77.4,60.3 82,59 m 18.3,-6.2 -7.2,45.4 -7,-45.4 c 0,0 -14.7,3.9 -18.8,5.3 -4.1,1.4 -6.5,2.1 -7,9.9 -0.5,7.8 -2.1,35.5 -2.1,35.5 h 34.9 35.1 c 0,0 -1.7,-27.7 -2.1,-35.5 -0.5,-7.8 -2.8,-8.5 -7,-9.9 -4.1,-1.5 -18.8,-5.3 -18.8,-5.3 z"></path>
+                    <path style="fill:#ffffff" d="M 126.8,144 H 35.2 V 114.5 L 20.8,98.8 h 120.8 l -14.8,15.8 z m -86.6,-5 h 81.6 v -26.5 l 8.2,-8.8 H 32.1 l 8.1,8.8 z"></path>
+                    <rect style="fill:#ffffff" height="20.6" width="5" y="80.699997" x="27"></rect>
+                    <path style="fill:#ffffff" d="m 21.6,88.3 c -0.7,0 -1.4,-0.3 -1.9,-1 -0.7,-1 -0.4,-2.4 0.6,-3.1 L 36.7,73 c 1,-0.7 2.4,-0.4 3.1,0.6 0.7,1 0.4,2.4 -0.6,3.1 L 22.9,87.9 c -0.4,0.2 -0.8,0.4 -1.3,0.4 z"></path>
+                    <circle style="fill:#ffffff" r="6.0999999" cy="73.199997" cx="40.599998"></circle>
+                </g>
+            </g>
+        </symbol>
+        <symbol id="icon-food" viewbox="0 0 60 60">
+            <title>
+                food
+            </title>
+            <g transform="matrix(0.3,0,0,0.3,0.003,0)">
+                <polyline style="fill:none" points="-0.01 200 -0.01 0 199.99 0 199.99 200"></polyline>
+                <path style="fill:#ffffff" d="M 68.55,79.13 25.61,37.31 21.05,42 l 38,37.14 H 41 v 3.26 c 0,48.1 18.31,63.11 24.64,66.86 v 11.6 h 69.57 v -11.58 c 6.39,-3.69 24.64,-18.5 24.64,-66.88 v -3.27 z m 62.25,65.07 -2.13,0.79 v 9.32 H 72.19 v -7 -2.21 l -2,-0.83 C 69.97,144.18 48.55,134.81 47.64,85.71 h 105.7 c -0.97,49.4 -22.34,58.41 -22.54,58.49 z"></path>
+                <path style="fill:#ffffff" d="m 103,69.23 a 3.65,3.65 0 0 1 -3.09,-0.44 2.7,2.7 0 0 1 -0.62,-4.11 c 5.23,-6 2.82,-10.12 -0.51,-15.78 -3,-5.12 -6.76,-11.49 -2.85,-19.5 a 3.53,3.53 0 0 1 4.39,-1.56 2.82,2.82 0 0 1 1.75,3.86 c -2.67,5.45 -0.21,9.63 2.64,14.47 3.43,5.82 7.69,13.06 -0.12,22.06 a 3.38,3.38 0 0 1 -1.59,1"></path>
+                <path style="fill:#ffffff" d="m 120.73,69.21 a 3.38,3.38 0 0 0 1.53,-1.09 c 4.25,-5.5 5.18,-11.25 1.23,-17.57 -2.7,-4.31 -1.75,-6.21 -1.27,-8.39 0.48,-2.18 -0.23,-3.21 -2,-3.75 a 3.54,3.54 0 0 0 -4.3,1.8 c 0,0 -2.34,4.62 -0.6,8.93 0.93,2.29 2.48,4 3.22,5.85 1.23,3 1.23,5.93 -1.82,9.88 a 2.71,2.71 0 0 0 0.85,4.08 3.72,3.72 0 0 0 3.12,0.26"></path>
+                <path style="fill:#ffffff" d="m 86.72,69 a 3.39,3.39 0 0 0 1.41,-1.24 c 3.69,-5.91 4,-11.72 -0.52,-17.61 -3.11,-4 -2.36,-6 -2.1,-8.22 0.26,-2.22 -0.55,-3.17 -2.33,-3.54 a 3.54,3.54 0 0 0 -4.09,2.22 c 0,0 -1.88,4.84 0.29,9 1.15,2.18 2.87,3.75 3.79,5.49 1.53,2.91 1.81,5.79 -0.83,10 a 2.71,2.71 0 0 0 1.25,4 3.72,3.72 0 0 0 3.13,0"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-sciences" viewbox="0 0 60 60">
+            <title>
+                sciences
+            </title>
+            <g transform="matrix(3.7795275,0,0,3.7795275,982.69996,-913.79113)">
+                <g transform="matrix(0.09597945,0,0,0.09597945,-259.98684,241.89388)">
+                    <path style="fill:#ffffff" d="m 74.33,34.86 a 6.49,6.49 0 1 1 6.48,-6.48 6.49,6.49 0 0 1 -6.48,6.48 z m 0,-9 a 2.49,2.49 0 1 0 2.48,2.49 2.49,2.49 0 0 0 -2.48,-2.46 z"></path>
+                    <path style="fill:#ffffff" d="m 91.51,25.46 a 7.91,7.91 0 1 1 7.91,-7.91 7.92,7.92 0 0 1 -7.91,7.91 z m 0,-11.82 a 3.91,3.91 0 1 0 3.91,3.91 3.91,3.91 0 0 0 -3.91,-3.91 z"></path>
+                    <path style="fill:#ffffff" d="M 125.5,134.07 97.2,71.41 V 48.88 c 4,-2.44 3.57,-4.47 3.41,-5.19 -0.69,-2.95 -4.52,-2.95 -6.15,-2.95 H 70.33 c -1.84,0 -5.66,0 -6.33,3 -0.41,1.86 0.76,3.57 3.59,5.19 v 22.5 l -28,62.41 -0.1,0.24 c -1.38,4.1 -1.26,7.19 0.37,9.46 2.63,3.63 7.91,3.62 13.52,3.61 h 59.27 c 5.2,0 10,-0.2 12.47,-3.61 1.64,-2.28 1.76,-5.37 0.38,-9.47 z M 72.89,72.55 V 46 h 19 v 6.07 h -8.8 v 4 h 8.81 v 4.57 h -8.81 v 4 h 8.81 v 4.58 h -8.81 v 4 h 9.13 l 15.48,34.25 H 57.21 Z m 47.94,67.88 c -1,1.43 -5.56,1.42 -9.2,1.41 H 53.37 c -3.63,0 -8.16,0 -9.2,-1.41 -0.51,-0.72 -0.4,-2.38 0.32,-4.55 l 10.34,-23.07 h 55.26 l 10.42,23.07 c 0.72,2.17 0.83,3.83 0.32,4.55 z"></path>
+                </g>
+            </g>
+        </symbol><!-- SOCIAL ICON -->
+        <symbol id="icon-facebook" viewbox="0 0 20 20">
+            <title>
+                Facebook
+            </title>
+            <path d="M5.7 7h1.8v-1.8000000000000003c0-.8 0-2 .6-2.8.6-.7 1.5-1.3 2.9-1.3 2.3 0 3.3.3 3.3.3l-.5 2.7s-.8-.2-1.5-.2-1.3.3-1.3 1v2.1h2.9l-.2 2.7h-2.7v9.2h-3.5v-9.2h-1.8v-2.7z"></path>
+        </symbol>
+        <symbol id="icon-whatsapp" viewbox="15 15 80.000000 80.000000">
+            <title>
+                Whatsapp
+            </title>
+            <g transform="matrix(1.25 0 0 -1.25 0 109.553)">
+                <path d="M58.113 37.793c-.752.412-4.45 2.407-5.143 2.69-.693.28-1.2.428-1.738-.32-.54-.747-2.074-2.418-2.54-2.913-.466-.495-.915-.54-1.667-.128-.752.41-3.192 1.314-6.02 4.033-2.202 2.116-3.646 4.683-4.065 5.467-.42.783-.003 1.183.395 1.55.358.33.8.867 1.2 1.3.4.433.54.747.814 1.25.272.5.16.953-.016 1.343-.178.39-1.57 4.22-2.15 5.777-.58 1.557-1.23 1.326-1.676 1.343-.448.017-.957.1-1.468.12-.51.018-1.348-.142-2.08-.884-.73-.736-2.78-2.516-2.92-6.29-.14-3.77 2.467-7.514 2.83-8.04.365-.524 4.983-8.7 12.658-12.06 7.677-3.36 7.716-2.335 9.125-2.26 1.41.075 4.604 1.685 5.31 3.45.706 1.764.763 3.3.583 3.626-.18.326-.684.538-1.435.95m-14.075-18.17a24.858 24.858 0 0 0-13.75 4.13l-9.604-3.073 3.123 9.28a24.86 24.86 0 0 0-4.76 14.654c0 13.782 11.212 24.993 24.992 24.993 13.78 0 24.992-11.21 24.992-24.994 0-13.78-11.213-24.99-24.994-24.99m0 55.012c-16.58 0-30.02-13.44-30.02-30.022a29.893 29.893 0 0 1 4.307-15.502L12.9 13.008l16.623 5.32a29.897 29.897 0 0 1 14.51-3.733c16.58 0 30.022 13.442 30.022 30.02 0 16.582-13.443 30.023-30.023 30.023" fill-rule="evenodd"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-twitter" viewbox="0 0 20 20">
+            <title>
+                Twitter
+            </title>
+            <path d="M19.5 4.1c-.7.3-1.5.5-2.2.6.8-.5 1.4-1.2 1.7-2.2-.8.4-1.6.8-2.5.9-.7-.8-1.7-1.2-2.8-1.2-2.2 0-3.9 1.7-3.9 3.9 0 .3 0 .6.1.9-3.3-.1-6.2-1.7-8.1-4-.3.6-.5 1.2-.5 2 0 1.3.7 2.5 1.7 3.2-.6 0-1.2-.2-1.7-.5 0 1.9 1.3 3.5 3.1 3.8-.3.1-.7.1-1 .1-.3 0-.5 0-.7-.1.5 1.5 1.9 2.7 3.6 2.7-1.3 1-3 1.7-4.8 1.7-.3 0-.6 0-.9-.1 1.7 1.1 3.8 1.8 6 1.8 7.2 0 11.1-5.9 11.1-11.1v-.5c.6-.4 1.3-1.1 1.8-1.9"></path>
+        </symbol>
+        <symbol id="icon-insta" viewbox="0 0 20 20">
+            <title>
+                insta
+            </title>
+            <path d="M14.6 2.5h-9.2c-1.6 0-2.9 1.3-2.9 2.9v9.3c0 1.6 1.3 2.9 2.9 2.9h9.3c1.6 0 2.9-1.3 2.9-2.9v-9.3c-.1-1.6-1.4-2.9-3-2.9zm.9 1.7h.3v2.5h-2.5v-2.6l2.2.1zm-7.7 4.3c.5-.7 1.3-1.2 2.2-1.2.9 0 1.7.4 2.2 1.1.3.4.5 1 .5 1.5 0 1.5-1.2 2.7-2.7 2.7s-2.7-1.1-2.7-2.6c0-.6.2-1.1.5-1.5zm8.3 6.1c0 .8-.6 1.4-1.4 1.4h-9.3c-.8 0-1.4-.6-1.4-1.4v-6.1h2.3c-.3.4-.4 1-.4 1.5 0 2.3 1.9 4.1 4.1 4.1 2.3 0 4.1-1.9 4.1-4.1 0-.5-.1-1.1-.3-1.5h2.3v6.1z"></path>
+        </symbol>
+        <symbol id="icon-vine" viewbox="0 0 20 20">
+            <title>
+                vine
+            </title>
+            <path d="M17 10c-.4.1-.8.1-1.2.1-2 0-3.6-1.4-3.6-3.9 0-1.2.5-1.8 1.1-1.8.6 0 1 .6 1 1.7 0 .6-.2 1.4-.3 1.8 0 0 .6 1.1 2.3.8.5-.9.7-1.9.7-2.8 0-2.5-1.2-3.9-3.5-3.9-2.4 0-3.7 1.8-3.7 4.2 0 2.4 1.1 4.4 2.9 5.3-.8 1.5-1.7 2.9-2.8 3.9-1.8-2.2-3.5-5.2-4.2-11h-2.7c1.3 9.7 5 12.8 6 13.4.6.3 1 .3 1.6 0 .8-.5 3.2-2.9 4.6-5.7.6 0 1.2-.1 1.9-.2v-1.9z"></path>
+        </symbol>
+        <symbol id="icon-later" viewbox="0 0 16 22">
+            <title>
+                later
+            </title>
+            <path d="M13.5 4.5h-11c0 3.4 2.1 6 5.5 6s5.5-2.6 5.5-6m-3.5 3h-4c-.7 0-1.2-.8-2-2h8c-.8 1.1-1.4 2-2 2"></path>
+            <path d="M.5 18.5h15v2h-15zM.5 1.5h15v2h-15zM2.5 17.5h11c0-3.4-2.1-6-5.5-6s-5.5 2.6-5.5 6m5.5-5c1.5 0 2.2.8 3 2h-6c.8-1.2 1.5-2 3-2"></path>
+            <path d="M9 10.5h-2v1h2z"></path>
+        </symbol>
+        <symbol id="icon-glass" viewbox="0 0 37 22">
+            <title>
+                glass
+            </title>
+            <path d="M27.8 4.5c-3.5 0-6.6 2-8.9 2-2.3 0-5.7-2-9.2-2s-4.2.2-9.2 1v1s2.3.1 2.3 4c0 3.5 3.5 7 7.1 7 3.6 0 7-2.5 7-5.9 0-3.4 2.1-3.1 2.1-3.1s2-.2 2 3c0 4.3 3.4 6 7 6s6.7-3.6 6.7-7.1c0-3.7 1.8-3.9 1.8-3.9v-1c-5-.8-5.2-1-8.7-1m-17.8 11c-2.9 0-5-1.8-5-4 0-2.8.5-3.5 1-4s2-1 4-1c1.8 0 3.5.7 4 1 1 .7 1 2.9 1 4 0 2.2-2.1 4-5 4m18 0c-2.9 0-5-1.8-5-4 0-1.1 0-3.3 1-4 .5-.3 2.2-1 4-1 2 0 3.5.5 4 1s1 1.2 1 4c0 2.2-2.1 4-5 4M9.5 8v1.5c2 0 2.5 1 2.5 2h1.5c0-3-1-3.5-4-3.5M27.5 8v1.5c2 0 2.5 1 2.5 2h1.5c0-3.1-1-3.5-4-3.5"></path>
+        </symbol>
+        <symbol id="icon-mail" viewbox="0 0 21 22">
+            <title>
+                Mail
+            </title>
+            <path d="M14.5 11.5l-4 3-4-3-6 6h20zM.5 6.5v9l5-5zM20.5 15.5v-9l-5 4zM20.5 4.5h-20l10 8z"></path>
+        </symbol>
+        <symbol id="icon-print" viewbox="0 0 27 22">
+            <title>
+                print
+            </title>
+            <path d="M23 6h-19c-1.6 0-3 1.3-3 3v4c0 1.7 1.4 3 3 3h2v-5h15v5h2c1.6 0 3-1.3 3-3v-4c0-1.7-1.4-3-3-3m1 4h-2v-2h2v2zM8 0h11v5h-11zM8 22h11v-10h-11v10zm9-3h-3v-1h3v1zm-6-4h6v1h-6v-1z"></path>
+        </symbol>
+        <symbol id="icon-losange-facebook" viewbox="0 0 116 43">
+            <title>
+                Facebook
+            </title>
+            <path d="M58 .6l-57.3 20.8 57.3 21 57.3-21-57.3-20.8zm1.7 20.9v8h-4v-8h-1v-3h1v-1.5c0-1.3.8-3.3 3.4-3.3h2.6v2.8h-1.8c-.3 0-.2 0-.2.6v1.4h1.9l-.3 3h-1.6z"></path>
+        </symbol>
+        <symbol id="icon-losange-insta" viewbox="0 0 116 43">
+            <title>
+                Instagram
+            </title>
+            <path d="M62.8 21.4c0 2.6-2.1 4.8-4.8 4.8-2.6 0-4.8-2.2-4.8-4.8 0-.6.1-.9.3-1.9h-3.1v7.3c0 .9 1.2 1.7 2.2 1.7h10.7c.9 0 2.2-.7 2.2-1.7v-7.3h-3.1c.2 1 .4 1.3.4 1.9zM58 24.6c1.7 0 3.1-1.4 3.1-3.1 0-.7-.2-1.3-.6-1.8-.6-.8-1.5-1.3-2.5-1.3s-1.9.5-2.5 1.3c-.4.5-.6 1.1-.6 1.8 0 1.7 1.4 3.1 3.1 3.1zM64.5 17.8v-3h-2.8l-.1 3zM58 .6l-57.3 20.8 57.3 21 57.3-21-57.3-20.8zm8.5 26.2c0 1.9-1.3 3.7-3.2 3.7h-10.6c-1.9 0-3.2-1.8-3.2-3.7v-10.6c0-1.9 1.3-3.7 3.2-3.7h10.7c1.9 0 3.2 1.8 3.2 3.7v10.6z"></path>
+        </symbol>
+        <symbol id="icon-losange-twitter" viewbox="0 0 116 43">
+            <title>
+                Twitter
+            </title>
+            <path d="M58 .6l-57.3 20.8 57.3 21 57.3-21-57.3-20.8zm6.5 18c0 4.4-3.4 9.6-9.6 9.6-1.9 0-3.7-.6-5.2-1.5h.8c1.6 0 3-.5 4.2-1.4-1.5 0-2.7-1-3.1-2.3l.6.1c.3 0 .5 0 .7-.1-1.5-.3-2.8-1.7-2.8-3.3 0 .3 1.1.4 1.7.4-.9-.6-1.4-1.6-1.4-2.8 0-.6.2-1.2.5-1.7 1.7 2 4.2 3.4 7 3.5-.1-.2-.1-.5-.1-.8 0-1.9 1.5-3.4 3.4-3.4 1 0 1.8.4 2.5 1.1.8-.2 1.5-.4 2.1-.8-.3.8-.8 1.4-1.5 1.9.7-.1 1.3-.3 1.9-.5-.5.7-1 1.3-1.7 1.7v.3z"></path>
+        </symbol><!-- READER -->
+        <symbol id="icon-reader-calendar" viewbox="0 0 31 40">
+            <title>
+                Calendar
+            </title>
+            <path d="M1 7v26h29v-26h-29zm2 8h7v7h-7v-7zm9 0h7v7h-7v-7zm-9 16v-7h7v7h-7zm9 0v-7h7v7h-7zm16 0h-7v-7h7v7zm0-9h-7v-7h7v7zm-7-9h-18v-4h25v4h-7z"></path>
+        </symbol>
+        <symbol id="icon-reader-download" viewbox="0 0 29 40">
+            <title>
+                download
+            </title>
+            <path d="M10 19.9l5.2 5.2 5.1-5.2-1.4-1.4-2.9 2.7v-19.2h-2v19l-2.6-2.5zM18 8v2h8v21h-23v-21h9v-2h-11v25h27v-25z"></path>
+        </symbol>
+        <symbol id="icon-reader-cross" viewbox="0 0 40 45">
+            <title>
+                cross
+            </title>
+            <path stroke-miterlimit="10" fill="none" d="M35.2 7.3l-30.4 30.4M35.2 37.7l-30.4-30.4"></path>
+        </symbol>
+        <symbol id="icon-reader-zoom-in" viewbox="0 0 43 45">
+            <title>
+                zoom-in
+            </title>
+            <g stroke="#fff" stroke-miterlimit="10" fill="none">
+                <circle stroke-width="1.2" cx="21.5" cy="22.5" r="20"></circle>
+                <path stroke-linecap="round" d="M22.1 16.1v14M29.6 22.6h-15"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-reader-zoom-out" viewbox="0 0 43 45">
+            <title>
+                zoom-out
+            </title>
+            <g stroke="#fff" stroke-miterlimit="10" fill="none">
+                <circle stroke-width="1.2" cx="21.5" cy="22.5" r="20"></circle>
+                <path stroke-linecap="round" d="M29.6 22.6h-15"></path>
+            </g>
+        </symbol><!-- READER -->
+        <symbol id="icon-viewer-previous" viewbox="0 0 20.7 40.8">
+            <title>
+                previous
+            </title>
+            <path fill="#878787" d="M.4.4l20 20"></path>
+            <path stroke="#fff" stroke-miterlimit="10" d="M.4.4l20 20" fill="none"></path>
+            <path fill="#878787" d="M20.4 20.4l-20 20"></path>
+            <path stroke="#fff" stroke-miterlimit="10" d="M20.4 20.4l-20 20" fill="none"></path>
+        </symbol>
+        <symbol id="icon-viewer-next" viewbox="0 0 20.7 40.8">
+            <title>
+                next
+            </title>
+            <path fill="#878787" d="M20.4 40.4l-20-20"></path>
+            <path stroke="#fff" stroke-miterlimit="10" d="M20.4 40.4l-20-20" fill="none"></path>
+            <path fill="#878787" d="M.4 20.4l20-20"></path>
+            <path stroke="#fff" stroke-miterlimit="10" d="M.4 20.4l20-20" fill="none"></path>
+        </symbol><!-- EBOOK -->
+        <symbol id="icon-truck" viewbox="0 0 29 21">
+            <title>
+                truck
+            </title>
+            <g stroke="#000" stroke-miterlimit="10" fill="none">
+                <circle stroke-width="2" stroke-linecap="round" cx="6.6" cy="16.3" r="2.8"></circle>
+                <path stroke-width="1.5" stroke-linejoin="round" d="M24.1 7.3l-2.1-5.6h-20.3v14h2.2c.3-1.2 1.4-2.1 2.7-2.1s2.4.9 2.7 2.1h10c.3-1.2 1.4-2.1 2.7-2.1 1.3 0 2.4.9 2.7 2.1h2.5v-6.3l-3.1-2.1z"></path>
+                <circle stroke-width="2" stroke-linecap="round" cx="22" cy="16.3" r="2.8"></circle>
+                <path stroke-width="2" stroke-linejoin="round" d="M26.2 8.7h-10v-4h7"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-visa" viewbox="0 0 27 20">
+            <title>
+                visa
+            </title>
+            <g fill-rule="evenodd" clip-rule="evenodd">
+                <path fill="#F6A90F" d="M2.8 17.9c5.1-2.2 12.3-4.2 21.8-2.2l.1-2.4c-10-1.1-17.2 2.1-21.9 4.4v.2z"></path>
+                <path fill="#005495" d="M8.1 11.6l2.3-7.3h1.9l-2.2 7.3zM7.3 4.3l-1.8 3.1c-.5.8-.7 1.2-.9 1.7 0-.6-.1-1.4-.1-1.9l-.2-2.9h-3.3v.2c.9 0 1.4.4 1.5 1.3l.6 5.8h2l4.1-7.3h-1.9zM22.6 11.6l-.1-1.1h-2.5l-.5 1.1h-2.1l3.9-7.3h2.7l.7 7.3h-2.1zm-.2-4.4v-1.7c-.1.4-.6 1.5-.9 2l-.7 1.6h1.7l-.1-1.9zM14.4 11.8c-1.4 0-2.3-.4-3-.8l.9-1.4c.6.3 1.1.7 2.1.7.3 0 .7-.1.9-.4.3-.5-.1-.7-.8-1.2l-.4-.2c-1.1-.9-1.6-1.7-1.1-2.9.3-.8 1.3-1.5 2.8-1.5 1 0 2 .4 2.6.9l-1.1 1.3c-.6-.4-1-.7-1.5-.7-.4 0-.7.2-.8.4-.3.4 0 .6.6 1l.4.3c1.4.9 1.7 1.8 1.4 2.7-.6 1.4-1.8 1.8-3 1.8M25.2 5.4h-.2v-.8h.3c.2 0 .3.1.3.2 0 .2-.1.2-.2.2l.2.3h-.1l-.2-.3h-.1v.4zm.1-.5c.1 0 .2 0 .2-.1s-.1-.1-.2-.1h-.2v.2h.2zm0 .8c-.4 0-.7-.3-.7-.7 0-.4.3-.7.7-.7.4 0 .7.2.7.7 0 .4-.3.7-.7.7m0-1.3c-.3 0-.6.2-.6.6 0 .3.2.6.6.6.3 0 .5-.2.5-.6.1-.4-.2-.6-.5-.6"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-mastercard" viewbox="0 0 26 20">
+            <title>
+                mastercard
+            </title>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#F8B31E" d="M18 17.4h1.1l.4-.1.3-.1.4-.1.3-.1.4-.1.3-.2.3-.2.3-.1.3-.2.3-.2.3-.3.3-.2.2-.2.3-.3.2-.3.2-.3.3-.2.2-.3.1-.4.2-.3.1-.3.2-.4.1-.3.1-.4.1-.3v-.4l.1-.4v-1.5l-.1-.3v-.4l-.1-.4-.1-.3-.1-.4-.2-.3-.1-.3-.2-.3-.1-.4-.2-.3-.3-.3-.2-.2-.2-.3-.3-.3-.2-.2-.3-.2-.3-.3-.3-.2-.3-.2-.3-.1-.3-.2-.3-.2-.4-.1-.3-.1-.4-.1-.3-.1-.4-.1h-2.3l-.3.1-.4.1-.3.1-.4.1-.3.1-.3.2-.4.2-.3.1-.3.2-.3.2-.2.3-.3.2-.3.2-.2.3-.3.3-.2.2-.2.3-.2.3-.2.4-.1.3-.2.3-.1.3-.1.4-.1.3-.1.4-.1.4v.7l-.1.4.1.4v.7l.1.4.1.3.1.4.1.3.1.4.2.3.1.3.2.4.2.3.2.2.2.3.3.3.2.3.3.2.3.2.2.3.3.2.3.2.3.1.4.2.3.2.3.1.4.1.3.1.4.1.3.1h.8z"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#E20520" d="M8 17.4h1.2000000000000002l.3-.1.4-.1.3-.1.4-.1.3-.1.3-.2.4-.2.3-.1.3-.2.3-.2.2-.3.3-.2.3-.2.2-.3.3-.3.2-.3.2-.2.2-.3.2-.4.1-.3.2-.3.1-.4.1-.3.1-.4.1-.3.1-.4v-2.1999999999999997l-.1-.4-.1-.4-.1-.3-.1-.4-.1-.3-.2-.3-.1-.3-.2-.4-.2-.3-.2-.3-.2-.2-.3-.3-.2-.3-.3-.2-.3-.2-.2-.3-.3-.2-.3-.2-.3-.1-.4-.2-.3-.2-.3-.1-.4-.1-.3-.1-.4-.1-.3-.1h-2.3000000000000003l-.4.1-.3.1-.4.1-.3.1-.4.1-.3.2-.3.2-.3.1-.3.2-.3.2-.3.3-.3.2-.2.2-.3.3-.2.3-.3.2-.2.3-.2.3-.1.4-.2.3-.1.3-.2.3-.1.4-.1.3-.1.4v.4l-.1.3v1.5000000000000002l.1.4v.4l.1.3.1.4.1.3.2.4.1.3.2.3.1.4.2.3.2.2.3.3.2.3.3.3.2.2.3.2.3.3.3.2.3.2.3.1.3.2.3.2.4.1.3.1.4.1.3.1.4.1h.7z"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#F8B31E" d="M11.5 6.3h4.6v-.4h-4.3zM11.1 7.2h5v-.4h-4.8zM10.8 8.1h5.3v-.4h-5.2zM11 12.4h5.1v-.4h-5.3zM11.3 13.3h4.8v-.4h-4.9zM11.9 14.2h4.2v-.4h-4.5zM12.6 15.1h3.5v-.4h-3.8zM10.6 9h5.5v-.4h-5.4zM13.9 11.6h2.1v-.5h-2zM14.1 10.7h1.9v-.5h-1.8zM10.5 10.2h.5v.5h-.5z"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M9.5 9.8h-.1v-.1h-.7l-.1.1h-.1v.30000000000000004h.1v.1h.2l.1.1h.1l.1.1h.1v.1h.1l.1.1v.7l-.1.1v.1l-.1.1-.1.1h-.1l-.1.1h-.1l-.1.1h-.9999999999999999l-.1-.1h-.2l.1-.6h.1v.1h.8999999999999999l.1-.1v-.30000000000000004l-.1-.1h-.1l-.1-.1h-.1l-.1-.1h-.1l-.1-.1h-.1l-.1-.1v-.7l.1-.1v-.1l.1-.1.1-.1.1-.1h.30000000000000004l.1-.1h.7999999999999999v.1h.30000000000000004z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M9.5 9.8h-.1v-.1h-.7l-.1.1h-.1v.30000000000000004h.1v.1h.2l.1.1h.1l.1.1h.1v.1h.1l.1.1v.7l-.1.1v.1l-.1.1-.1.1h-.1l-.1.1h-.1l-.1.1h-.9999999999999999l-.1-.1h-.2l.1-.6h.1v.1h.8999999999999999l.1-.1v-.30000000000000004l-.1-.1h-.1l-.1-.1h-.1l-.1-.1h-.1l-.1-.1h-.1l-.1-.1v-.7l.1-.1v-.1l.1-.1.1-.1.1-.1h.30000000000000004l.1-.1h.7999999999999999v.1h.30000000000000004l-.1.6"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M10.1 8.6h.7l-.1.6h.4l-.1.5h-.5l-.2 1.4v.2h.5v.5h-.30000000000000004v.1h-.5l-.1-.1h-.2v-.1h-.1v-.4z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M10.1 8.6h.7l-.1.6h.4l-.1.5h-.5l-.2 1.4v.2h.5v.5h-.30000000000000004v.1h-.5l-.1-.1h-.2v-.1h-.1v-.4l.5-2.7"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M11.6 10.7v.2l.1.1v.1h.1v.1h.1l.1.1h.8999999999999999v-.1h.2l.1-.1-.1.6h-.1v.1h-.30000000000000004l-.1.1h-.6l-.1-.1h-.30000000000000004l-.1-.1h-.1l-.1-.1-.1-.1-.1-.1-.1-.1v-.2l-.1-.1v-.8l.1-.1v-.1l.1-.2v-.1l.1-.1.1-.1.1-.1h.1l.1-.1.1-.1h.2l.2-.1h.4l.1.1h.2l.1.1h.1l.1.1v.1l.1.1.1.1v.8999999999999999l-.1.1h-1.8l.1-.5h1.1v-.30000000000000004l-.1-.1-.1-.1h-.4v.1h-.1v.1h-.1v.2h-.1v.1z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M11.6 10.7v.2l.1.1v.1h.1v.1h.1l.1.1h.8999999999999999v-.1h.2l.1-.1-.1.6h-.1v.1h-.30000000000000004l-.1.1h-.6l-.1-.1h-.30000000000000004l-.1-.1h-.1l-.1-.1-.1-.1-.1-.1-.1-.1v-.2l-.1-.1v-.8l.1-.1v-.1l.1-.2v-.1l.1-.1.1-.1.1-.1h.1l.1-.1.1-.1h.2l.2-.1h.4l.1.1h.2l.1.1h.1l.1.1v.1l.1.1.1.1v.8999999999999999l-.1.1h-1.8l.1-.5h1.1v-.30000000000000004l-.1-.1-.1-.1h-.4v.1h-.1v.1h-.1v.2h-.1v.1l-.1.5"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M17.6 9.3h-.1l-.1-.1h-.8999999999999999l-.1.1h-.1l-.1.1-.1.1v.1l-.1.1v.1l-.1.2v.2l-.1.1v.30000000000000004l.1.1v.1l.1.1v.1h.1l.1.1h.1v.1h.7999999999999999l.1-.1h.1v-.1l-.1.7h-.1v.1h-.30000000000000004l-.1.1h-.5l-.1-.1h-.2l-.1-.1h-.2l-.1-.1-.1-.1-.1-.1v-.1l-.1-.1-.1-.2v-1.0999999999999999l.1-.1v-.2l.1-.1v-.2l.1-.1.1-.1v-.1h.1v-.1h.1v-.1h.1v-.1h.2v-.1h.2l.1-.1h1.0999999999999999l.1.1h.2z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M17.6 9.3h-.1l-.1-.1h-.8999999999999999l-.1.1h-.1l-.1.1-.1.1v.1l-.1.1v.1l-.1.2v.2l-.1.1v.30000000000000004l.1.1v.1l.1.1v.1h.1l.1.1h.1v.1h.7999999999999999l.1-.1h.1v-.1l-.1.7h-.1v.1h-.30000000000000004l-.1.1h-.5l-.1-.1h-.2l-.1-.1h-.2l-.1-.1-.1-.1-.1-.1v-.1l-.1-.1-.1-.2v-1.0999999999999999l.1-.1v-.2l.1-.1v-.2l.1-.1.1-.1v-.1h.1v-.1h.1v-.1h.1v-.1h.2v-.1h.2l.1-.1h1.0999999999999999l.1.1h.2l-.1.7"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M23.8 11.9h-.7v-.3.1h-.1l-.1.1h-.1l-.1.1h-.6000000000000001l-.1-.1h-.1l-.1-.1v-.1l-.1-.1-.1-.1v-.1l-.1-.1v-.7999999999999999l.1-.1v-.2l.1-.1v-.1l.1-.1.1-.1v-.1l.1-.1.1-.1h.1l.1-.1h.1l.1-.1h.6l.1.1h.1l.1.1v.1h.1v.1l.2-1h.7z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M23.8 11.9h-.7v-.3.1h-.1l-.1.1h-.1l-.1.1h-.6000000000000001l-.1-.1h-.1l-.1-.1v-.1l-.1-.1-.1-.1v-.1l-.1-.1v-.7999999999999999l.1-.1v-.2l.1-.1v-.1l.1-.1.1-.1v-.1l.1-.1.1-.1h.1l.1-.1h.1l.1-.1h.6l.1.1h.1l.1.1v.1h.1v.1l.2-1h.7l-.6 3.3"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#F8B31E" d="M22.7 11.3l.1-.1h.2v-.1h.1v-.1l.1-.1v-.1h.1v-.7999999999999999h-.1v-.1h-.1v-.1h-.4v.1h-.1v.1h-.1v.1l-.1.1v.1l-.1.1v.5l.1.1v.1l.1.1h.1z"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M7.2 11.3l-.1.6h-.6v-.30000000000000004h.1-.1l-.1.1-.1.1h-.2v.1h-.6l-.1-.1h-.2v-.1h-.1v-.1l-.1-.1v-.7l.1-.1v-.1h.1v-.1l.1-.1h.1v-.1h.2l.1-.1h.6v-.1h.1l.1.1h.2v-.4h-.2v-.1h-.5l-.1.1h-.5v.1l.1-.6.1-.1h.6v-.1h.30000000000000004l.1.1h.4l.1.1h.1l.1.1.1.1.1.1v.4z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M7.2 11.3l-.1.6h-.6v-.30000000000000004h.1-.1l-.1.1-.1.1h-.2v.1h-.6l-.1-.1h-.2v-.1h-.1v-.1l-.1-.1v-.7l.1-.1v-.1h.1v-.1l.1-.1h.1v-.1h.2l.1-.1h.6v-.1h.1l.1.1h.2v-.4h-.2v-.1h-.5l-.1.1h-.5v.1l.1-.6.1-.1h.6v-.1h.30000000000000004l.1.1h.4l.1.1h.1l.1.1.1.1.1.1v.4l-.3 1.3"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#E20520" d="M6.6 10.7v-.1h-.4v.1h-.2l-.1.1h-.1v.1l-.1.1v.2h.1v.1h.5v-.1h.1l.1-.1v-.1h.1v-.30000000000000004z"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M2 11.9h-.7l.5-3.3h1.2l.1 1.9.9-1.9h1.2l-.6 3.3h-.7l.5-2.5h-.1l-1 2.5h-.7l-.1-.1v-1.6l-.1-.4v-.4z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M2 11.9h-.7l.5-3.3h1.2l.1 1.9.9-1.9h1.2l-.6 3.3h-.7l.5-2.5h-.1l-1 2.5h-.7l-.1-.1v-1.6l-.1-.4v-.4l-.4 2.5"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M19.7 11.3l-.1.6h-.6v-.30000000000000004h-.1v.1h-.1v.1h-.2l-.1.1h-.6l-.1-.1h-.1v-.1h-.1v-.1h-.1v-.2h-.1v-.4l.1-.1v-.2l.1-.1.1-.1.1-.1.1-.1h.2v-.1h.7v-.1h.1v.1h.30000000000000004v-.30000000000000004l-.1-.1h-.1l-.1-.1h-.5l-.1.1h-.4v.1h-.1l.2-.6.1-.1h.5l.1-.1h.2l.1.1h.5l.1.1.1.1h.1v.1h.1v.1l.1.1v.30000000000000004zM19.6 11.9l.1-.6-.1.6zM18.9 11.9h.7999999999999999-.6-.1zM19 11.6v.2l-.1.1h.1v-.30000000000000004zM18 11.9h.6v-.1h.2v-.1h.1l.1-.1h-.1l-.1.1-.1.1h-.2l-.1.1h-.4zM17.4 11.1v.30000000000000004l.1.1v.1l.1.1.1.1h.1v.1h.2-.1l-.1-.1h-.1v-.1h-.1v-.1h-.1v-.2l-.1-.1v-.2zM18.3 10.2h-.30000000000000004v.1h-.1l-.1.1h-.1v.1l-.1.1-.1.1v.1l-.1.1v.2l.1-.1v-.2l.1-.1v-.1l.1-.1h.1v-.1h.1l.1-.1h.1l.1-.1h.1zM18.8 10.1h-.2v.1h-.30000000000000004.1.1.1.1.1zM19.2 10.2v-.1h-.4v.1h.4zM19.2 10v.2-.1-.1zM18.9 9.8h.2v.1h.1v.1-.1-.1h-.1l-.1-.1h-.1zM17.8 9.9h.1v-.1h.6l.1-.1h.2l.1.1v-.1h-.6l-.1.1h-.4v.1zM18 9.3l-.2.6.2-.6zM19.1 9.1h-.7v.1h-.30000000000000004l-.1.1h.1v-.1h.9999999999999999zM20 10v-.30000000000000004l-.1-.1v-.1l-.1-.1h-.1v-.1h-.1l-.1-.1h-.2l-.1-.1h-.1v.1h.30000000000000004l.1.1h.1l.1.1h.1v.1l.1.1v.1l.1.1v.1l-.1.1zM19.7 11.3l.3-1.3h-.1l-.2 1.3z"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#F8B31E" d="M19.1 10.7v-.1h-.4l-.1.1h-.2v.1h-.1v.1h-.1v.30000000000000004l.1.1h.5v-.1h.1v-.1h.1v-.1l.1-.1v-.2z"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M24.3 11.5v-.2h.1v-.1h.4l.1.1v.1l.1.1h-.1v-.1h-.1v-.1h-.1l-.1-.1v.1h-.2v.1l-.1.1zM24.5 11.5v-.1h.2v.1h-.1.1v-.1h-.2v.1zM24.3 11.5v.2l.1.1.1.1h.2l.1-.1h.1v-.1l.1-.1v-.1h-.1v.2h-.1v.1h-.30000000000000004l-.1-.1-.1-.1v-.1zM24.5 11.5v.2-.1h.1l.1.1v-.2h-.2z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" d="M24.3 11.5v-.30000000000000004h.7999999999999999v.7h-.7999999999999999v-.4m.2.2l-.1-.3h.1l.1.1h-.1l-.1-.1h-.1v.3m.3-.2v-.1h-.1l.1.1m0 .3h.1v-.4h-.4v.4h.3" fill="none"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M19.9 11.9h.7l.2-1.5h.1v-.2l.1-.1v-.1h.1v-.1h.2v-.1h.4l.1-.6h-.4l-.1.1-.1.1h-.1v.1l-.1.1.1-.4h-.7z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M19.9 11.9h.7l.2-1.5h.1v-.2l.1-.1v-.1h.1v-.1h.2v-.1h.4l.1-.6h-.4l-.1.1-.1.1h-.1v.1l-.1.1.1-.4h-.7l-.5 2.7"></path>
+            <path fill-rule="evenodd" clip-rule="evenodd" fill="#fff" d="M13.2 11.9h.7999999999999999l.2-1.5v-.1l.1-.1v-.1l.1-.1.1-.1h.30000000000000004l.1-.1v.1h.1v-.30000000000000004l.1-.1v-.2h.1v-.1h-.5v.1h-.1v.1h-.1l-.1.1v.1h-.1l.1-.4h-.7z"></path>
+            <path stroke="#fff" stroke-width=".216" stroke-miterlimit="2.613" fill="none" d="M13.2 11.9h.7999999999999999l.2-1.5v-.1l.1-.1v-.1l.1-.1.1-.1h.30000000000000004l.1-.1v.1h.1v-.30000000000000004l.1-.1v-.2h.1v-.1h-.5v.1h-.1v.1h-.1l-.1.1v.1h-.1l.1-.4h-.7l-.5 2.7"></path>
+        </symbol><!-- USER MENU -->
+        <symbol id="icon-user-libe" viewbox="0 0 34 30">
+            <title>
+                user-libe
+            </title>
+            <path d="M17 21.2h-.2l-15.5-5.7c-.2-.1-.4-.3-.4-.6s.2-.5.4-.6l15.5-5.6h.4l15.5 5.6c.2.1.4.3.4.6s-.2.5-.4.6l-15.5 5.7h-.2zm-13.7-6.2l13.7 5 13.7-5-13.7-5-13.7 5z"></path>
+        </symbol>
+        <symbol id="icon-user-doc" viewbox="0 0 30 30">
+            <title>
+                user-doc
+            </title>
+            <path fill="#fff" d="M22 6v18h-14v-18h14m0-1h-14c-.5 0-1 .5-1 1v18c0 .5.5 1 1 1h14c.5 0 1-.5 1-1v-18c0-.5-.5-1-1-1zM10 9h10v1h-10zM10 12h10v1h-10zM10 15h10v1h-10zM10 18h6v1h-6z"></path>
+        </symbol>
+        <symbol id="icon-user-doc-list" viewbox="0 0 30 30">
+            <title>
+                user-doc-list
+            </title>
+            <path d="M22.5 5.5v19h-15v-19h15m0-1h-15c-.5 0-1 .5-1 1v19c0 .5.5 1 1 1h15c.5 0 1-.5 1-1v-19c0-.5-.5-1-1-1zm-13 5h6.8v1h-6.8zm0 5h6.8v1h-6.8zm0 5h6.8v1h-6.8z"></path>
+            <circle cx="19.4" cy="10" r="1.1"></circle>
+            <circle cx="19.4" cy="14.8" r="1.1"></circle>
+            <circle cx="19.4" cy="19.7" r="1.1"></circle>
+        </symbol>
+        <symbol id="icon-user-mail" viewbox="0 0 30 30">
+            <title>
+                user-mail
+            </title>
+            <path fill="#fff" d="M23.6 8.2v13.6h-17.2v-13.6h17.2m0-1h-17.2c-.5 0-1 .5-1 1v13.6c0 .5.5 1 1 1h17.2c.5 0 1-.5 1-1v-13.6c0-.5-.5-1-1-1z"></path>
+            <path stroke="#fff" stroke-linejoin="round" stroke-miterlimit="10" fill="none" d="M6.1 8l8.9 9.3 8.9-9.3M6.1 21.7l7.1-6.5M23.9 21.7l-7.1-6.5"></path>
+        </symbol>
+        <symbol id="icon-user-security" viewbox="0 0 30 30">
+            <title>
+                user-security
+            </title>
+            <path d="M19 13v-4c0-2.2-1.8-4-4-4s-4 1.8-4 4v4h-2v11h12v-11h-2zm-7-4c0-1.6 1.4-3 3-3s3 1.4 3 3v4h-6v-4zm8 14h-10v-9h10v9zM12 16h6v1h-6zM12 19h6v1h-6z"></path>
+        </symbol>
+        <symbol id="icon-user-settings" viewbox="0 0 30 30">
+            <title>
+                user-settings
+            </title>
+            <path stroke="#fff" stroke-linejoin="round" stroke-miterlimit="10" d="M21.5 14.9v-.6l2-1-1-2.3-1.9.5c-.5-.9-1.3-1.6-2.2-2.2l.6-2-2.3-.9-1 1.9h-.6c-.8 0-1.5.1-2.2.4l-1.5-1.7-2 1.4 1 1.9c-.6.7-1.2 1.5-1.5 2.4h-2.1l-.2 2.4 2.1.5c.1 1 .5 1.8 1 2.6l-1.4 1.8 1.8 1.7 1.7-1.2c.7.4 1.5.7 2.3.8l.6 2.2 2.4-.2v-2.2c1-.3 1.8-.7 2.5-1.5l1.9 1 1.3-2-1.7-1.4c.2-.7.4-1.5.4-2.3zm-6.5 2.5c-1.3 0-2.4-1.1-2.4-2.4 0-1.3 1.1-2.4 2.4-2.4 1.3 0 2.4 1.1 2.4 2.4 0 1.3-1.1 2.4-2.4 2.4z" fill="none"></path>
+        </symbol>
+        <symbol id="icon-user-shop" viewbox="0 0 30 30">
+            <title>
+                user-shop
+            </title>
+            <path fill="#fff" d="M21.2 8.7l-.8 7.8h-13.3l-1.6-7.8h15.7m1.1-1h-18l2 9.8h15l1-9.8zM15.3 8.7h1v7.8h-1zM10.3 8.7h1v7.8h-1z"></path>
+            <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" fill="none" d="M25.2 5.6h-2.9l-1.7 14.6h-13.9"></path>
+            <circle fill="#fff" cx="10" cy="23.3" r="1.7"></circle>
+            <circle fill="#fff" cx="17.6" cy="23.3" r="1.7"></circle>
+        </symbol>
+        <symbol id="icon-user-star" viewbox="0 0 30 30">
+            <title>
+                user-star
+            </title>
+            <path fill="#fff" d="M15 9.2l1.3 4h4.2l-3.4 2.5 1.3 4-3.4-2.5-3.4 2.5 1.3-4-3.4-2.5h4.2l1.3-4m0-1c-.4 0-.8.3-1 .7l-1 3.3h-3.5c-.4 0-.8.3-1 .7-.1.4 0 .9.4 1.1l2.8 2.1-1.1 3.3c-.1.4 0 .9.4 1.1.2.1.4.2.6.2s.4-.1.6-.2l2.8-2.1 2.8 2.1c.2.1.4.2.6.2s.4-.1.6-.2c.4-.3.5-.7.4-1.1l-1.1-3.3 2.8-2.1c.4-.3.5-.7.4-1.1-.1-.4-.5-.7-1-.7h-3.5l-1-3.3c-.2-.5-.6-.7-1-.7z"></path>
+            <circle stroke="#fff" stroke-width="1.5" stroke-linejoin="round" stroke-miterlimit="10" cx="15" cy="15" r="12" fill="none"></circle>
+        </symbol><!-- ABO -->
+        <symbol id="icon-abo-ribbon" viewbox="0 0 15 24">
+            <title>
+                Ruban abo
+            </title>
+            <path fill="#fff" d="M13.2 23c-.2 0-.4-.1-.5-.2l-5.2-5.3-5.2 5.3c-.2.2-.5.3-.8.2-.3-.2-.5-.4-.5-.7v-20.5c0-.2.1-.4.2-.5s.4-.3.6-.3h11.5c.4 0 .7.3.7.7v20.5c0 .3-.2.6-.5.7-.1.1-.2.1-.3.1zm-5.7-7.4c.2 0 .4.1.5.2l4.5 4.7v-18l-10-.1v17.9l4.5-4.4c.1-.2.3-.3.5-.3z"></path>
+        </symbol>
+        <symbol id="icon-gold-diamond" viewbox="0 0 40 15">
+            <title>
+                Losange orange
+            </title>
+            <path fill="#F7AF13" d="M.8 7.5l19.2-7 19.2 7-19.2 7-19.2-7"></path>
+        </symbol>
+        <symbol id="icon-list-check" viewbox="0 0 20 15">
+            <title>
+                List check
+            </title>
+            <path fill="#00BC84" d="M1.54 6.758l2.828-2.828 5.657 5.657-2.828 2.828zM5.743 11.051l9.899-9.899 2.828 2.828-9.899 9.899z"></path>
+        </symbol>
+        <symbol id="icon-most-read" viewbox="0 0 94 161">
+            <title>
+                Most read
+            </title>
+            <path fill="#1D1D1B" d="M47 .3l-46.3 80.2 46.3 80.2 46.3-80.2z"></path>
+        </symbol>
+        <symbol id="icon-ptit-libe" viewbox="-269 271 60 60">
+            <title>
+                Ptit Libé
+            </title>
+            <path fill="#fff" d="M-243.5 292.5c.2.6 1.1.8 1.6.5s.7-.9.5-1.5-.9-.7-1.3-.6c-.9.1-1 1.1-.8 1.6zM-238.7 291.5c0 .7.4 1.2.9 1.3 1.1.2 1.6-.5 1.6-1.3s-.6-1.7-1.8-1.4c-.4.2-.7.8-.7 1.4zM-239.4 307.6c-.5 0-3.1 1.9-3.1 2.4 0 .4 2.6 2 3 2.1.4.1 3.5-1.1 3.5-2.1 0-.6-2.6-2.4-3.4-2.4z"></path>
+            <path fill="#fff" d="M-228.8 304.3c-.3-.3-.7-.4-1.2-.4-.3 0-1.6.4-1.7.4 0-.1-1.1-4.1-1.3-5.7v-.2c3.5-1.5 5-4.1 5.1-7.5.1-5.1-3.2-8.5-7.3-9.7-.9-.3-1.7.2-1.8.8-.1.7.3 1.1.9 1.3 2.7.8 5.6 2.9 6.1 6.3s-1.9 6-4.4 6.9c-1.8.6-4.1 1-6.3 1-2.7 0-9.2-1-9.5-6.5-.2-3.6 2.5-6.3 5.4-7.5.6-.2 1.1-.9.8-1.5-.2-.5-1-.6-1.8-.3-3.9 1.6-5.9 4.5-6.5 7.8-.9 6.9 6.3 9.3 6.7 9.4-.3 1-.9 5.1-.9 5.1-.2 0-2-.2-2.1-.2h-.7c-1.8 0-2.2 1.1-2.3 1.8-.1.9-.2 2 .5 2.6.5.5 1.3.5 1.5.5h1.8c.5 0 .9-.1 1.3-.3l-.8 5.7c-.1.7.3 1.4 1 1.5.8.2 2 .3 2.9.4-.1.7-.1 1.6-.2 2.9-.6-.1-1.5-.1-2.1-.1h-.5c-.7 0-1.3.6-1.3 1.3 0 .1-.2 2.1.3 2.8.5 1 4.4.4 5-.2.6-.6.7-1.4.8-2.3.1-1 .3-4 .3-4 .8 0 1.5.1 2.3.1h.8c0 .9 0 2.2.1 3v.6s0-.1 0 0c0 1 .2 1.9.7 2.6.6.7 3.4.4 3.6.3 1.2-.3 1.7-2.5 1.7-2.6.1-.4.1-.7-.1-1.1-.2-.3-.7-.5-1.1-.5 0 0-1.7-.1-2.3-.1 0-.8 0-1.4-.1-2.5.5 0 4.2-.4 4.8-1.5.3-.6-.4-5.1-.5-5.7h.5c.7 0 1.4-.2 1.7-.3 1.2-.3 1-3.8.2-4.4zm-18.9 2.9c-.3.2-2.1 0-2.3-.2s-.2-.6 0-1.1c.2-.5.7-.4 1.1-.4h1.6c0 .5-.3 1.6-.4 1.7zm4.1 14.8c-.5.1-1 .3-1.7.3-.6.1-.6-.1-.6-.6-.1-.4 0-.7 0-1.1 1 0 1.9.1 2.9.3-.2.3 0 1-.6 1.1zm9.6-1.8c-.1.2-.1.5-.2.7-.2.5-.3.5-.8.6-.4 0-.9.1-1.1 0-.5-.2-.4-.7-.4-1.2.8 0 1.7 0 2.5-.1zm1-7c-3.5.8-8 1.2-12.1.1l1.3-13.7c.6.1 2.5.2 3.1.2 1.6 0 3.8-.2 5.8-.7.7 4.5 2 14 1.9 14.1zm3.3-5.8c-.2 0-1.3.5-1.6.2-.1-.1-.3-1.4-.3-1.8.4-.1 1.4-.6 1.9-.2 0 .1.4 1.7 0 1.8z"></path>
+        </symbol>
+        <symbol id="icon-sport" viewbox="0 0 60 60">
+            <title>
+                sport
+            </title>
+            <g stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <circle cx="30" cy="30" r="18"></circle>
+                <path d="M29.6 48c-.1-4.5-1.9-8.9-5.3-12.3-3.4-3.4-7.9-5.2-12.3-5.3m18.4-18.4c.1 4.5 1.9 8.9 5.3 12.3 3.4 3.4 7.9 5.2 12.3 5.3m-30.7-12.3l25.4 25.4m0-25.4l-25.4 25.4"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-blog" viewbox="0 0 60 60">
+            <title>
+                blog
+            </title>
+            <g stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none">
+                <path d="M39 28v21h-24v-32h17M27.035 27.005l16.97-16.97 4.03 4.03-16.97 16.97zm3.965 3.995l-4-4-2 6zm-12 10h7m2 0h7m-16-3h7m2 0h7m-16 6h7m2 0h7"></path>
+            </g>
+        </symbol>
+        <symbol id="icon-voyage" viewbox="0 0 60 60">
+            <title>
+                voyage
+            </title>
+            <path d="M47 45c-2.7-6.6-9.5-11-17-11s-14.3 4.4-17 11h34zm-38 0h38m-25 4h12m16-4h3m-37 4h3m13-29v14h-3v-14m3 0c.8-.5 7.3.3 10 3-1.1-4.7-7.1-8-11-8h-1c-3.9 0-9.9 3.3-11 8 2.7-2.7 9-3.5 10-3m-4-4s-1.7-2.1-6-1.5c2.4-3.5 9.2-3.3 11.6.3m5.4 1.2s1.7-2.1 6-1.5c-2.4-3.5-9.1-3.3-11.6.3" stroke="#fff" stroke-width="2" stroke-miterlimit="10" fill="none"></path>
+        </symbol><!-- 2017 -->
+        <defs>
+            <lineargradient id="Gradient_1" gradientunits="userSpaceOnUse" x1="0" y1="18.5" x2="37" y2="18.5">
+                <stop offset="0" stop-color="#3857C4"></stop>
+                <stop offset="1" stop-color="#E72743"></stop>
+            </lineargradient>
+        </defs>
+        <symbol id="icon-2017" viewbox="0, 0, 37, 37">
+            <g id="Calque_1">
+                <path d="M37,37 L0,37 L0,0 L37,0 z" fill="url(#Gradient_1)"></path>
+                <g>
+                    <path d="M8.312,15.566 C5.879,15.566 4.71,16.56 4.403,18.24 L4.403,18.42 L6.539,18.42 L6.539,18.145 C6.662,17.539 7.231,17.195 8.291,17.195 C9.334,17.195 9.957,17.714 9.957,17.714 L9.957,17.721 C9.957,18.063 9.781,18.162 4.83,19.957 L4.83,21.41 L11.665,21.41 L11.665,20.128 L8.502,20.128 C8.502,20.128 11.775,18.327 11.665,17.589 L11.665,17.524 C11.775,16.26 10.701,15.566 8.312,15.566" fill="#FFFFFF"></path>
+                    <path d="M18.073,18.612 C18.073,19.534 17.516,19.841 16.353,19.841 C15.168,19.841 14.655,19.519 14.655,18.612 L14.655,18.546 C14.655,17.595 15.189,17.302 16.353,17.302 C17.538,17.302 18.073,17.58 18.073,18.546 z M16.154,15.587 C13.63,15.587 12.519,16.609 12.519,18.394 L12.519,18.561 C12.519,20.687 13.666,21.571 16.154,21.571 C18.57,21.571 19.781,20.636 19.781,18.561 L19.781,18.394 C19.781,16.588 18.613,15.587 16.154,15.587" fill="#FFFFFF"></path>
+                    <path d="M20.636,16.618 L20.636,18.437 L21.917,17.758 L21.917,21.41 L24.054,21.41 L24.054,15.429 L22.958,15.429 z" fill="#FFFFFF"></path>
+                    <path d="M25.762,15.429 L25.762,17.137 L30.145,17.137 C28.656,18.209 27.158,20.03 26.791,21.402 L29.103,21.409 C29.419,20.176 30.497,18.635 32.597,16.741 L32.597,15.429 z" fill="#FFFFFF"></path>
+                </g>
+            </g>
+        </symbol></svg> 
+        <script>
+        <![CDATA[
+
+        // Facebook PW
+        var getParameterByName = function(name, url) {
+        if (!url) url = window.location.href;
+        name = name.replace(/[\[\]]/g, '\\$&');
+        var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+            results = regex.exec(url);
+        if (!results) return null;
+        if (!results[2]) return '';
+        return decodeURIComponent(results[2].replace(/\+/g, ' '));
+        }
+
+        var FBRedirect = function() {
+        var search = location.search.substring(1);
+        var hasSurface = getParameterByName('surface')
+        if(hasSurface) {
+                var nxturl = 'https://bolq.liberation.fr/paywall' + document.location.search;
+                document.location.href= nxturl;
+        }
+        };
+        FBRedirect();
+        ]]>
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        var session_cookie = getCookie('djazsession'); var libeUserInfo = { authenticated: false, access_level: "BAS", }; var isPubActive = true; if (session_cookie) { document.write('<script type="text/javascript" src="/session_info/?format=json&confirm=' + escape(session_cookie) + '"></' + 'script>'); };
+        var is_responsive_mobile = (document.documentElement.clientWidth <= 640);
+        var releaseSuffix = "c05ba9975432d75cc66fb3e70859d5b6";
+        //]]>
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        libeUserInfo["cookie_domain"] = '.liberation.Fr';
+        libeUserInfo["softwarer_blocker"] = 1;
+        libeUserInfo["token_host"] = 'token.liberation.fr';
+        var dispayName = (typeof libeUserInfo['displayname'] == 'undefined') ? '' : libeUserInfo['displayname']; var accessLevel = (typeof libeUserInfo['access_level'] == 'undefined') ? 'BAS' : libeUserInfo['access_level']; var isPubActive = !(accessLevel == 'PRE' || accessLevel == 'ESS' || accessLevel == 'MAYDAY'); var bodyClass = ' ' + 'access-' + accessLevel.toLowerCase(); bodyClass += ' ' + (libeUserInfo['authenticated'] ? 'authenticated' : 'unlogged'); document.body.className = document.body.className + bodyClass;
+        // Global api url
+        apiUrl = "https://www.liberation.fr/api/v3/";
+        currentPath = '/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047';
+        flavour = 'desktop';
+        libeSiteUrl = 'https://www.liberation.fr';
+
+        objectId = '1612047'
+
+        // Check kill switch for ads.
+
+        // Recovery
+        if (typeof libeUserInfo !== 'undefined' && libeUserInfo.access_level == 'MAYDAY') { document.body.className = document.body.className + ' recovery-mode'; }
+        //]]>
+        </script>
+        <div role="navigation">
+            <div class="header-fix-nav">
+                <div class="alert-nav red-alert js-alert">
+                    <a href="" class="alert-nav-label js-alert-link"></a>
+                </div>
+                <nav class="main-nav">
+                    <div class="left-nav v-centerer">
+                        <a role="button" class="button menu-nav open v-centered open"><span class="menu-nav-label">Menu</span></a> <a href="https://www.liberation.fr" class="menu-nav-libe-logo v-centered"><img src="https://statics.liberation.fr/newnext/images/logo-libe.svg" height="42" alt="Libération" /></a>
+                    </div>
+                    <div class="subs-label v-centerer js-nav-label"></div>
+                    <div class="right-nav v-centerer">
+                        <a href="" role="button" class="button v-centered init twitter-share"><span class="button-icon"><svg class="icon fill-black" role="img" width="20" height="20">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use></svg></span></a> <a href="" role="button" class="button v-centered init facebook-share"><span class="button-icon"><svg class="icon fill-black" role="img" width="20" height="20">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use></svg></span></a>
+                        <div class="button search-nav v-centered">
+                            <form action="https://www.liberation.fr/recherche/" method="get">
+                                <input type="search" name="q" class="search-nav-input" placeholder="rechercher" /> <button type="submit" class="search-nav-button"><svg class="icon fill-black" role="img" width="21" height="22">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use></svg></button>
+                            </form>
+                        </div><a href="https://www.liberation.fr/direct/" class="button v-centered js-nav-live-button"><span class="button-icon"><svg xmlns="http://www.w3.org/2000/svg" class="icon" width="26" height="22" viewbox="0 0 26 22">
+                        <path class="stroke-anim" stroke="#000" stroke-width="2" stroke-miterlimit="10" d="M15.5 8c.7-1 2-2 4-2 3 0 5 2.1 5 5s-2.1 5-5 5c-3.3 0-5-2.1-6.5-5s-3.2-5-6.5-5c-2.9 0-5 2.1-5 5s2 5 5 5c2 0 3.2-.9 4-2" fill="none"></path></svg></span></a> <a href="https://www.liberation.fr/top100/" role="button" class="button v-centered"><span class="button-icon"><svg class="icon fill-black" role="img" width="26" height="22">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-100"></use></svg></span></a> <a href="http://token.liberation.fr/accounts/login/" role="button" class="button nav-user-button v-centered js-nav-user-button"><span class="button-icon"><svg class="icon fill-black" role="img" width="21" height="22">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-user"></use></svg></span> <span class="button-label js-nav-user-button-name">Connexion</span></a> <a href="http://token.liberation.fr/accounts/offers/" role="button" class="subscribe-button v-centered js-nav-subscribe-button"><span>Abonnement</span></a>
+                    </div>
+                    <div class="title-nav-container">
+                        <div class="title-nav-wrap width-wrap width-padded v-centerer">
+                            <div class="title-nav hide v-centered">
+                                <div class="title-nav-article ellipsis show">
+                                    <div class="share">
+                                        <div class="share-link js-nav-share">
+                                            <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot-vape-wave-6-days-alphonse-president_1612047&amp;t=Screenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6" class="js-share-facebook" rel="nofollow"><svg class="icon share-link-fb" role="img" width="20" height="20">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use></svg></a> <a href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot-vape-wave-6-days-alphonse-president_1612047&amp;text=Screenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6&amp;via=libe&amp;related=libe" class="js-share-twitter" rel="nofollow"><svg class="icon share-link-tw" role="img" width="20" height="20">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use></svg></a>
+                                        </div>
+                                    </div><span class="nav-title js-nav-title">Screenshot&#160;: «Vape Wave», «6&#160;Days», «Alphonse Président»…</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </nav>
+            </div>
+            <div class="menu hide">
+                <div class="menu-container">
+                    <div class="mosaic">
+                        <div class="mosaic-container clearfix">
+                            <ul class="menu-univers">
+                                <li class="menu-univer">
+                                    <a class="menu-univer-item v-centerer active" data-item-target="first-item" href="https://www.liberation.fr/france,11">
+                                    <div class="v-centered">
+                                        <span class="menu-univer-title">France</span>
+                                    </div></a>
+                                </li>
+                                <li class="menu-univer">
+                                    <a class="menu-univer-item v-centerer" data-item-target="second-item" href="https://www.liberation.fr/planete,10">
+                                    <div class="v-centered">
+                                        <span class="menu-univer-title">Planète</span>
+                                    </div></a>
+                                </li>
+                                <li class="menu-univer">
+                                    <a class="menu-univer-item v-centerer" data-item-target="third-item" href="https://www.liberation.fr/debats,18">
+                                    <div class="v-centered">
+                                        <span class="menu-univer-title">Idées</span>
+                                    </div></a>
+                                </li>
+                                <li class="menu-univer">
+                                    <a class="menu-univer-item v-centerer" data-item-target="fourth-item" href="/">
+                                    <div class="v-centered">
+                                        <span class="menu-univer-title">Culture</span>
+                                    </div></a>
+                                </li>
+                                <li class="menu-univer">
+                                    <a class="menu-univer-item v-centerer" data-item-target="fifth-item" href="https://www.liberation.fr/checknews,100893">
+                                    <div class="v-centered">
+                                        <span class="menu-univer-title">Checknews</span>
+                                    </div></a>
+                                </li>
+                            </ul>
+                            <div class="menu-univers-pictures">
+                                <div class="menu-pictures first-item clearfix show">
+                                    <div class="menu-pictures-col-1">
+                                        <a href="https://www.liberation.fr/france/2019/03/01/c-est-important-que-les-agricultures-alternatives-soient-visibles-au-salon_1712334" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1199482-imagappel-agriculture.jpg?modified_at=1551361794&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                «C'est important que les agricultures alternatives soient visibles au Salon»
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 15:20</span>
+                                        </div></a> <a href="https://www.liberation.fr/france/2019/03/01/immobilier-a-paris-le-metre-carre-frole-la-barre-des-10-000-euros_1712329" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1199725-000_17v5u6.jpg?modified_at=1551449721&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Immobilier&#160;: à Paris, le mètre carré frôle la barre des 10&#160;000&#160;euros
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 15:15</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-2">
+                                        <a href="https://www.liberation.fr/france/2019/03/01/air-france-klm-paris-et-la-haye-calment-le-jeu_1712338" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1199678-le-ministre-de-l-economie-bruno-le-maire-d-et-son-homologue-wopke-hoekstra-g-lors-d-une-conference-d.jpg?modified_at=1551444312&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Air France-KLM&#160;: Paris et La&#160;Haye calment le jeu
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 13:16</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-2 menu-pictures-last-col">
+                                        <a href="https://www.liberation.fr/france/2019/03/01/ligue-du-lol-deux-salaries-licencies-aux-inrocks_1712320" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1169564-logo-a-chaud.png?modified_at=1551434128&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Ligue du LOL : deux salariés licenciés aux «Inrocks»
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 10:55</span>
+                                        </div></a>
+                                    </div>
+                                </div>
+                                <div class="menu-pictures second-item clearfix">
+                                    <div class="menu-pictures-col-2">
+                                        <a href="https://www.liberation.fr/planete/2019/03/01/fespaco-des-actrices-lancent-une-petition-contre-un-realisateur-burkinabe_1712360" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1199722-000_1e1213.jpg?modified_at=1551448366&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Fespaco&#160;: des actrices lancent une pétition contre un réalisateur burkinabè
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 15:17</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-1">
+                                        <a href="https://www.liberation.fr/planete/2019/03/01/vonhier-un-hashtag-ou-debattre-de-l-obsession-des-allemands-pour-les-origines_1712171" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1199676-outrerhin.jpg?modified_at=1551433451&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                #VonHier, un hashtag où débattre de l'obsession des Allemands pour les origines
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 10:44</span>
+                                        </div></a> <a href="https://www.liberation.fr/planete/2019/02/28/proces-nemmouche-defense-et-indecence_1712248" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1199577-prodlibe-2019-0257-proces-nemmouche-a-bruxelles.jpg?modified_at=1551383309&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Procès Nemmouche&#160;: défense et indécence
+                                            </p><span class="menu-picture-desc-authors">28 février 2019 à 20:36</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-2 menu-pictures-last-col">
+                                        <a href="https://www.liberation.fr/planete/2019/02/28/triple-inculpation-imminente-pour-un-roi-bibi-toujours-dans-le-deni_1712244" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1199581-netanyahu-and-wife-sara-attend-the-mimona-ceremony-at-the-israeli-town-of-or-akiva.jpg?modified_at=1551383141&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Triple inculpation imminente pour un «roi Bibi» toujours dans le déni
+                                            </p><span class="menu-picture-desc-authors">28 février 2019 à 20:36</span>
+                                        </div></a>
+                                    </div>
+                                </div>
+                                <div class="menu-pictures third-item clearfix">
+                                    <div class="menu-pictures-col-2">
+                                        <a href="/debats/2019/03/01/quand-le-genre-et-la-race-divisent-le-milieu-universitaire_1712336" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1199702-mouvement.jpg?modified_at=1551439556&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Quand le genre et la race divisent le milieu universitaire
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 12:26</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-2">
+                                        <a href="https://www.liberation.fr/debats/2019/02/28/l-anarchisme-convivial-d-illich-seduit-ceux-qui-veulent-vivre-leur-autonomie-face-aux-institutions_1712214" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1199543-ivan-illich.jpg?modified_at=1551374904&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                «L’anarchisme convivial d’Illich&#160;séduit ceux qui&#160;veulent vivre leur&#160;autonomie face aux institutions»
+                                            </p><span class="menu-picture-desc-authors">28 février 2019 à 18:06</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-1 menu-pictures-last-col">
+                                        <a href="https://www.liberation.fr/debats/2019/02/28/quand-le-genre-et-la-race-divisent-le-milieu-universitaire_1712211" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1199674-mouvement.jpg?modified_at=1551432871&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Quand le genre et la&#160;race&#160;divisent le&#160;milieu universitaire
+                                            </p><span class="menu-picture-desc-authors">28 février 2019 à 17:56</span>
+                                        </div></a> <a href="https://www.liberation.fr/debats/2019/02/28/oscars-le-black-le-green-et-miss-daisy-ii_1712209" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1198527-oscars-2019.jpg?modified_at=1551086117&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Oscars : le black, le&#160;green et «Miss&#160;Daisy&#160;II»
+                                            </p><span class="menu-picture-desc-authors">28 février 2019 à 17:56</span>
+                                        </div></a>
+                                    </div>
+                                </div>
+                                <div class="menu-pictures fourth-item clearfix">
+                                    <div class="menu-pictures-col-1">
+                                        <a href="/musique/2019/03/01/de-little-simz-a-sakamoto-cinq-sons-de-sortie-ce-vendredi_1711753" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1192248-1139650-infographie-illustration-disques-dans-les-bacs.jpg?modified_at=1551369474&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                De Little Simz à Sakamoto, cinq sons de sortie ce vendredi
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 06:43</span>
+                                        </div></a> <a href="/culture/2019/03/01/fashion-week-au-petit-trot_1712148" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1199621-prodlibe-pacorabane1.jpg?modified_at=1551393234&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Fashion Week&#160;: au petit trot
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 06:14</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-2">
+                                        <a href="/theatre/2019/02/28/eins-zwei-drei-le-clown-du-spectacle_1712205" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1199527-martin-zimmermann_einszweidrei_photo1_nelly_rodriguezjpg.jpg?modified_at=1551376407&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                «Eins Zwei Drei», le clown du spectacle
+                                            </p><span class="menu-picture-desc-authors">28 février 2019 à 18:46</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-2 menu-pictures-last-col">
+                                        <a href="/theatre/2019/02/28/direction-d-operas-prise-de-tetes-a-paris-et-lyon_1712204" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1199528-palais-garnier-1-c-jean-pierre-delagarde-opera-national-de-parisjpg.jpg?modified_at=1551376301&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Direction d’opéras&#160;: prise de têtes à Paris et Lyon
+                                            </p><span class="menu-picture-desc-authors">28 février 2019 à 18:46</span>
+                                        </div></a>
+                                    </div>
+                                </div>
+                                <div class="menu-pictures fifth-item clearfix">
+                                    <div class="menu-pictures-col-1">
+                                        <a href="https://www.liberation.fr/checknews/2019/03/01/le-colonialisme-a-t-il-ete-presente-comme-une-oeuvre-civilisatrice-a-l-ecole-publique_1712332" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1185761--.jpg?modified_at=1547122257&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Le colonialisme a-t-il été présenté comme une «œuvre civilisatrice» à l'école publique ?
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 13:38</span>
+                                        </div></a> <a href="https://www.liberation.fr/checknews/2019/03/01/l-euro-a-t-il-vraiment-fait-perdre-56-000-a-chaque-francais_1712170" class="menu-picture" style="background-image: url(https://medias.liberation.fr/photo/1199693-cep4.jpg?modified_at=1551436916&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                L'Euro a-t-il vraiment fait perdre 56 000€ à chaque Français?
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 12:54</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-2">
+                                        <a href="https://www.liberation.fr/checknews/2019/03/01/les-animaux-exposes-au-salon-de-l-agriculture-seront-ils-directement-envoyes-a-l-abattoir_1712212" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1199451-checknews_prodlibe-2019-0337-salon-de-l-agriculture-2019.jpg?modified_at=1551356738&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Les animaux exposés au salon de l'Agriculture seront-ils directement envoyés à l'abattoir&#160;?
+                                            </p><span class="menu-picture-desc-authors">1 mars 2019 à 12:45</span>
+                                        </div></a>
+                                    </div>
+                                    <div class="menu-pictures-col-2 menu-pictures-last-col">
+                                        <a href="https://www.liberation.fr/checknews/2019/02/28/si-un-depute-est-elu-au-parlement-europeen-organise-t-on-une-nouvelle-election_1707531" class="menu-picture menu-high-picture" style="background-image: url(https://medias.liberation.fr/photo/1193398-checknews.jpg?modified_at=1549392233&amp;amp;ratio_x=03&amp;amp;ratio_y=02&amp;amp;width=580);">
+                                        <div class="menu-picture-desc">
+                                            <p>
+                                                Si un député est élu au Parlement européen, organise-t-on une nouvelle élection ?
+                                            </p><span class="menu-picture-desc-authors">28 février 2019 à 17:44</span>
+                                        </div></a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="menu-rubric clearfix">
+                        <ul class="menu-rubric-bloc">
+                            <li>
+                                <a href="https://www.liberation.fr/liseuse/publication/01-03-2019/" class="menu-rubric-link menu-rubric-direct"><span>Le journal du jour</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/direct/" class="menu-rubric-link menu-rubric-live"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-live"></use></svg> <span>Le direct</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/libe-labo-data-nouveaux-formats,100538" class="menu-rubric-link menu-rubric-data"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-data"></use></svg> <span>Libé Labo</span></a>
+                            </li>
+                            <li>
+                                <a href="/food,100293" class="menu-rubric-link menu-rubric-food"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-food"></use></svg> <span>Food</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/photographie,99965" class="menu-rubric-link menu-rubric-diapo"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-diapo"></use></svg> <span>Photo</span></a>
+                            </li>
+                            <li>
+                                <a href="http://www.leptitlibe.fr" class="menu-rubric-link menu-rubric-ptitlibe"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-ptit-libe"></use></svg> <span>Le P'tit Libé</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/politiques,100666" class="menu-rubric-link menu-rubric-politiques"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-politiques"></use></svg> <span>Politiques</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/portrait,67" class="menu-rubric-link menu-rubric-portrait"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-portrait"></use></svg> <span>Portrait</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/sports,14" class="menu-rubric-link menu-rubric-sport"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-sport"></use></svg> <span>Sports</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/voyages,55" class="menu-rubric-link menu-rubric-voyage"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-voyage"></use></svg> <span>Voyages</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/blogs,26" class="menu-rubric-link menu-rubric-blogs"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-blog"></use></svg> <span>Blogs</span></a>
+                            </li>
+                            <li>
+                                <a href="https://www.liberation.fr/sciences,90" class="menu-rubric-link menu-rubric-sciences"><svg class="icon" role="img" width="60" height="60">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-sciences"></use></svg> <span>Sciences</span></a>
+                            </li>
+                        </ul>
+                        <div class="menu-link-bloc-subscription">
+                            <div class="menu-link-bloc-subscription-title">
+                                <div class="bloc-subscription-link-title">
+                                    <a href="http://token.liberation.fr/accounts/offers/">Abonnement</a>
+                                </div><a href="/offre-numerique/" class="menu-link-bloc-title">100% numérique<br />
+                                <span class="small-link-title"><span class="yellow-title">8€ par mois sans engagement</span></span></a> <a href="/offre-integrale/" class="menu-link-bloc-title">Formule Intégrale<br />
+                                <span class="small-link-title"><span class="yellow-title">Libération en version papier et numérique</span></span></a>
+                            </div>
+                        </div>
+                        <div class="menu-link-bloc-event">
+                            <div class="menu-link-bloc-event-title">
+                                <div class="bloc-event-link-title">
+                                    <a href="https://www.liberation.fr/evenements/">Èvénements</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="menu-link-bloc-store">
+                            <div class="menu-link-bloc-store-title">
+                                <div class="bloc-store-link-title">
+                                    <a href="http://boutique.liberation.fr/">La Boutique</a>
+                                </div><a href="http://boutique.liberation.fr/collections/unes" class="menu-link-bloc-title">Unes en affiches<br />
+                                <span class="small-link-title"><span class="green-title">Les unes cultes en tirage photo</span></span></a> <a href="http://boutique.liberation.fr/collections/all" class="menu-link-bloc-title">Relire Libé<br />
+                                <span class="small-link-title"><span class="green-title">Commander des anciens numéros</span></span></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <footer class="footer-menu clearfix">
+                    <div class="footer-social-links">
+                        <a href="/" role="button" class="button v-centered init facebook-share"><span class="button-icon"><svg class="icon fill-black" role="img" width="20" height="20">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use></svg></span></a> <a href="/" role="button" class="button v-centered init twitter-share"><span class="button-icon"><svg class="icon fill-black" role="img" width="20" height="20">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use></svg></span></a>
+                    </div>
+                    <div class="footer-newsletter">
+                        <span class="newsletter-title-bloc">newsletter</span>
+                        <form class="newsletter-inscription">
+                            <input type="email" class="input-email newsletter-bar" value="" placeholder="email" /> <button class="newsletter-bar-submit" onclick="return validForm(this, 'newsletter-form');">ok</button>
+                        </form>
+                    </div>
+                    <ul class="footer-menu-links clearfix">
+                        <li class="footer-menu-link">
+                            <a href="https://liberation.zendesk.com/hc/fr" class="link-footer">FAQ</a>
+                        </li>
+                        <li class="footer-menu-link">
+                            <a href="/cgvu/#mentions-legales" class="link-footer">La rédaction</a>
+                        </li>
+                        <li class="footer-menu-link">
+                            <a href="/contacts/" class="link-footer">Contact</a>
+                        </li>
+                        <li class="footer-menu-link">
+                            <a href="http://www.alticemediapublicite.fr/marques/liberation-presse/" class="link-footer">Publicité</a>
+                        </li>
+                        <li class="footer-menu-link">
+                            <a href="/cgvu/#donnees-personnelles" class="link-footer">Données personnelles</a>
+                        </li>
+                        <li class="footer-menu-link">
+                            <a href="/cgvu/#cgv" class="link-footer">CGV</a>
+                        </li>
+                        <li class="footer-menu-link">
+                            <a href="/cgvu/#charte-ethique" class="link-footer">Charte éthique</a>
+                        </li>
+                        <li class="footer-menu-link">
+                            <a href="/cgvu/#credits" class="link-footer">Crédits</a>
+                        </li>
+                    </ul>
+                </footer>
+            </div>
+            <div class="modal-shadow"></div>
+            <script type="text/javascript">
+            //<![CDATA[
+            var body = document.getElementsByTagName('body')[0];
+
+            var navSubscribeButton = document.getElementsByClassName('js-nav-subscribe-button')[0];
+            var navUserButton = document.getElementsByClassName('js-nav-user-button')[0];
+            var navUserButtonName = document.getElementsByClassName('js-nav-user-button-name')[0];
+
+            if (libeUserInfo.authenticated) {
+            body.className += ' authenticated';
+            navUserButtonName.innerHTML = libeUserInfo.displayname;
+            if(navUserButtonName.href) {
+            navUserButtonName.href = 'http://token.liberation.fr/accounts/home/';
+            } else {
+            navUserButton.href = 'http://token.liberation.fr/accounts/home/';
+            }
+            }
+
+            if (libeUserInfo.access_level === 'PRE' || libeUserInfo.access_level === 'ESS' ) {
+            body.className += ' subscribed';
+            navSubscribeButton.style.display = 'none';
+            }
+
+            // staff
+            if (typeof libeUserInfo !== 'undefined' && libeUserInfo.is_staff) {
+            var elements = document.getElementsByClassName('header-fix-nav');
+            if(elements.length > 0) {
+            var headerElem = elements[0];
+
+            // div
+            var adminNav = document.createElement('div');
+            adminNav.className = 'admin-nav active';
+
+            // span
+            var titleElem = document.createElement('span');
+            var titleTxt = document.createTextNode('Réservés aux administrateurs');
+            titleElem.appendChild(titleTxt);
+
+            adminNav.appendChild(titleElem);
+
+
+            // buttons
+            var adminButtons = [{
+            text: 'Annuaire',
+            href: libeUserInfo.url_dock + '/annuaire/',
+            },{
+            text: 'Back office',
+            href: libeUserInfo.url_quai + '/quai/',
+            },{
+            text: 'Éditer',
+            href: "javascript:location.href = '"+ libeUserInfo.url_quai +"/quai/redirect_to_change_view?u=' + location.href;",
+            },{
+            text: 'Actualiser',
+            href: "javascript: window.location.href = window.location.pathname + '?refresh=' + Math.floor((Math.random() * 1000000) + 1);",
+            }];
+
+            if (libeUserInfo.is_superuser && typeof(objectId) !== 'undefined') {
+            adminButtons.push({
+            text: 'Compose',
+            href: libeUserInfo.url_dock + '/compose/' + objectId + '/'
+            })
+            }
+
+            for (i = 0; i < adminButtons.length; i++) {
+            var elem = document.createElement('a');
+            elem.href = adminButtons[i]['href'];
+            var txt = document.createTextNode(adminButtons[i]['text']);
+            elem.appendChild(txt);
+            adminNav.appendChild(elem);
+            }
+
+            headerElem.insertBefore(adminNav, headerElem.firstChild);
+            headerFixNavHeight = headerElem.offsetHeight;
+            document.body.style.paddingTop = headerFixNavHeight + 'px';
+            }
+            }
+
+            //]]>
+            </script> 
+            <script src="https://statics.liberation.fr/newnext/js/advertisement.js"></script>
+        </div>
+        <nav class="next-nav white-bg">
+            <ul class="next-nav-cat next-color-07-c">
+                <li>
+                    <a href="/cinema,58">Cinéma</a>
+                </li>
+                <li>
+                    <a href="/musique,59">Musique</a>
+                </li>
+                <li>
+                    <a href="/livres,60">Livres</a>
+                </li>
+                <li>
+                    <a href="/theatre,28">Scènes</a>
+                </li>
+                <li>
+                    <a href="/arts,99964">Arts</a>
+                </li>
+                <li>
+                    <a href="/images,100296">Images</a>
+                </li>
+                <li>
+                    <a href="/vous,15">Lifestyle</a>
+                </li>
+                <li>
+                    <a href="/mode,99924">Mode</a>
+                </li>
+                <li>
+                    <a href="https://www.liberation.fr/beaute,100215">Beauté</a>
+                </li>
+                <li>
+                    <a href="/food,100293">Food</a>
+                </li>
+            </ul>
+        </nav>
+        <main id="main-content" class="main-content page-next">
+            <div class="viewer-container js-viewer">
+                <div class="viewer-photo">
+                    <ul class="viewer-slider-container js-viewer-pictures-container"></ul>
+                </div>
+                <div class="reader-nav">
+                    <a href="javascript:void(0)" class="reader-nav-bloc reader-nav-button js-viewer-close-button"><svg class="icon" role="img" width="40" height="44">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-reader-cross"></use></svg></a> <a href="javascript:void(0)" class="reader-nav-bloc reader-nav-button js-viewer-next-button"><svg class="icon" role="img" width="38" height="44">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-viewer-previous"></use></svg></a> <a href="javascript:void(0)" class="reader-nav-bloc reader-nav-button js-viewer-prev-button"><svg class="icon" role="img" width="40" height="44">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-viewer-next"></use></svg></a> <a href="javascript:void(0)" class="reader-nav-bloc reader-nav-button viewer-infos-button js-viewer-info-button">info</a> <a href="javascript:void(0)" class="reader-nav-bloc reader-nav-button js-viewer-next-button">/</a>
+                </div>
+            </div>
+            <div class="pub-container ad-container">
+                <div id="sas_28993"></div>
+            </div>
+            <div class="width-wrap">
+                <article data-progress-bar="push" class="article-box top-line" data-url="/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047">
+                    <div class="width-padded">
+                        <header class="article-header">
+                            <div class="read-left-padding">
+                                <div class="article-subhead">
+                                    Sur vos écrans cette semaine
+                                </div>
+                                <h1 class="article-headline">
+                                    Screenshot&#160;: «Vape Wave», «6&#160;Days», «Alphonse Président»…
+                                </h1>
+                                <div class="article-head-metas">
+                                    <span class="authors">Par <span class="author"><a href="https://www.liberation.fr/auteur/5631-alexandre-hervaud">Alexandre Hervaud</a></span> et <span class="author"><a href="https://www.liberation.fr/auteur/17350-jeremy-piette">Jérémy Piette</a></span></span> — <span class="date"><time datetime="2017-11-24T18:42:20">24 novembre 2017 à 18:42</time></span>
+                                </div>
+                            </div>
+                        </header>
+                    </div>
+                    <div class="container-column clearfix">
+                        <div class="wide-column width-padded-left">
+                            <figure class="article-image article-header-image">
+                                <a role="button" class="figure-zoom js-figure-zoom"><img src="https://medias.liberation.fr/photo/1075029-screenshot-alphonse-vape-wave-6-days.jpg?modified_at=1511536242&amp;width=975" alt="«Vape Wave», «6 Days», «Alphonse président» et «Braguino»" data-src="https://medias.liberation.fr/photo/1075029-screenshot-alphonse-vape-wave-6-days.jpg?modified_at=1511536242&amp;width=975" data-src-retina="https://medias.liberation.fr/photo/1075029-screenshot-alphonse-vape-wave-6-days.jpg?modified_at=1511536242&amp;width=975" data-lazy-load="false" width="975" /> <i class="zoom-icon"><svg class="icon" role="img" width="22" height="22">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-zoom"></use></svg></i></a>
+                                <figcaption class="read-left-padding caption">
+                                    <span class="desc">«Vape Wave», «6 Days», «Alphonse président» et «Braguino»</span> <span class="copy">DR</span>
+                                    <div class="share-link">
+                                        <span class="share"><a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot-vape-wave-6-days-alphonse-president_1612047&amp;t=Screenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6" class="js-share-facebook" rel="nofollow"><svg class="icon share-link-fb" role="img" width="20" height="20">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use></svg></a> <a href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot-vape-wave-6-days-alphonse-president_1612047&amp;text=Screenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6&amp;via=libe&amp;related=libe" class="js-share-twitter" rel="nofollow"><svg class="icon share-link-tw" role="img" width="20" height="20">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use></svg></a></span>
+                                    </div>
+                                </figcaption>
+                            </figure>
+                            <div class="article-body read-left-padding js-figure-zoom">
+                                <p>
+                                    Séries, documentaires, programmes jeunesse… Retrouvez les recommandations de&#160;<em>Libération</em>&#160;pour savoir quoi regarder sur vos écrans cette semaine.
+                                </p>
+                                <h3>
+                                    Pour dépasser le tabac
+                                </h3>
+                                <p>
+                                    <strong><em>Vape Wave</em> (documentaire, 1h28, Planète+)</strong>
+                                </p>
+                                <p>
+                                    <iframe width="100%" src="https://www.youtube.com/embed/lGL7RgHn5f0" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+                                </p>
+                                <p>
+                                    Pendant quelques jours, le doute a plané&#160;: l’Etat comptait-il vraiment légiférer contre la cigarette dans les films français, que ce soit via une interdiction pure et simple ou via un système de «punition» (coupe des aides CNC, par exemple) pour les longs-métrages qui sentent le mégot&#160;? Si <a href="https://www.liberation.fr/direct/element/agnes-buzyn-assure-quelle-na-jamais-envisage-linterdiction-de-la-cigarette-au-cinema_73855/" target="_blank">le rétropédalage de la ministre Buzyn</a> n’en est pas vraiment un (elle n’avait jamais clairement menacé le septième art), la polémique a le mérite de pointer la (sur)représentation clopesque sur écran. Et si, comme c’est le cas dans la vie quotidienne, on voyait progressivement les cigarettes électroniques remplacer les tiges nicotinées authentiques&#160;? Que ceux qui mettraient en doute le potentiel cinématographique des vapoteuses se ruent sur <a href="http://www.vapewave.net/" target="_blank"><em>Vape Wave</em></a>, documentaire militant signé Jan Kounen, ex-fumeur reconverti à la vape dont les images magnifient les volutes de vapeur recrachée.
+                                </p>
+                                <p>
+                                    Si le film du réalisateur de <em>Dobermann</em> et <em>99 Francs</em> part un peu dans tous les sens, il a le mérite de défendre avec une passion contagieuse ce qui semble, de loin, être <a href="https://www.liberation.fr/societe/2015/08/20/une-e-cigarette-tres-frequentable_1366687" target="_blank">le meilleur et plus sain substitut à la clope</a>, n’en déplaise aux mesures restrictives imposées en France <a href="https://www.liberation.fr/france/2017/10/03/la-cigarette-electronique-bannie-de-certains-lieux-publics_1600601" target="_blank">à son égard</a>. Financé en partie via crowdfunding, le documentaire a été présenté par Kounen à travers toute la France lors de projection tenant quasiment de l’évangélisation. Disponible en VOD/DVD, il a été diffusé cette semaine sur la chaîne Planète+, qui le rediffusera les 25/11, 30/11 et 02/12 prochains. <strong>(Alexandre Hervaud)</strong>
+                                </p>
+                                <h3>
+                                    Pour écouter parler un génie
+                                </h3>
+                                <p>
+                                    <strong><em>Dans la tête d’Alan Moore</em> (websérie documentaire, 8x5min, Arte Creative)</strong>
+                                </p>
+                                <p>
+                                    <iframe width="100%" src="https://www.youtube.com/embed/s_rw5fPHz2g" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+                                </p>
+                                <p>
+                                    Le week-end dernier, <em>Libération</em> publiait <a href="http://next.liberation.fr/livres/2017/11/17/alan-moore-dernier-barde-avant-la-fin-du-monde_1610854" target="_blank">un portrait de der consacré à l’auteur britannique Alan Moore</a>, connu pour ses BD cultes (<em>V pour Vendetta, Watchmen, From Hell</em>), à l’occasion de la sortie de son deuxième roman, le pavé <em>Jérusalem</em>. En attendant l’imminente sortie d’une version longue de son entretien avec <em>Libé</em>, on pourra se replonger dans les épisodes d’une websérie documentaire d’Arte Creative en 8 épisodes consacré au maître. Brexit, magie, Anonymous font partie des sujets discutés avec le maître au fil de ce programme sobrement intitulé <a href="https://www.arte.tv/fr/videos/RC-014342/dans-la-tete-d-alan-moore/" target="_blank"><em>Dans la tête d’Alan Moore</em></a>. <strong>(A.H.)</strong>
+                                </p>
+                                <h3>
+                                    Pour honorer la mémoire d’une icône queer
+                                </h3>
+                                <p>
+                                    <strong><em>The Death and Life of Marsha P. Johnson</em> (docu, 1h45, Netflix)</strong>
+                                </p>
+                                <p>
+                                    <iframe width="100%" src="https://www.youtube.com/embed/pADsuuPd79E" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+                                </p>
+                                <p>
+                                    Marsha, la <em>«Rosa Parks du mouvement LGBTQ»</em>. Marsha <em>«la prostituée, l’actrice et la sainte, modèle d’Andy Warhol»</em> ou encore Marsha l’élaborée, la radicale, <em>«avec ses plumes et ce maquillage qu’elle ne mettait jamais bien»</em>. «Queen Marsha» a été retrouvée morte dans l’Hudson en juillet&#160;1992, alors qu’on la voyait encore parader dans les rues de Greenwich Village quelques jours auparavant. Un choc glaçant. Là où son corps a été repêché puis ingratement déposé, les sans-abri ont constitué le lendemain un mémorial de bouteilles et de plantes qui délimitent les contours de l’absente.
+                                </p>
+                                <p>
+                                    Marsha P. Johnson de son nom complet, icône queer, femme transgenre noire américaine et emblème de la lutte pour les droits des LGBTQ avait été l’une des premières à s’engager lors des émeutes de Stonewall à New York, en&#160;1969&#160;: <em>«C’est la révolution. Dieu merci.»</em> Marsha était une fleur souriante au parfum d’espoir. Le documentaire <em>The Death and Life of Marsha P. Johnson</em> du cinéaste David France relate l’enquête de l’activiste Victoria Cruz, membre de l’organisation Anti-Violence Project à New York qui, avant de prendre sa retraite, réclame que lumière soit faite sur la disparition de l’icône […]&#160;<a href="http://next.liberation.fr/cinema/2017/11/17/docu-marsha-p-johnson-unique-en-son-genre_1610846" target="_blank">Lire la suite de la critique de Jérémy Piette sur Libération.fr</a>
+                                </p>
+                                <h3>
+                                    Pour Michel Vuilermoz (et rien d’autre)
+                                </h3>
+                                <p>
+                                    <strong><em>Alphonse President</em> (série, 10x26, OCS Max)</strong>
+                                </p>
+                                <p>
+                                    <iframe width="100%" frameborder="0" src="https://www.dailymotion.com/embed/video/x67iqc9" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+                                </p>
+                                <p>
+                                    Un temps baptisée <em>French Touch</em>, la série <em>Alphonse Président</em> est le dernier né des programmes originaux made in OCS. On savait les budgets de la chaîne bien moins généreux que ceux de Canal+ (voire que ceux de France 3 Limousin), et cette série le prouve à nouveau régulièrement, notamment lors d’une scène de conférence de presse alternant plans larges d’une authentique conf' à l’Elysée période François Hollande et plans serrés d’acteurs filmés dans un château des Pays de la Loire où a eu lieu le tournage. Le principal atout (et quel atout) de cette série écrite et réalisée par Nicolas Castro (<em>Des lendemains qui chantent</em>, 2014) réside dans son interprète principal, Michel Vuillermoz.
+                                </p>
+                                <p>
+                                    Dans le rôle d’un sénateur ringard devenu par un concours de circonstances président de la République, ce pensionnaire de la Comédie-Française et complice d’Albert Dupontel fait des merveilles, notamment lorsque le scénario lui prête des répliques enflammées typiques de la langue de bois politicienne –&#160;pas étonnant qu’il brasse du vent, son personnage de prof d’histoire retraité s’appelle Alphonse Dumoulin. C’est lorsqu’il n’est plus à l’écran que les choses se gâtent&#160;: si Jean-Michel Lahmi (de la bande d’Edouard Baer) fait le job en grand patron des flics, difficile de croire une seconde à Nabiha Akkari dans le rôle de la Première ministre –&#160;et pas uniquement parce que l’idée d’avoir une femme trentenaire issue de la diversité à Matignon sonne hélas comme un doux rêve en&#160;2017. Si, en matière de fiction politique sérieuse, un <em>Baron Noir</em> n’a pas grand-chose à envier à un <em>House of Cards</em>, côté comique la France est encore loin d’avoir son <em>Veep</em>. Gageons que la génération LREM saura largement inspirer des scénaristes moqueurs. <strong>(A.H.)</strong>
+                                </p>
+                                <h3>
+                                    Pour les coulisses d’un tournage dément
+                                </h3>
+                                <p>
+                                    <strong><em>Jim &amp; Andy</em> (documentaire, 1h33, Netflix)&#160;</strong>
+                                </p>
+                                <p>
+                                    <iframe width="100%" src="https://www.youtube.com/embed/kB15UFO5ebA" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+                                </p>
+                                <p>
+                                    A la sortie de <em>Man on the Moon</em> (2000), le magnifique film de Milos Forman consacré à Andy Kaufman –&#160;comique et génie de la performance absurde mort en 1984&#160;–, le cinéaste et les acteurs insistaient dans chaque interview sur l’in­croyable comportement de Jim Carrey pendant le tournage&#160;: il aurait été comme possédé par Kaufman, se prenant pour lui 24&#160;heures sur 24. Certains affirmaient même ne jamais avoir eu l’impression que l’acteur était présent, tant son modèle avait littéralement pris sa place. Nous en avons aujourd’hui la preuve en images car tout cela avait été filmé par Bob Zmuda et Lynne Margulies, l’ancien complice et la veuve de Kaufman.
+                                </p>
+                                <p>
+                                    Dans le passionnant <em>Jim &amp; Andy&#160;: the Great Beyond</em>, disponible sur Netflix, Chris Smith a monté ces documents inédits parallèlement à un entretien dans lequel Jim Carrey revient sur cette expérience unique. <a href="http://next.liberation.fr/cinema,58" target="_blank">Lire la suite de la critique de Marcos Uzal sur Liberation.fr</a>
+                                </p>
+                                <h3>
+                                    Pour un trip sibérien en totale autarcie
+                                </h3>
+                                <p>
+                                    <strong><em>Braguino</em> (documentaire, 50min, Arte)</strong>
+                                </p>
+                                <p>
+                                    <iframe width="100%" src="https://www.youtube.com/embed/OIS-P-0-cRk" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+                                </p>
+                                <p>
+                                    La querelle peut se trouver derrière toutes les portes, y compris celle de l’exil. On a beau croire avoir tourné le dos à tout, à cette inclination humaine à nourrir sa&#160;propre haine, l’allergie peut regermer fissa sur une&#160;peau qui frissonne à&#160;l’approche de ce voisin que l’on ne comprend pas. Issu&#160;d’une lignée de vieux-croyants orthodoxes russes, Sacha Braguine a pris sa famille sous le bras, loin de toute autre présence humaine en taïga sibérienne. Un autre groupe, les Kiline, a décidé d’en faire de même et de s’installer de l’autre côté de la rivière. Qui est arrivé en premier&#160;? Qui menace l’autre&#160;? L’histoire de l’impossible communauté peut commencer.
+                                </p>
+                                <p>
+                                    La lecture d’<em>Ermites dans la taïga</em>&#160;(1992) de Vassili Peskov, authentique récit sur la famille Lykov opérant une migration similaire en&#160;1938, a poussé l’artiste&#160;<a href="http://next.liberation.fr/images/2017/09/29/clement-cogitore-j-essaye-de-raconter-les-terreurs-profondes-de-l-etre-humain_1599854">Clément Cogitore</a>&#160;à&#160;rencontrer les Braguine, puis à se faire témoin de la&#160;bisbille de voisinage en&#160;2016. Il en est revenu avec un nouveau film d’une cinquantaine de minutes&#160;:&#160;<em>Braguino,</em>&#160;soutenu par le prix Le&#160;Bal de la&#160;jeune création avec l’ADAGP.<em>&#160;</em>Le documentaire y frôle son déguisement fictionnel, tant ce qui s’y déroule convoque une dramaturgie comme invoquée par on ne sait quel rituel vaudou […] <a href="http://next.liberation.fr/cinema/2017/10/30/braguino-prises-de-bec-dans-la-taiga_1606859" target="_blank">Lire la suite de la critique de Jérémy Piette sur Liberation.fr</a>, le film diffusé cette semaine sur Arte est visible en intégralité ci-dessus.
+                                </p>
+                                <h3>
+                                    Pour un thriller tiré de faits réels
+                                </h3>
+                                <p>
+                                    <strong><em>6 Days</em> (film, 1h34, Netflix)</strong>
+                                </p>
+                                <p>
+                                    <iframe width="100%" src="https://www.youtube.com/embed/7HthiTi_IcI" frameborder="0" allowfullscreen="allowfullscreen" data-aspect-ratio="0.5625" data-responsive="1"></iframe>
+                                </p>
+                                <p>
+                                    Fin avril 1980, l’ambassade d’Iran à Londres a été le théâtre d’une prise d’otages largement médiatisée : une trentaine de personnes ont ainsi été retenues pendant six jours par des soldats iraniens dissidents exigeant la libération de 91 prisonniers. Avec Margaret Thatcher au 10 Downing Street à l’époque, pas question pour l’Angleterre d’avoir l’air mou du genou sur la réponse à apporter à cette crise scrutée par les caméras du monde entier. Le SAS (Special Air Service) est sur le coup : l’opération Nimrod se met en place pour prendre d’assaut l’ambassade.
+                                </p>
+                                <p>
+                                    Inspiré par cet épisode, <em>6 Days</em> de&#160;Toa Fraser (<em>The Dead Lands</em>, 2014) est un thriller carré pouvant compter sur l'autorité naturelle de Mark Strong (<em>Kingsman</em>) ici recyclé en flic londonien et sur la néo-badass attitude de Jamie Bell, bien loin du freluquet danseur de <em>Billy Elliot</em> puisqu'on le retrouve ici&#160;en soldat chargé d’organiser l’opération de secours. Attention, la bande-annonce ci-dessus dévoile à peu près l’intégralité des scènes d’action du film. <strong>(A.H.)</strong>
+                                </p><span class="authors"><span class="author"><a href="https://www.liberation.fr/auteur/5631-alexandre-hervaud">Alexandre Hervaud</a></span> , <span class="author"><a href="https://www.liberation.fr/auteur/17350-jeremy-piette">Jérémy Piette</a></span></span>
+                            </div>
+                        </div>
+                        <aside class="aside-column side-flow-bloc width-padded">
+                            <div class="bloc-share clearfix">
+                                <div class="bloc-share-button">
+                                    <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot-vape-wave-6-days-alphonse-president_1612047&amp;t=Screenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6" class="js-share-facebook bloc-share-social fb" rel="nofollow"><i class="button-icon fb"><svg class="icon" role="img" width="20" height="20">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use></svg></i>
+                                    <p>
+                                        partager
+                                    </p></a>
+                                </div>
+                                <div class="bloc-share-button">
+                                    <a href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot-vape-wave-6-days-alphonse-president_1612047&amp;text=Screenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6&amp;via=libe&amp;related=libe" class="js-share-twitter bloc-share-social tw" rel="nofollow"><i class="button-icon tw"><svg class="icon" role="img" width="20" height="20">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use></svg></i>
+                                    <p>
+                                        tweeter
+                                    </p></a>
+                                </div>
+                                <div class="bloc-share-tools">
+                                    <a data-libe-tooltip="Imprimer" class="bloc-share-action js-share-print" href="javascript:;" onclick="window.print();"><svg class="icon" role="img" width="27" height="22">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print"></use></svg></a> <a data-libe-tooltip="Envoyer par mail" class="bloc-share-action" href="mailto:?subject=Lu%20sur%20liberation.fr%20&amp;body=Screenshot%C2%A0%3A%20%C2%ABVape%20Wave%C2%BB%2C%20%C2%AB6%C2%A0Days%C2%BB%2C%20%C2%ABAlphonse%20Pr%C3%A9sident%C2%BB%E2%80%A6%0D%0A%0D%0A%0D%0ARetrouvez%20cet%20article%20sur%20le%20site%20de%20Lib%C3%A9ration%20:%20https%3A//next.liberation.fr/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047"><svg class="icon" role="img" width="23" height="24">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-mail"></use></svg></a>
+                                </div>
+                            </div>
+                            <div class="sticky-element-container sideblocks-container js-sideblocks-container">
+                                <div class="unsubs-content sticky-element">
+                                    <div class="bloc-yellow-header unsubs-content">
+                                        <a href="http://token.liberation.fr/accounts/personal-data/"><svg class="icon" role="img" width="15" height="24">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-abo-ribbon"></use></svg>
+                                        <div class="header-title js-nav-user-button-name"></div><span class="header-text">Vous êtes abonné à Libération</span></a>
+                                    </div>
+                                    <script type="text/javascript">
+                                    //<![CDATA[
+                                    (function() {
+                                    buttons = document.getElementsByClassName('header-title js-nav-user-button-name')
+                                    for( pos = 0 ; pos < buttons.length ; pos++ ){
+                                    buttons[pos].innerHTML = libeUserInfo['full_name'] ? libeUserInfo['full_name'] : libeUserInfo['displayname'];
+                                    }
+                                    })();
+                                    //]]>
+                                    </script>
+                                    <div class="flow-bloc flow-bloc-subscription">
+                                        <div class="bloc-title">
+                                            Le journal d'aujourd'hui
+                                        </div>
+                                        <div class="flow-bloc-content">
+                                            <a href="/liseuse/publication/01-03-2019/" class="">
+                                            <div class="flow-bloc-journal">
+                                                <img src="/liseuse/paperpage/262207/" alt="" class="journal-une-img" width="229" />
+                                            </div></a>
+                                            <ul class="list-bottom-box">
+                                                <li>
+                                                    <a class="list-bottom-item" href="/publication/">découvrir le sommaire</a>
+                                                </li>
+                                                <li>
+                                                    <a class="list-bottom-item" href="https://www.liberation.fr/france/2019/02/28/dilemmes_1712264">lire l'édito</a>
+                                                </li>
+                                                <li>
+                                                    <a class="list-bottom-item" href="/liseuse/publication/01-03-2019/">feuilleter</a>
+                                                </li>
+                                                <li>
+                                                    <a class="list-bottom-item subscription-bloc" href="http://token.liberation.fr/accounts/offers"><strong>s'abonner</strong> à partir de 8€</a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="sticky-element js-replace-asq" style="display: none;">
+                                    <div class="flow-bloc flow-bloc-subscription subs-desc single full-bg subs-content">
+                                        <div class="subs-punch">
+                                            Offre 100% numérique: <strong>8€ par mois sans engagement</strong>
+                                        </div><img width="170" height="100" alt="" src="https://statics.liberation.fr/newnext/images/illu-daily-journal-wb.svg" />
+                                        <p class="desc-txt">
+                                            Le journal du jour en exclusivité et le journal de demain avant tout le monde
+                                        </p><a href="http://token.liberation.fr/accounts/offers" class="subscription-desc-button">Voir les offres d’abonnement</a>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="pined-bottom">
+                                <div class="bloc-share clearfix">
+                                    <div class="bloc-share-button">
+                                        <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot-vape-wave-6-days-alphonse-president_1612047&amp;t=Screenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6" class="js-share-facebook bloc-share-social fb" rel="nofollow"><i class="button-icon fb"><svg class="icon" role="img" width="20" height="20">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use></svg></i>
+                                        <p>
+                                            partager
+                                        </p></a>
+                                    </div>
+                                    <div class="bloc-share-button">
+                                        <a href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot-vape-wave-6-days-alphonse-president_1612047&amp;text=Screenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6&amp;via=libe&amp;related=libe" class="js-share-twitter bloc-share-social tw" rel="nofollow"><i class="button-icon tw"><svg class="icon" role="img" width="20" height="20">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use></svg></i>
+                                        <p>
+                                            tweeter
+                                        </p></a>
+                                    </div>
+                                    <div class="bloc-share-tools">
+                                        <a data-libe-tooltip="Imprimer" class="bloc-share-action js-share-print" href="javascript:;" onclick="window.print();"><svg class="icon" role="img" width="27" height="22">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print"></use></svg></a> <a data-libe-tooltip="Envoyer par mail" class="bloc-share-action" href="mailto:?subject=Lu%20sur%20liberation.fr%20&amp;body=Screenshot%C2%A0%3A%20%C2%ABVape%20Wave%C2%BB%2C%20%C2%AB6%C2%A0Days%C2%BB%2C%20%C2%ABAlphonse%20Pr%C3%A9sident%C2%BB%E2%80%A6%0D%0A%0D%0A%0D%0ARetrouvez%20cet%20article%20sur%20le%20site%20de%20Lib%C3%A9ration%20:%20https%3A//next.liberation.fr/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047"><svg class="icon" role="img" width="23" height="24">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-mail"></use></svg></a>
+                                    </div>
+                                </div>
+                            </div>
+                        </aside>
+                    </div>
+                </article>
+            </div>
+            <div class="width-wrap category-container">
+                <div class="container-column clearfix">
+                    <div class="wide-column js-infinity-section-container next-footer-section">
+                        <link rel="next" href="/?page=1&amp;list" />
+                    </div>
+                    <aside class="next-aside-container aside-column width-padded">
+                        <div class="sticky-element-container sideblocks-container js-sideblocks-container">
+                            <div class="unsubs-content sticky-element">
+                                <div class="bloc-yellow-header unsubs-content">
+                                    <a href="http://token.liberation.fr/accounts/personal-data/"><svg class="icon" role="img" width="15" height="24">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-abo-ribbon"></use></svg>
+                                    <div class="header-title js-nav-user-button-name"></div><span class="header-text">Vous êtes abonné à Libération</span></a>
+                                </div>
+                                <script type="text/javascript">
+                                //<![CDATA[
+                                (function() {
+                                buttons = document.getElementsByClassName('header-title js-nav-user-button-name')
+                                for( pos = 0 ; pos < buttons.length ; pos++ ){
+                                buttons[pos].innerHTML = libeUserInfo['full_name'] ? libeUserInfo['full_name'] : libeUserInfo['displayname'];
+                                }
+                                })();
+                                //]]>
+                                </script>
+                                <div class="flow-bloc flow-bloc-subscription">
+                                    <div class="bloc-title">
+                                        Le journal d'aujourd'hui
+                                    </div>
+                                    <div class="flow-bloc-content">
+                                        <a href="/liseuse/publication/01-03-2019/" class="">
+                                        <div class="flow-bloc-journal">
+                                            <img src="/liseuse/paperpage/262207/" alt="" class="journal-une-img" width="229" />
+                                        </div></a>
+                                        <ul class="list-bottom-box">
+                                            <li>
+                                                <a class="list-bottom-item" href="/publication/">découvrir le sommaire</a>
+                                            </li>
+                                            <li>
+                                                <a class="list-bottom-item" href="https://www.liberation.fr/france/2019/02/28/dilemmes_1712264">lire l'édito</a>
+                                            </li>
+                                            <li>
+                                                <a class="list-bottom-item" href="/liseuse/publication/01-03-2019/">feuilleter</a>
+                                            </li>
+                                            <li>
+                                                <a class="list-bottom-item subscription-bloc" href="http://token.liberation.fr/accounts/offers"><strong>s'abonner</strong> à partir de 8€</a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sticky-element bloc-ads ad-container">
+                                <div id="sas_28999"></div>
+                            </div>
+                        </div>
+                    </aside>
+                </div>
+            </div>
+            <div class="js-infinity-contentmodel-container"></div>
+            <div class="libe-aside-comment js-stop-scroll-propagation">
+                <div class="libe-comment-header">
+                    <a href="" class="libe-comment-close"></a>
+                    <div class="libe-comment-header-title">
+                        Un mot à ajouter ?
+                    </div>
+                </div>
+            </div>
+            <div id="sas_28991"></div>
+            <div id="sas_28990"></div>
+        </main>
+        <script type="text/javascript" src="https://statics.liberation.fr/newnext/cache/js/321bd053e6d6.js"></script> 
+        <script type="text/javascript" src="https://statics.liberation.fr/newnext/cache/js/107fa81103c2.js"></script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+
+          var JSONData = JSON.parse("{\u0022title\u0022: \u0022Screenshot\u005Cu00a0: \u005Cu00abVape Wave\u005Cu00bb, \u005Cu00ab6\u005Cu00a0Days\u005Cu00bb, \u005Cu00abAlphonse Pr\u005Cu00e9sident\u005Cu00bb\u005Cu2026\u0022, \u0022xiti_level\u0022: \u002242\u0022, \u0022section\u0022: \u0022Culture\u0022, \u0022author\u0022: \u0022Web\u0022, \u0022xiti_page\u0022: \u0022Culture::Article_\u002D_Screenshot_Vape_Wave_6_Days_Alphonse_President_\u002D_1612047\u0022, \u0022facebook\u0022: \u0022https://www.facebook.com/sharer/sharer.php?u\u003Dhttps%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot\u002Dvape\u002Dwave\u002D6\u002Ddays\u002Dalphonse\u002Dpresident_1612047\u0026t\u003DScreenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6\u0022, \u0022pw_date\u0022: \u00222019\u002D03\u002D01T15:32:22.666827\u0022, \u0022pk\u0022: 1612047, \u0022twitter\u0022: \u0022https://twitter.com/intent/tweet?url\u003Dhttps%3A%2F%2Fnext.liberation.fr%2Fculture%2F2017%2F11%2F24%2Fscreenshot\u002Dvape\u002Dwave\u002D6\u002Ddays\u002Dalphonse\u002Dpresident_1612047\u0026text\u003DScreenshot%C2%A0%3A+%C2%ABVape+Wave%C2%BB%2C+%C2%AB6%C2%A0Days%C2%BB%2C+%C2%ABAlphonse+Pr%C3%A9sident%C2%BB%E2%80%A6\u0026via\u003Dlibe\u0026related\u003Dlibe\u0022}");
+
+
+        var genericSettings = {};
+
+          genericSettings['paddix'] = JSON.parse('{"enabled": true}');
+
+          genericSettings['paywall'] = JSON.parse('{"enabled": true}');
+
+          genericSettings['ads'] = JSON.parse('{"enabled": true}');
+
+          genericSettings['elections'] = JSON.parse('{"election_tour": "2", "election_name": "Pr\u00e9sidentielle 2017", "enabled": false, "election_constant": "PR2017", "file_path": "/data/ftp/fremen/data/PR2017/", "election_url": "/elections/presidentielle-2017/"}');
+
+        var StaticUrl = "https://statics.liberation.fr/newnext/";
+        //]]>
+        </script> 
+        <script type="text/javascript" src="https://www6.smartadserver.com/config.js?nwid=14"></script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        if (typeof sas !== 'undefined') {
+          sas.setup({domain: 'https://www6.smartadserver.com', async: true, renderMode: 0});
+        }
+        //]]>
+        </script> 
+        <script type="text/javascript" src="https://widgets.outbrain.com/outbrain.js"></script> 
+        <script id="twitter-wjs" type="text/javascript" async="async" defer="defer" src="https://platform.twitter.com/widgets.js"></script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        (function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(d.getElementById(id)) return;js=d.createElement(s);js.id=id;js.src='//connect.facebook.net/fr_FR/all.js#xfbml=1&appId=WWWWWW';fjs.parentNode.insertBefore(js,fjs);}(document,'script','facebook-jssdk'));
+        //]]>
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+
+        var pw_duration = 7;
+        var pw_session_time = 30;
+        var pw_session_count = 4;
+        var pw_date = '2019-03-01T15:32:23.483787';
+
+
+
+
+        var pw_constants = {"PW_DENY": {"footer_link": "https://token.liberation.fr/accounts/login/", "cta_link": "https://next.liberation.fr/offre-numerique/", "text": "Pour continuer \u00e0 consulter nos articles et nous soutenir, abonnez-vous d\u00e8s maintenant", "title": "Vous avez profit\u00e9 des 4 visites\n offertes par Lib\u00e9ration", "cta_text": "Je m'abonne", "poster": "https://statics.liberation.fr/newnext/images/paywall/paywall-5.jpg", "offer_name": "100% num\u00e9rique", "offer_price": "8\u20ac", "footer_text": "Je suis d\u00e9j\u00e0 abonn\u00e9"}, "PW_MSG": [{"count": 1, "status": "Lib\u00e9ration vous offre 4 visites !", "cta_link": null, "text": "Soutenez notre culture de d\u00e9bats et de libert\u00e9 en rejoignant la communaut\u00e9 des abonn\u00e9s et des journalistes de Lib\u00e9ration", "title": "Nos contenus ont de la valeur\npour vous comme pour nous", "cta_text": "Poursuivre ma lecture", "poster": "https://statics.liberation.fr/newnext/images/paywall/paywall-1.jpg", "footer_text": "D\u00e9couvrir l'offre", "footer_link": "https://token.liberation.fr/accounts/offers/"}, {"count": 2, "status": "Lib\u00e9ration vous offre encore 3 visites !", "cta_link": null, "text": "en \u00e9tant toujours honn\u00eate, tol\u00e9rant et prospectif", "title": "Cr\u00e9er le d\u00e9bat et le nourrir", "cta_text": "Poursuivre ma lecture", "poster": "https://statics.liberation.fr/newnext/images/paywall/paywall-2.jpg", "footer_text": "D\u00e9couvrir l'offre", "footer_link": "https://token.liberation.fr/accounts/offers/"}, {"count": 3, "status": "Lib\u00e9ration vous offre encore 2 visites !", "cta_link": "https://next.liberation.fr/offre-numerique/", "text": "Contribuez \u00e0 faire vivre le journalisme exigeant en vous abonnant", "title": "Soyons r\u00e9alistes:\nIl n'y a pas de qualit\u00e9 sans financement", "cta_text": "M'abonner sans engagement - 8\u20ac/MOIS", "poster": "https://statics.liberation.fr/newnext/images/paywall/paywall-3.jpg", "footer_text": "D\u00e9couvrir l'offre", "footer_link": "https://token.liberation.fr/accounts/offers/"}, {"count": 4, "status": "C'est votre derni\u00e8re visite gratuite", "cta_link": "https://next.liberation.fr/offre-numerique/", "text": "Soutenez le journalisme vigilant et progressiste en vous abonnant", "title": "Si vous \u00eates arriv\u00e9(e) jusque l\u00e0 c\u2019est que vous aimez Lib\u00e9, merci", "cta_text": "M'abonner sans engagement - 8\u20ac/MOIS", "poster": "https://statics.liberation.fr/newnext/images/paywall/paywall-4.jpg", "footer_text": "D\u00e9couvrir l'offre", "footer_link": "https://token.liberation.fr/accounts/offers/"}]};
+        var pw_json_alert = "\n<div class=\"pws anim-in\">\n  <div class=\"pw-container\">\n    <a class=\"pw-action-close discard\">\n      <img src=\"https://statics.liberation.fr/newnext/images/paywall/icons/close-cross.png\" alt=\"\">\n    <\/a>\n    <div class=\"pw-status\">\n      <p class=\"pw-status-text\">%%status%%<\/p>\n    <\/div>\n\n    <div class=\"pw-poster\" style=\"background-image: url(%%poster%%);\">\n      <img src=\"https://statics.liberation.fr/newnext/images/paywall/calque-paywall.png\" alt=\"\" class=\"pw-poster__image__calque\">\n    <\/div>\n\n    <div class=\"pw-text\">\n      <div class=\"pw-text__title\">\n        <p class=\"pw-text__title__text\">%%title%%<\/p>\n      <\/div>\n      <div class=\"pw-text__desc\">\n        <p class=\"pw-text__desc__text\">%%text%%<\/p>\n      <\/div>\n    <\/div>\n    <div class=\"pw-footer\">\n      <button class=\"pw-footer__main-cta ldg__main-button\">%%cta_text%%<\/button>\n      <a href=\"%%footer_link%%\" class=\"pw-footer__offer-cta\">%%footer_text%%<\/a>\n    <\/div>\n  <\/div>\n<\/div>\n";
+        var pw_json_deny = "\n<div class=\"pws\">\n  <!-- PAYWALL DENY -->\n  <div class=\"pw-container pw-container--last\">\n    <div class=\"pw-poster\" style=\"background-image: url(%%poster%%);\">\n      <img src=\"https://statics.liberation.fr/newnext/images/paywall/calque-paywall.png\" alt=\"\" class=\"pw-poster__image__calque\">\n    <\/div>\n    <div class=\"pw-text\">\n      <div class=\"pw-text__title\">\n        <p class=\"pw-text__title__text\">%%title%%<\/p>\n      <\/div>\n      <div class=\"pw-text__desc\">\n        <p class=\"pw-text__desc__text\">%%text%%<\/p>\n      <\/div>\n    <\/div>\n    <div class=\"pw-cta cta-paywall-1\">\n      <div class=\"cta-paywall-1__mockup\">\n        <img class=\"cta-paywall-1__mockup__image\" src=\"https://statics.liberation.fr/newnext/images/paywall/offer-numerique-mobile.png\" alt=\"\">\n      <\/div>\n      <div class=\"cta-paywall-1__body\">\n        <span class=\"cta-paywall-1__body__info\">%%offer_name%%<\/span>\n        <div class=\"cta-paywall-1__body__price\">\n          <span class=\"cta-paywall-1__body__price__item\">%%offer_price%%<\/span>\n          <p class=\"cta-paywall-1__body__price__text\">\n            <span class=\"cta-paywall-1__body__price__text__1\">par mois<\/span>\n            <span class=\"cta-paywall-1__body__price__text__2\">sans engagement<\/span>\n          <\/p>\n        <\/div>\n      <\/div>\n      <div class=\"cta-paywall-1__footer\">\n        <button class=\"ldg__main-button cta-paywall-1__footer__cta ldg__main-button\" data-location=\"%%cta_link%%\">%%cta_text%%<\/button>\n      <\/div>\n    <\/div>\n    <div class=\"pw-footer\">\n      <a href=\"%%footer_link%%?next=/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047\" class=\"pw-footer__offer-cta\">%%footer_text%%<\/a>\n    <\/div>\n  <\/div>\n<\/div>\n";
+
+
+        var paywall = new Paywall();
+
+        paywall.updateCurrentSession();
+
+        paywall.readArticle();
+
+        //]]>
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        /*************************************************
+        *                   Chartbeat                    *
+        *************************************************/
+
+        var _sf_async_config = {};
+        _sf_async_config.uid = 43601;
+        _sf_async_config.domain = 'liberation.fr';
+        _sf_async_config.useCanonical = true;
+
+
+        _sf_async_config.sections = 'Culture';
+
+
+
+        _sf_async_config.authors = 'Web';
+
+
+        (function() {
+        function loadChartbeat() {
+        window._sf_endpt = (new Date()).getTime();
+        var e = document.createElement('script');
+        e.setAttribute('language', 'javascript');
+        e.setAttribute('type', 'text/javascript');
+        e.setAttribute('src', '//static.chartbeat.com/js/chartbeat.js');
+        document.body.appendChild(e);
+        }
+
+        var oldonload = window.onload;
+        window.onload = (typeof window.onload != "function") ?
+        loadChartbeat : function() { oldonload(); loadChartbeat(); };
+        })();
+
+        /*************************************************
+        *                Google Analytics                *
+        *************************************************/
+
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+
+        ga('create', 'UA-41822557-1', 'auto');
+
+        ga('set', 'dimension1', libeUserInfo.authenticated.toString());            // authenticated
+        ga('set', 'dimension2', libeUserInfo.access_level);                        // level
+        ga('set', 'dimension3', libeUserInfo.softwarer_blocker ? 'true': 'false'); // adblock
+        ga('set', 'dimension4', libeUserInfo.xiti_user_id ?                        // uid
+        libeUserInfo.xiti_user_id.toString() :
+        null
+        );
+
+        if ('undefined' !== typeof libe_ga_datas) {
+        for(var key in libe_ga_datas) {
+        var value = libe_ga_datas[key];
+        ga('set', key, value);
+        }
+        }
+
+        ga('send', 'pageview');
+        //]]>
+        </script> <!--**********************************************
+*                      Xiti                      *
+***********************************************-->
+         
+        <script type="text/javascript">
+        //<![CDATA[
+
+        xtnv = document;        //parent.document or top.document or document
+        xtsd = "https://logs1091";
+        xtsite = "381060";
+        xtn2 = "42";        // level 2
+        xtpage = "Culture::Article_\u002D_Screenshot_Vape_Wave_6_Days_Alphonse_President_\u002D_1612047";        //page name (with the use of :: to create chapters)
+        xtdi = "";
+        xt_pagetype = "2\u002D1\u002D0";
+        xt_multc = "\u0026x1\u003D0\u0026x2\u003D40\u0026x3\u003D10\u0026x4\u003D\u0026x5\u003D20171124\u0026x6\u003D20\u0026x7\u003D1612047";
+
+        // if the user is part of the staff we don't take it into account
+        if (typeof(libeUserInfo["is_staff"]) != "undefined" && libeUserInfo["is_staff"]) {
+            xt_an = "";
+            xt_ac = "";
+        }
+        else {
+            // it is ok to test against libeUserInfo because the script that sets it is blocking
+            xt_an = typeof(libeUserInfo["xiti_user_id"]) == "undefined" ? "" : libeUserInfo["xiti_user_id"];
+            xt_ac = typeof(libeUserInfo["xiti_access_level"]) == "undefined" ? "" : libeUserInfo["xiti_access_level"];
+        }
+
+        // software blocker
+        if (typeof(libeUserInfo["softwarer_blocker"]) != "undefined") {
+            xt_multc += "&x8=" + libeUserInfo["softwarer_blocker"]
+        }
+
+        if (window.xtparam==null) { window.xtparam = ''; }
+        window.xtparam += "&ptype="+xt_pagetype+"&ac="+xt_ac+"&an="+xt_an+xt_multc;
+        //]]>
+        </script> <noscript><img width="1" height="1" alt="xiti" src="https://logs1091.xiti.com/hit.xiti?s=381060&amp;s2=42&amp;p=Culture::Article_-_Screenshot_Vape_Wave_6_Days_Alphonse_President_-_1612047&amp;ptype=2-1-0&amp;di=&amp;ac=&amp;an=&amp;x1=0&amp;x2=40&amp;x3=10&amp;x4=&amp;x5=20171124&amp;x6=20&amp;x7=1612047" /></noscript> 
+        <script type="text/javascript" src="https://statics.liberation.fr/newnext/cache/js/8f00b3ddc4db.js"></script> <!--/*********************************************
+*                  Mediametrie                   *
+**********************************************/-->
+        <script>
+        <![CDATA[
+
+        (function(){  
+        // 1. Loading the measurement system  
+        var aS = document.createElement('script');  
+        aS.type = 'text/javascript';  
+        aS.async = true;  
+        aS.src = 'https://tag.audience.acpm.fr/js/on-1.0.min.js';  
+
+        var s = document.getElementsByTagName('script')[0];  
+        s.parentNode.insertBefore(aS, s);  
+
+        // 2. Sending the measurement  
+        if(aS.addEventListener) {  
+          aS.addEventListener('load', function(){  
+              aSloaded();  
+          }, false)  
+        } else {  
+          aS.onreadystatechange = function () {  
+              if (aS.readyState in {complete: 1, loaded: 1}) {  
+                  aSloaded();  
+              }  
+          };  
+        }  
+        aSloaded = function(){  
+          var tag = new Acpm.Tag("201001216586");  // Insert the serial provided by ACPM
+          tag.send();                     
+        };  
+        })();  
+        ]]>
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        var sasOptions = {
+        siteId: 130093,
+        pageId: 736918,
+        formats: ['28993', '28999', '28991', '28990', '29000'],
+        target: {
+        support: 'article',
+        objectId: '1612047',
+        primarySection: '54',
+        typology: '10',
+        section: [9,54],
+        site: '2'
+        }
+        };
+
+
+        Article.init();
+
+        //]]>
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        initInfinityScroll({
+        $container: $('.js-infinity-section-container'),
+        replaceState: false,
+        limitPages: 1,
+        });
+        $(document).on('infinityScrollNewPage', function(){
+        $('img').unveil();
+        })
+        //]]>
+        </script> <!-- Eulerian Analytics - Tag Generique -->
+         
+        <script type="text/javascript">
+
+        /*<![CDATA[*/
+        var dmp = {
+        cat1: '',
+        cats: '',
+        keywords: '',
+        uid: libeUserInfo.email_hash
+        };
+
+        dmp.keywords = ['Documentaire', 'Libération', 'Netflix', 'Arte', 'Marsha P. Johnson', 'Alan Moore', 'France', 'New York', 'Cinéaste', 'Thriller', 'Special Air Service', 'Acteur', 'Web\u002Dsérie', 'Opération Nimrod', 'Jim Carrey', 'Winamp', 'Planète+', 'Queer', 'LGBT', 'Icône', 'From Hell', 'Comique', 'Etty Buzyn', 'Bande\u002Dannonce', 'Jefferson Starship', 'Vieux\u002Dcroyants', 'Greenwich Village', 'V pour Vendetta', 'Michel Vuillermoz', 'Évangélisation', 'Sans\u002Dabri', 'Frein de bicyclette', 'Cigarette', 'Allergie', 'États\u002DUnis', 'Dieu merci!', 'Londres', 'Édouard Baer', 'Clément Cogitore', 'Margaret Thatcher', 'Vidéo à la demande', 'Pays de la Loire', 'Cinéma', 'Brasses', 'Réalisateur', '10 Downing Street', 'Jérusalem', 'Orange Cinéhappy', 'Mégot', 'Long métrage', 'Un grand patron', 'Droits de l\u0027homme', 'Baron noir', 'Ermites dans la taïga', 'DVD', 'Parfum', 'Financement participatif', 'Révolution', 'Albert Dupontel', 'Sénat', 'Andy Kaufman', 'Autarcie', 'Royaume\u002DUni', 'Famille Lykov', 'Brexit', 'Captures d\u0027écran', 'Jan Kounen', 'Dobermann', 'Comédie\u002DFrançaise', 'Famille', 'Taïga', 'Queen', 'Prise d\u0027otages des Jeux olympiques de Munich', 'Président de la République', '99 francs', 'Langue de bois', 'Miloš Forman', 'Torture', 'Watchmen', 'Anonymous', 'François Hollande', 'The Dead Lands', 'Mark Strong', 'Jamie Bell', 'Nabiha Akkari', 'Jean\u002DMichel Lahmi', 'France 3 Limousin', 'Tournage', 'Élysée', 'Cigarette électronique', 'Billy Elliot', 'Andy Warhol', 'Vaudou', 'Des lendemains qui chantent', 'Prostitution', 'Angleterre', 'Rosa Parks', 'Bob Zmuda', 'Émeutes de Stonewall', 'CNC', 'MtF', 'Tabac', 'Michel Serres', 'Violence', 'ADAGP', 'French Touch', 'Premier ministre', 'Canal+', 'Danse', 'Man on the Moon', 'The Great Beyond', 'Veep', 'House of Cards', 'Vassili Peskov', ];
+        dmp.cat1 = 'culture';
+        dmp.cats = ['la-une','culture'];
+
+
+        var EA_data = [
+        'path','LIB_WEB/https://next.liberation.fr/culture/2017/11/24/screenshot-vape-wave-6-days-alphonse-president_1612047'.replace('http://', '') /*Nom de page*/
+        ,'uid',dmp.uid /*Email hashé*/
+        ,'cflag-key','keywords'
+        ,'cflag-val',dmp.keywords /*Mots-clef gestion de type array*/
+        ,'adblocker',Boolean(libeUserInfo.softwarer_blocker) ? 'oui' : 'non' /*Présence adblocker actif*/
+        ,'abonnement',libeUserInfo.access_level/*Niveau d'abonnement*/
+        ,'login_status', libeUserInfo.authenticated ? 'oui' : 'non' /*Statut login*/
+        ,'cflag-key','site'
+        ,'cflag-val','LIB_WEB'/*sites apps*/
+        ,'cflag-key','sous-domaine'
+        ,'cflag-val','next.liberation.fr'/*Sous domaine*/
+        ,'cflag-key','page_cat1'
+        ,'cflag-val',dmp.cat1/*Catégorie page niv.1*/
+        ,'cflag-key','page-cats'
+        ,'cflag-val',dmp.cats/*gestion de type array*/
+        ,'cflag-key','Login_status'
+        ,'cflag-val',libeUserInfo.authenticated ? 'oui' : 'non'/*Statut login*/
+        ];
+        (function(){var td='f7ds.liberation.fr',d=document,l=d.location;if(!l.protocol.indexOf('http')){var
+        o=d.createElement('script'),a=d.getElementsByTagName('script')[0],cn=parseInt((new Date()).getTime()/3600000),cj='',cdh=(l.host+td).replace(/[^az]/g,''),cdr=cdh+cdh.toUpperCase(),acdr=cdr.split('');for(var
+        i=-1;i<cn%7;i++){cj+=acdr[(cn+i)%acdr.length];}o.type='text/javascript';o.async='async';o.defer='defer';o.src='//'+td+'/'+cj+(cn%8760)+'.js';a.parentNode.insertBefore(o,a);}})();
+        /*]]>*/
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        var n_pbt='';
+        var nuggrid = encodeURIComponent(top.location.href);
+        document.write(
+        '<scr' + 'ipt type="text/javascript" src="//asqliberation.nuggad.net/rc?nuggn=400929945&nuggsid=1709843951&nuggrid=' + nuggrid + '"><\/scr' + 'ipt>');
+        //]]>
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        // -- Libération -- //
+
+        !function(a,b,c){"use strict";function d(a){var b=e[c]||{};e[c]=b,b[a]||(b[a]=function(){e._queue[c].push({method:a,args:Array.prototype.slice.apply(arguments)})})}var e=a.scimhtiraidem||{},f="init call config push pushDefault addProperties addProperty onFinish onStart _reset".split(" ");e._queue=e._queue||{},e._names=e._names||[],e._names.push(c),e._queue[c]=e._queue[c]||[],e._startTime=(new Date).getTime(),e._snippetVersion="2.0";for(var g=0;g<f.length;g++)d(f[g]);a.scimhtiraidem=e,a[c]=e[c];var h=b.createElement("script");h.setAttribute("type","text/javascript"),h.setAttribute("src","//static.mediarithmics.com/tag/1/tag.min.js"),h.setAttribute("async","true"),b.getElementsByTagName("script")[0].parentNode.appendChild(h)}(window,document,"gravity");
+
+        gravity.init({
+        mode: "VISIT",
+        site_token: "lib-main17"
+        });
+
+        var drProperties = {"page_keywords": "Documentaire,Lib\u00e9ration,Netflix,Arte,Marsha P. Johnson,Alan Moore,France,New York,Cin\u00e9aste,Thriller,Special Air Service,Acteur,Web-s\u00e9rie,Op\u00e9ration Nimrod,Jim Carrey,Winamp,Plan\u00e8te+,Queer,LGBT,Ic\u00f4ne,From Hell,Comique,Etty Buzyn,Bande-annonce,Jefferson Starship,Vieux-croyants,Greenwich Village,V pour Vendetta,Michel Vuillermoz,\u00c9vang\u00e9lisation,Sans-abri,Frein de bicyclette,Cigarette,Allergie,\u00c9tats-Unis,Dieu merci!,Londres,\u00c9douard Baer,Cl\u00e9ment Cogitore,Margaret Thatcher,Vid\u00e9o \u00e0 la demande,Pays de la Loire,Cin\u00e9ma,Brasses,R\u00e9alisateur,10 Downing Street,J\u00e9rusalem,Orange Cin\u00e9happy,M\u00e9got,Long m\u00e9trage,Un grand patron,Droits de l'homme,Baron noir,Ermites dans la ta\u00efga,DVD,Parfum,Financement participatif,R\u00e9volution,Albert Dupontel,S\u00e9nat,Andy Kaufman,Autarcie,Royaume-Uni,Famille Lykov,Brexit,Captures d'\u00e9cran,Jan Kounen,Dobermann,Com\u00e9die-Fran\u00e7aise,Famille,Ta\u00efga,Queen,Prise d'otages des Jeux olympiques de Munich,Pr\u00e9sident de la R\u00e9publique,99 francs,Langue de bois,Milo\u0161 Forman,Torture,Watchmen,Anonymous,Fran\u00e7ois Hollande,The Dead Lands,Mark Strong,Jamie Bell,Nabiha Akkari,Jean-Michel Lahmi,France 3 Limousin,Tournage,\u00c9lys\u00e9e,Cigarette \u00e9lectronique,Billy Elliot,Andy Warhol,Vaudou,Des lendemains qui chantent,Prostitution,Angleterre,Rosa Parks,Bob Zmuda,\u00c9meutes de Stonewall,CNC,MtF,Tabac,Michel Serres,Violence,ADAGP,French Touch,Premier ministre,Canal+,Danse,Man on the Moon,The Great Beyond,Veep,House of Cards,Vassili Peskov", "page_typology": "Article", "page_domain": "next.liberation.fr", "page_title": "Screenshot\u00a0: \u00abVape Wave\u00bb, \u00ab6\u00a0Days\u00bb, \u00abAlphonse Pr\u00e9sident\u00bb\u2026", "page_section": "culture"};
+
+        gravity.push("$page_view", drProperties);
+
+        //]]>
+        </script> <!-- Google Tag Manager -->
+        <!-- <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-V9PX"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-V9PX');</script> -->
+        <!-- End Google Tag Manager -->
+         <!-- Twitter universal website tag code -->
+        <script>
+        <![CDATA[
+
+        !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+        },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
+        a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+        // Insert Twitter Pixel ID and Standard Event data below
+        twq('init','nx3h2');
+        twq('track','PageView');
+        ]]>
+        </script> <!-- End Twitter universal website tag code -->
+         <!-- Facebook Pixel Code -->
+        <script>
+        <![CDATA[
+
+        !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+        n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+        n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+        document,'script','https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '342040669704613'); // Insert your pixel ID here.
+        fbq('track', 'PageView');
+        ]]>
+        </script> <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=342040669704613&amp;ev=PageView&amp;noscript=1" /></noscript> <!-- DO NOT MODIFY -->
+        <!-- End Facebook Pixel Code -->
+         <!-- Code Google de la balise de remarketing -->
+        <script type="text/javascript">
+
+        /* <![CDATA[ */
+        var google_conversion_id = 964330869;
+        var google_custom_params = window.google_tag_params;
+        var google_remarketing_only = true;
+        /* ]]> */
+        </script> 
+        <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js"></script> <noscript>
+        <div style="display:inline;">
+            <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/964330869/?guid=ON&amp;script=0" />
+        </div></noscript> <!--  Quantcast Tag -->
+        <script>
+        <![CDATA[
+
+        var ezt = ezt ||[];
+
+        (function(){
+        var elem = document.createElement('script');
+        elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://pixel") + ".quantserve.com/aquant.js?a=p-9E79g-9qXk8bk";
+        elem.async = true;
+        elem.type = "text/javascript";
+        var scpt = document.getElementsByTagName('script')[0];
+        scpt.parentNode.insertBefore(elem,scpt);
+        }());
+
+
+        ezt.push({qacct: 'p-9E79g-9qXk8bk',
+           uid: ''
+           });
+        ]]>
+        </script> <noscript><img src="//pixel.quantserve.com/pixel/p-9E79g-9qXk8bk.gif" style="display: none;" border="0" height="1" width="1" alt="Quantcast" /></noscript> <!-- End Quantcast Tag -->
+         <!-- Pixel MathTag Tag -->
+        <img src="//pixel.mathtag.com/event/img?mt_id=1202018&amp;mt_adid=192531&amp;mt_exem=&amp;mt_excl=&amp;v1=&amp;v2=&amp;v3=&amp;s1=&amp;s2=&amp;s3=" width="1" height="1" /> <!-- End Pixel MathTag Tag-->
+         
+        <script src="https://dhpikd1t89arn.cloudfront.net/js/include/sharethefacts-v1.js"></script>
+    </body>
+</html>


### PR DESCRIPTION
This PR should fix #410.

Previously, in [`_cleanConditionally`](https://github.com/mozilla/readability/blob/master/Readability.js#L1619), we only check the `embed` tag for video container. However, the embedded videos usually found inside `iframe` or maybe `object`. In fact, that's how [`_clean`](https://github.com/mozilla/readability/blob/master/Readability.js#L1479) method filters which embed that must be deleted.

This PR add a simple check to see if the `node` is actually a video container. I've also added two tests from URLs provided in #410. If you think it's too much, feel free to remove it.