### PR TITLE
Fix text element grouping for FONT tag when cleaning up redundant BR nodes

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -542,11 +542,11 @@ Readability.prototype = {
     // Remove all style tags in head
     this._removeNodes(this._getAllNodesWithTag(doc, ["style"]));
 
+    this._replaceNodeTags(this._getAllNodesWithTag(doc, ["font"]), "SPAN");
+
     if (doc.body) {
       this._replaceBrs(doc.body);
     }
-
-    this._replaceNodeTags(this._getAllNodesWithTag(doc, ["font"]), "SPAN");
   },
 
   /**

--- a/test/test-pages/hukumusume/expected.html
+++ b/test/test-pages/hukumusume/expected.html
@@ -110,44 +110,67 @@
             <table>
                 <tbody>
                     <tr>
-                        <td> &#160;&#160;&#160;&#160; <span size="-1"><b>1月 1日の豆知識</b></span><span size="-2"><u>
-                                    <p> 366日への旅</p>
-                                </u></span>
+                        <td> &#160;&#160;&#160;&#160; <span size="-1"><b>1月 1日の豆知識</b></span>
+                            <p>
+                                <span size="-2"><u>
+                                        <p> 366日への旅</p>
+                                    </u></span>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <img src="file:///C:/Documents%20and%20Settings/%E7%A6%8F%E5%A8%98note/%E3%83%87%E3%82%B9%E3%82%AF%E3%83%88%E3%83%83%E3%83%97" width="1" height="1" /><b><span size="-1">きょうの記念日</span></b><a href="http://fakehost/366/kinenbi/pc/01gatu/1_01.htm"><span size="-1">元旦</span></a>
+                            <img src="file:///C:/Documents%20and%20Settings/%E7%A6%8F%E5%A8%98note/%E3%83%87%E3%82%B9%E3%82%AF%E3%83%88%E3%83%83%E3%83%97" width="1" height="1" /><b><span size="-1">きょうの記念日</span></b>
+                            <p>
+                                <a href="http://fakehost/366/kinenbi/pc/01gatu/1_01.htm"><span size="-1">元旦</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <img src="file:///C:/Documents%20and%20Settings/%E7%A6%8F%E5%A8%98note/%E3%83%87%E3%82%B9%E3%82%AF%E3%83%88%E3%83%83%E3%83%97/company_website15/image/spacer.gif" width="1" height="1" /><b><span size="-1">きょうの誕生花</span></b><a href="http://fakehost/366/hana/pc/01gatu/1_01.htm"><span size="-1">松(まつ)</span></a>
+                            <img src="file:///C:/Documents%20and%20Settings/%E7%A6%8F%E5%A8%98note/%E3%83%87%E3%82%B9%E3%82%AF%E3%83%88%E3%83%83%E3%83%97/company_website15/image/spacer.gif" width="1" height="1" /><b><span size="-1">きょうの誕生花</span></b>
+                            <p>
+                                <a href="http://fakehost/366/hana/pc/01gatu/1_01.htm"><span size="-1">松(まつ)</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">きょうの誕生日・出来事</span></b><a href="http://fakehost/366/birthday/pc/01gatu/1_01.htm"><span size="-1">1949年　Mr.マリック(マジシャン)</span></a>
+                            <b><span size="-1">きょうの誕生日・出来事</span></b>
+                            <p>
+                                <a href="http://fakehost/366/birthday/pc/01gatu/1_01.htm"><span size="-1">1949年　Mr.マリック(マジシャン)</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">恋の誕生日占い</span></b><a href="http://fakehost/sakura/uranai/birthday/01/01.html"><span size="-1">自分の考えをしっかりと持った女の子。</span></a>
+                            <b><span size="-1">恋の誕生日占い</span></b>
+                            <p>
+                                <a href="http://fakehost/sakura/uranai/birthday/01/01.html"><span size="-1">自分の考えをしっかりと持った女の子。</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">なぞなぞ小学校</span></b><a href="http://fakehost/nazonazo/new/2012/04/02.html"><span size="-1">○(丸)を取ったらお母さんになってしまう男の人は？</span></a>
+                            <b><span size="-1">なぞなぞ小学校</span></b>
+                            <p>
+                                <a href="http://fakehost/nazonazo/new/2012/04/02.html"><span size="-1">○(丸)を取ったらお母さんになってしまう男の人は？</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">あこがれの職業紹介</span></b><a href="http://fakehost/sakura/navi/work/2017/041.html"><span size="-1">歌手</span></a>
+                            <b><span size="-1">あこがれの職業紹介</span></b>
+                            <p>
+                                <a href="http://fakehost/sakura/navi/work/2017/041.html"><span size="-1">歌手</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">恋の魔法とおまじない</span></b> 001<a href="http://fakehost/omajinai/new/2012/00/re01.html"><span size="-1">両思いになれる おまじない</span></a>
+                            <b><span size="-1">恋の魔法とおまじない</span></b> 001<p>
+                                <a href="http://fakehost/omajinai/new/2012/00/re01.html"><span size="-1">両思いになれる おまじない</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
@@ -159,32 +182,50 @@
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">きょうの日本昔話</span></b><a href="http://fakehost/douwa/pc/jap/01/01.htm"><span size="-1">ネコがネズミを追いかける訳</span></a>
+                            <b><span size="-1">きょうの日本昔話</span></b>
+                            <p>
+                                <a href="http://fakehost/douwa/pc/jap/01/01.htm"><span size="-1">ネコがネズミを追いかける訳</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">きょうの世界昔話<img src="file:///C:/Documents%20and%20Settings/%E7%A6%8F%E5%A8%98note/%E3%83%87%E3%82%B9%E3%82%AF%E3%83%88%E3%83%83%E3%83%97/company_website15/image/spacer.gif" width="1" height="1" /></span></b><a href="http://fakehost/douwa/pc/world/01/01a.htm"><span size="-1">モンゴルの十二支話</span></a>
+                            <b><span size="-1">きょうの世界昔話<img src="file:///C:/Documents%20and%20Settings/%E7%A6%8F%E5%A8%98note/%E3%83%87%E3%82%B9%E3%82%AF%E3%83%88%E3%83%83%E3%83%97/company_website15/image/spacer.gif" width="1" height="1" /></span></b>
+                            <p>
+                                <a href="http://fakehost/douwa/pc/world/01/01a.htm"><span size="-1">モンゴルの十二支話</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <img src="file:///C:/Documents%20and%20Settings/%E7%A6%8F%E5%A8%98note/%E3%83%87%E3%82%B9%E3%82%AF%E3%83%88%E3%83%83%E3%83%97/company_website15/image/spacer.gif" width="1" height="1" /><b><span size="-1">きょうの日本民話</span></b><a href="http://fakehost/douwa/pc/minwa/01/01c.html"><span size="-1">仕事の取替えっこ</span></a>
+                            <img src="file:///C:/Documents%20and%20Settings/%E7%A6%8F%E5%A8%98note/%E3%83%87%E3%82%B9%E3%82%AF%E3%83%88%E3%83%83%E3%83%97/company_website15/image/spacer.gif" width="1" height="1" /><b><span size="-1">きょうの日本民話</span></b>
+                            <p>
+                                <a href="http://fakehost/douwa/pc/minwa/01/01c.html"><span size="-1">仕事の取替えっこ</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">きょうのイソップ童話</span></b><a href="http://fakehost/douwa/pc/aesop/01/01.htm"><span size="-1">欲張りなイヌ</span></a>
+                            <b><span size="-1">きょうのイソップ童話</span></b>
+                            <p>
+                                <a href="http://fakehost/douwa/pc/aesop/01/01.htm"><span size="-1">欲張りなイヌ</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">きょうの江戸小話</span></b><a href="http://fakehost/douwa/pc/kobanashi/01/01.htm"><span size="-1">ぞうきんとお年玉</span></a>
+                            <b><span size="-1">きょうの江戸小話</span></b>
+                            <p>
+                                <a href="http://fakehost/douwa/pc/kobanashi/01/01.htm"><span size="-1">ぞうきんとお年玉</span></a>
+                            </p>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <b><span size="-1">きょうの百物語</span></b><a href="http://fakehost/douwa/pc/kaidan/01/01.htm"><span size="-1">百物語の幽霊</span></a>
+                            <b><span size="-1">きょうの百物語</span></b>
+                            <p>
+                                <a href="http://fakehost/douwa/pc/kaidan/01/01.htm"><span size="-1">百物語の幽霊</span></a>
+                            </p>
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
### Issue
Text element grouping after `BR` cleanup, was broken when there was a `FONT` element inside.

The problem is better visible on a page that actually was broken while I used the readability. 
You can see it on [a test branch](https://github.com/mpazik/readability/commit/95afe0de8300eda87bfca2c6d41da6ad7051a905#diff-20fcb902cc028c15c21d866c52af8f15e8ca51a4ba1c151fe5b22f99add2a629L89) when I regenerate the test case after this fix.
Notice broken `<p> [</p>`. The paragraph didn't include other text elements as in the source they contained `FONT` element. Source of that fragment: `[<a name="f1n" id="f1n"><font color="#000000">1</font></a>]`

### Cause
Inside the `_prepDocument,` `_replaceBrs` was executed before `FONT` elements were replaces.

### Solution
As the `FONT` element is not part of `PHRASING_ELEMS` it was not considered a text element, resulting in a broken grouping of elements inside a create wrapping paragraph. 

To fix the problem, we could either add the `FONT` tag to `PHRASING_ELEMS` or make sure that all of the invocations of `_isPhrasingContent` are only invoked on cleaned up dom.

