### PR TITLE
Replace a Dead Link in Comment

### DIFF
--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -278,7 +278,7 @@
 
   var whitespace = [" ", "\t", "\n", "\r"];
 
-  // See http://www.w3schools.com/dom/dom_nodetype.asp
+  // See https://www.w3schools.com/jsref/prop_node_nodetype.asp
   var nodeTypes = {
     ELEMENT_NODE: 1,
     ATTRIBUTE_NODE: 2,

--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -278,7 +278,7 @@
 
   var whitespace = [" ", "\t", "\n", "\r"];
 
-  // See https://www.w3schools.com/jsref/prop_node_nodetype.asp
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
   var nodeTypes = {
     ELEMENT_NODE: 1,
     ATTRIBUTE_NODE: 2,
@@ -705,7 +705,6 @@
       }
 
       // Using Array.join() avoids the overhead from lazy string concatenation.
-      // See http://blog.cdleary.com/2012/01/string-representation-in-spidermonkey/#ropes
       var arr = [];
       getHTML(this);
       return arr.join("");


### PR DESCRIPTION
So, I was just reviewing JSDOMParser.js and came upon two dead links. I have replaced on of them and couldn't find a replacement for the other. (2nd Link is just above the .join() method. LINE: 708)