### PR TITLE
Fix #580 by not using live node lists when removing items

### DIFF
--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -308,6 +308,7 @@
       }
     }
     getElems(this);
+    elems._isLiveNodeList = true;
     return elems;
   }
 


### PR DESCRIPTION
It turns out that having a 15k live node list which we remove items from 1 at a time, which then causes us to recompute the length and all the members, is really slow. This change:

- makes us use `querySelectorAll` in places that support it (e.g. jsdom), which returns a static node list (as opposed to the live node list from `getElementsByTagName`), by using the `_getAllNodesWithTag` helper. In the JSDOMParser case (ie in Firefox), it'll return an array, which is also static.
- makes the node removal/replacement helpers throw errors if you pass the result of `getElementsByTagName` to them, to avoid hitting this problem when we implement other removals.