### PR TITLE
Improve images detection

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1807,30 +1807,14 @@ Readability.prototype = {
     return weight;
   },
 
-  _contains (parent, child) {
-    if (parent.contains) {
-      return parent.contains(child);
-    }
-
-    // For JSDOM, which does not have contains function
-    let p = child.parentNode;
-    while (p) {
-      if (p === parent) {
-        return true;
-      }
-      p = p.parentNode;
-    }
-
-    return false;
-  },
-
   _getTotalClassWeight: function(node) {
     let weight = this._getClassWeight(node);
-    let nextNode = this._getNextNode(node, false);
-    while (nextNode && this._contains(node, nextNode)) {
-      weight += this._getClassWeight(nextNode);
-      nextNode = this._getNextNode(nextNode, false);
+
+    let children = node.getElementsByTagName('*')
+    for (const child of children) {
+      weight += this._getClassWeight(child);
     }
+
     return weight;
   },
 

--- a/Readability.js
+++ b/Readability.js
@@ -1778,9 +1778,9 @@ Readability.prototype = {
     var weight = 0;
 
     // If the element is an image and size is big enough, increase weight
-    if (e.tagName === 'IMG') {
+    if (e.tagName === "IMG") {
       if (e.width > 400 && e.height > 400) {
-        weight += 50
+        weight += 50;
       } else if (e.width > 200 && e.height > 200) {
         weight += 25;
       }

--- a/Readability.js
+++ b/Readability.js
@@ -1777,15 +1777,6 @@ Readability.prototype = {
 
     var weight = 0;
 
-    // If the element is an image and size is big enough, increase weight
-    if (e.tagName === "IMG") {
-      if (e.width > 400 && e.height > 400) {
-        weight += 50;
-      } else if (e.width > 200 && e.height > 200) {
-        weight += 25;
-      }
-    }
-
     // Look for a special classname
     if (typeof(e.className) === "string" && e.className !== "") {
       if (this.REGEXPS.negative.test(e.className))
@@ -1802,17 +1793,6 @@ Readability.prototype = {
 
       if (this.REGEXPS.positive.test(e.id))
         weight += 25;
-    }
-
-    return weight;
-  },
-
-  _getTotalClassWeight: function(node) {
-    let weight = this._getClassWeight(node);
-
-    let children = node.getElementsByTagName("*");
-    for (const child of children) {
-      weight += this._getClassWeight(child);
     }
 
     return weight;
@@ -2083,9 +2063,23 @@ Readability.prototype = {
         return false;
       }
 
-      // Calculate the weight of a node based on its own weight
-      // plus its children weight
-      var weight = this._getTotalClassWeight(node);
+      var hasImage = false;
+      if (node.querySelector) {
+        if (node.querySelector("img")) {
+          hasImage = true;
+        }
+      } else {
+        var images = node.getElementsByTagName("img");
+        if (images && images.length > 0) {
+          hasImage = true;
+        }
+      }
+
+      if (hasImage) {
+        return false;
+      }
+
+      var weight = this._getClassWeight(node);
 
       this.log("Cleaning Conditionally", node);
 

--- a/Readability.js
+++ b/Readability.js
@@ -1810,7 +1810,7 @@ Readability.prototype = {
   _getTotalClassWeight: function(node) {
     let weight = this._getClassWeight(node);
 
-    let children = node.getElementsByTagName('*');
+    let children = node.getElementsByTagName("*");
     for (const child of children) {
       weight += this._getClassWeight(child);
     }

--- a/Readability.js
+++ b/Readability.js
@@ -1777,6 +1777,15 @@ Readability.prototype = {
 
     var weight = 0;
 
+    // If the element is an image and size is big enough, increase weight
+    if (e.tagName === 'IMG') {
+      if (e.width > 400 && e.height > 400) {
+        weight += 50
+      } else if (e.width > 200 && e.height > 200) {
+        weight += 25;
+      }
+    }
+
     // Look for a special classname
     if (typeof(e.className) === "string" && e.className !== "") {
       if (this.REGEXPS.negative.test(e.className))
@@ -1795,6 +1804,16 @@ Readability.prototype = {
         weight += 25;
     }
 
+    return weight;
+  },
+
+  _getTotalClassWeight: function(node) {
+    let weight = this._getClassWeight(node);
+    let nextNode = this._getNextNode(node, false);
+    while (nextNode && node.contains(nextNode)) {
+      weight += this._getClassWeight(nextNode);
+      nextNode = this._getNextNode(nextNode, false);
+    }
     return weight;
   },
 
@@ -2063,7 +2082,9 @@ Readability.prototype = {
         return false;
       }
 
-      var weight = this._getClassWeight(node);
+      // Calculate the weight of a node based on its own weight
+      // plus its children weight
+      var weight = this._getTotalClassWeight(node);
 
       this.log("Cleaning Conditionally", node);
 

--- a/Readability.js
+++ b/Readability.js
@@ -1807,10 +1807,27 @@ Readability.prototype = {
     return weight;
   },
 
+  _contains (parent, child) {
+    if (parent.contains) {
+      return parent.contains(child);
+    }
+
+    // For JSDOM, which does not have contains function
+    let p = child.parentNode;
+    while (p) {
+      if (p === parent) {
+        return true;
+      }
+      p = p.parentNode;
+    }
+
+    return false;
+  },
+
   _getTotalClassWeight: function(node) {
     let weight = this._getClassWeight(node);
     let nextNode = this._getNextNode(node, false);
-    while (nextNode && node.contains(nextNode)) {
+    while (nextNode && this._contains(node, nextNode)) {
       weight += this._getClassWeight(nextNode);
       nextNode = this._getNextNode(nextNode, false);
     }

--- a/Readability.js
+++ b/Readability.js
@@ -1810,7 +1810,7 @@ Readability.prototype = {
   _getTotalClassWeight: function(node) {
     let weight = this._getClassWeight(node);
 
-    let children = node.getElementsByTagName('*')
+    let children = node.getElementsByTagName('*');
     for (const child of children) {
       weight += this._getClassWeight(child);
     }

--- a/test/test-pages/buzzfeed-1/expected.html
+++ b/test/test-pages/buzzfeed-1/expected.html
@@ -2,6 +2,10 @@
     <div id="buzz_sub_buzz">
         <div id="superlist_3758406_5547137" rel:buzz_num="1">
             <h2>The mother of a woman who took suspected diet pills bought online has described how her daughter was “literally burning up from within” moments before her death.</h2>
+            <div>
+                <p><img src="http://ak-hdl.buzzfed.com/static/2015-04/21/4/enhanced/webdr10/enhanced-6418-1429605460-16.jpg" rel:bf_image_src="http://ak-hdl.buzzfed.com/static/2015-04/21/4/enhanced/webdr10/enhanced-6418-1429605460-16.jpg" rel:bf_bucket="progload" alt="The mother of a woman who took suspected diet pills bought online has described how her daughter was &quot;literally burning up from within&quot; moments before her death." height="422" width="625" /></p>
+                <p><a href="http://ak-hdl.buzzfed.com/static/2015-04/21/4/enhanced/webdr10/enhanced-6418-1429605460-16.jpg" rel="nofollow"><b>View this image ›</b></a></p>
+            </div>
             <p> <span>West Merica Police</span></p>
         </div>
         <div id="superlist_3758406_5547213" rel:buzz_num="2">

--- a/test/test-pages/ehow-1/expected.html
+++ b/test/test-pages/ehow-1/expected.html
@@ -11,6 +11,14 @@
             <header>
                 <h3>Other People Are Reading</h3>
             </header>
+            <ul data-type="more-relatedArticles">
+                <li>
+                    <a href="http://www.ehow.com/video_12263138_plant-terrarium-ideas.html"> <img src="http://img-aws.ehowcdn.com/105x70/viper/media/2b3830ca-4eb6-4bfd-a1cd-d430b3e28d59/jpeg/a7edbb0f-86a7-4c73-9c2d-f85f87b49efa_0.jpg" /> </a> <a href="http://www.ehow.com/video_12263138_plant-terrarium-ideas.html">Plant Terrarium Ideas</a>
+                </li>
+                <li>
+                    <a href="http://www.ehow.com/how_4885344_build-terrarium-succulent-plants.html"> <img src="http://img-aws.ehowcdn.com/105x70/cme/photography.prod.demandstudios.com/619daaaa-7991-4fc6-9b62-dfeab8a285b4.jpg" /> </a> <a href="http://www.ehow.com/how_4885344_build-terrarium-succulent-plants.html">How to Build a Terrarium With Succulent Plants</a>
+                </li>
+            </ul>
         </div>
         <div>
             <p><span>What You'll Need:</span></p>
@@ -109,6 +117,23 @@
         </div>
         <section id="FeaturedTombstone" data-module="rcp_tombstone">
             <h2>Featured</h2>
+            <div>
+                <section data-cme-module="0">
+                    <a href="http://www.ehow.com/how_2056495_make-ballet-tutu.html"> <img src="http://img-aws.ehowcdn.com/200x133/cme/photography.prod.demandstudios.com/7f06be69-3650-4e94-88d4-2289c1a5c6a2.jpg" alt="" /> <span>Read Article</span>
+                        <p>How to Make a Ballet Tutu</p>
+                    </a>
+                </section>
+                <section data-cme-module="1">
+                    <a href="http://www.ehow.com/how_7687715_paint-tulip-watercolor.html"> <img src="http://img-aws.ehowcdn.com/200x133/cme/uploadedimages.demandmedia/tulips-1.jpg" alt="" /> <span>Read Article</span>
+                        <p>How to Paint a Tulip in Watercolor</p>
+                    </a>
+                </section>
+                <section data-cme-module="2">
+                    <a href="http://www.ehow.com/info_12340422_kids-kitchen-slipcover.html"> <img src="http://img-aws.ehowcdn.com/200x133/cme/uploadedimages.demandmedia/kitchen-1.jpg" alt="" /> <span>Read Article</span>
+                        <p>Kids Kitchen Slipcover</p>
+                    </a>
+                </section>
+            </div>
         </section>
     </div>
 </div>

--- a/test/test-pages/ehow-2/expected.html
+++ b/test/test-pages/ehow-2/expected.html
@@ -120,6 +120,18 @@
                         <header>
                             <h3>Other People Are Reading</h3>
                         </header>
+                        <ul data-type="more-relatedArticles">
+                            <li>
+                                <a href="http://www.ehow.com/how_4900703_high-school-graduation-party-budget.html">
+                                    <img src="http://img-aws.ehowcdn.com/105x70/cme/cme_public_images/www_ehow_com/i.ehow.com/images/a04/lh/qv/high-school-graduation-party-budget-800x800.jpg" /> </a>
+                                <a href="http://www.ehow.com/how_4900703_high-school-graduation-party-budget.html">How to Throw a High School Graduation Party on a Budget</a>
+                            </li>
+                            <li>
+                                <a href="http://www.ehow.com/way_5173339_cheap-graduation-party-meal-ideas.html">
+                                    <img src="http://img-aws.ehowcdn.com/105x70/cme/cme_public_images/www_ehow_com/i.ehow.com/images/a04/ts/2r/cheap-graduation-party-meal-ideas-800x800.jpg" /> </a>
+                                <a href="http://www.ehow.com/way_5173339_cheap-graduation-party-meal-ideas.html">Cheap Graduation Party Meal Ideas</a>
+                            </li>
+                        </ul>
                     </div>
                 </span>
             </span>

--- a/test/test-pages/engadget/expected.html
+++ b/test/test-pages/engadget/expected.html
@@ -8,6 +8,24 @@
             <p><a href="#" data-index="0" data-engadget-slide-id="7142088" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142088,&quot;index&quot;:0}">
                     <img src="https://o.aolcdn.com/images/dims?thumbnail=980%2C653&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F208%2F8%2FS7142088%2Fslug%2Fl%2Fxbox-one-x-review-gallery-1-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=9bb08b52e12de8e4060f863a52c613489529818d" />
                 </a></p>
+            <ul>
+                <li><a href="#" data-index="1" data-engadget-slide-id="7142089" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142089,&quot;index&quot;:0}">
+                        <img src="https://o.aolcdn.com/images/dims?thumbnail=130%2C87&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F208%2F9%2FS7142089%2Fslug%2Fl%2Fxbox-one-x-review-gallery-2-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=916edb7e63b5363e0d7ddfa5a1eb84cde5b6c0f9" />
+                    </a></li>
+                <li><a href="#" data-index="2" data-engadget-slide-id="7142090" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142090,&quot;index&quot;:0}">
+                        <img src="https://o.aolcdn.com/images/dims?thumbnail=130%2C87&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F209%2F0%2FS7142090%2Fslug%2Fl%2Fxbox-one-x-review-gallery-3-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=2ff9a50b64a05d9bb5f006c6a7ed6a38818c6111" />
+                    </a></li>
+                <li><a href="#" data-index="3" data-engadget-slide-id="7142091" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142091,&quot;index&quot;:0}">
+                        <img src="https://o.aolcdn.com/images/dims?thumbnail=130%2C87&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F209%2F1%2FS7142091%2Fslug%2Fl%2Fxbox-one-x-review-gallery-4-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=05f59c708541c0bcc6569a09deb733249b6ffce6" />
+                    </a></li>
+                <li><a href="#" data-index="4" data-engadget-slide-id="7142092" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142092,&quot;index&quot;:0}">
+                        <img src="https://o.aolcdn.com/images/dims?thumbnail=130%2C87&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F209%2F2%2FS7142092%2Fslug%2Fl%2Fxbox-one-x-review-gallery-5-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=e9fe81e42526f7f32e57e22fcc6cd7ac4e00801a" />
+                    </a>
+                    <a href="#" data-index="grid" data-engadget-slide-type="grid" data-eng-bang="{&quot;gallery&quot;:803271,&quot;view&quot;:&quot;grid&quot;}">
+                        <p> +10 </p>
+                    </a>
+                </li>
+            </ul>
         </div>
     </section>
     <div>
@@ -75,6 +93,24 @@
                 <p><a href="#" data-index="0" data-engadget-slide-id="7142924" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142924}">
                         <img src="https://o.aolcdn.com/images/dims?thumbnail=980%2C653&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F292%2F4%2FS7142924%2Fslug%2Fl%2Fxbox-one-x-screenshot-gallery-2-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=38c95635c7aad58a8a48038e05589f5cf35b1e28" />
                     </a></p>
+                <ul>
+                    <li><a href="#" data-index="1" data-engadget-slide-id="7142925" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142925}">
+                            <img src="https://o.aolcdn.com/images/dims?thumbnail=130%2C87&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F292%2F5%2FS7142925%2Fslug%2Fl%2Fxbox-one-x-screenshot-gallery-3-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=4dfa6e80acd3f2286ec97fadee78f05d440b1b64" />
+                        </a></li>
+                    <li><a href="#" data-index="2" data-engadget-slide-id="7142926" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142926}">
+                            <img src="https://o.aolcdn.com/images/dims?thumbnail=130%2C87&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F292%2F6%2FS7142926%2Fslug%2Fl%2Fxbox-one-x-screenshot-gallery-4-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=e35908c4fa292b0578fb81152657eea02ae148fd" />
+                        </a></li>
+                    <li><a href="#" data-index="3" data-engadget-slide-id="7142927" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142927}">
+                            <img src="https://o.aolcdn.com/images/dims?thumbnail=130%2C87&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F292%2F7%2FS7142927%2Fslug%2Fl%2Fxbox-one-x-screenshot-gallery-5-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=894210646519be60ae021b1835372b3fb2055339" />
+                        </a></li>
+                    <li><a href="#" data-index="4" data-engadget-slide-id="7142923" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142923}">
+                            <img src="https://o.aolcdn.com/images/dims?thumbnail=130%2C87&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F292%2F3%2FS7142923%2Fslug%2Fl%2Fxbox-one-x-screenshot-gallery-1-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=9a6cc2c58efde1b4dbd4989d5a534ae67dac6f2e" />
+                        </a>
+                        <a href="#" data-index="grid" data-engadget-slide-type="grid" data-eng-bang="{&quot;gallery&quot;:803330,&quot;view&quot;:&quot;grid&quot;}">
+                            <p> +6 </p>
+                        </a>
+                    </li>
+                </ul>
             </div>
         </section>
         <div>

--- a/test/test-pages/folha/expected.html
+++ b/test/test-pages/folha/expected.html
@@ -4,6 +4,17 @@
         <p> Ao lado de representantes do clube paulista, o atual comandante do Brasil ainda entregou uma réplica do troféu a Lula. </p>
         <p> "Em 2012 eu errei. Ele não era presidente, mas fui ao Instituto e mandei felicitações por um aniversário. Não me posicionei politicamente. Não tenho partido político, tenho sim a torcida para que o Brasil seja melhor em igualdade social. E que nossas prioridades sejam educação e punição. Que seja dada a possibilidade de estudo ao garoto de São Braz, que não tem chão batido para ir à escola, ou da periferia de Caixas ou do morro do Rio de Janeiro. Seja dada a ele a prioridade de estudo e não a outras situações", falou Tite ao programa "Grande Círculo", que ainda irá ao ar no SporTV. </p>
         <p> Na ocasião, Tite e outros representantes do Corinthians <a href="https://www1.folha.uol.com.br/poder/1124743-corinthians-leva-a-taca-da-libertadores-para-lula.shtml">foram ao Instituto Lula para mostrar a taça</a> original da Libertadores ao ex-presidente. </p>
+        <div>
+            <figure>
+                <figcaption>
+                    <a href="https://fotografia.folha.uol.com.br/galerias/nova/1618838542352047-os-times-de-coracao-dos-presidentes">Os times de coração dos presidentes</a>
+                </figcaption><a href="https://fotografia.folha.uol.com.br/galerias/nova/1618838542352047-os-times-de-coracao-dos-presidentes"><img src="https://f.i.uol.com.br/fotografia/2018/12/03/15438447625c05339a96ad0_1543844762_3x2_md.jpg" alt="Os times de coração dos presidentes" /></a>
+            </figure>
+            <div data-channel="esporte">
+                <p><img src="http://f.i.uol.com.br/hunting/furniture/1/common/icons/spin.gif" alt="Loading" />
+                </p>
+            </div>
+        </div>
         <p> O assunto foi levantado&#160;porque recentemente Tite foi questionado se aceitaria um encontro da seleção brasileira com Bolsonaro em uma conquista de título ou <a href="https://www1.folha.uol.com.br/esporte/2018/12/selecao-brasileira-jogara-duas-vezes-em-sao-paulo-na-copa-america.shtml">antes da Copa América de 2019</a>, por exemplo. O treinador deixou claro que preferiria evitar esse tipo de formalidade. </p>
         <p> Apesar disso, Tite não questionou a ação de Palmeiras e CBF, que <a href="https://www1.folha.uol.com.br/esporte/2018/12/cbf-usa-festa-do-palmeiras-para-se-aproximar-de-governo-bolsonaro.shtml">convidaram Bolsonaro para a festa do título do Campeonato Brasileiro</a>. O presidente eleito até levantou a taça conquistada pelo clube alviverde. </p>
         <p> "Em 2012 eu fiz e errei. O protocolo e a situação gerada no jogo do Palmeiras são fatos de opinião pessoal. CBF e Palmeiras, enquanto instituições têm a opinião. Errei lá atrás, não faria com o presidente antes da Copa e nem agora porque entendo que misturar esporte e política não é legal. Fiz errado lá atrás? Sim. Faria de novo? Não", acrescentou o comandante. </p>

--- a/test/test-pages/hukumusume/expected.html
+++ b/test/test-pages/hukumusume/expected.html
@@ -14,17 +14,6 @@
                     </tr>
                 </tbody>
             </table>
-            <table>
-                <tbody>
-                    <tr>
-                        <td>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td> &#160; </td>
-                    </tr>
-                </tbody>
-            </table>
         </td>
         <td>
             <p>
@@ -67,23 +56,6 @@
                     </tbody>
                 </table>
             </div>
-            <table>
-                <tbody>
-                    <tr>
-                        <td> ♪音声配信(html5) </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <audio src="http://ohanashi2.up.seesaa.net/mp3/ae_0101.mp3" controls=""></audio>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <a href="http://www.voiceblog.jp/onokuboaki/"><span size="-1">亜姫の朗読☆　イソップ童話より</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
             <p> 　肉をくわえたイヌが、橋を渡っていました。 　ふと下を見ると、川の中にも肉をくわえたイヌがいます。　イヌはそれを見て、思いました。（あいつの肉の方が、大きそうだ） 　イヌは、くやしくてたまりません。 （そうだ、あいつをおどかして、あの肉を取ってやろう） 　そこでイヌは、川の中のイヌに向かって思いっきり吠えました。 「ウゥー、ワン！！」 　そのとたん、くわえていた肉はポチャンと川の中に落ちてしまいました。 「ああー、ぁぁー」 　川の中には、がっかりしたイヌの顔がうつっています。 　さっきの川の中のイヌは、水にうつった自分の顔だったのです。 　同じ物を持っていても、人が持っている物の方が良く見え、また、欲張るとけっきょく損をするというお話しです。 </p>
             <p> おしまい </p>
             <div>
@@ -185,60 +157,6 @@
                     <tr>
                         <td>
                             <b><span size="-1">きょうの百物語</span></b><a href="http://fakehost/douwa/pc/kaidan/01/01.htm"><span size="-1">百物語の幽霊</span></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <table>
-                <tbody>
-                    <tr>
-                        <td>
-                            <b><span size="-1">福娘のサイト</span></b>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span size="-1"><b>366日への旅</b>
-                                <p>
-                                    <a href="http://hukumusume.com/366/">毎日の記念日・誕生花 ・有名人の誕生日と性格判断</a>
-                                </p>
-                            </span>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span size="-1"><b>福娘童話集</b>
-                                <p>
-                                    <a href="http://hukumusume.com/douwa/">世界と日本の童話と昔話</a>
-                                </p>
-                            </span>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span size="-1"><b>女の子応援サイト -さくら-</b>
-                                <p>
-                                    <a href="http://hukumusume.com/sakura/index.html">誕生日占い、お仕事紹介、おまじない、など</a>
-                                </p>
-                            </span>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span size="-1"><b>子どもの病気相談所</b>
-                                <p>
-                                    <a href="http://hukumusume.com/my_baby/sick/">病気検索と対応方法、症状から検索するWEB問診</a>
-                                </p>
-                            </span>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span size="-1"><b>世界60秒巡り</b>
-                                <p>
-                                    <a href="http://hukumusume.com/366/world/">国旗国歌や世界遺産など、世界の国々の豆知識</a>
-                                </p>
-                            </span>
                         </td>
                     </tr>
                 </tbody>

--- a/test/test-pages/medicalnewstoday/expected.html
+++ b/test/test-pages/medicalnewstoday/expected.html
@@ -14,6 +14,16 @@
         <h2> The hypothesis </h2>
         <p> Dr. Shadlen and colleagues started out from an interesting hypothesis, one which they derived from previous research on the neurobiological processes involved in decision-making. </p>
         <p> As the authors explain, research conducted in both monkeys and humans shows that many of our decisions take place at a point when the brain "feels" as though it has gathered enough information, or when a critical level of information has been accumulated. </p>
+        <div>
+            <a href="http://fakehost/articles/315184.php?iacp" title="Scientists find new mechanism for memory formation" target="_blank">
+                <div>
+                    <p><img data-src="/content/images/headlines/315/315184/memory-cogs.jpg" alt="Scientists find new mechanism for memory formation" src="http://fakehost/content/images/headlines/315/315184/memory-cogs.jpg" /></p>
+                    <p> Scientists find new mechanism for memory formation </p>
+                    <p> How do we form memories? New research uncovers key brain area. </p>
+                    <p> Read now </p>
+                </div>
+            </a>
+        </div>
         <p> This process of making a decision once the brain has accumulated enough evidence bears the name of "bounded evidence accumulation." Reaching this threshold is important because, although the brain does not use <em>all</em> of the information available, it uses as much as is necessary to make a speedy yet accurate decision. </p>
         <p>
             <strong>The researchers wondered whether or not this threshold is also responsible for our "eureka!" moments.</strong>

--- a/test/test-pages/nytimes-3/expected.html
+++ b/test/test-pages/nytimes-3/expected.html
@@ -160,6 +160,17 @@
                 <p> “Don’t get nervous,” instructed Milton Velez, the agency’s district supervisor for Queens. </p>
                 <p> “I’m not,” Mr. Dejesus said as he secured the clamp and stopped the leak. “It’s ‘Showtime at the Apollo.’” </p>
             </div>
+            <div>
+                <a href="https://www.nytimes.com/interactive/2016/08/18/nyregion/new-york-101-streets-repair-and-maintenance.html?action=click&amp;module=RelatedLinks&amp;pgtype=Article">
+                    <div>
+                        <p> Why Are New York City’s Streets Always Under Construction? </p>
+                        <p><time datetime="2016-08-18">Aug. 18, 2016</time>
+                        </p>
+                    </div>
+                    <p><img src="https://static01.nyt.com/images/2016/08/12/nyregion/nyc101-01/nyc101-01-videoLarge-v7.jpg" />
+                    </p>
+                </a>
+            </div>
         </section>
         <div>
             <div>

--- a/test/test-pages/pixnet/expected.html
+++ b/test/test-pages/pixnet/expected.html
@@ -184,5 +184,10 @@
         <p><span><span><span>內文有不定期的更新旅遊、露營圖文訊息 </span></span><span><span>謝謝!</span></span>
             </span>
         </p>
+        <div>
+            <p><img src="http://panel.pixfs.net/images/icons/tag_blue.gif" original="http://panel.pixfs.net/images/icons/tag_blue.gif" />
+                <a href="http://tags.pixnet.net/blog/user/stevenhgm/%E7%8E%89%E5%B3%B0%E9%81%93%E8%B7%AF" rel="tag" target="_blank">玉峰道路</a>, <a href="http://tags.pixnet.net/blog/user/stevenhgm/%E4%B8%8A%E5%AE%87%E8%80%81%E8%A7%80%E6%99%AF%E5%8F%B0" rel="tag" target="_blank">上宇老觀景台</a>, <a href="http://tags.pixnet.net/blog/user/stevenhgm/%E7%BE%8E%E6%A8%B9%E7%87%9F%E5%9C%B0" rel="tag" target="_blank">美樹營地</a>, <a href="http://tags.pixnet.net/blog/user/stevenhgm/%E6%8E%A7%E6%BA%AA%E5%90%8A%E6%A9%8B" rel="tag" target="_blank">控溪吊橋</a>, <a href="http://tags.pixnet.net/blog/user/stevenhgm/%E7%9F%B3%E7%A3%8A%E9%83%A8%E8%90%BD" rel="tag" target="_blank">石磊部落</a>
+            </p>
+        </div>
     </div>
 </div>

--- a/test/test-pages/simplyfound-1/expected.html
+++ b/test/test-pages/simplyfound-1/expected.html
@@ -1,10 +1,38 @@
 <div id="readability-page-1" class="page">
     <div>
         <p>The Raspberry Pi Foundation started by a handful of volunteers in 2012 when they released the original Raspberry Pi 256MB Model B without knowing what to expect. &nbsp;In a short four-year period they have grown to over sixty full-time&nbsp;employees&nbsp;and have shipped over <b>eight million</b> units to-date. &nbsp;Raspberry Pi has achieved new heights by being shipped to the&nbsp;International&nbsp;Space Station for research and by being an affordable computing platforms used by teachers throughout the world. &nbsp;"It has become the all-time best-selling computer in the UK".</p>
+        <div>
+            <p><img src="https://d34hb2g9mvfppu.cloudfront.net/m/images/cache/images/2016/02/29/apcnews2012raspberry_pi_logo_mainimage8_jpg8_322_27630a8388eb_lg.jpg" /> </p>
+        </div>
         <p>Raspberry Pi 3 - A credit card sized PC that only costs $35 - Image: Raspberry Pi Foundation</p>
         <p>Raspberry Pi Foundation is charity organization that pushes for a digital revolution with a mission to inspire kids to learn by&nbsp;creating computer-powered objects. &nbsp;The foundation also helps teachers learn computing &nbsp;skills through free training and readily available tutorials &amp; example code for creating cool things such as music.</p>
+        <div>
+            <p><img src="https://d34hb2g9mvfppu.cloudfront.net/m/images/cache/images/2016/02/29/teachers_classroom_guide_324_a221bf31d64c_lg.png" /> </p>
+        </div>
         <p>Raspberry Pi in educations - Image: Raspberry Pi Foundation</p>
         <p>In celebration of their 4th year&nbsp;anniversary, the foundation has released&nbsp;<b>Raspberry Pi 3</b> with the same price tag of<b>&nbsp;</b>$35 USD. &nbsp;The 3rd revision features a <b>1.2GHz 64-bit quad-core</b>&nbsp;ARM CPU with integrated Bluetooth 4.1 and 802.11n wireless LAN chipsets. &nbsp;The ARM Cortex-A53 CPU along with other architectural enhancements making it the fastest Raspberry Pi to-date. &nbsp;The 3rd revision is reportedly about 50-60% times faster than its predecessor Raspberry Pi 2 and about 10 times faster then the original Raspberry PI.</p>
+        <div id="snippet-326-image-carousel" data-ride="carousel" data-interval="false">
+            <ol>
+                <li data-target="#snippet-326-image-carousel" data-slide-to="0"></li>
+                <li data-target="#snippet-326-image-carousel" data-slide-to="1"></li>
+                <li data-target="#snippet-326-image-carousel" data-slide-to="2"></li>
+            </ol>
+            <div>
+                <div>
+                    <p><img src="https://d34hb2g9mvfppu.cloudfront.net/m/images/cache/images/2016/02/29/handj_326_eb8b50597a3f_lg.jpg" alt="Image 1" /> </p>
+                </div>
+                <div>
+                    <p><img src="https://d34hb2g9mvfppu.cloudfront.net/m/images/cache/images/2016/02/29/images_326_b1f81e087284_lg.jpeg" alt="Image 2" /> </p>
+                </div>
+                <div>
+                    <p><img src="https://d34hb2g9mvfppu.cloudfront.net/m/images/cache/images/2016/02/29/images_2_326_c32fa7688f70_lg.jpeg" alt="Image 3" /> </p>
+                </div>
+            </div>
+            <a href="#snippet-326-image-carousel" data-slide="prev">
+            </a>
+            <a href="#snippet-326-image-carousel" data-slide="next">
+            </a>
+        </div>
         <p>Raspberry Pi - Various Usage</p>
         <p>Raspberry Pi 3 is now available via many online resellers. &nbsp;At this time, you should use a recent <b>32-bit </b>NOOBS or Raspbian image from their&nbsp;<a href="https://www.raspberrypi.org/downloads/" rel="nofollow" target="_blank">downloads</a> page with a promise of a switch to a 64-bit version only if further investigation proves that there is indeed some value in moving to 64-bit mode.</p>
     </div>

--- a/test/test-pages/wapo-1/expected.html
+++ b/test/test-pages/wapo-1/expected.html
@@ -7,6 +7,17 @@
                 <p>Close</p>
             </div>
             <div>
+                <p><span>At least 17 dead in Tunisia after attack in capital city</span>
+                </p>
+                <div>
+                    <p><img src="https://img.washingtonpost.com/rf/image_606w/2010-2019/WashingtonPost/2015/03/18/Foreign/Images/Nic6429732.jpg" />
+                    </p>
+                    <p><i></i>View Photos</p>
+                </div>
+                <p><span>Security forces in Tunisia stormed the country’s most prominent museum, freeing hostages and ending a siege by gunmen.</span>
+                </p>
+            </div>
+            <div>
                 <p>Caption</p>
                 <div>
                     <p>Security forces in Tunisia stormed the country’s most prominent museum, freeing hostages and ending a siege by gunmen.</p>
@@ -50,6 +61,17 @@
                 <p>Close</p>
             </div>
             <div>
+                <p><span>Inside Tunisia’s Bardo National Museum</span>
+                </p>
+                <div>
+                    <p><img src="https://img.washingtonpost.com/rf/image_606w/2010-2019/WashingtonPost/2015/03/18/Foreign/Images/144714787.jpg" />
+                    </p>
+                    <p><i></i>View Photos</p>
+                </div>
+                <p><span>Housed in a 19th-century palace, the museum where gunmen killed foreign tourists is famous for its Roman mosaics and other antiquities.</span>
+                </p>
+            </div>
+            <div>
                 <p>Caption</p>
                 <div>
                     <p>Housed in a 19th-century palace, the museum where gunmen killed foreign tourists is famous for its Roman mosaics and other antiquities.</p>
@@ -70,6 +92,14 @@
         <p>Tunisian Islamists and secular forces have worked together — often reluctantly — to defuse the country’s political crises in the years since the revolt.</p>
         <p>Last fall, Tunisians elected a secular-minded president and parliament dominated by liberal forces after <a href="http://www.washingtonpost.com/world/middle_east/tunisias-islamists-get-sobering-lesson-in-governing/2014/11/20/b6fc8988-65ad-11e4-ab86-46000e1d0035_story.html">souring on Islamist-led rule</a>. In 2011, voters had elected a government led by the Ennahda party — a movement similar to Egypt’s Islamist Muslim Brotherhood. But a political stalemate developed as the party and others tried to draft the country’s new constitution. The Islamists failed to improve a slumping economy. And Ennahda came under fire for what many Tunisians saw as a failure to crack down on Islamist extremists.</p>
         <div>
+            <div>
+                <p><a href="http://www.washingtonpost.com/world/foreign-fighters-flow-to-syria/2015/01/27/7fa56b70-a631-11e4-a7c2-03d37af98440_graphic.html"><img data-hi-res-src="https://img.washingtonpost.com/rf/image_1484w/2010-2019/WashingtonPost/2015/01/27/Foreign/Graphics/foreignFighters-Jan14-GS.jpg?uuid=CDUNJKYyEeShYhIdBsp38Q" data-low-res-src="https://img.washingtonpost.com/rf/image_480w/2010-2019/WashingtonPost/2015/01/27/Foreign/Graphics/foreignFighters-Jan14-GS.jpg?uuid=CDUNJKYyEeShYhIdBsp38Q" src="https://img.washingtonpost.com/rf/image_480w/2010-2019/WashingtonPost/2015/01/27/Foreign/Graphics/foreignFighters-Jan14-GS.jpg?uuid=CDUNJKYyEeShYhIdBsp38Q" /></a>
+                    <a href="http://www.washingtonpost.com/world/foreign-fighters-flow-to-syria/2015/01/27/7fa56b70-a631-11e4-a7c2-03d37af98440_graphic.html"> <span> <span>Map: Flow of foreign fighters to Syria </span>
+                            <span>View Graphic <span></span></span>
+                        </span>
+                    </a>
+                </p>
+            </div>
             <p><span>Map: Flow of foreign fighters to Syria</span>
             </p>
         </div>

--- a/test/test-pages/wapo-1/expected.html
+++ b/test/test-pages/wapo-1/expected.html
@@ -1,5 +1,26 @@
 <div id="readability-page-1" class="page">
     <article>
+        <div data-category="Foreign" data-commercial-node="world" data-first-published="1426686630" data-permalink="http://www.washingtonpost.com/world/at-least-8-dead-in-tunisia-attack-on-leading-museum/2015/03/18/ef22654e-cd72-11e4-8c54-ffb5ba6f2f69_gallery.html" data-preroll-zone="" data-published="1426713600" data-section="world" data-show-interstitials="true" data-show-preroll="true" data-slug="at-least-8-dead-in-tunisia-attack-on-leading-museum" data-subsection="" data-title="At least 17 dead in Tunisia after attack in capital city" data-uuid="ef22654e-cd72-11e4-8c54-ffb5ba6f2f69" data-pb-content-uri="/pb/galleryEmbed/ef22654e-cd72-11e4-8c54-ffb5ba6f2f69" data-pb-name="gallery-gallery" id="gallery-embed_1417452270618_709">
+            <div>
+                <p>Full Screen</p>
+                <p>Autoplay</p>
+                <p>Close</p>
+            </div>
+            <div>
+                <p>Caption</p>
+                <div>
+                    <p>Security forces in Tunisia stormed the country’s most prominent museum, freeing hostages and ending a siege by gunmen.</p>
+                    <p><span>March 18, 2015</span> <span>Tunisian security forces secure the area after gunmen attacked the famed Bardo National Museum in Tunis, the capital.</span>
+                        <span>Fethi Belaid/AFP/Getty Images</span>
+                    </p>
+                    <p><a href="#" target="_blank">Buy Photo</a>
+                    </p>
+                </div>
+            </div>
+            <div>
+                <p>Wait 1 second to continue.</p>
+            </div>
+        </div>
         <p> <span>CAIRO —</span> Gunmen opened fire on visitors at Tunisia’s most renowned museum on Wednesday, killing at least 19 people, including 17 foreigners, in an assault that threatened to upset the fragile stability of a country seen as the lone success of the Arab Spring.</p>
         <p>It was the most deadly terrorist attack in the North African nation in more than a decade. Although no group claimed responsibility, the bloodshed raised fears that militants linked to the Islamic State were expanding their operations.</p>
         <p>The attackers, clad in military uniforms, <a href="http://www.washingtonpost.com/world/gunmen-storm-museum-in-tunisia-killing-at-least-8/2015/03/18/00202e76-cd73-11e4-8730-4f473416e759_story.html">stormed the Bardo National Museum</a> on Wednesday afternoon, seizing and gunning down foreign tourists before security forces raided the building to end the siege. The museum is a major tourist draw and is near the heavily guarded national parliament in downtown Tunis.</p>
@@ -22,6 +43,27 @@
         </p>
         <p>The attack is “also aimed at the country’s security and stability during the transition period,” Azzouz said. “And it could have political repercussions — like the curtailing of human rights, or even less government transparency if there’s fear of further attacks.”</p>
         <p>The attack raised concerns that the government, led by secularists, would be pressured to stage a wider crackdown on Islamists of all stripes. Lawmakers are drafting an anti-terrorism bill to give security forces additional tools to fight militants.</p>
+        <div data-category="Foreign" data-commercial-node="world/africa" data-first-published="1426694580" data-permalink="http://www.washingtonpost.com/world/africa/inside-tunisias-bardo-museum/2015/03/18/b9af65dc-cd7d-11e4-a2a7-9517a3a70506_gallery.html" data-preroll-zone="" data-published="1426694580" data-section="world" data-show-interstitials="true" data-show-preroll="true" data-slug="inside-tunisias-bardo-museum" data-subsection="africa" data-title="Inside Tunisia’s Bardo National Museum" data-uuid="b9af65dc-cd7d-11e4-a2a7-9517a3a70506" data-pb-content-uri="/pb/galleryEmbed/b9af65dc-cd7d-11e4-a2a7-9517a3a70506" data-pb-name="gallery-gallery" id="gallery-embed_1417452270618_709">
+            <div>
+                <p>Full Screen</p>
+                <p>Autoplay</p>
+                <p>Close</p>
+            </div>
+            <div>
+                <p>Caption</p>
+                <div>
+                    <p>Housed in a 19th-century palace, the museum where gunmen killed foreign tourists is famous for its Roman mosaics and other antiquities.</p>
+                    <p><span>May 17, 2012</span> <span>One of the many mosaics for which the Bardo National Museum in Tunis is famous. On March 18, 2015, gunmen attacked the museum and killed at least 19 people.</span>
+                        <span>Fethi Belaid/AFP/Getty Images</span>
+                    </p>
+                    <p><a href="#" target="_blank">Buy Photo</a>
+                    </p>
+                </div>
+            </div>
+            <div>
+                <p>Wait 1 second to continue.</p>
+            </div>
+        </div>
         <p channel="wp.com"> <i> <a href="http://www.washingtonpost.com/world/national-security/tunisia-after-igniting-arab-spring-sends-the-most-fighters-to-islamic-state-in-syria/2014/10/28/b5db4faa-5971-11e4-8264-deed989ae9a2_story.html">[Read: Tunisia sends most foreign fighters to Islamic State in Syria]</a> </i>
         </p>
         <p>“We must pay attention to what is written” in that law, Azzouz said. “There is worry the government will use the attack to justify some draconian measures.”</p>

--- a/test/test-pages/wikipedia-2/expected.html
+++ b/test/test-pages/wikipedia-2/expected.html
@@ -691,6 +691,10 @@
         <h3>
             <span id="Geography">Geography</span>
         </h3>
+        <div role="note">
+            <p><img alt="" src="http://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/12px-Commons-logo.svg.png" decoding="async" width="12" height="16" srcset="http://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/18px-Commons-logo.svg.png 1.5x, http://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/24px-Commons-logo.svg.png 2x" data-file-width="1024" data-file-height="1376" /> See also: <a href="https://commons.wikimedia.org/wiki/Atlas_of_New_Zealand" title="commons:Atlas of New Zealand">Atlas of New Zealand</a> at <a href="http://fakehost/wiki/Wikimedia_Commons" title="Wikimedia Commons">Wikimedia Commons</a>
+            </p>
+        </div>
         <div>
             <p><a href="http://fakehost/wiki/File:New_Zealand_23_October_2002.jpg"><img alt="Islands of New Zealand as seen from satellite" src="http://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/New_Zealand_23_October_2002.jpg/170px-New_Zealand_23_October_2002.jpg" decoding="async" width="170" height="227" srcset="http://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/New_Zealand_23_October_2002.jpg/255px-New_Zealand_23_October_2002.jpg 1.5x, http://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/New_Zealand_23_October_2002.jpg/340px-New_Zealand_23_October_2002.jpg 2x" data-file-width="4200" data-file-height="5600" /></a></p>
         </div>
@@ -718,8 +722,28 @@
         <ul>
             <li>Landscapes of New Zealand </li>
             <li>
+                <div>
+                    <div>
+                        <p><a href="http://fakehost/wiki/File:NZ_Landscape.jpg"><img alt="" src="http://upload.wikimedia.org/wikipedia/commons/thumb/4/44/NZ_Landscape.jpg/270px-NZ_Landscape.jpg" decoding="async" width="180" height="120" srcset="http://upload.wikimedia.org/wikipedia/commons/thumb/4/44/NZ_Landscape.jpg/405px-NZ_Landscape.jpg 1.5x, http://upload.wikimedia.org/wikipedia/commons/thumb/4/44/NZ_Landscape.jpg/540px-NZ_Landscape.jpg 2x" data-file-width="5963" data-file-height="3975" /></a>
+                        </p>
+                    </div>
+                    <div>
+                        <p> Rural scene near <a href="http://fakehost/wiki/Queenstown,_New_Zealand" title="Queenstown, New Zealand">Queenstown</a>
+                        </p>
+                    </div>
+                </div>
             </li>
             <li>
+                <div>
+                    <div>
+                        <p><a href="http://fakehost/wiki/File:Emerald_Lakes,_New_Zealand.jpg"><img alt="" src="http://upload.wikimedia.org/wikipedia/commons/thumb/6/61/Emerald_Lakes%2C_New_Zealand.jpg/270px-Emerald_Lakes%2C_New_Zealand.jpg" decoding="async" width="180" height="120" srcset="http://upload.wikimedia.org/wikipedia/commons/thumb/6/61/Emerald_Lakes%2C_New_Zealand.jpg/405px-Emerald_Lakes%2C_New_Zealand.jpg 1.5x, http://upload.wikimedia.org/wikipedia/commons/thumb/6/61/Emerald_Lakes%2C_New_Zealand.jpg/540px-Emerald_Lakes%2C_New_Zealand.jpg 2x" data-file-width="4272" data-file-height="2848" /></a>
+                        </p>
+                    </div>
+                    <div>
+                        <p> The Emerald Lakes, <a href="http://fakehost/wiki/Mt_Tongariro" title="Mt Tongariro">Mt Tongariro</a>
+                        </p>
+                    </div>
+                </div>
             </li>
             <li>
                 <div>

--- a/test/test-pages/wikipedia-3/expected.html
+++ b/test/test-pages/wikipedia-3/expected.html
@@ -135,6 +135,9 @@
             <dd> Thus <span><i>A</i><sup><i>n</i></sup></span> is Hermitian if <span>A</span> is Hermitian and <span>n</span> is an integer. </dd>
         </dl>
         <ul>
+            <li>For an arbitrary complex valued vector <span>v</span> the product <span><img src="https://wikimedia.org/api/rest_v1/media/math/render/svg/3c23d6757968a2267ee906cffc07cfe1bbc8aecc" aria-hidden="true" alt="{\displaystyle v^{\mathsf {H}}Av}" /></span> is real because of <span><img src="https://wikimedia.org/api/rest_v1/media/math/render/svg/b7839ef3cdbc89c3ea1acd17a507d03a33ed79df" aria-hidden="true" alt="{\displaystyle v^{\mathsf {H}}Av=\left(v^{\mathsf {H}}Av\right)^{\mathsf {H}}}" /></span>. This is especially important in quantum physics where Hermitian matrices are operators that measure properties of a system e.g. total <a href="http://fakehost/wiki/Spin_(physics)" title="Spin (physics)">spin</a> which have to be real. </li>
+        </ul>
+        <ul>
             <li>The Hermitian complex <span>n</span>-by-<span>n</span> matrices do not form a <a href="http://fakehost/wiki/Vector_space" title="Vector space">vector space</a> over the <a href="http://fakehost/wiki/Complex_number" title="Complex number">complex numbers</a>, <span>ℂ</span>, since the identity matrix <span><i>I</i><sub><i>n</i></sub></span> is Hermitian, but <span><i>i</i> <i>I</i><sub><i>n</i></sub></span> is not. However the complex Hermitian matrices <i>do</i> form a vector space over the <a href="http://fakehost/wiki/Real_numbers" title="Real numbers">real numbers</a> <span>ℝ</span>. In the <span>2<i>n</i><sup>2</sup></span>-<a href="http://fakehost/wiki/Dimension_of_a_vector_space" title="Dimension of a vector space">dimensional</a> vector space of complex <span><i>n</i> × <i>n</i></span> matrices over <span>ℝ</span>, the complex Hermitian matrices form a subspace of dimension <span><i>n</i><sup>2</sup></span>. If <span><i>E</i><sub><i>jk</i></sub></span> denotes the <span>n</span>-by-<span>n</span> matrix with a <span>1</span> in the <span><i>j</i>,<i>k</i></span> position and zeros elsewhere, a basis (orthonormal w.r.t. the Frobenius inner product) can be described as follows: </li>
         </ul>
         <dl>
@@ -173,6 +176,9 @@
         <dl>
             <dd> where <span><img src="https://wikimedia.org/api/rest_v1/media/math/render/svg/add78d8608ad86e54951b8c8bd6c8d8416533d20" aria-hidden="true" alt="i" /></span> denotes the complex number <span><img src="https://wikimedia.org/api/rest_v1/media/math/render/svg/4ea1ea9ac61e6e1e84ac39130f78143c18865719" aria-hidden="true" alt="{\sqrt {-1}}" /></span>, called the <i><a href="http://fakehost/wiki/Imaginary_unit" title="Imaginary unit">imaginary unit</a></i>. </dd>
         </dl>
+        <ul>
+            <li>If <span>n</span> orthonormal eigenvectors <span><img src="https://wikimedia.org/api/rest_v1/media/math/render/svg/ba291b64c0d3afa90b4556a7a601116dfd74ef2e" aria-hidden="true" alt="{\displaystyle u_{1},\dots ,u_{n}}" /></span> of a Hermitian matrix are chosen and written as the columns of the matrix <span>U</span>, then one <a href="http://fakehost/wiki/Eigendecomposition_of_a_matrix" title="Eigendecomposition of a matrix">eigendecomposition</a> of <span>A</span> is <span><img src="https://wikimedia.org/api/rest_v1/media/math/render/svg/d89ef5bade4fb04b1aaf53c0d73e4763d4d154eb" aria-hidden="true" alt="{\displaystyle A=U\Lambda U^{\mathsf {H}}}" /></span> where <span><img src="https://wikimedia.org/api/rest_v1/media/math/render/svg/b819b015c1984e6cb07153c675815d4657b90da8" aria-hidden="true" alt="{\displaystyle UU^{\mathsf {H}}=I=U^{\mathsf {H}}U}" /></span> and therefore </li>
+        </ul>
         <dl>
             <dd>
                 <dl>

--- a/test/test-pages/yahoo-2/expected.html
+++ b/test/test-pages/yahoo-2/expected.html
@@ -2,10 +2,37 @@
     <div id="tgt1-Col1-2-ContentCanvas-Proxy">
         <article data-uuid="8dd27580-6b4e-3cfb-a389-5b1ab90bd0eb" data-type="story">
             <div>
-                <p><span>1 / 5</span></p>
                 <div>
-                    <h2>In this photo dated Tuesday, Nov, 29, 2016 the Soyuz-FG rocket booster with the Progress MS-04 cargo ship is installed on a launch pad in Baikonur, Kazakhstan. The unmanned Russian cargo space ship Progress MS-04 broke up in the atmosphere over Siberia on Thursday Dec. 1, 2016, just minutes after the launch en route to the International Space Station due to an unspecified malfunction, the Russian space agency said.(Oleg Urusov/ Roscosmos Space Agency Press Service photo via AP)</h2>
-                    <p>In this photo dated Tuesday, Nov, 29, 2016 the Soyuz-FG rocket booster with the Progress MS-04 cargo ship is installed on a launch pad in Baikonur, Kazakhstan. The unmanned Russian cargo space ship Progress MS-04 broke up in the atmosphere over Siberia on Thursday Dec. 1, 2016, just minutes after the launch en route to the International Space Station due to an unspecified malfunction, the Russian space agency said.(Oleg Urusov/ Roscosmos Space Agency Press Service photo via AP)</p>
+                    <div id="modal-slideshow-8dd27580-6b4e-3cfb-a389-5b1ab90bd0eb" tabindex="2">
+                        <ul>
+                            <li>
+                                <div>
+                                    <figure><img src="https://s.yimg.com/ny/api/res/1.2/lNHGeC84b29OU62FMISl7g--/YXBwaWQ9aGlnaGxhbmRlcjtzbT0xO3c9ODAwO2g9NjAwO2lsPXBsYW5l/http://media.zenfs.com/en_us/News/ap_webfeeds/c9375de6acbf4c168be78ffe4ec71ea9.jpg" alt="In this photo dated Tuesday, Nov, 29, 2016 the Soyuz-FG rocket booster with the Progress MS-04 cargo ship is installed on a launch pad in Baikonur, Kazakhstan. The unmanned Russian cargo space ship Progress MS-04 broke up in the atmosphere over Siberia on Thursday Dec. 1, 2016, just minutes after the launch en route to the International Space Station due to an unspecified malfunction, the Russian space agency said.(Oleg Urusov/ Roscosmos Space Agency Press Service photo via AP)" /></figure>
+                                </div>
+                            </li>
+                            <li>
+                                <div>
+                                    <figure><img src="https://s.yimg.com/ny/api/res/1.2/lweVDC7ZjZpHtU0S8gpbNA--/YXBwaWQ9aGlnaGxhbmRlcjtzbT0xO3c9ODAwO2g9NjAwO2lsPXBsYW5l/http://media.zenfs.com/en_us/News/ap_webfeeds/daa4cec687a64fff8c4060e11ee9e39d.jpg" alt="In this photo dated Tuesday, Nov, 29, 2016 the Soyuz-FG rocket booster with the Progress MS-04 cargo ship is installed on a launch pad in Baikonur, Kazakhstan. The unmanned Russian cargo space ship Progress MS-04 broke up in the atmosphere over Siberia on Thursday Dec. 1, 2016, en route to the International Space Station due to an unspecified malfunction, the Russian space agency said. (Sergei Sergeev/ Roscosmos Space Agency Press Service photo via AP)" /></figure>
+                                </div>
+                            </li>
+                            <li>
+                                <div>
+                                    <figure><img src="https://s.yimg.com/ny/api/res/1.2/AE_dA6RMl8RF7SQmMQl_pw--/YXBwaWQ9aGlnaGxhbmRlcjtzbT0xO3c9ODAwO2g9NjAwO2lsPXBsYW5l/http://media.zenfs.com/en_us/News/gettyimages.com/day-seven-championships-wimbledon-2016-20160704-162516-521.jpg" alt="LONDON, ENGLAND - JULY 04:  Kim Sears (Wife of Andy Murray of Great Britain) watches on from Centre court on day seven of the Wimbledon Lawn Tennis Championships at the All England Lawn Tennis and Croquet Club on July 4, 2016 in London, England.  (Photo by Shaun Botterill/Getty Images)" /></figure>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                    <a href="">
+                    </a>
+                    <a href="">
+                    </a>
+                </div>
+                <div>
+                    <p><span>1 / 5</span></p>
+                    <div>
+                        <h2>In this photo dated Tuesday, Nov, 29, 2016 the Soyuz-FG rocket booster with the Progress MS-04 cargo ship is installed on a launch pad in Baikonur, Kazakhstan. The unmanned Russian cargo space ship Progress MS-04 broke up in the atmosphere over Siberia on Thursday Dec. 1, 2016, just minutes after the launch en route to the International Space Station due to an unspecified malfunction, the Russian space agency said.(Oleg Urusov/ Roscosmos Space Agency Press Service photo via AP)</h2>
+                        <p>In this photo dated Tuesday, Nov, 29, 2016 the Soyuz-FG rocket booster with the Progress MS-04 cargo ship is installed on a launch pad in Baikonur, Kazakhstan. The unmanned Russian cargo space ship Progress MS-04 broke up in the atmosphere over Siberia on Thursday Dec. 1, 2016, just minutes after the launch en route to the International Space Station due to an unspecified malfunction, the Russian space agency said.(Oleg Urusov/ Roscosmos Space Agency Press Service photo via AP)</p>
+                    </div>
                 </div>
             </div>
             <div>


### PR DESCRIPTION
Hi, thanks for the great library. I notice that Readability sometimes remove images from website, like in this ticket #678 and a few websites that I have tested like https://www.news.com.au/sport/american-sports/nba/michael-jordans-reveals-final-texts-to-kobe-bryant/news-story/43297745901f8e10a60cda2ad4ce2e8f (and all articles on that site).

This commit improves the algorithm for cleaning up elements by:
- If the image size is big, increase its weight
- When clean up an element, first calculate total weight of the element from its own weight and its children weight

Please help review, thank you!