### PR TITLE
jpg/webp/png may appear at alt attribute cause a mistake

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1985,7 +1985,7 @@ Readability.prototype = {
 
       for (var j = 0; j < elem.attributes.length; j++) {
         attr = elem.attributes[j];
-        if (attr.name === "src" || attr.name === "srcset") {
+        if (attr.name === "src" || attr.name === "srcset" || attr.name === "alt") {
           continue;
         }
         var copyTo = null;

--- a/test/test-pages/lazy-image-3/expected-metadata.json
+++ b/test/test-pages/lazy-image-3/expected-metadata.json
@@ -1,0 +1,7 @@
+{
+  "title": "Lazy Load with Alt includes jpg/png/webp extensions",
+  "byline": null,
+  "dir": null,
+  "siteName": null,
+  "readerable": false
+}

--- a/test/test-pages/lazy-image-3/expected.html
+++ b/test/test-pages/lazy-image-3/expected.html
@@ -1,0 +1,8 @@
+<div id="readability-page-1" class="page">
+    <article>
+        <h2>Test Case 1</h2>
+        <img data-src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.jpg" alt="performance.jpg" src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.jpg" />
+        <h2>Test Case 2</h2>
+        <img data-src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.png" alt="performance.jpg" src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.png" />
+    </article>
+</div>

--- a/test/test-pages/lazy-image-3/source.html
+++ b/test/test-pages/lazy-image-3/source.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Lazy Load with Alt includes jpg/png/webp extensions</title>
+</head>
+<body>  
+  <article class="markdown-body">
+    <h2>Test Case 1</h2>
+    <img class="lazyload inited loaded"
+      data-src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.jpg"
+      alt="performance.jpg"
+    />
+    <h2>Test Case 2</h2>
+    <img class="lazyload inited loaded"
+      data-src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.png"
+      alt="performance.jpg"
+    />
+  </article>
+</body>
+</html>


### PR DESCRIPTION
jpg/webp/png may appear at alt attribute, will cause a mistake

``` html
<img
  class="lazyload inited loaded"
  data-src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.jpg"
  alt="performance.jpg"
>
```

**expected**

``` html
<img
  class="lazyload inited loaded"
  data-src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.jpg"
  alt="performance.jpg"
  src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.jpg"
>
```

**actually**

``` html
<img
  class="lazyload inited loaded"
  data-src="https://p3-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/0579d17015b145a88dd93992c6447d7d~tplv-k3u1fbpfcp-watermark.jpg"
  alt="performance.jpg"
  src="performance.jpg"
>
```