### PR TITLE
Configuration for isProbablyReaderable thresholds

### DIFF
--- a/Readability-readerable.js
+++ b/Readability-readerable.js
@@ -46,7 +46,7 @@ function isNodeVisible(node) {
 function isProbablyReaderable(doc, options = {}) {
   // For backward compatibility reasons 'options' can either be a configuration object or the function used
   // to determine if a node is visible.
-  if (typeof options === "function") {
+  if (typeof options == "function") {
     options = { visibilityChecker: options };
   }
 

--- a/Readability-readerable.js
+++ b/Readability-readerable.js
@@ -38,8 +38,8 @@ function isNodeVisible(node) {
 /**
  * Decides whether or not the document is reader-able without parsing the whole thing.
  * @param {Object} options Configuration object.
- * @param {number} [options.minContentLength=140] The minimum content length used to decide if the document is readerable.
- * @param {number} [options.minScore=20] The minumum 'score' used to determine if the document is readerable.
+ * @param {number} [options.minContentLength=140] The minimum node content length used to decide if the document is readerable.
+ * @param {number} [options.minScore=20] The minumum cumulated 'score' used to determine if the document is readerable.
  * @param {Function} [options.visibilityChecker=isNodeVisible] The function used to determine if a node is visible.
  * @return {boolean} Whether or not we suspect Readability.parse() will suceeed at returning an article object.
  */
@@ -51,7 +51,7 @@ function isProbablyReaderable(doc, options = {}) {
   }
 
   var defaultOptions = { minScore: 20, minContentLength: 140, visibilityChecker: isNodeVisible };
-  options = Object.assign(options || {}, defaultOptions);
+  options = Object.assign(defaultOptions, options);
 
   var nodes = doc.querySelectorAll("p, pre");
 
@@ -65,7 +65,7 @@ function isProbablyReaderable(doc, options = {}) {
   var brNodes = doc.querySelectorAll("div > br");
   if (brNodes.length) {
     var set = new Set(nodes);
-    [].forEach.call(brNodes, function(node) {
+    [].forEach.call(brNodes, function (node) {
       set.add(node.parentNode);
     });
     nodes = Array.from(set);
@@ -74,13 +74,14 @@ function isProbablyReaderable(doc, options = {}) {
   var score = 0;
   // This is a little cheeky, we use the accumulator 'score' to decide what to return from
   // this callback:
-  return [].some.call(nodes, function(node) {
-    if (!options.visibilityChecker(node))
+  return [].some.call(nodes, function (node) {
+    if (!options.visibilityChecker(node)) {
       return false;
+    }
 
     var matchString = node.className + " " + node.id;
     if (REGEXPS.unlikelyCandidates.test(matchString) &&
-        !REGEXPS.okMaybeItsACandidate.test(matchString)) {
+      !REGEXPS.okMaybeItsACandidate.test(matchString)) {
       return false;
     }
 

--- a/Readability-readerable.js
+++ b/Readability-readerable.js
@@ -81,7 +81,7 @@ function isProbablyReaderable(doc, options = {}) {
 
     var matchString = node.className + " " + node.id;
     if (REGEXPS.unlikelyCandidates.test(matchString) &&
-      !REGEXPS.okMaybeItsACandidate.test(matchString)) {
+        !REGEXPS.okMaybeItsACandidate.test(matchString)) {
       return false;
     }
 

--- a/Readability-readerable.js
+++ b/Readability-readerable.js
@@ -40,7 +40,7 @@ function isNodeVisible(node) {
  *
  * @return boolean Whether or not we suspect Readability.parse() will suceeed at returning an article object.
  */
-function isProbablyReaderable(doc, isVisible) {
+function isProbablyReaderable(doc, isVisible = null, options = { minScore: 20, minContentLength: 140 }) {
   if (!isVisible) {
     isVisible = isNodeVisible;
   }
@@ -81,13 +81,13 @@ function isProbablyReaderable(doc, isVisible) {
     }
 
     var textContentLength = node.textContent.trim().length;
-    if (textContentLength < 140) {
+    if (textContentLength < options.minContentLength) {
       return false;
     }
 
-    score += Math.sqrt(textContentLength - 140);
+    score += Math.sqrt(textContentLength - options.minContentLength);
 
-    if (score > 20) {
+    if (score > options.minScore) {
       return true;
     }
     return false;

--- a/test/test-isProbablyReaderable.js
+++ b/test/test-isProbablyReaderable.js
@@ -94,7 +94,8 @@ describe("isProbablyReaderable", function () {
   it("should use node visibility checker provided as parameter - not visible", function () {
     var called = false;
     var visibilityChecker = () => {
-      called = true; return false;
+      called = true;
+      return false;
     };
     expect(isProbablyReaderable(veryLargeDoc, visibilityChecker)).to.be.false;
     expect(called).to.be.true;
@@ -103,7 +104,8 @@ describe("isProbablyReaderable", function () {
   it("should use node visibility checker provided as parameter - visible", function () {
     var called = false;
     var visibilityChecker = () => {
-      called = true; return true;
+      called = true;
+      return true;
     };
     expect(isProbablyReaderable(veryLargeDoc, visibilityChecker)).to.be.true;
     expect(called).to.be.true;

--- a/test/test-isProbablyReaderable.js
+++ b/test/test-isProbablyReaderable.js
@@ -6,18 +6,106 @@ var expect = chai.expect;
 var testPages = require("./utils").getTestPages();
 var isProbablyReaderable = require("../index").isProbablyReaderable;
 
-describe("isProbablyReaderable - test pages", function() {
-  testPages.forEach(function(testPage) {
+describe("isProbablyReaderable - test pages", function () {
+  testPages.forEach(function (testPage) {
     var uri = "http://fakehost/test/page.html";
-    describe(testPage.dir, function() {
+    describe(testPage.dir, function () {
       var doc = new JSDOM(testPage.source, {
         url: uri,
       }).window.document;
       var expected = testPage.expectedMetadata.readerable;
-      it("The result should " + (expected ? "" : "not ") + "be readerable", function() {
+      it("The result should " + (expected ? "" : "not ") + "be readerable", function () {
         expect(isProbablyReaderable(doc)).eql(expected);
       });
     });
   });
 });
 
+describe("isProbablyReaderable", function () {
+  const makeDoc = (source) => new JSDOM(source).window.document;
+  var verySmallDoc = makeDoc("<html><p id=\"main\">hello there</p></html>"); // content length: 11
+  var smallDoc = makeDoc(`<html><p id="main">${"hello there ".repeat(11)}</p></html>`); // content length: 132
+  var largeDoc = makeDoc(`<html><p id="main">${"hello there ".repeat(12)}</p></html>`); // content length: 144
+  var veryLargeDoc = makeDoc(`<html><p id="main">${"hello there ".repeat(50)}</p></html>`); // content length: 600
+
+  it("should only declare large documents as readerable when default options", function () {
+    expect(isProbablyReaderable(verySmallDoc), "very small doc").to.be.false; // score: 0
+    expect(isProbablyReaderable(smallDoc), "small doc").to.be.false; // score: 0
+    expect(isProbablyReaderable(largeDoc), "large doc").to.be.false; // score: ~1.7
+    expect(isProbablyReaderable(veryLargeDoc), "very large doc").to.be.true; // score: ~21.4
+  });
+
+  it("should declare small and large documents as readerable when lower minContentLength", function () {
+    var options = { minContentLength: 120, minScore: 0 };
+    expect(isProbablyReaderable(verySmallDoc, options), "very small doc").to.be.false;
+    expect(isProbablyReaderable(smallDoc, options), "small doc").to.be.true;
+    expect(isProbablyReaderable(largeDoc, options), "large doc").to.be.true;
+    expect(isProbablyReaderable(veryLargeDoc, options), "very large doc").to.be.true;
+  });
+
+  it("should only declare largest document as readerable when higher minContentLength", function () {
+    var options = { minContentLength: 200, minScore: 0 };
+    expect(isProbablyReaderable(verySmallDoc, options), "very small doc").to.be.false;
+    expect(isProbablyReaderable(smallDoc, options), "small doc").to.be.false;
+    expect(isProbablyReaderable(largeDoc, options), "large doc").to.be.false;
+    expect(isProbablyReaderable(veryLargeDoc, options), "very large doc").to.be.true;
+  });
+
+  it("should declare small and large documents as readerable when lower minScore", function () {
+    var options = { minContentLength: 0, minScore: 4 };
+    expect(isProbablyReaderable(verySmallDoc, options), "very small doc").to.be.false; // score: ~3.3
+    expect(isProbablyReaderable(smallDoc, options), "small doc").to.be.true; // score: ~11.4
+    expect(isProbablyReaderable(largeDoc, options), "large doc").to.be.true; // score: ~11.9
+    expect(isProbablyReaderable(veryLargeDoc, options), "very large doc").to.be.true; // score: ~24.4
+  });
+
+  it("should declare large documents as readerable when higher minScore", function () {
+    var options = { minContentLength: 0, minScore: 11.5 };
+    expect(isProbablyReaderable(verySmallDoc, options), "very small doc").to.be.false; // score: ~3.3
+    expect(isProbablyReaderable(smallDoc, options), "small doc").to.be.false; // score: ~11.4
+    expect(isProbablyReaderable(largeDoc, options), "large doc").to.be.true; // score: ~11.9
+    expect(isProbablyReaderable(veryLargeDoc, options), "very large doc").to.be.true; // score: ~24.4
+  });
+
+  it("should use node visibility checker provided as option - not visible", function () {
+    var called = false;
+    var options = {
+      visibilityChecker() {
+        called = true;
+        return false;
+      }
+    };
+    expect(isProbablyReaderable(veryLargeDoc, options)).to.be.false;
+    expect(called).to.be.true;
+  });
+
+  it("should use node visibility checker provided as option - visible", function () {
+    var called = false;
+    var options = {
+      visibilityChecker() {
+        called = true;
+        return true;
+      }
+    };
+    expect(isProbablyReaderable(veryLargeDoc, options)).to.be.true;
+    expect(called).to.be.true;
+  });
+
+  it("should use node visibility checker provided as parameter - not visible", function () {
+    var called = false;
+    var visibilityChecker = () => {
+      called = true; return false;
+    };
+    expect(isProbablyReaderable(veryLargeDoc, visibilityChecker)).to.be.false;
+    expect(called).to.be.true;
+  });
+
+  it("should use node visibility checker provided as parameter - visible", function () {
+    var called = false;
+    var visibilityChecker = () => {
+      called = true; return true;
+    };
+    expect(isProbablyReaderable(veryLargeDoc, visibilityChecker)).to.be.true;
+    expect(called).to.be.true;
+  });
+});


### PR DESCRIPTION
This pull request makes it possible to change the score and content length limits used to determine if a content is probably readable. That allows callers to have more control over the sensitivity of the function `isProbablyReaderable `.

It would be nice to also move `isVisible` to the `options` object but that would be a breaking change.