### PR TITLE
Avoid live collection

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -390,8 +390,8 @@ Readability.prototype = {
           } else {
             // if the link has multiple children, they should all be preserved
             var container = this._doc.createElement("span");
-            while (link.childNodes.length > 0) {
-              container.appendChild(link.childNodes[0]);
+            while (link.firstChild) {
+              container.appendChild(link.firstChild);
             }
             link.parentNode.replaceChild(container, link);
           }
@@ -1085,10 +1085,9 @@ Readability.prototype = {
         neededToCreateTopCandidate = true;
         // Move everything (not just elements, also text nodes etc.) into the container
         // so we even include text directly in the body:
-        var kids = page.childNodes;
-        while (kids.length) {
-          this.log("Moving child out:", kids[0]);
-          topCandidate.appendChild(kids[0]);
+        while (page.firstChild) {
+          this.log("Moving child out:", page.firstChild);
+          topCandidate.appendChild(page.firstChild);
         }
 
         page.appendChild(topCandidate);

--- a/Readability.js
+++ b/Readability.js
@@ -1218,6 +1218,9 @@ Readability.prototype = {
           }
 
           articleContent.appendChild(sibling);
+          // Fetch children again to make it compatible
+          // with DOM parsers without live collection support.
+          siblings = parentOfTopCandidate.children;
           // siblings is a reference to the children array, and
           // sibling is removed from the array when we call appendChild().
           // As a result, we must revisit this index since the nodes


### PR DESCRIPTION
Avoid using childNodes live collection logic and replace with `firstChild` logic.
This small change fixes compatibility with [linkedom](https://github.com/WebReflection/linkedom)

It's already partly fixed with #677 , but some pages still cause infinite loop, like this one: [ansa.it](https://www.ansa.it/canale_saluteebenessere/notizie/sanita/2021/05/16/covid-5.753-positivi-93-vittime.-e-il-dato-piu-basso-da-sette-mesi_4e28d22f-3ded-418c-bab1-2ad7e9a6f9be.html)