### PR TITLE
Add iframe support for cdn.embedly.com in REGEXPS.videos

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -130,7 +130,7 @@ Readability.prototype = {
     byline: /byline|author|dateline|writtenby|p-author/i,
     replaceFonts: /<(\/?)font[^>]*>/gi,
     normalize: /\s{2,}/g,
-    videos: /\/\/(www\.)?((dailymotion|youtube|youtube-nocookie|player\.vimeo|v\.qq)\.com|(archive|upload\.wikimedia)\.org|player\.twitch\.tv)/i,
+    videos: /\/\/(www\.)?((dailymotion|youtube|youtube-nocookie|player\.vimeo|v\.qq)\.com|(archive|upload\.wikimedia)\.org|player\.twitch\.tv|cdn\.embedly\.com)/i,
     shareElements: /(\b|_)(share|sharedaddy)(\b|_)/i,
     nextLink: /(next|weiter|continue|>([^\|]|$)|»([^\|]|$))/i,
     prevLink: /(prev|earl|old|new|<|«)/i,


### PR DESCRIPTION
This pull request adds support for extracting iframes with src from cdn.embedly.com which is common on many websites.