### PR TITLE
Fix for LinkeDOM compatibility: don't rely on live collections

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1246,9 +1246,8 @@ Readability.prototype = {
         var div = doc.createElement("DIV");
         div.id = "readability-page-1";
         div.className = "page";
-        var children = articleContent.childNodes;
-        while (children.length) {
-          div.appendChild(children[0]);
+        while (articleContent.firstChild) {
+          div.appendChild(articleContent.firstChild);
         }
         articleContent.appendChild(div);
       }


### PR DESCRIPTION
This allows `@mozilla/readability` to work with `LinkeDOM`, an alternative to `jsdom` that is much faster, has a smaller RAM footprint, and uses less dependencies (4 vs 96).

It's intended as a drop-in replacement for `jsdom`, but when trying to use it with `readability`, I stumbled into one small issue with a cached instance of childNodes. This new lib, `LinkeDOM`, does not update cached instances, so there is an incompatibility with how `Readability.js` accesses the DOM. This practice of using `childNodes` as both a node of a tree, with the expectations and side effects of modifying the tree indirectly, and also as an Array, sounds like 1990's JavaScript -- it feels awkward to use it nowadays.

More info here: https://github.com/WebReflection/linkedom/issues/43