### PR TITLE
Switch to a newer node.js to fix build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - '7.0'
+  - '11.0'
 script:
   - npm run lint
   - npm run test


### PR DESCRIPTION
Travis seems upset:

```
> readability@0.2.0 lint /home/travis/build/mozilla/readability
> eslint .
/home/travis/build/mozilla/readability/node_modules/eslint/lib/cli-engine/cli-engine.js:257
        ...calculateStatsPerFile(messages)
        ^^^
SyntaxError: Unexpected token ...
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:545:28)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/travis/build/mozilla/readability/node_modules/eslint/lib/cli-engine/index.js:3:23)
    at Module._compile (module.js:573:32)
```

Hopefully this helps...