### PR TITLE
Preserve children when removing javascript: links

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -332,11 +332,21 @@ Readability.prototype = {
     this._forEachNode(links, function(link) {
       var href = link.getAttribute("href");
       if (href) {
-        // Replace links with javascript: URIs with text content, since
+        // Remove links with javascript: URIs, since
         // they won't work after scripts have been removed from the page.
         if (href.indexOf("javascript:") === 0) {
-          var text = this._doc.createTextNode(link.textContent);
-          link.parentNode.replaceChild(text, link);
+          // if the link only contains simple text content, it can be converted to a text node
+          if (link.childNodes.length === 1 && link.childNodes[0].nodeType === this.TEXT_NODE) {
+            var text = this._doc.createTextNode(link.textContent);
+            link.parentNode.replaceChild(text, link);  
+          } else {
+            // if the link has multiple children, they should all be preserved
+            var container = this._doc.createElement('span')
+            while (link.childNodes.length > 0) {
+              container.appendChild(link.childNodes[0])
+            }
+            link.parentNode.replaceChild(container, link);
+          }
         } else {
           link.setAttribute("href", toAbsoluteURI(href));
         }

--- a/test/test-pages/js-link-replacement/expected-metadata.json
+++ b/test/test-pages/js-link-replacement/expected-metadata.json
@@ -1,0 +1,7 @@
+{
+  "title": "Replace javascript: links",
+  "byline": null,
+  "excerpt": "abc",
+  "siteName": null,
+  "readerable": false
+}

--- a/test/test-pages/js-link-replacement/expected.html
+++ b/test/test-pages/js-link-replacement/expected.html
@@ -1,0 +1,7 @@
+<div id="readability-page-1" class="page">  
+    <span>
+        <p>abc</p>
+        <p>def</p>
+        ghi
+      </span>
+  </div>

--- a/test/test-pages/js-link-replacement/source.html
+++ b/test/test-pages/js-link-replacement/source.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Replace javascript: links</title>
+</head>
+<body>  
+  <a href="javascript:">
+      <p>abc</p>
+      <p>def</p>
+      ghi
+    </a>
+</body>
+</html>


### PR DESCRIPTION
Fixes #575 

The site has markup like this:
```
どもへの<a href='javascript:void(0)' class='dicWin' id='id-0002'><ruby><span class="under">虐待</span><rt>ぎゃくたい</rt></ruby></a>をな
```

Previously, when removing the `javascript:` link, all the children of the link would be flattened into a single text node, removing the `<ruby>` tag. Now, the children are preserved and the link is replaced with a `<span>` to hold the children.