### PR TITLE
Add option.serializer, fixes #605

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -202,4 +202,4 @@ module.exports = {
     // Only check typeof against valid results
     "valid-typeof": 2,
   },
-}
+};

--- a/Readability.js
+++ b/Readability.js
@@ -50,6 +50,9 @@ function Readability(doc, options) {
   this._charThreshold = options.charThreshold || this.DEFAULT_CHAR_THRESHOLD;
   this._classesToPreserve = this.CLASSES_TO_PRESERVE.concat(options.classesToPreserve || []);
   this._keepClasses = !!options.keepClasses;
+  this._serializer = options.serializer || function(el) {
+    return el.innerHTML;
+  };
 
   // Start with all flags set
   this._flags = this.FLAG_STRIP_UNLIKELYS |
@@ -2057,7 +2060,7 @@ Readability.prototype = {
       title: this._articleTitle,
       byline: metadata.byline || this._articleByline,
       dir: this._articleDir,
-      content: articleContent.innerHTML,
+      content: this._serializer(articleContent),
       textContent: textContent,
       length: textContent.length,
       excerpt: metadata.excerpt,

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -258,6 +258,17 @@ describe("Readability API", function() {
       expect(parser._cleanClasses.called).eql(false);
     });
 
+    it("should use custom content serializer sent as option", function() {
+      var dom = new JSDOM("My cat: <img src=''>");
+      var expected_xhtml = "<div xmlns=\"http://www.w3.org/1999/xhtml\" id=\"readability-page-1\" class=\"page\">My cat: <img src=\"\" /></div>";
+      var xml = new dom.window.XMLSerializer();
+      var content = new Readability(dom.window.document, {
+        serializer: function(el) {
+          return xml.serializeToString(el.firstChild);
+        }
+      }).parse().content;
+      expect(content).eql(expected_xhtml);
+    });
   });
 });
 


### PR DESCRIPTION
Adds `option.serializer` as a solution to the problem discussed in #605. 

An alternative approach I've considered was add the `articleContent` DOM element in the `parse()` return object, but that makes the object poorly serializable. 