### PR TITLE
Fix doc re: disableJSONLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The `options` object accepts a number of properties, all optional:
 * `charThreshold` (number, default `500`): the number of characters an article must have in order to return a result.
 * `classesToPreserve` (array): a set of classes to preserve on HTML elements when the `keepClasses` options is set to `false`.
 * `keepClasses` (boolean, default `false`): whether to preserve all classes on HTML elements. When set to `false` only classes specified in the `classesToPreserve` array are kept.
-* `disableJSONLD` (boolean, default `false`): when extracting page metadata, Readability gives precendence to Schema.org fields specified in the JSON-LD format. Set this option to false to skip JSON-LD parsing.
+* `disableJSONLD` (boolean, default `false`): when extracting page metadata, Readability gives precendence to Schema.org fields specified in the JSON-LD format. Set this option to `true` to skip JSON-LD parsing.
 * `serializer` (function, default `el => el.innerHTML`) controls how the the `content` property returned by the `parse()` method is produced from the root DOM element. It may be useful to specify the `serializer` as the identity function (`el => el`) to obtain a DOM element instead of a string for `content` if you plan to process it further.
 
 ### `parse()`


### PR DESCRIPTION
Since Readability parses Schema.org fields by default, one needs to set `disableJSONLD` to `true`, not `false`, to skip JSON-LD parsing.