### PR TITLE
fixes a problem on aktualne.cz which puts article title into "headline" in JSON-LD and uses "name" for site name

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1389,7 +1389,22 @@ Readability.prototype = {
         ) {
           return metadata;
         }
-        if (typeof parsed.name === "string") {
+        if (typeof parsed.name === "string" && typeof parsed.headline === "string" && parsed.name !== parsed.headline) {
+          // we have both name and headline element in the JSON-LD. They should both be the same but some websites like aktualne.cz
+          // put their own name into "name" and the article title to "headline" which confuses Readability. So we try to check if either
+          // "name" or "headline" closely matches the html title, and if so, use that one. If not, then we use "name" by default.
+
+          var title = this._getArticleTitle();
+          var nameMatches = this._textSimilarity(parsed.name, title) > 0.75;
+          var headlineMatches = this._textSimilarity(parsed.headline, title) > 0.75;
+
+          if (headlineMatches && !nameMatches) {
+            metadata.title = parsed.headline;
+          } else {
+            metadata.title = parsed.name;
+          }
+
+        } else if (typeof parsed.name === "string") {
           metadata.title = parsed.name.trim();
         } else if (typeof parsed.headline === "string") {
           metadata.title = parsed.headline.trim();

--- a/test/test-pages/aktualne/expected-metadata.json
+++ b/test/test-pages/aktualne/expected-metadata.json
@@ -1,0 +1,8 @@
+{
+  "title": "West Ham hrozí gigantům, okouzlil i Linekera. Součka je snadné přehlédnout",
+  "byline": "Aleš Vávra",
+  "dir": null,
+  "excerpt": "Zázrak jedné sezony? West Ham United dává pochybovačům stále pádnější odpovědi.",
+  "siteName": "Aktuálně.cz",
+  "readerable": true
+}

--- a/test/test-pages/aktualne/expected.html
+++ b/test/test-pages/aktualne/expected.html
@@ -1,0 +1,29 @@
+<div id="readability-page-1" class="page">
+    <p> Zázrak jedné sezony? West Ham dává pochybovačům stále pádnější odpovědi a fotbalový svět si začíná uvědomovat, že se absolutní anglická fotbalová elita rozrůstá o nového člena. Tým manažera Davida Moyese prohání giganty i v aktuálním ročníku Premier League. </p>
+    <div id="article-content">
+        <p> Pět vítězných soutěžních duelů v řadě, během nich jediný inkasovaný gól. Čtvrté místo v lize, stejný bodový zisk jako loňský šampion Manchester City a nadšené ohlasy z tábora těch nejrenomovanějších komentátorů ostrovního fotbalu. </p>
+        <p> West Ham je opět v kurzu, nadšené ohlasy po nedělní jasné výhře 4:1 na hřišti Aston Villy zaplnily anglický mediální prostor. </p>
+        <p> "Stali se excelentním týmem. Jsou skvělí ve všech částech hřiště a David Moyes si zaslouží obrovský kredit za to, do jaké pozice je dostal," píše na Twitter Gary Lineker. </p>
+        <p> "Nenapadá mě jediný důvod, proč by letos nemohli skončit v elitní čtyřce," přidává se Emile Heskey, někdejší útočník Liverpoolu. "Je fér říct, že vypadají fantasticky. Moyes je neskutečně oživil." </p>
+        <p> I Heskey si všiml, že se Kladiváři skvěle vyrovnávají s náročným programem a pro ně novou rolí: účastí ve více soutěžích najednou. Moyes zůstává konzervativní v určování základní sestavy, chytře ale rozšířil kádr a v Evropské lize či ligovém poháru nechává některé opory odpočívat. Výjimkou potvrzující pravidlo je přitom Tomáš Souček, o jehož nezbytnosti bude řeč níže. </p>
+        <p> "Klíčová věc je ta, že když udělá změny, pořád jim zůstává stejná struktura. To je něco, co pravidelně říkáme třeba o Manchesteru City. Ve hře neustále zůstává nějaká fundamentální filosofie. West Ham to má podobně a už kvůli tomu je třeba před Moyesem smeknout," přirovnává Heskey. </p>
+        <p>
+            <em>Podívejte se na důležité momenty zápasu Aston Villa - West Ham:</em>
+        </p>
+        <p> V Evropské lize má West Ham po třech zápasech plný bodový zisk. V anglickém ligovém poháru dobyl čtvrtfinále, když vyřadil oba bohaté velkokluby z Manchesteru. </p>
+        <p> Čeští fotbalisté nicméně momentálně nejsou ve světlech těch nejjasnějších reflektorů. </p>
+        <p> Vladimír Coufal už sice uzdravil poraněné tříslo, v sestavě ale před ním dostal přednost rozjetý Ben Johnson. Anglický mladík další působivé představení okořenil parádním gólem a potvrdil, že se stává tvrdou konkurencí pro českého reprezentačního beka. </p>
+        <p> Tomáš Souček zůstává nepostradatelným členem základní sestavy, navzdory tomu, že jeho poslední výkony působí nenápadně. </p>
+        <p> "Pořád toho odvádí strašnou spoustu mimo hlavní pozornost. Jsou to důležité věci, které je snadné přehlédnout," píše ve svém hodnocení server Claret and Hugh.&#160; </p>
+        <p> "S Declanem Ricem vytvořil silné partnerství a udělal spoustu těžké práce. Má dobrou rozehrávku. Jediné, na co si lze stěžovat, jsou jeho občasná špatná rozhodnutí ve finální třetině hřiště," hodnotí českého středopolaře londýnský večerník Evening Standard. </p>
+        <p> Web Football.London to vidí podobně. "Opět byl silný ve vzduchu, na obou koncích hřiště. Ve finální fázi se ale nerozhodoval dobře, příliš často volil špatnou variantu." </p>
+        <p> Moyes nicméně nenechává Součka oddechnout. V pěti posledních utkáních, které West Ham odehrál během pouhých čtrnácti dnů, chyběl Čech jen pár minut v závěru na Evertonu, když utrpěl zranění v obličeji. </p>
+        <p> Fanoušci pravidelně spekulují o únavě, skotský manažer ale - jak se zdá - bude mít v sestavě raději unaveného Součka než kohokoli jiného. Zvlášť, když Alex Král, plánovaný back-up do středu zálohy, stále není k dispozici. </p>
+        <p> Zatímco v minulé sezoně Souček častokrát zastínil svého kolegu Rice, letos je to právě anglický reprezentant, kdo si užívá zasloužené ódy na svou adresu. </p>
+        <p> "Hraje prostě velkolepě a připomínám, že je mu stále jen dvaadvacet let," kroutí hlavou Lineker. Není sám. Ještě před pár měsíci se většina odborníků pozastavovala nad údajnou cenovkou kolem 100 milionů liber. Nyní už zaznívají hlasy o tom, jak může být i tato hranice při případném přestupu Declana Rice výrazně překročena. </p>
+        <p> S blížícím se zimním přestupním termínem budou spekulace nabývat na síle, fanoušci Hammers ale věří, že Rice zůstane nejméně do léta. Jeho spokojenost je do očí bijící, stejně jako ochota nechat na hřišti všechno ve prospěch Clarets and Blues. </p>
+        <p> "Náš kolektiv je teď opravdu speciální. Působíme ve výjimečném prostředí. Každé ráno se probouzíme s obrovskou touhou po dalším tréninku. Jsme nadšení," tvrdí mladá anglická superstar. </p>
+        <p> "Jsme na děleném třetím místě. Lidé se před sezonou hodně ptali, zda to můžeme dokázat znovu. Ukázali jsme, že ano. Ale musíme pokračovat. Tohle musí být náš standard. Nesmíme polevit, pokud chceme být velkým týmem," zdůrazňuje Rice. </p>
+    </div>
+    <p> Pokud jste v článku zaznamenali chybu nebo překlep, dejte nám, prosím, vědět prostřednictvím <a href="https://ankety.aktualne.cz/s3/00310d93156a?utm_source=aktualne.cz&amp;utm_medium=upozorneni&amp;from=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F">kontaktního formuláře</a>. Děkujeme! </p>
+</div>

--- a/test/test-pages/aktualne/source.html
+++ b/test/test-pages/aktualne/source.html
@@ -1,0 +1,1661 @@
+<!DOCTYPE html>
+<html lang="cs" prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#" xmlns="http://www.w3.org/1999/xhtml" xml:lang="cs">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="referrer" content="unsafe-url" />
+        <title>
+            West Ham hrozí gigantům, okouzlil i Linekera. Součkovu práci je snadné přehlédnout - Aktuálně.cz
+        </title>
+        <meta name="robots" content="index, follow" />
+        <meta name="keywords" content="West Ham United FC, Tomáš Souček, fotbal, David Moyes, Premier League, Manchester City FC, Emile Heskey, Aston Villa FC, Evropská liga UEFA, Liverpool FC" />
+        <meta name="copyright" content="1999-2021 (c) Economia, a.s." />
+        <meta property="og:site_name" content="Aktuálně.cz - Víte, co se právě děje" />
+        <meta property="og:locale" content="cs_CZ" />
+        <meta property="og:type" content="article" />
+        <meta property="article:published_time" content="2021-11-01T10:52:50+01:00" />
+        <meta property="article:modified_time" content="2021-11-01T12:34:23+01:00" />
+        <meta property="article:section" content="Zahraniční ligy" />
+        <meta property="og:url" content="https://sport.aktualne.cz/fotbal/zahranici/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j/r~8fa032ba3add11ec8a900cc47ab5f122/" />
+        <link rel="canonical" href="https://sport.aktualne.cz/fotbal/zahranici/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j/r~8fa032ba3add11ec8a900cc47ab5f122/" />
+        <meta property="og:title" content="West Ham hrozí gigantům, okouzlil i Linekera. Součka je snadné přehlédnout | Aktuálně.cz" />
+        <meta property="og:image" content="https://cdn.xsd.cz/original/9b6b601b440031309c748f864087a138.jpg" />
+        <meta property="og:description" content="Zázrak jedné sezony? West Ham United dává pochybovačům stále pádnější odpovědi." />
+        <meta name="description" content="Zázrak jedné sezony? West Ham United dává pochybovačům stále pádnější odpovědi." />
+        <meta property="fb:admins" content="751454461" />
+        <meta property="fb:admins" content="568193362" />
+        <meta property="fb:admins" content="1162950483" />
+        <meta property="fb:admins" content="713863314" />
+        <meta property="fb:admins" content="1053518352" />
+        <meta property="fb:admins" content="1300718444" />
+        <meta property="fb:admins" content="1649469665" />
+        <meta property="fb:app_id" content="120597348021544" />
+        <meta property="fb:pages" content="137301989386,219372751414211,114573568574344" />
+        <meta name="twitter:site" content="@Aktualnecz" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="West Ham hrozí gigantům, okouzlil i Linekera. Součka je snadné přehlédnout" />
+        <meta name="twitter:description" content="Zázrak jedné sezony? West Ham United dává pochybovačům stále pádnější odpovědi." />
+        <meta name="twitter:url" content="https://sport.aktualne.cz/fotbal/zahranici/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j/r~8fa032ba3add11ec8a900cc47ab5f122/" />
+        <meta name="twitter:image" content="https://cdn.xsd.cz/resize/9b6b601b440031309c748f864087a138_extract=67,0,1867,1050_resize=720,405_.jpg?hash=460bb7264e563859fd174bc40225d7ad" />
+        <link rel="manifest" href="/manifest.json" />
+        <script type="application/ld+json">
+        <![CDATA[
+                {"@context":"http:\/\/schema.org","url":"https:\/\/sport.aktualne.cz\/fotbal\/zahranici\/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j\/r~8fa032ba3add11ec8a900cc47ab5f122\/","name":"Aktu\u00e1ln\u011b.cz","@type":"NewsArticle","publisher":{"@type":"Organization","name":"Aktu\u00e1ln\u011b.cz","logo":{"@type":"ImageObject","url":"\/\/asset.stdout.cz\/fe\/aktualne\/img\/apple-touch-icon.png","description":"V\u00edte, co se pr\u00e1v\u011b d\u011bje"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https:\/\/sport.aktualne.cz\/fotbal\/zahranici\/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j\/r~8fa032ba3add11ec8a900cc47ab5f122\/"},"headline":"West Ham hroz\u00ed gigant\u016fm, okouzlil i Linekera. Sou\u010dka je snadn\u00e9 p\u0159ehl\u00e9dnout","description":"Z\u00e1zrak jedn\u00e9 sezony? West Ham United d\u00e1v\u00e1 pochybova\u010d\u016fm st\u00e1le p\u00e1dn\u011bj\u0161\u00ed odpov\u011bdi.","datePublished":"2021-11-01T10:52:50+0100","dateModified":"2021-11-01T10:52:50+0100","image":{"@type":"ImageObject","url":"https:\/\/cdn.xsd.cz\/original\/9b6b601b440031309c748f864087a138.jpg","creditText":"Reuters"},"author":[{"@type":"Person","name":"Ale\u0161 V\u00e1vra"}],"about":[{"@id":"wd:Q2736","name":"Fotbal"},{"@id":"wd:Q349","name":"sport"}],"keywords":["West Ham United FC","Tom\u00e1\u0161 Sou\u010dek","fotbal","David Moyes","Premier League","Manchester City FC","Emile Heskey","Aston Villa FC","Evropsk\u00e1 liga UEFA","Liverpool FC"],"wordcount":672}
+        ]]>
+        </script>
+        <meta content="width=device-width, initial-scale=1, minimum-scale=1, shrink-to-fit=no" name="viewport" /><!-- Google Tag Manager -->
+
+        <script type="text/javascript">
+        //<![CDATA[
+        (function (w, d, s, l, i) {
+                w[l] = w[l] || [];
+                w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+                var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+                j.async = true;
+                j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+                f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-KHBVHG8');
+        //]]>
+        </script><!-- End Google Tag Manager -->
+
+        <script>
+        <![CDATA[
+                (function(w) {
+                        var path = 'https://mer.stdout.cz/l.gif?s=pramon&v=1&e=view&';
+                        var id = "8fa032ba3add11ec8a900cc47ab5f122", site = "sport", typ = "article";
+                        var getTime = function() {
+                                return new Date().getTime();
+                        };
+                        var now = getTime();
+                        var hasPerformance = !!w.performance;
+                        var hasPerformanceNow = hasPerformance && typeof w.performance.now === 'function';
+                        var getPerfTime = function() {
+                                return parseInt(
+                                        hasPerformanceNow
+                                        && w.performance.now()
+                                        || (getTime() - now)
+                                        || 0
+                                , 10);
+                        };
+                        var resource = '&bt=' + typ + '&bs=' + site + '&bi=' + id + '&br=' + (Math.floor(Math.random() * 1e9).toString(36));
+                        var hasBeacon = !!navigator.sendBeacon;
+                        w.bbxtrck = {
+                                startTime: now,
+                                perfTime: getPerfTime(),
+                                getPerfTime: getPerfTime,
+                                getTime: getTime,
+                                hasBeacon: hasBeacon,
+                                hasPerformance: hasPerformance,
+                                hasPerformanceNow: hasPerformanceNow,
+                                active: {
+                                        dom: true,
+                                        load: true,
+                                        resource: true,
+                                        unload: true,
+                                        bbxError: true
+                                },
+                                setActive: function(state) {
+                                        this.active = state || {};
+                                },
+                                used: { },
+                                track: function(name, params, repeat) {
+                                        var src = this.getTrackUri(name, params, repeat);
+                                        if (src) {
+                                                var im = new Image();
+                                                return im.src = src;
+                                        }
+                                },
+                                getTrackUri: function(name, params, readOnly) {
+                                        var tr = this.pramons[name];
+                                        if (tr) {
+                                                var uri = tr + '&nm=' + name + '&mt=' + now + '&bp=' + this.getPerfTime() + resource + (params || '');
+                                                if (readOnly) {
+                                                        return uri;
+                                                }
+                                                if (!this.used[name]) {
+                                                        return this.used[name] = uri;
+                                                }
+                                        }
+                                        return false;
+                                },
+                                id: id,
+                                site: site,
+                                type: typ,
+                                resource: resource,
+                                pramons: {
+                                        visit: path + 't=B23dXNkT',
+                                        resource: path + 't=NCxsF2PK',
+                                        dom: path + 't=HkF5SttR',
+                                        unload: path + 't=MeAOkuJ5',
+                                        load: path + 't=JKXHkjxM',
+                                        bbxError: path + 't=DbfxLMIf'
+                                }
+                        };
+                        w.bbxtrck.track('visit');
+                })(window);
+        ]]>
+        </script>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&amp;subset=latin-ext&amp;display=fallback" />
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Barlow:400,400i,700,700i&amp;subset=latin-ext&amp;display=fallback" />
+        <link rel="stylesheet" href="//asset.stdout.cz/fe/common/css/font-awesome.css" />
+        <link rel="stylesheet" type="text/css" href="//asset.stdout.cz/fe/aktualne/css/aktualne.bfb7f0af.css" />
+        <link title="Aktuálně.cz" rel="search" type="application/opensearchdescription+xml" href="//asset.stdout.cz/fe/opensearch/aktualne-cz.xml" />
+        <link rel="shortcut icon" href="//asset.stdout.cz/fe/common/img/aktualne_cz.ico" />
+        <link rel="apple-touch-icon" href="//asset.stdout.cz/fe/aktualne/img/apple-touch-icon.png" />
+        <link rel="icon" type="image/png" href="//asset.stdout.cz/fe/aktualne/img/favicon-16x16.png" sizes="16x16" />
+        <link rel="icon" type="image/png" href="//asset.stdout.cz/fe/aktualne/img/favicon-32x32.png" sizes="32x32" />
+        <link rel="icon" type="image/png" href="//asset.stdout.cz/fe/aktualne/img/favicon-96x96.png" sizes="96x96" />
+        <link rel="icon" type="image/png" href="//asset.stdout.cz/fe/aktualne/img/android-chrome-192x192.png" sizes="192x192" />
+        <meta name="msapplication-square70x70logo" content="//asset.stdout.cz/fe/aktualne/img/smalltile.png" />
+        <meta name="msapplication-square150x150logo" content="//asset.stdout.cz/fe/aktualne/img/mediumtile.png" />
+        <meta name="msapplication-wide310x150logo" content="//asset.stdout.cz/fe/aktualne/img/widetile.png" />
+        <meta name="msapplication-square310x310logo" content="//asset.stdout.cz/fe/aktualne/img/largetile.png" />
+        <script>
+        <![CDATA[
+        window.gdprAppliesGlobally = true;
+        function a (e) {
+        if (!window.frames[e]) {
+                if (document.body && document.body.firstChild) { var t = document.body; var n = document.createElement("iframe"); n.style.display = "none"; n.name = e; n.title = e; t.insertBefore(n, t.firstChild) }
+                else { setTimeout(function () { a(e) }, 5) }
+        }
+        }
+        function e (n, r, o, c, s) {
+        function e (e, t, n, a) { if (typeof n !== "function") { return } if (!window[r]) { window[r] = [] } var i = false; if (s) { i = s(e, t, n) } if (!i) { window[r].push({ command: e, parameter: t, callback: n, version: a }) } }
+        e.stub = true;
+        function t (a) {
+                if (!window[n] || window[n].stub !== true) { return }
+                if (!a.data) { return }
+                var i = typeof a.data === "string"; var e; try { e = i ? JSON.parse(a.data) : a.data } catch (t) { return } if (e[o]) { var r = e[o]; window[n](r.command, r.parameter, function (e, t) { var n = {}; n[c] = { returnValue: e, success: t, callId: r.callId }; a.source.postMessage(i ? JSON.stringify(n) : n, "*") }, r.version) }
+        }
+        if (typeof window[n] !== "function") { window[n] = e; if (window.addEventListener) { window.addEventListener("message", t, false) } else { window.attachEvent("onmessage", t) } }
+        }
+        e("__tcfapi", "__tcfapiBuffer", "__tcfapiCall", "__tcfapiReturn"); a("__tcfapiLocator");
+        (function (e) {
+        var t = document.createElement("script");
+        t.id = "spcloader";
+        t.type = "text/javascript";
+        t.async = true;
+        t.src = "https://sdk.privacy-center.org/" + e + "/loader.js?target=" + document.location.hostname;
+        t.charset = "utf-8";
+        var n = document.getElementsByTagName("script")[0];
+        n.parentNode.insertBefore(t, n)
+        })("9a8e2159-3781-4da1-9590-fbf86806f86e");
+        window.didomiLoaded = true;
+        var script = document.createElement("script");
+        script.type = "text/javascript";
+        script.src = "https://cdn.cpex.cz/cmp/v2/cpex-cmp.min.js";
+        document.head.append(script);
+        ]]>
+        </script>
+        <script type="text/javascript" src="//asset.stdout.cz/fe/appc/js/appc.f9173786.js"></script>
+        <script>
+        <![CDATA[
+        (function() {
+                APPC.recommendations.setTestGroup("alson,zz")
+        })()
+        ]]>
+        </script>
+        <script type="text/javascript" src="//asset.stdout.cz/fe/sport/js/bbx-desktop.80a0d535.js"></script>
+        <script type="text/javascript">
+        //<![CDATA[
+                BBX.context.site = "sport";
+                BBX.context.crumblast = "zahranici";
+                BBX.context.experiment = "alson,zz";
+                BBX.context.page_type = "article";
+                BBX.context.virtual = "";
+                BBX.device = "desktop";
+        //]]>
+        </script>
+        <script type="text/javascript" src="//asset.stdout.cz/fe/external/iframe.js?v=fie"></script>
+        <script type="text/javascript">
+        //<![CDATA[
+        var _virtual_prefix = "\/_article";
+
+        var _virtual_path = "";
+        if (!_virtual_path) {
+                _virtual_path = location.pathname.split(';')[0];
+        }
+
+        var _virtual_url = BBX.urlParser(_virtual_path + location.search).prefix(_virtual_prefix).getPathQuery();
+        //]]>
+        </script>
+        <script type="text/javascript">
+        //<![CDATA[
+        /* na kazdou n-tou reload reklam, url */
+        SiteAdvert.initRefresh(3, _virtual_url);
+        //]]>
+        </script>
+        <script type="text/javascript">
+        //<![CDATA[
+        /* template:'article' (svetly obsah) || 'gallery' (tmavy obsah) || hp (homepage) || 'list' (sekce, tag, hledani...) */
+        var page_type = "article";
+                var s_template = 'article';
+
+        var s_keywords = [];
+                s_keywords = ["zahranicni-ligy","fotbal","sport","premier-league","west-ham-united","tomas-soucek","declan-rice","vladimir-coufal-fotbalista"];
+
+        var _sashec_queue = _sashec_queue || [];
+
+        (function (w, d, bbx, options) {
+                function activateAls(tag) {
+                        w[options.als.queueName] = w[options.als.queueName] || [];
+                        w[options.als.optionsName] = { tag: tag };
+
+                        bbx.loadScript(
+                                options.als.origin + "dist/als.min.js",
+                                {
+                                        async: "async"
+                                },
+                                function () {
+                                        _feLogging.initLogging();
+                                }
+                        );
+                }
+
+                function activateSasic() {
+                        d.write(
+                                '<sc' +
+                                'ript type="text/javascript" src="' +
+                                options.sasic.origin +
+                                'dist/aktualne/sasic.min.js' +
+                                '"onLoad="_sasic.init()"><\/sc' +
+                                'ript>'
+                        );
+                        d.write(
+                                '<sc' +
+                                'ript type="text/javascript" src="' +
+                                options.sasic.origin +
+                                'libs/sashec-connector.min.js' +
+                                '"onLoad="_sashec.init()"><\/sc' +
+                                'ript>'
+                        );
+                }
+
+                function activateSashec() {
+                        d.write(
+                                '<sc' +
+                                'ript src="//i0.cz/sashec/js/sashec.bundle.min.js?v=' +
+                                parseInt((new Date()).getTime() / 216e5) +
+                                '"><\/sc' + 'ript>'
+                        );
+                }
+
+                function createCookieValue(sasic, als) {
+                        sasic = sasic || 'off';
+                        als = als || 'off';
+                        if (als === 'off' && sasic === 'off') {
+                                return '';
+                        }
+                        return 'sasic=' + sasic + '/als=' + als;
+                }
+
+                var sasicQs = bbx.parseQueryParams().sasic;
+                var alsQs = bbx.parseQueryParams().als;
+
+                if (sasicQs || alsQs) {
+                        var cookieValue = createCookieValue(sasicQs, alsQs);
+                        d.cookie = [
+                                '_sasicv=' + cookieValue,
+                                'path=/',
+                                'SameSite=Lax',
+                                'Secure',
+                                'domain=' + w.location.hostname.split('.').slice(-2).join('.'),
+                                'max-age=' + (cookieValue ? '3600' : '-1')
+                        ].join('; ');
+                }
+
+                var sasicCookie = bbx.getCookieByName('_sasicv');
+
+                if (sasicCookie) {
+                        var sasicOn = sasicCookie.indexOf('sasic=on') > -1;
+
+                        if (sasicOn) {
+                                activateSasic();
+                        } else {
+                                activateSashec();
+                        }
+                        if (sasicCookie.indexOf('als=on') > -1) {
+                                activateAls(options.als.tag + (sasicOn ? '-sasic': ''));
+                        }
+                } else {
+                        var sasicOn = (options.experiment || '').indexOf('alson') > -1;
+
+                        if (sasicOn){
+                                activateSasic();
+                                activateAls(options.als.tag + '-sasic');
+                        } else {
+                                activateSashec();
+                                if (Math.random() <= options.als.loggingSample){
+                                        activateAls(options.als.tag);
+                                }
+                        }
+                }
+        })(
+                window,
+                document,
+                BBX,
+                {
+                        experiment: "alson,zz",
+                        als: {
+                                optionsName: 'AlsOptions',
+                                queueName: '_als_queue',
+                                tag: 'aktualne',
+                                loggingSample: 1, // sashec logging percent
+                                origin: "https:\/\/prod-snowly-als.stdout.cz\/",
+                        },
+                        sasic: {
+                                origin: "https:\/\/prod-snowly-sasic.stdout.cz\/",
+                        }
+                }
+        );
+
+        BBX.context.saGroups = ['extra', 'default'];
+        var saGroupSettings = {
+                site: 'aktualne',
+                area: "sport",
+                keyword: s_keywords,
+                targets: {
+                        device: SiteAdvert.device || 'u',
+                        template: s_template,
+                        ab: "alson,zz"
+                        
+                        ,id:"8fa032ba3add11ec8a900cc47ab5f122"
+                        ,sec1:"fotbal"
+                        ,sec2:"zahranici"
+                },
+                callback: SiteAdvert.eventCallback
+        };
+        BBX.context.saGroups.map(function(group) {
+                return SiteAdvert.Queue.push(['group', Object.assign({}, saGroupSettings), group]);
+        });
+        SiteAdvert.Queue.push(['adobetag', 'insert', { service: 'launch' }]);
+        //]]>
+        </script><!-- OnTheIo -->
+        <!-- script tag to enable API -->
+
+        <script>
+        <![CDATA[
+                window.ioObject='io';
+                (function(i) {
+                        window[i] = window[i] || function() {
+                                (window[i].a = window[i].a || []).push(arguments)
+                        };
+                })(window.ioObject);
+        ]]>
+        </script>
+        <script async="async" src="https://cdn.onthe.io/io.js/hlpB7Dc9rDVk"></script>
+        <script>
+        <![CDATA[
+                window._io_config = window._io_config || {};
+                window._io_config["0.2.0"] = window._io_config["0.2.0"] || [];
+
+                        window._io_config["0.2.0"].push({
+                                page_url: "https:\/\/sport.aktualne.cz\/fotbal\/zahranici\/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j\/r~8fa032ba3add11ec8a900cc47ab5f122\/",
+                                page_title: "West Ham hrozí gigantům, okouzlil i Linekera. Součka je snadné přehlédnout",
+                                page_type: 'article',
+                                page_language: "cs",
+                                article_authors: ["Aleš Vávra"],
+                                article_categories: ["Fotbal"],
+                                article_word_count: 709,
+                                article_publication_date: "Mon, 01 Nov 21 10:52:50 +0100",
+                                article_subcategories: ["Zahraniční ligy"],
+                                page_url_canonical: "https:\/\/sport.aktualne.cz\/fotbal\/zahranici\/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j\/r~8fa032ba3add11ec8a900cc47ab5f122\/",
+                                
+                        });
+        ]]>
+        </script><!-- End of OnTheIo -->
+
+        <script type="text/javascript" src="//asset.stdout.cz/fe/external/js/bbx-lightbox.c57e6bbe.js"></script>
+        <script>
+        <![CDATA[
+        BBX.loader.loadLib("\/\/asset.stdout.cz\/fe\/react-apps\/js\/bbx-react.11a84f36.js", 'React');
+        ]]>
+        </script><!-- Google Analytics -->
+
+        <script type="text/javascript">
+        //<![CDATA[
+        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+
+        BBX.wsaga.registerProfile('UA-47740374-1', 'auto');
+        BBX.wsaga.setAccounts();
+        BBX.wsaga.push('set', 'dimension1', BBX.context.experiment);
+        BBX.wsaga.push('set', 'dimension3', SiteAdvert.device);
+
+        // Initialize Ecommerce
+        BBX.wsaga.push('require', 'ec');
+        BBX.ready(function () {
+                BBX.wsaga.ecRegister('[data-ec-list]');
+                BBX.wsaga.ontheioRegister('[data-vr-zone]');
+        });
+
+        BBX.wsaga.trackPageView(_virtual_url || undefined);
+        //]]>
+        </script>
+        <script async="async" src="https://www.google-analytics.com/analytics.js"></script><!-- End Google Analytics -->
+
+        <script>
+        <![CDATA[
+                (function(w) {
+                        var hasBbxLibrary = null;
+                        var ft = [];
+                        try {
+                                var c = BBX.cookies.get('bbxuid');
+                                ft.push('bc=' + (c || 'warn_no_cookie'));
+                                hasBbxLibrary = true;
+                        } catch(e) {
+                                ft.push('bc=fail_bbx_cook');
+                                ft.push('err=' + encodeURIComponent(e.message));
+                        }
+                        try {
+                                var queuePush = SiteAdvert.Queue.push;
+                                if (typeof queuePush === 'function') {
+                                        if (queuePush.toString().match(/_sashec_queue\.push/)) {
+                                                ft.push('bq=fail_original');
+                                        } else if (queuePush.toString().match(/\.size/)) {
+                                                ft.push('bq=seems_ok');
+                                        } else {
+                                                ft.push('bq=fail_size_parse_missing');
+                                        }
+                                } else {
+                                        ft.push('bq=fail_queue_not_func');
+                                }
+                        } catch(e) {
+                                ft.push('bq=fail_queue');
+                                ft.push('err=' + encodeURIComponent(e.message));
+                        }
+                        try {
+                                ft.push('sat=' + _satellite.getVar('bbxDevice'));
+                        } catch(e) {
+                                ft.push('sat=fail_satellite');
+                                ft.push('err=' + encodeURIComponent(e.message));
+                        }
+                        var device = 'x';
+                        try {
+                                var s = _sashec.ad_groups.default.options;
+                                var lt = [
+                                        'sd=' + s.targets.device,
+                                        'st=' + s.targets.template,
+                                        'ss=' + s.site,
+                                        'sa=' + s.area,
+                                        'sb=' + s.targets.ab
+                                ];
+                                device = s.targets.device;
+                                ft.push(lt.join('&'));
+                        } catch(e) {
+                                ft.push('sd=fail_sashec');
+                                ft.push('err=' + encodeURIComponent(e.message));
+                        }
+                        try {
+                                ft.push('ie=' + (w.document.documentMode || 'no'));
+                        } catch (e) {
+                                ft.push('ie=warn_cannot_detect');
+                        }
+                        var noads = false;
+                        if(!w.bbxtrck.hasBeacon) {
+                                ft.push('nb=warn_no_navigator_beacon');
+                        }
+                        if(!w.bbxtrck.hasPerformance) {
+                                ft.push('pf=warn_no_performance_api');
+                        }
+                        if(!w.bbxtrck.hasPerformanceNow) {
+                                ft.push('pfn=warn_no_performance_now');
+                        }
+                        w.bbxtrck.hasBbxLibrary = hasBbxLibrary;
+                        w.bbxtrck.active.resource && w.bbxtrck.track('resource', '&' + ft.join('&'));
+                        if(w.bbxtrck.active.unload && w.bbxtrck.hasBeacon) {
+                                var once = true;
+                                var unload = function() {
+                                        if (!once) {
+                                                return;
+                                        }
+                                        once = false;
+                                        var info = w.bbxtrck.getTrackUri('unload', '&sd=' + device);
+                                        info && navigator.sendBeacon(info);
+                                };
+                                w.addEventListener('beforeunload', unload);
+                                w.addEventListener('unload', unload);
+                        }
+                        if (hasBbxLibrary) {
+                                BBX.ready(function() {
+                                        w.bbxtrck.active.dom && w.bbxtrck.track('dom');
+                                });
+                        } else {
+                                w.bbxtrck.active.bbxError && w.bbxtrck.track('bbxError', '&rsn=fail_bbx_lib');
+                        }
+                        w.bbxtrck.active.load && w.addEventListener('load', function() {
+                                w.bbxtrck.track('load', '&sd=' + device);
+                        });
+                })(window);
+        ]]>
+        </script>
+    </head>
+    <body class="no-focus bbx-site-sport" data-template="" data-section="zahranicni-ligy" data-bbx-design="v2">
+        <script type="text/javascript">
+        //<![CDATA[
+        /* (C)2000-"2021" Gemius SA - gemiusAudience / aktualne.cz / "Sport-ostatni" */
+        var pp_gemius_identifier = "zChFZLBsdR7tN8z8j2.RRHaILU9Z2CbKrKq1ZuMa7eb._7";
+        var pp_gemius_extraparameters = [
+        'title='+ "west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-je-snadne-prehlednout",
+        'guid='+ "8fa032ba3add11ec8a900cc47ab5f122",
+        'pubtime='+ ("2021-11-01T10:52:50" || '')
+        ];
+        SiteAdvert.setGemiusId(pp_gemius_identifier);
+        //]]>
+        </script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        function gemius_pending(i) { window[i] = window[i] || function() { var x = window[i+'_pdata'] = window[i+'_pdata'] || []; x[x.length]=arguments;};};
+        gemius_pending('gemius_hit'); gemius_pending('gemius_event'); gemius_pending('pp_gemius_hit'); gemius_pending('pp_gemius_event');
+        (function(d,t) { try { var gt=d.createElement(t),s=d.getElementsByTagName(t)[0]; gt.setAttribute('async','async'); gt.setAttribute('defer','defer');
+        gt.src=document.location.protocol+'//spir.hit.gemius.pl/xgemius.js'; s.parentNode.insertBefore(gt,s);} catch (e) { }})(document,'script');
+        //]]>
+        </script> <!-- Google Tag Manager (noscript) -->
+         <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KHBVHG8" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
+        <script type="text/javascript">
+        //<![CDATA[
+
+        BBX.assetsDir = "\/\/asset.stdout.cz\/fe\/";
+        BBX.imgDir = "\/\/asset.stdout.cz\/fe\/aktualne\/img\/";
+        //]]>
+        </script>
+        <div class="brand-a" id="brand-a">
+            <div class="brand-b" id="brand-b">
+                <div class="brand-c" id="brand-c">
+                    <div id="header" data-src="//asset.stdout.cz/fe/react-apps/js/bbx-menu.901b314b.js" class="header header--with-title">
+                        <a id="header-logo" class="header__logo" href="https://www.aktualne.cz/" data-evt-active="true" data-evt-category="menu-logo"><svg width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M22.283 19.28h-4.825l1.58-4.97a10.9 10.9 0 0 0 .273-.89c.086-.324.176-.64.272-.947.096-.345.192-.699.287-1.063h.058c.076.364.163.718.258 1.063.077.307.163.623.259.947.095.326.191.624.287.89l1.55 4.97zM20 40C8.955 40 0 31.045 0 20 0 8.954 8.955 0 20 0s20 8.954 20 20c0 11.045-8.955 20-20 20zM9.991 26.631h5.112l1.178-3.704h7.18l1.205 3.704h5.342l-7.41-20.533h-5.226L9.992 26.63zm-.245 5.023h20.508v-3.587H9.746v3.587z" fill="#FFF"></path></svg></a> <a id="header-logo-text" class="header__logo header__logo--text" href="https://www.aktualne.cz/" data-evt-active="true" data-evt-category="menu-logo-text"><span class="logo-text">&#160;</span></a> <button id="menu-icon" class="header__menu__icon" aria-label="Menu"></button>
+                        <div class="menu">
+                            <div class="menu__app" id="menu-root">
+                                <nav class="menu__primary" data-evt-active="true" data-evt-modify="action$@href" data-evt-category="menu-categories" data-evt-action="parallel" data-evt-filter="a[href]" data-evt-label="https://sport.aktualne.cz/fotbal/zahranici/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j/r~8fa032ba3add11ec8a900cc47ab5f122/">
+                                    <ul>
+                                        <li>
+                                            <a href="https://zpravy.aktualne.cz/domaci/" class="menu__primary__item">Domácí</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://zpravy.aktualne.cz/zahranici/" class="menu__primary__item">Zahraničí</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://sport.aktualne.cz/" class="menu__primary__item active">Sport</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://video.aktualne.cz/" class="menu__primary__item">Video</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://zpravy.aktualne.cz/ekonomika/" class="menu__primary__item">Ekonomika</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://zpravy.aktualne.cz/planeta-v-nouzi-klimaticky-special-aktualnecz/l~072e8ac8b6bb11eaa6f6ac1f6b220ee8/" class="menu__primary__item menu__primary__item--climatic-special">Klima</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://nazory.aktualne.cz/" class="menu__primary__item">Názory</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://magazin.aktualne.cz/kultura/" class="menu__primary__item">Kultura</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://magazin.aktualne.cz/" class="menu__primary__item">Magazín</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://zena.aktualne.cz/" class="menu__primary__item">Žena</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://zpravy.aktualne.cz/ekonomika/auto/" class="menu__primary__item">Auto</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://pracovna.aktualne.cz/" class="menu__primary__item">Pracovna</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://magazin.aktualne.cz/bydleni/" class="menu__primary__item">Bydlení</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://zpravy.aktualne.cz/ekonomika/specialy-aktualnecz/r~26c2381a57d611ea8362ac1f6b220ee8/" class="menu__primary__item">Speciály</a>
+                                        </li>
+                                        <li>
+                                            <a href="https://zpravy.aktualne.cz/ekonomika/native-specialy-na-aktualnecz/r~954d3fb25d3c11eab0f60cc47ab5f122/" class="menu__primary__item">Spolupráce</a>
+                                        </li>
+                                    </ul><!-- /.menu__primary -->
+                                </nav>
+                            </div>
+                            <div class="menu__content">
+                                <div class="menu__box">
+                                    <a href="https://zpravy.aktualne.cz/domaci/covid-online/r~866ee1e0331811ec9322ac1f6b220ee8/" data-evt-active="true" data-evt-category="menu-article" data-evt-action="click" data-evt-label="@href">
+                                    <h3 class="menu__box__title">
+                                        Policisté budou s hygieniky častěji kontrolovat opatření, uvedl Hamáček
+                                    </h3>
+                                    <div class="menu__box__image">
+                                        <span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/79f046ec10ec3e40ae78d027d8c121eb_extract=0,0,1959,1306_resize=140,93_.jpg?hash=40c2690f8335f86b95647310ef5ed8a3" srcset="//cdn.xsd.cz/resize/79f046ec10ec3e40ae78d027d8c121eb_extract=0,0,1959,1306_resize=140,93_.jpg?hash=40c2690f8335f86b95647310ef5ed8a3 1x, //cdn.xsd.cz/resize/79f046ec10ec3e40ae78d027d8c121eb_extract=0,0,1959,1306_resize=210,140_.jpg?hash=c9b05fc3dd2d1f25b23eaa9797f30109 1.5x, //cdn.xsd.cz/resize/79f046ec10ec3e40ae78d027d8c121eb_extract=0,0,1959,1306_resize=280,187_.jpg?hash=0f952f575edefce5f0c4e2d7a45c30e9 2x" sizes="140px" alt="Policisté budou s hygieniky častěji kontrolovat opatření, uvedl Hamáček" restricted="off" /></span>
+                                    </div></a>
+                                </div><!-- menu__box -->
+                                <div class="menu__newsletter">
+                                    <div class="menu__newsletter__title">
+                                        Nejnovější zprávy do e-mailu
+                                    </div>
+                                    <form action="https://newsletters.aws.xsd.cz/signup/" method="post" data-nl-form="menu">
+                                        <input type="hidden" name="account" value="aktualne" /> <input name="interests[]" value="e893040ac0" type="hidden" /> <input type="email" name="EMAIL" value="" required="" placeholder="zadejte e-mail" /> <input type="submit" value="Odebírat" name="submit" />
+                                    </form>
+                                    <div data-nl-resp="menu" class="lp-text"></div>
+                                    <div class="menu__newsletter__info">
+                                        Odhlásit se můžete kdykoliv.<br />
+                                        Přihlášením k newsletteru beru na vědomí, že mé osobní údaje budou zpracovány dle <a href="https://www.economia.cz/ochrana-osobnich-udaju/">Zásad ochrany osobních a dalších zpracovávaných údajů</a>, a souhlasím se <a href="https://predplatne.ihned.cz/economia/vop">Všeobecnými obchodními podmínkami</a> vydavatelství Economia, a.s.
+                                    </div>
+                                </div><!-- /.menu__newsletter -->
+                                <div class="menu__social menu__social--top" data-evt-active="true" data-evt-category="menu-info" data-evt-action="click-social" data-evt-filter="a[href]" data-evt-label="@class" data-evt-value="1">
+                                    <a class="fb" href="https://www.facebook.com/Aktualne.cz"></a> <a class="tw" href="https://twitter.com/aktualnecz"></a> <a class="ig" href="https://www.instagram.com/aktualne.cz/"></a>
+                                </div>
+                            </div><!-- /.menu__content -->
+                        </div><!-- /.menu -->
+                        <div class="header__menu" data-evt-active="true" data-evt-modify="action$@href" data-evt-category="menu-categories" data-evt-action="horizontal" data-evt-filter="a[href]" data-evt-label="https://sport.aktualne.cz/fotbal/zahranici/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j/r~8fa032ba3add11ec8a900cc47ab5f122/">
+                            <nav>
+                                <ul>
+                                    <li>
+                                        <a class="header__menu__name" href="https://sport.aktualne.cz/fotbal/zahranici/">Zahraniční ligy</a>
+                                    </li>
+                                    <li class="header__menu__item--first">
+                                        <a href="https://sport.aktualne.cz/fotbal/ceska-liga/" class="podmenu-b-vs-f447490b68db36f70c3029e16b4">FORTUNA:LIGA</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/fotbal/fotbalova-reprezentace/" class="podmenu-b-vs-5505f9e5e2774910c96eaee27df">Reprezentace</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/fotbal/zahranici/" class="podmenu-b-vs-7442de72e12954cd5267000c537">Zahraniční ligy</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/fotbal/euro/" class="podmenu-b-vs-fotbal-euro2012">Euro</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/fotbal/liga-mistru/" class="podmenu-b-vs-16f2be96df5af1cd31e4d3df245">Liga mistrů</a>
+                                    </li>
+                                    <li class="header__menu__item--last">
+                                        <a href="https://sport.aktualne.cz/fotbal/evropska-liga/" class="podmenu-b-vs-e048b2782355bd2cd7552fdbf7e">Evropská liga</a>
+                                    </li>
+                                    <script>
+                                    <![CDATA[
+                                    window.__INITIAL_STATE_MENU__ = {
+                                    defaultSubmenu: [{"guid":"b:vs:f447490b68db36f70c3029e16b4","title":"FORTUNA:LIGA","commercial":false,"link":"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/"},{"guid":"b:vs:5505f9e5e2774910c96eaee27df","title":"Reprezentace","commercial":false,"link":"https:\/\/sport.aktualne.cz\/fotbal\/fotbalova-reprezentace\/"},{"guid":"b:vs:7442de72e12954cd5267000c537","title":"Zahraniční ligy","commercial":false,"link":"https:\/\/sport.aktualne.cz\/fotbal\/zahranici\/"},{"guid":"b:vs:fotbal:euro2012","title":"Euro","commercial":false,"link":"https:\/\/sport.aktualne.cz\/fotbal\/euro\/"},{"guid":"b:vs:16f2be96df5af1cd31e4d3df245","title":"Liga mistrů","commercial":false,"link":"https:\/\/sport.aktualne.cz\/fotbal\/liga-mistru\/"},{"guid":"b:vs:e048b2782355bd2cd7552fdbf7e","title":"Evropská liga","commercial":false,"link":"https:\/\/sport.aktualne.cz\/fotbal\/evropska-liga\/"}]
+                                    };
+                                    ]]>
+                                    </script>
+                                </ul>
+                            </nav>
+                        </div>
+                        <div class="header__title">
+                            West Ham hrozí gigantům, okouzlil i Linekera. Součka je snadné přehlédnout
+                        </div>
+                        <div class="header__search">
+                            <form action="/hledani/" id="search-form" name="search-form">
+                                <input id="search-field" class="header__search__field" type="text" placeholder="Co hledáte?" name="query" value="" aria-label="Hledaný výraz" /> <input type="hidden" name="time" value="time" /> <button id="search-icon" class="header__search__icon" aria-label="Hledání"></button>
+                            </form>
+                        </div>
+                        <div class="header__movable">
+                            <div class="header__info">
+                                <span class="header__info__name" data-evt-active="true" data-evt-category="menu-info" data-evt-action="click-nameday" data-evt-filter="a[href]">1. 11.&#160; <a target="_blank" href="http://svatky.centrum.cz/">Felix</a></span>
+                                <div id="widget_aktualne_oneday_small_container" data-evt-active="true" data-evt-category="menu-info" data-evt-action="click-weather" data-evt-filter="a[href]"></div>
+                                <script type="text/javascript">
+                                //<![CDATA[
+                                (function(widgets) {
+                                var me = document.getElementsByTagName('script');
+                                me = me[me.length - 1];
+                                var load = function(path) {
+                                var s = document.createElement('script');
+                                s.type = 'text/javascript';
+                                s.async = true;
+                                s.defer = 'defer';
+                                s.src = 'https://pocasi-moravio.centrum.cz/public/' + path;
+                                var next = widgets.shift();
+                                if (next) {
+                                var loaded = false;
+                                var onceLoad = function() {
+                                if(!loaded) {
+                                loaded = true;
+                                load(next);
+                                }
+                                };
+                                s.onload = onceLoad;
+                                s.onerror = onceLoad;
+                                }
+                                me.parentNode.insertBefore(s, me);
+                                };
+                                load(widgets.shift());
+                                }(["user_data_storage.bundle.js","aktualne_oneday_small.bundle.js"]));
+                                //]]>
+                                </script>
+                            </div><!-- /.header__info -->
+                            <div class="header__aktualneplus header__aktualneplus--top" data-evt-active="true" data-evt-category="menu-info" data-evt-action="click-aktualneplus" data-evt-filter="a[href]">
+                                <a href="https://www.aktualne.cz/aktualneplus/r~b:r:aktualneplus/">Aktuálně+</a>
+                            </div>
+                            <div class="social-share-box social-share-box--header">
+                                <span class="social-share-box__share" onclick="BBX.dropDown('dropDownHeader', this)" data-evt-label="header">Sdílet článek</span>
+                                <div id="dropDownHeader" class="social-share-box__dropdown hidden">
+                                    <a class="fb" onclick="return !window.open(this.href, '_blank', 'width=550,height=400');" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F" data-evt-active="" data-evt-category="dropdown-share" data-evt-action="fb" data-evt-label="header" data-evt-value="1">Facebook</a> <a class="tw" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F&amp;related=Aktualnecz&amp;via=Aktualnecz&amp;text=West%20Ham%20hroz%C3%AD%20gigant%C5%AFm%2C%20okouzlil%20i%20Linekera.%20Sou%C4%8Dka%20je%20snadn%C3%A9%20p%C5%99ehl%C3%A9dnout" data-evt-active="" data-evt-category="dropdown-share" data-evt-action="tw" data-evt-label="header" data-evt-value="1"> Twitter</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div><!-- /.header -->
+                    <script type="text/javascript">
+                    //<![CDATA[
+                    (function (d) {
+                    BBX.addClass(d.querySelector('.menu__secondary li .podmenu-b-vs-7442de72e12954cd5267000c537'), 'active');
+                    var active = d.querySelector('.menu__primary .active');
+                    if (active) {
+                        active = active.href;
+                    }
+                    window.__INITIAL_STATE_MENU__ = Object.assign(window.__INITIAL_STATE_MENU__ || {}, {
+                        sectionGuid: "b:vs:7442de72e12954cd5267000c537",
+                        active: active,
+                        eventLabel: "https:\/\/sport.aktualne.cz\/fotbal\/zahranici\/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j\/r~8fa032ba3add11ec8a900cc47ab5f122\/"
+                    });
+                    }(document))
+                    //]]>
+                    </script>
+                    <div class="advert sa-hide" id="reklama-leader">
+                        <div class="advert__inner">
+                            <div class="advert__name">
+                                reklama
+                            </div>
+                            <div class="advert__content" id="sas-leader">
+                                <script type="text/javascript">
+                                //<![CDATA[
+                                (function (w) {
+                                        var getWholeLeaderElement = function(element) {
+                                                return element.parentNode.parentNode;
+                                        };
+                                        var fixAdvert = _sashec.scrollAnchor &&
+                                                _sashec.scrollAnchor(w, getWholeLeaderElement) ||
+                                                function () { };
+                                        var leaderCallback = function (evt) {
+                                                fixAdvert(evt);
+                                                SiteAdvert.trackLeader(evt, "article");
+                                        };
+
+                                        SiteAdvert.Queue.push([
+                                                'position',
+                                                'sas-leader',
+                                                {
+                                                        size: function (device) {
+                                                                if (w.BBX.context.site === "aktualnehp" && w.s_template === 'hp' && device === 'm') {
+                                                                        return {
+                                                                                size: null
+                                                                        }
+                                                                }
+                                                                if (device === 'm') {
+                                                                        return { size: ['strip'] };
+                                                                } else if (device === 't') {
+                                                                        return {
+                                                                                size: ['leader', '79a', '91a', '92a'],
+                                                                                hbId: 'leaderboard'
+                                                                        };
+                                                                } else {
+                                                                        return {
+                                                                                size: ['leader', '79a', '91a', '92a', '11a', '21a'],
+                                                                                hbId: 'leaderboard'
+                                                                        }
+                                                                }
+                                                        },
+                                                        _hbBbx: 'exact_set',
+                                                        callback: leaderCallback,
+                                                        callbackData: 'leader'
+                                                },
+                                                'extra'
+                                        ]);
+                                })(window);
+                                //]]>
+                                </script>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="page clearfix">
+                        <div class="social-buttons top-panel">
+                            <div class="social-share-box social-share-box--sidebar">
+                                <div onclick="BBX.dropDown(&quot;socialshare-sidebar&quot;, this)" data-evt-label="top">
+                                    <a class="social-share-box__share">Sdílet článek </a>
+                                </div>
+                                <div id="socialshare-sidebar" class="social-share-box__dropdown hidden">
+                                    <a class="fb" onclick="return !window.open(this.href, '_blank', 'width=550,height=400');" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F" data-evt-active="" data-evt-category="dropdown-share" data-evt-action="fb" data-evt-label="top" data-evt-value="1">Facebook</a> <a class="tw" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F&amp;related=Aktualnecz&amp;via=Aktualnecz&amp;text=West%20Ham%20hroz%C3%AD%20gigant%C5%AFm%2C%20okouzlil%20i%20Linekera.%20Sou%C4%8Dka%20je%20snadn%C3%A9%20p%C5%99ehl%C3%A9dnout" data-evt-active="" data-evt-category="dropdown-share" data-evt-action="tw" data-evt-label="top" data-evt-value="1"> Twitter</a>
+                                </div>
+                            </div><span class="social-share-wrap"><span class="social-button facebook fb-like" data-href="https://sport.aktualne.cz/fotbal/zahranici/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j/r~8fa032ba3add11ec8a900cc47ab5f122/" data-layout="button" data-width="320" data-action="like" data-show-faces="false" data-share="false" data-size="small"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F">To se mi líbí</a></span></span>
+                        </div><!-- /.top-panel -->
+                        <h1 class="article-title">
+                            West Ham hrozí gigantům, okouzlil i Linekera. Součka je snadné přehlédnout
+                        </h1>
+                        <div data-io-article-url="https://sport.aktualne.cz/fotbal/zahranici/west-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j/r~8fa032ba3add11ec8a900cc47ab5f122/" class="wrapper">
+                            <div class="left-column">
+                                <div class="article">
+                                    <div data-ga4-type="article" data-ga4-id="8fa032ba3add11ec8a900cc47ab5f122" data-ga4-title="West Ham hrozí gigantům, okouzlil i Linekera. Součka je snadné přehlédnout" data-ga4-category="Sport, Fotbal, Zahraniční ligy" data-ga4-author="Aleš Vávra" data-ga4-published="2021-11-01" data-ga4-testing="alson,zz" data-ga4-position="0" data-ga4-section="sport" data-ga4-device="desktop" data-ga4-event="detail" data-ga4-length="0"></div>
+                                    <div class="author author--article author--sport">
+                                        <a href="https://www.aktualne.cz/autori/ales-vavra/l~i:author:189/" class="author__photo"><span class="intrinsic intrinsic-1x1"><img src="//cdn.xsd.cz/resize/a5b43d39e2fe32359bcb01a51a090864_extract=17,136,876,876_resize=80,80_.jpg?hash=83ebc2f07d84d7b7543faf0225af7587" srcset="//cdn.xsd.cz/resize/a5b43d39e2fe32359bcb01a51a090864_extract=17,136,876,876_resize=80,80_.jpg?hash=83ebc2f07d84d7b7543faf0225af7587 1x, //cdn.xsd.cz/resize/a5b43d39e2fe32359bcb01a51a090864_extract=17,136,876,876_resize=120,120_.jpg?hash=2a622eb6b8eb5842dc4279313099e1f5 1.5x, //cdn.xsd.cz/resize/a5b43d39e2fe32359bcb01a51a090864_extract=17,136,876,876_resize=160,160_.jpg?hash=2668981c05ff07335c289d01c6c13a34 2x" sizes="80px" alt="Aleš Vávra" restricted="off" /></span></a> <a href="https://www.aktualne.cz/autori/ales-vavra/l~i:author:189/" class="author__name">Aleš Vávra</a>
+                                        <div class="author__date">
+                                            před 2 hodinami
+                                        </div>
+                                    </div><!-- /.author -->
+                                    <div class="article__perex">
+                                        Zázrak jedné sezony? West Ham dává pochybovačům stále pádnější odpovědi a fotbalový svět si začíná uvědomovat, že se absolutní anglická fotbalová elita rozrůstá o nového člena. Tým manažera Davida Moyese prohání giganty i v aktuálním ročníku Premier League.
+                                    </div><!-- /.article__perex -->
+                                    <div class="article__photo article__photo--opener">
+                                        <a href="/aston-villa-west-ham-premier-league/r~ada3322c3af511ecad06ac1f6b220ee8/r~8fa032ba3add11ec8a900cc47ab5f122/" class="lightbbox" data-img="//cdn.xsd.cz/original/9b6b601b440031309c748f864087a138.jpg">
+                                        <div class="article__photo__image">
+                                            <span class="intrinsic intrinsic-16x9"><img src="//cdn.xsd.cz/resize/9b6b601b440031309c748f864087a138_extract=67,0,1867,1050_resize=680,383_.jpg?hash=a5d8d41d89e8a45d414aeeb977aa9193" srcset="//cdn.xsd.cz/resize/9b6b601b440031309c748f864087a138_extract=67,0,1867,1050_resize=226,127_.jpg?hash=c9f76083246618b4addd59fd86534ce1 226w, //cdn.xsd.cz/resize/9b6b601b440031309c748f864087a138_extract=67,0,1867,1050_resize=340,191_.jpg?hash=978cdc73cdb58fee130dc665bf9ef915 340w, //cdn.xsd.cz/resize/9b6b601b440031309c748f864087a138_extract=67,0,1867,1050_resize=680,383_.jpg?hash=a5d8d41d89e8a45d414aeeb977aa9193 680w, //cdn.xsd.cz/resize/9b6b601b440031309c748f864087a138_extract=67,0,1867,1050_resize=1020,574_.jpg?hash=3591d3f7658f2087e1ecbb06b9a1808a 1020w, //cdn.xsd.cz/resize/9b6b601b440031309c748f864087a138_extract=67,0,1867,1050_resize=1360,765_.jpg?hash=0a517379275cc6d08a02c80e4e1e5133 1360w" sizes="(max-width: 850px) 100vw, 680px" alt="Spokojený Tomáš Souček po vítězství ve Villa Parku." restricted="off" /></span>
+                                        </div>
+                                        <div class="article__photo__desc">
+                                            Spokojený Tomáš Souček po vítězství ve Villa Parku. | Foto: Reuters
+                                        </div></a>
+                                    </div><!-- /.article__photo -->
+                                    <div class="article__content" id="article-content">
+                                        <p>
+                                            Pět vítězných soutěžních duelů v řadě, během nich jediný inkasovaný gól. Čtvrté místo v lize, stejný bodový zisk jako loňský šampion Manchester City a nadšené ohlasy z tábora těch nejrenomovanějších komentátorů ostrovního fotbalu.
+                                        </p>
+                                        <div class="related-wrap related-wrap--small">
+                                            <div class="block-title">
+                                                Související
+                                            </div>
+                                            <div class="related-box related-box--small clearfix">
+                                                <a class="related-box--a" href="/fotbal/repka-a-spol-zustali-na-travniku-sami-jejich-souper-odesel-n/r~a0bdceac3a5d11ec9322ac1f6b220ee8/">
+                                                <h3 class="related-box__text">
+                                                    Řepka a spol. zůstali na trávníku sami. Jejich soupeř odešel na protest ze hřiště
+                                                </h3>
+                                                <div class="related-box__image">
+                                                    <span class="intrinsic intrinsic-16x9"><img src="//cdn.xsd.cz/resize/12222367bfb8328ebe9f25d65ca83215_resize=240,135_.jpg?hash=931415c04c02851604c97fb8f43f580a" srcset="//cdn.xsd.cz/resize/12222367bfb8328ebe9f25d65ca83215_resize=240,135_.jpg?hash=931415c04c02851604c97fb8f43f580a 1x, //cdn.xsd.cz/resize/12222367bfb8328ebe9f25d65ca83215_resize=360,203_.jpg?hash=dd12d033d7b74af8e0dfbde2cd244243 1.5x, //cdn.xsd.cz/resize/12222367bfb8328ebe9f25d65ca83215_resize=480,270_.jpg?hash=07825e3a3f0073246141e13678937b49 2x" sizes="240px" restricted="off" alt="Fotbalisté Červených Janovic v utkání s béčkem Tupadel" /></span>
+                                                </div></a>
+                                            </div><!-- /.related-box -->
+                                        </div><!-- /.related-wrap -->
+                                        <p>
+                                            West Ham je opět v kurzu, nadšené ohlasy po nedělní jasné výhře 4:1 na hřišti Aston Villy zaplnily anglický mediální prostor.
+                                        </p>
+                                        <p>
+                                            "Stali se excelentním týmem. Jsou skvělí ve všech částech hřiště a David Moyes si zaslouží obrovský kredit za to, do jaké pozice je dostal," píše na Twitter Gary Lineker.
+                                        </p>
+                                        <p>
+                                            "Nenapadá mě jediný důvod, proč by letos nemohli skončit v elitní čtyřce," přidává se Emile Heskey, někdejší útočník Liverpoolu. "Je fér říct, že vypadají fantasticky. Moyes je neskutečně oživil."
+                                        </p>
+                                        <p>
+                                            I Heskey si všiml, že se Kladiváři skvěle vyrovnávají s náročným programem a pro ně novou rolí: účastí ve více soutěžích najednou. Moyes zůstává konzervativní v určování základní sestavy, chytře ale rozšířil kádr a v Evropské lize či ligovém poháru nechává některé opory odpočívat. Výjimkou potvrzující pravidlo je přitom Tomáš Souček, o jehož nezbytnosti bude řeč níže.
+                                        </p>
+                                        <p>
+                                            "Klíčová věc je ta, že když udělá změny, pořád jim zůstává stejná struktura. To je něco, co pravidelně říkáme třeba o Manchesteru City. Ve hře neustále zůstává nějaká fundamentální filosofie. West Ham to má podobně a už kvůli tomu je třeba před Moyesem smeknout," přirovnává Heskey.
+                                        </p>
+                                        <p>
+                                            <em>Podívejte se na důležité momenty zápasu Aston Villa - West Ham:</em>
+                                        </p>
+                                        <div id="twttr_c90e4f563af511eca7d3ac1f6b220ee8" class="codefragment codefragment--twitter">
+                                            <blockquote class="twitter-tweet">
+                                                <p lang="en" dir="ltr" xml:lang="en">
+                                                    ⭐️⭐️⭐️⭐️<br />
+                                                    <br />
+                                                    Highlights from our 4-1 win at Villa Park ⬇️ <a href="https://t.co/BUPgYtgHaY">pic.twitter.com/BUPgYtgHaY</a>
+                                                </p>— West Ham United (@WestHam) <a href="https://twitter.com/WestHam/status/1454931184966770696?ref_src=twsrc%5Etfw">October 31, 2021</a>
+                                            </blockquote>
+                                        </div>
+                                        <script>
+                                        <![CDATA[
+                                        BBX.social.loadTwitter("twttr_c90e4f563af511eca7d3ac1f6b220ee8", BBX.repairSticky);
+                                        ]]>
+                                        </script>
+                                        <p>
+                                            V Evropské lize má West Ham po třech zápasech plný bodový zisk. V anglickém ligovém poháru dobyl čtvrtfinále, když vyřadil oba bohaté velkokluby z Manchesteru.
+                                        </p>
+                                        <p>
+                                            Čeští fotbalisté nicméně momentálně nejsou ve světlech těch nejjasnějších reflektorů.
+                                        </p>
+                                        <p>
+                                            Vladimír Coufal už sice uzdravil poraněné tříslo, v sestavě ale před ním dostal přednost rozjetý Ben Johnson. Anglický mladík další působivé představení okořenil parádním gólem a potvrdil, že se stává tvrdou konkurencí pro českého reprezentačního beka.
+                                        </p>
+                                        <p>
+                                            Tomáš Souček zůstává nepostradatelným členem základní sestavy, navzdory tomu, že jeho poslední výkony působí nenápadně.
+                                        </p>
+                                        <p>
+                                            "Pořád toho odvádí strašnou spoustu mimo hlavní pozornost. Jsou to důležité věci, které je snadné přehlédnout," píše ve svém hodnocení server Claret and Hugh.&#160;
+                                        </p>
+                                        <div class="related-wrap related-wrap--small">
+                                            <div class="block-title">
+                                                Související
+                                            </div>
+                                            <div class="related-box related-box--small clearfix">
+                                                <a class="related-box--a" href="/fotbal/zahranici/slavny-scholes-namichl-fanousky-west-hamu-jeho-slova-o-souck/r~4d87fa76381611ecad06ac1f6b220ee8/">
+                                                <h3 class="related-box__text">
+                                                    Slavný Scholes namíchl fanoušky West Hamu. Jeho slova o Součkovi berou jako urážku
+                                                </h3>
+                                                <div class="related-box__image">
+                                                    <span class="intrinsic intrinsic-16x9"><img src="//cdn.xsd.cz/resize/527c0a2087573b83935d075190690d90_resize=240,135_.jpg?hash=32a64b0139cb4877ff938ce8654b0472" srcset="//cdn.xsd.cz/resize/527c0a2087573b83935d075190690d90_resize=240,135_.jpg?hash=32a64b0139cb4877ff938ce8654b0472 1x, //cdn.xsd.cz/resize/527c0a2087573b83935d075190690d90_resize=360,203_.jpg?hash=8d240404feca6fd7935774e151959952 1.5x, //cdn.xsd.cz/resize/527c0a2087573b83935d075190690d90_resize=480,270_.jpg?hash=169ff3929de350b9cce171bf18b6cf4e 2x" sizes="240px" restricted="off" alt="Coufal, Souček, Diop (West Ham - Manchester City)" /></span>
+                                                </div></a>
+                                            </div><!-- /.related-box -->
+                                        </div><!-- /.related-wrap -->
+                                        <p>
+                                            "S Declanem Ricem vytvořil silné partnerství a udělal spoustu těžké práce. Má dobrou rozehrávku. Jediné, na co si lze stěžovat, jsou jeho občasná špatná rozhodnutí ve finální třetině hřiště," hodnotí českého středopolaře londýnský večerník Evening Standard.
+                                        </p>
+                                        <p>
+                                            Web Football.London to vidí podobně. "Opět byl silný ve vzduchu, na obou koncích hřiště. Ve finální fázi se ale nerozhodoval dobře, příliš často volil špatnou variantu."
+                                        </p>
+                                        <p>
+                                            Moyes nicméně nenechává Součka oddechnout. V pěti posledních utkáních, které West Ham odehrál během pouhých čtrnácti dnů, chyběl Čech jen pár minut v závěru na Evertonu, když utrpěl zranění v obličeji.
+                                        </p>
+                                        <p>
+                                            Fanoušci pravidelně spekulují o únavě, skotský manažer ale - jak se zdá - bude mít v sestavě raději unaveného Součka než kohokoli jiného. Zvlášť, když Alex Král, plánovaný back-up do středu zálohy, stále není k dispozici.
+                                        </p>
+                                        <p>
+                                            Zatímco v minulé sezoně Souček častokrát zastínil svého kolegu Rice, letos je to právě anglický reprezentant, kdo si užívá zasloužené ódy na svou adresu.
+                                        </p>
+                                        <p>
+                                            "Hraje prostě velkolepě a připomínám, že je mu stále jen dvaadvacet let," kroutí hlavou Lineker. Není sám. Ještě před pár měsíci se většina odborníků pozastavovala nad údajnou cenovkou kolem 100 milionů liber. Nyní už zaznívají hlasy o tom, jak může být i tato hranice při případném přestupu Declana Rice výrazně překročena.
+                                        </p>
+                                        <div class="article__photo">
+                                            <a href="/aston-villa-west-ham-premier-league/r~a1838afa3af511ec8fa20cc47ab5f122/r~8fa032ba3add11ec8a900cc47ab5f122/" class="lightbbox" data-img="//cdn.xsd.cz/original/45c8c36d01e530bd83206c44f1fd341b.jpg">
+                                            <div class="article__photo__image">
+                                                <span class="intrinsic source" style="padding-bottom: 71.913%"><img src="//cdn.xsd.cz/resize/45c8c36d01e530bd83206c44f1fd341b_resize=560,403_.jpg?hash=d19aad3d8d0905964352d35120e0b5fd" srcset="//cdn.xsd.cz/resize/45c8c36d01e530bd83206c44f1fd341b_resize=186,134_.jpg?hash=e1bf622a5bdbd764041e2b55223bac36 186w, //cdn.xsd.cz/resize/45c8c36d01e530bd83206c44f1fd341b_resize=280,201_.jpg?hash=b3e4406670610a83ce5bb6e8521a3061 280w, //cdn.xsd.cz/resize/45c8c36d01e530bd83206c44f1fd341b_resize=560,403_.jpg?hash=d19aad3d8d0905964352d35120e0b5fd 560w, //cdn.xsd.cz/resize/45c8c36d01e530bd83206c44f1fd341b_resize=840,604_.jpg?hash=fdb1dc7d2287bacf6fa822f568c08269 840w, //cdn.xsd.cz/resize/45c8c36d01e530bd83206c44f1fd341b_resize=1120,805_.jpg?hash=ad2142927725af446373ee9345d82a1b 1120w" sizes="(max-width: 850px) 100vw, 560px" alt="Declan Rice po vítězství na Aston Ville." restricted="off" /></span>
+                                            </div>
+                                            <div class="article__photo__desc">
+                                                Declan Rice po vítězství na Aston Ville. | Foto: Reuters
+                                            </div></a>
+                                        </div><!-- /.article__photo -->
+                                        <p>
+                                            S blížícím se zimním přestupním termínem budou spekulace nabývat na síle, fanoušci Hammers ale věří, že Rice zůstane nejméně do léta. Jeho spokojenost je do očí bijící, stejně jako ochota nechat na hřišti všechno ve prospěch Clarets and Blues.
+                                        </p>
+                                        <p>
+                                            "Náš kolektiv je teď opravdu speciální. Působíme ve výjimečném prostředí. Každé ráno se probouzíme s obrovskou touhou po dalším tréninku. Jsme nadšení," tvrdí mladá anglická superstar.
+                                        </p>
+                                        <p>
+                                            "Jsme na děleném třetím místě. Lidé se před sezonou hodně ptali, zda to můžeme dokázat znovu. Ukázali jsme, že ano. Ale musíme pokračovat. Tohle musí být náš standard. Nesmíme polevit, pokud chceme být velkým týmem," zdůrazňuje Rice.
+                                        </p>
+                                    </div>
+                                    <script>
+                                    <![CDATA[
+                                    BBX.inlineAds(
+                                    document.getElementById('article-content'),
+                                    function (pos) {
+                                    return function (device) {
+                                        if (device === 'm') {
+                                                return { size: ['mediumrectangle', 'square300'] };
+                                        }
+                                                if (pos === 2) {
+                                                        return { size: ['wallpaper', 'mpu', 'sq3'] };
+                                                }
+                                        return { size: null };
+                                    }
+                                    },
+                                    {
+                                    paragraphs: {
+                                        firstPos: 1,
+                                        fixedParagraphs: [0, 4],
+                                        iterateByParagraphs: 6
+                                    }
+                                    }
+                                    );
+                                    ]]>
+                                    </script>
+                                    <div id="article-widget-7f676662e93311eba824ac1f6b220ee8" class="graphicswidget-article clearfix"></div>
+                                    <script>
+                                    <![CDATA[
+                                    (function (d) {
+                                    var target = d.getElementById("article-widget-7f676662e93311eba824ac1f6b220ee8");
+                                    var widget = new DisposableIframe({
+                                    raw_content: true,
+                                    content: "<html>\n<head>\n    <meta charset=\"utf-8\">\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n    <base target=\"_parent\">\n    <link rel=\"stylesheet\" href=\"https:\/\/fonts.googleapis.com\/css?family=Barlow:400,400i,700,700i&amp;subset=latin-ext&amp;display=fallback\">\n    <script type=\"text\/javascript\" src=\"https:\/\/i0.cz\/l\/js\/jquery\/jquery-1.8.3.js\"><\/script>\n    <script src=\"https:\/\/i0.cz\/bbx-8\/external\/lib-graphics.js\"><\/script>\n    <script src=\"https:\/\/i0.cz\/sashec\/js\/disposable-iframe.min.js\"><\/script>\n    <script src=\"https:\/\/asset.stdout.cz\/fe\/external\/iframe.js\"><\/script>\n    <style>\n        * {\n            margin: 0;\n            padding: 0;\n        }\n\n\n\n        body {\n            overflow: hidden;\n        }\n\n        .obal-widget {\n            width: 100%;\n            overflow: hidden;\n            background-color: #e8f1f8;\n            -webkit-box-sizing: border-box;\n            box-sizing: border-box;\n            font-family: Barlow, sans-serif;\n            border-radius: 8px;\n            margin: 0;\n            max-width: 1032px;\n            min-height: 150px;\n            display: flex;\n            position: relative;\n        }\n\n\n        .intrinsic-1x1 {\n            display: block;\n            position: relative;\n            height: 0;\n            overflow: hidden;\n            padding-bottom: 100% !important;\n        }\n\n        .intrinsic-1x1 img {\n            border: 0;\n            overflow: hidden;\n            position: absolute;\n            top: 0;\n            left: 0;\n            width: 100%;\n            height: auto;\n        }\n\n        .klub-logo{\n            width: 20px;\n        }\n\n        .sou{\n            width: 22%;\n        }\n        .sou .clanek{\n            background-size: cover;\n            background-position: center;\n            position: relative;\n            display: flex;\n            height: 100%;\n            align-items: flex-end;\n            text-decoration: none;\n        }\n        .sou .clanek span{\n            background: rgba(27, 105, 191, 0.8);\n            color: white;\n            font-size: 13px;\n            box-sizing: border-box;\n            padding: 10px;\n            line-height: 1.2em;\n            display: block;\n        }\n\n\n\n\n        .zapasy{\n            width: 60%;\n            position: relative;\n            overflow: hidden;\n        }\n        .zapasy .zapasy-hlavicka{\n            display: flex;\n            justify-content: space-between;\n            align-items: center;\n            background: #ffdd00;\n        }\n        .zapasy .zapasy-hlavicka img{\n            width: auto;\n            height: 24px;\n            display: block;\n        }\n        .zapasy .zapasy-hlavicka .left-b,.zapasy .zapasy-hlavicka .right-b{\n            font-size: 11px;\n            font-weight: 100;\n            line-height: 1em;\n            box-sizing: border-box;\n            padding: 0 10px;\n            opacity: 1;\n            cursor: pointer;\n            transition: .3s ease-out;\n            font-weight: bold;\n        }\n        .zapasy .zapasy-hlavicka .left-b:hover{\n            transform: translateX(5px);\n        }\n        .zapasy .zapasy-hlavicka .right-b:hover{\n            transform: translateX(-5px);\n        }\n        .zapasy .varovani {\n            font-size: 8px;\n    width: 100%;\n    display: block;\n    background: rgba(27, 105, 191, 0.05);\n    text-align: center;\n    box-sizing: border-box;\n    padding: 3px;\n    line-height: 1em;\n    color: #7b91a5;\n}\n        \n        .zapasy .zapasy-wrapper{\n            display: flex;\n            flex-wrap: wrap;\n            position: relative;\n            align-items: flex-start;\n        }\n        .zapasy-slider {\n            position: relative;\n            transition: .5s ease-out;\n            left: 0;\n        }\n\n        .zapasy.slide-left .zapasy-slider{left: 100%;}\n        .zapasy.slide-left .left-b {opacity: 0; cursor: default;}\n\n        .zapasy.slide-right .zapasy-slider{left: -100%;}\n        .zapasy.slide-right .right-b {opacity: 0;cursor: default;}\n\n\n        .zapasy .zapasy-wrapper-left{\n            position: absolute;\n            left: 0;\n            bottom: 0;\n            transform: translateX(-100%);\n        }\n        .zapasy .zapasy-wrapper-right{\n            position: absolute;\n            left: 0;\n            bottom: 0;\n            transform: translateX(100%);\n        }\n\n        .zapasy .zapasy-wrapper .zapas{\n            width: 50%;\n            box-sizing: border-box;\n            padding: 12px;\n            text-align: center;\n            text-decoration: none;\n            color: #000;\n        }\n        .zapasy .zapasy-wrapper .zapas:hover {\n           background: rgba(27, 105, 191, 0.1);\n        }\n        .zapasy .zapasy-wrapper .zapas:nth-child(1),\n        .zapasy .zapasy-wrapper .zapas:nth-child(3){\n            border-right: 1px dashed rgba(27, 105, 191, 0.2);\n        }\n        .zapasy .zapasy-wrapper .zapas:nth-child(1),\n        .zapasy .zapasy-wrapper .zapas:nth-child(2){\n            border-bottom: 1px dashed rgba(27, 105, 191, 0.2);\n        }\n        .zapasy .zapasy-wrapper .zapas .zapas-detail{\n            font-size: 12px;\n            font-weight: 100;\n            margin-bottom: 5px;\n        }\n        .bet{color: #E2BF30;font-weight: bold;}\n        .online{color: #DA1630;font-weight: bold;}\n        .report{color: #1B69BF;font-weight: bold;}\n        \n        .zapasy .zapasy-wrapper .zapas .zapas-info{\n            display: flex;\n            align-items: center;\n            justify-content: center;\n            min-height: 20px;\n        }\n        .zapasy .zapasy-wrapper .zapas .zapas-info .klub-logo{\n            display: inline-table;\n            margin: 0 5px;\n        }\n        .zapasy .zapasy-wrapper .zapas .zapas-info .zapsa-stav{\n            line-height: 1em;\n            font-weight: bold;\n            font-size: 12px;\n            white-space: nowrap;\n        }\n        .klub-l{\n            text-align: right;\n        }\n        .klub-r{\n            text-align: left;\n        }\n        .klub-l, .klub-r{\n            text-overflow: ellipsis;\n            overflow: hidden;\n            white-space: nowrap;\n            font-size: 14px;\n            line-height: 1em;\n            width: 40%;\n        }\n\n\n\n\n\n        .tabulka{\n            background: rgba(27, 105, 191, 0.05);\n            text-decoration: none;\n            color: black;\n            width: 18%;\n        }\n\n        .tabulka table{\n            height: 100%;\n            width: 100%;\n            border-collapse: none;\n            border-spacing: 0;\n        }\n        .tabulka table td{\n            font-size: 12px;\n            border-bottom: 1px solid rgba(27, 105, 191, 0.1);\n            box-sizing: border-box;\n            line-height: 1em;\n            vertical-align: middle;\n            text-align: center;\n            min-height: 20px;\n        }\n        .tabulka table thead td{\n            background: #ecce05;\n            font-weight: bold;\n            box-sizing: border-box;\n            padding: 0 5px;\n            border: none;\n            height: 24px;\n        }\n        .tabulka table tbody td em{\n            font-weight: bold;\n        }\n        .tabulka table tbody td .klub-logo{\n            vertical-align: middle;\n            margin: 0 5px;\n            display: inline-block;\n        }\n        .tabulka table tbody td:first-child{\n            padding: 0 0 0 5px;\n            text-align: left;\n        }\n        .tabulka table tbody td:last-child{\n            padding: 0 5px 0 0;\n            font-weight: bold;\n        }\n        .tabulka table tbody tr:last-child td{\n            border: none;\n        }\n\n        .tabulka table.hide-rest tbody tr{\n            display: none;\n        }\n        .tabulka table.hide-rest tbody tr:nth-child(1){display: table-row;}\n        .tabulka table.hide-rest tbody tr:nth-child(2){display: table-row;}\n        .tabulka table.hide-rest tbody tr:nth-child(3){display: table-row;}\n        .tabulka table.hide-rest tbody tr:nth-child(4){display: table-row;}\n        .tabulka table.hide-rest tbody tr:nth-child(5){display: table-row;}\n\n        .rozbal{\n            width: 100%;\n            font-size: 12px;\n            font-weight: bold;\n            box-sizing: border-box;\n            padding: 5px;\n            text-align: center;\n            background: rgba(27, 105, 191, 0.1);\n            color: black;\n            cursor: pointer;\n            display: block;\n        }\n\n        .infografika{\n            width: 100%;\n            font-size: 12px;\n            font-weight: bold;\n            box-sizing: border-box;\n            padding: 5px;\n            text-align: center;\n            background: #1b69bf;\n            color: #ffffff;\n            cursor: pointer;\n            display: none;\n            text-decoration: underline;\n        }\n        .infografika.aktiv{display: block;}\n\n        .article-type .obal-widget{flex-wrap: wrap;}\n        .article-type .zapasy{width: 100%;}\n        .article-type .tabulka{width: 100%;}\n        .article-type .tabulka table{height: auto;}\n        .article-type .tabulka table td{\n            padding: 5px 10px !important;\n        }\n        .article-type .tabulka table thead td:first-child{\n            text-align: left;\n        }\n\n\n        @media screen and (max-width: 870px) {\n            .sou{display: none;}\n            .zapasy{width: 70%;}\n            .tabulka{width: 30%;}\n        }\n        @media screen and (max-width: 670px) {\n            .obal-widget{flex-wrap: wrap;}\n            .zapasy{width: 100%;}\n            .tabulka{width: 100%; display: none;}\n            .obal.article-type .tabulka{display: block;}\n            .tabulka table td{\n                padding: 5px 10px !important;\n            }\n        }\n\n        @media screen and (max-width: 480px) {\n            .obal{\n                box-sizing: border-box;\n                padding: 0 16px;\n            }\n            .obal .tabulka{display: none;}\n            .obal.article-type .tabulka{display: block;}\n            .obal.article-type{\n                padding: 0 !important;\n            }\n            .article-type .tabulka table td:nth-child(2),\n            .article-type .tabulka table td:nth-child(3),\n            .article-type .tabulka table td:nth-child(4),\n            .article-type .tabulka table td:nth-child(5){\n                display: none;\n            }\n        }\n\n        @media screen and (max-width: 420px) {\n            .zapasy .zapasy-wrapper .zapas{\n                width: 100%;\n                border-right: none !important;\n                border-bottom: 1px dashed rgba(27, 105, 191, 0.2);\n                padding: 5px;\n            }\n            .zapasy .zapasy-wrapper .zapas .zapas-detail{font-size: 9px;}\n            .zapasy .zapasy-wrapper .zapas:last-child{border: none;}\n\n        }\n\n\n    <\/style> \n<\/head>\n<body>\n\n    <div class=\"obal\">\n        <div class=\"obal-widget\">\n            <img style=\"position: absolute;top: 0;left: 0;z-index: -1;\" src=\"http:\/\/r.i0.cz\/l.gif?s=pramon&v=1&e=view&t=NbVtYf_v\" \/>\n            <div class=\"sou\"><\/div>\n            <div class=\"zapasy\">\n                <div class=\"zapasy-hlavicka\">\n                    <span class=\"left-b\">&#171; Předchozí<\/span>\n                    <a href=\"http:\/\/r.i0.cz\/?url=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fceska-liga%2Fprogram-vysledky-tabulka-a-statistiky-fortuna-ligy-2021-22%2Fr%7E7f676662e93311eba824ac1f6b220ee8%2F&s=pramon&v=1&t=NbVtYf_v&e=click\"><img src=\"https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/logo-fl._2_.svg\" alt=\"fortuna:liga\"><\/a>\n                    <span class=\"right-b\">Další &#187;<\/span>\n                <\/div>\n                <div class=\"zapasy-slider\">\n                    <div class=\"zapasy-wrapper zapasy-wrapper-main\">\n                        <a href=\"#\" class=\"zapas\"><div class=\"zapas-detail\">-<span class=\"report\"><\/span><\/div><div class=\"zapas-info\"><span class=\"klub-l\">-<\/span><div style=\"width:15px;display:block;\"><\/div><div class=\"zapsa-stav\">-<\/div><div style=\"width:15px;display:block;\"><\/div><span class=\"klub-r\">-<\/span><\/div><\/a>\n                        <a href=\"#\" class=\"zapas\"><div class=\"zapas-detail\">-<span class=\"report\"><\/span><\/div><div class=\"zapas-info\"><span class=\"klub-l\">-<\/span><div style=\"width:15px;display:block;\"><\/div><div class=\"zapsa-stav\">-<\/div><div style=\"width:15px;display:block;\"><\/div><span class=\"klub-r\">-<\/span><\/div><\/a>\n                        <a href=\"#\" class=\"zapas\"><div class=\"zapas-detail\">-<span class=\"report\"><\/span><\/div><div class=\"zapas-info\"><span class=\"klub-l\">-<\/span><div style=\"width:15px;display:block;\"><\/div><div class=\"zapsa-stav\">-<\/div><div style=\"width:15px;display:block;\"><\/div><span class=\"klub-r\">-<\/span><\/div><\/a>\n                        <a href=\"#\" class=\"zapas\"><div class=\"zapas-detail\">-<span class=\"report\"><\/span><\/div><div class=\"zapas-info\"><span class=\"klub-l\">-<\/span><div style=\"width:15px;display:block;\"><\/div><div class=\"zapsa-stav\">-<\/div><div style=\"width:15px;display:block;\"><\/div><span class=\"klub-r\">-<\/span><\/div><\/a>\n                    <\/div>\n                <\/div>\n                <span class=\"varovani\">Ministerstvo financí varuje: Účastí na hazardní hře může vzniknout závislost! Zákaz účasti osob mladších 18 let na hazardní hře.<\/span>\n            <\/div>\n\n            <a href=\"http:\/\/r.i0.cz\/?url=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fceska-liga%2Fprogram-vysledky-tabulka-a-statistiky-fortuna-ligy-2021-22%2Fr%7E7f676662e93311eba824ac1f6b220ee8%2F&s=pramon&v=1&t=NbVtYf_v&e=click\" class=\"tabulka\">\n                <table>\n                    <thead><tr><td colspan=\"2\">Body a další statistiky»<\/td><\/tr><\/thead>\n                    <tbody>\n                        <tr><em>1.<\/em><td>-<\/td><td>-<\/td><\/tr>\n                        <tr><em>2.<\/em><td>-<\/td><td>-<\/td><\/tr>\n                        <tr><em>3.<\/em><td>-<\/td><td>-<\/td><\/tr>\n                        <tr><em>4.<\/em><td>-<\/td><td>-<\/td><\/tr>\n                        <tr><em>5.<\/em><td>-<\/td><td>-<\/td><\/tr>\n                    <\/tbody>\n                <\/table>\n            <\/a>\n\n        <\/div>\n    <\/div>\n\n\n    <script type=\"text\/javascript\">\n\n        fceResize();\n\n        String.prototype.escapeIdSelector = window.top.String.prototype.escapeIdSelector;\n\n        var target;\n        var article = window.top.page_type == 'article';\n        if (article) $('.obal').addClass('article-type');\n\n        var kluby = {\n            BOH:{name_full:'Bohemians Praha 1905',name:'Bohemians 1905',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/boh._3_.png',shortcut:'BOH',},\n            BRN:{name_full:'FC Zbrojovka Brno',name:'Brno',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/brn._4_.png',shortcut:'BRN',},\n            CEB:{name_full:'SK D. Č. Budějovice',name:'Č. Budějovice',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/ceb._5_.png',shortcut:'CEB',},\n            JAB:{name_full:'FK Jablonec',name:'Jablonec',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/jab._6_.png',shortcut:'JAB',},\n            KAR:{name_full:'MFK Karviná',name:'Karviná',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/kar._7_.png',shortcut:'KAR',},\n            LIB:{name_full:'FC Slovan Liberec',name:'Liberec',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/lib._8_.png',shortcut:'LIB',},\n            MBL:{name_full:'FK Mladá Boleslav',name:'Ml. Boleslav',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/mbl._9_.png',shortcut:'MBL',},\n            OLO:{name_full:'SK Sigma Olomouc',name:'Olomouc',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/olo._10_.png',shortcut:'OLO',},\n            OPA:{name_full:'SFC Opava',name:'Opava',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/opa._11_.png',shortcut:'OPA',},\n            OVA:{name_full:'FC Baník Ostrava',name:'Ostrava',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/ova._12_.png',shortcut:'OVA',},\n            PCE:{name_full:'FK Pardubice',name:'Pardubice',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/pce._13_.png',shortcut:'PCE',},\n            PLZ:{name_full:'FC Viktoria Plzeň',name:'Plzeň',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/plz._14_.png',shortcut:'PLZ',},\n            PRI:{name_full:'1.FK Příbram',name:'Příbram',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/pri._15_.png',shortcut:'PRI',},\n            SLA:{name_full:'SK Slavia Praha',name:'Slavia',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/sla._16_.png',shortcut:'SLA',},\n            SLO:{name_full:'1.FC Slovácko',name:'Slovácko',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/slo._17_.png',shortcut:'SLO',},\n            SPA:{name_full:'AC Sparta Praha',name:'Sparta',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/spa2._114_.png',shortcut:'SPA',},\n            TEP:{name_full:'FK Teplice',name:'Teplice',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/tep._19_.png',shortcut:'TEP',},\n            ZLN:{name_full:'FC Fastav Zlín',name:'Zlín',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/zln._20_.png',shortcut:'ZLN',},\n            HKR:{name_full:'FC Hradec Králové',name:'Hradec Králové',logoUrl:'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/hrk._107_.png',shortcut:'HKR',},\n        }\n\n\n        function fceResize() {\n            var h = $('.obal-widget').outerHeight(true);            \n            $(target).height(h);\n\n            var sliderW = $('.zapasy-wrapper-main').width();\n            $('.zapasy-wrapper-left,.zapasy-wrapper-right').width(sliderW);\n        }\n\n        $(window).on('resize',function() { fceResize(); })\n\n\n        function run(div,xml){\n            target = div.children[0];\n            var $xml = $($.parseXML(xml));\n\n            if(!article){\n\n                if ($(window).width()>870) {\n                    \/\/sou clánek a img\n                    var clanek = $('widgetClanek',$xml).find('idClanok');\n                    var clanekObr = LIB_GRAPHICS.utils.nodeToString($('widgetClanek',$xml).find('idPutak').contents());\n                \n                    if (clanek) {\n                        var tit = LIB_GRAPHICS.utils.nodeToString(clanek.find('[bbxtype=\"article\"]').find('title:eq(0)').contents());\n                        var url = LIB_GRAPHICS.utils.nodeToString(clanek.find('[bbxtype=\"article\"]').find('link:eq(0)').contents());\n                        var obr = clanekObr.length>0 ? clanekObr : 'https:\/\/graphics.stdout.cz\/76843e9042c65bbbc56c8b89dae02859\/clanek-placeholder._27_.jpg';\n                        $('.sou').html('<a href=\"'+url+'\" class=\"clanek\" style=\"background-image: url('+obr+');\"><span>'+tit+'<\/span><\/a>');\n                    }else{\n                        $('.sou').remove();\n                    }\n\n                }else{\n                    $('.sou').remove();\n                }\n                \n                if ($(window).width()>670) {\n                    var lastTable = $($xml).find('boxKola tabItem').last().parent();\n\n                    var tableHtml = '<table><thead><tr><td colspan=\"2\">Body a další statistiky»<\/td><\/tr><\/thead><tbody>';\n                        lastTable.find('tabItem').each(function(index){\n                            tableHtml +='<tr>'+\n                                            '<td><em>'+$(this).attr('poradi')+' <\/em>'+kluby[$(this).attr('zkratkaID')].name_full+'<\/td>'+\n                                            '<td>'+$(this).attr('body')+'<\/td>'+\n                                        '<\/tr>'; \n                            if (index==4) return false;\n                        })\n                    tableHtml += '<\/tbody><\/table>';\n                    $('.tabulka').html(tableHtml);    \n                }else{\n                    $('.tabulka').remove();\n                }\n\n            }else{\n\n                var lastTable = $($xml).find('boxKola tabItem').last().parent();\n                var kolo = lastTable.parent().attr('cislo');\n\n                var tableHtml = '<table class=\"hide-rest\"><thead><tr><td>Tabulka po '+kolo+' kole<\/td><td>Z<\/td><td>V<\/td><td>R<\/td><td>P<\/td><td>Skóre<\/td><td>Body<\/td><\/tr><\/thead><tbody>';\n                    lastTable.find('tabItem').each(function(index){\n                        tableHtml +='<tr>'+\n                                        '<td><em>'+$(this).attr('poradi')+' <\/em>'+\n                                            '<div class=\"klub-logo\"><span class=\"intrinsic-1x1\"><img src=\"'+kluby[$(this).attr('zkratkaID')].logoUrl+'\"><\/span><\/div>'+\n                                            kluby[$(this).attr('zkratkaID')].name_full+'<\/td>'+\n                                        '<td>'+$(this).attr('Z')+'<\/td>'+\n                                        '<td>'+$(this).attr('V')+'<\/td>'+\n                                        '<td>'+$(this).attr('R')+'<\/td>'+\n                                        '<td>'+$(this).attr('P')+'<\/td>'+\n                                        '<td>'+$(this).attr('skore')+'<\/td>'+\n                                        '<td>'+$(this).attr('body')+'<\/td>'+\n                                    '<\/tr>'; \n                    })\n                    tableHtml += '<\/tbody><\/table><span class=\"rozbal\">Rozbalit tabulku<\/span><a class=\"infografika\" href=\"http:\/\/r.i0.cz\/?url=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fceska-liga%2Fprogram-vysledky-tabulka-a-statistiky-fortuna-ligy-2021-22%2Fr%7E7f676662e93311eba824ac1f6b220ee8%2F&s=pramon&v=1&t=NbVtYf_v&e=click\">Celý přehled &#187;<\/a>';\n\n                    $('.tabulka').html(tableHtml);\n                \n                    $('.rozbal').on('click', function(e){\n                        e.preventDefault();\n                        $(this).remove();\n                        $('.infografika').addClass('aktiv');\n                        $('.hide-rest').removeClass('hide-rest');\n                        fceResize();\n                    })\n\n            }\n\n\n        \n            \n\n            \/\/ Zápasy ------------------------------------------------------------------------------\n                var pattern = \/(\\d{2})\\.(\\d{2})\\.(\\d{4})\/;\n                var todayTimestamp = new Date().getTime();\n\n                var poleObjZapasu = [];\n                $('itemKolo',$xml).each(function(index){\n                    var koloDate = $(this).attr('datum');\n                        \n                        if(\/\\d\/.test($(this).attr('cas'))) koloDate += ' '+$(this).attr('cas'); \/\/ak attr-cas obsahuje číslo\n                        \n                        koloDate = koloDate.slice(3).replace(pattern, '$3-$2-$1'); \/\/prevadim do datumového formátu\n                        \n                        koloDate = new Date(koloDate.replace(\/-\/g, '\/')).getTime(); \/\/prevadim do milisekund\n\n                        if(koloDate){\n                            poleObjZapasu.push({index:index,timestamp:koloDate,datum:$(this).attr('datum')});\n                        }\n                })\n                \n\n\n                poleObjZapasu.sort(function(a,b){\n                    return a.timestamp - b.timestamp\n                });\n\n                \/\/hladam najbližiší hraný zápas\n                var closestMachIndex = null;\n                for (var i = 0; i < poleObjZapasu.length; i++) {\n                    closestMachIndex = i;\n                    if(poleObjZapasu[i].timestamp>=todayTimestamp){\n                        break;\n                    } \n                }\n\n                \n                \/\/hladam 4 posledné hrané a vytváram HTMl\n                var slideLeft = []\n                for (var i = 1; i < 5; i++) {\n                    var z = poleObjZapasu[closestMachIndex-i];\n                    if (z) {\n                        var zapas = $xml.find('itemKolo:eq('+z.index+')');\n                        var d = kluby[zapas.attr('domaci')];\n                        var h = kluby[zapas.attr('hoste')];\n                            \n                        var zapasData = {\n                            domaci:{nazev:d.name,logoUrl:d.logoUrl},\n                            hoste:{nazev:h.name,logoUrl:h.logoUrl},\n                            skore:zapas.attr('skore'),\n                            timestamp: z.timestamp,\n                            datum: zapas.attr('datum'),\n                            cas: zapas.attr('cas'),\n                            fortunaUrl:zapas.attr('fortunaUrl'),\n                            onlineUrl:zapas.attr('onlineUrl'),\n                            reportUrl:zapas.attr('reportUrl'),\n                        }\n                        slideLeft.push(createZapasHtml(zapasData))                        \n                    }\n                }\n                slideLeft = slideLeft.reverse();\n\n                \/\/hladam 4 nasledujúce hrané a vytváram HTMl\n                var slideMain = []\n                for (var i = 0 ; i < 4; i++) {\n                    var z = poleObjZapasu[closestMachIndex+i];\n                    if (z) {\n                        var zapas = $xml.find('itemKolo:eq('+z.index+')');\n                        var d = kluby[zapas.attr('domaci')];\n                        var h = kluby[zapas.attr('hoste')];\n                            \n                        var zapasData = {\n                            domaci:{nazev:d.name,logoUrl:d.logoUrl},\n                            hoste:{nazev:h.name,logoUrl:h.logoUrl},\n                            skore:zapas.attr('skore'),\n                            timestamp: z.timestamp,\n                            datum: zapas.attr('datum'),\n                            cas: zapas.attr('cas'),\n                            fortunaUrl:zapas.attr('fortunaUrl'),\n                            onlineUrl:zapas.attr('onlineUrl'),\n                            reportUrl:zapas.attr('reportUrl'),\n                        }\n    \n                        slideMain.push(createZapasHtml(zapasData))\n                    }\n                }\n                \n                \/\/hladam 4-8 nasledujúce hrané a vytváram HTMl\n                var slideRight = []\n                for (var i = 4 ; i < 8; i++) {\n                    var z = poleObjZapasu[closestMachIndex+i];\n                    if (z) {\n                        var zapas = $xml.find('itemKolo:eq('+z.index+')');\n                        var d = kluby[zapas.attr('domaci')];\n                        var h = kluby[zapas.attr('hoste')];\n                            \n                        var zapasData = {\n                            domaci:{nazev:d.name,logoUrl:d.logoUrl},\n                            hoste:{nazev:h.name,logoUrl:h.logoUrl},\n                            skore:zapas.attr('skore'),\n                            timestamp: z.timestamp,\n                            datum: zapas.attr('datum'),\n                            cas: zapas.attr('cas'),\n                            fortunaUrl:zapas.attr('fortunaUrl'),\n                            onlineUrl:zapas.attr('onlineUrl'),\n                            reportUrl:zapas.attr('reportUrl'),\n                        }\n    \n                        slideRight.push(createZapasHtml(zapasData))\n                    }\n                }\n\n\n                function createZapasHtml(data){\n                    var url = 'https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/program-vysledky-tabulka-a-statistiky-fortuna-ligy-2020-21\/r~3bd2cb28dbdb11ea80e60cc47ab5f122\/';\n                    var clUrl = '';\n                    var zapasTimestamp = data.timestamp;\n\n                    if(zapasTimestamp<=todayTimestamp){\n                        if(data.reportUrl) url = data.reportUrl, clUrl='report';\n                        if(data.onlineUrl) url = data.onlineUrl, clUrl='online';\n                    }else{\n                        if( data.reportUrl) url = data.reportUrl, clUrl='report';\n                        if( data.onlineUrl) url = data.onlineUrl, clUrl='online';\n                        if( data.fortunaUrl) url = data.fortunaUrl, clUrl='bet'; \n                    }\n\n                    var date = new Date(zapasTimestamp);\n                        date = date.getDate()+'.'+(date.getMonth()+1)+'. | '+date.getHours()+':'+(date.getMinutes() == 0 ? '00' : date.getMinutes());\n\n                    if (clUrl.length>0) {\n                        switch (clUrl) {\n                            case 'report':\n                                date += ' | <span class=\"'+clUrl+'\">Report&#187;<\/span>'\n                            break;\n                            case 'online':\n                                date += ' | <span class=\"'+clUrl+'\">Online&#187;<\/span>'\n                            break;\n                            case 'bet':\n                                date += ' | <span class=\"'+clUrl+'\">Vsaďte si&#187;<\/span>'\n                            break;\n                        }\n                    }\n\n                    var str =   '<a href=\"'+url+'\" class=\"zapas\">'+\n                                    '<div class=\"zapas-detail\">'+date+'<\/div>'+\n                                    '<div class=\"zapas-info\">'+\n                                        '<span class=\"klub-l\">'+data.domaci.nazev+'<\/span>'+\n                                        '<div class=\"klub-logo\"><span class=\"intrinsic-1x1\"><img src=\"'+data.domaci.logoUrl+'\"><\/span><\/div>'+\n                                        '<div class=\"zapsa-stav\">'+data.skore+'<\/div>'+\n                                        '<div class=\"klub-logo\"><span class=\"intrinsic-1x1\"><img src=\"'+data.hoste.logoUrl+'\"><\/span><\/div>'+\n                                        '<span class=\"klub-r\">'+data.hoste.nazev+'<\/span>'+\n                                    '<\/div>'+\n                                '<\/a>';\n\n                    return str;\n                }\n                \n\n                \/\/skladám html slideru\n                var sliderZapasy = '';\n                if (slideLeft.length>0 && slideMain.length>0) {\n                    sliderZapasy += '<div class=\"zapasy-wrapper zapasy-wrapper-left\">'+slideLeft.join('')+'<\/div>';\n                }else if(slideLeft.length>0){\n                    sliderZapasy += '<div class=\"zapasy-wrapper zapasy-wrapper-main\">'+slideLeft.join('')+'<\/div>';\n                    $('.zapasy-hlavicka .left-b').remove();\n                }\n\n                if (slideMain.length>0) {\n                    sliderZapasy += '<div class=\"zapasy-wrapper zapasy-wrapper-main\">'+slideMain.join('')+'<\/div>';\n                }\n\n                if (slideRight.length>0 && slideMain.length>0) {\n                    sliderZapasy += '<div class=\"zapasy-wrapper zapasy-wrapper-right\">'+slideRight.join('')+'<\/div>';\n                }else if(slideRight.length>0){\n                    sliderZapasy += '<div class=\"zapasy-wrapper zapasy-wrapper-main\">'+slideRight.join('')+'<\/div>';\n                    $('.zapasy-hlavicka .right-b').remove();\n                }\n\n                $('.zapasy-slider').html(sliderZapasy);\n\n                $('.zapasy-hlavicka span').on('click', function(){\n                    if($(this).hasClass('left-b')){\n                        if($('.zapasy').hasClass('slide-right')){\n                            $('.zapasy').removeClass('slide-right');\n                        }else{\n                            $('.zapasy').addClass('slide-left');\n                        }\n                    }\n                    if($(this).hasClass('right-b')){\n                        if($('.zapasy').hasClass('slide-left')){\n                            $('.zapasy').removeClass('slide-left');\n                        }else{\n                            $('.zapasy').addClass('slide-right');\n                        }\n                    }\n                })\n\n            \/\/ Konec Zápasy ------------------------------------------------------------------------------\n            $(document).ready(function(){\n                fceResize();\n            })\n            $(window).on('load', function(){\n                fceResize();\n            })\n        }\n\n\n    <\/script>\n<\/body>\n<\/html>",
+                                    width: '100%',
+                                    height: 1,
+                                    onload: function () {
+                                        widget.callFunction('run', [target, "<boxData>\n  \n    \x3C!--   \n    idClanok = Do atributu guid vlož ID článku, ktorý sa zobrazí vo widgete na HP \n    idPutak = Do atributu guid vlož ID pútacieho obrázku článku   \n  -->\n  \t<widgetClanek>\n    \t<idPutak>\/\/cdn.xsd.cz\/resize\/4c9ea1e129b73b728f92275f0f1838b5_resize=820,_.jpg?hash=ca999f0a5ae82ac712d5ef03df8121c7<\/idPutak>\n    \t<idClanok><blackbox:object xmlns:blackbox=\"http:\/\/i0.cz\/bbx\/rss\/\" bbxtype=\"article\" guid=\"fa565df43a7f11ec8fa20cc47ab5f122\"><shorttitle>Krmenčík divoce slavil gól \"své\" Plzni. On je ta největší ostuda, čílil se Limberský<\/shorttitle><updated>off<\/updated><authorcontent>off<\/authorcontent><title>Krmenčík divoce slavil gól \"své\" Plzni. On je ta největší ostuda, čílil se Limberský<\/title><annotation>Prohlédněte si fotografie z nedělních ligových šlágrů, v nichž se utkali fotbalisté Baníku se Spartou a Slavia s Plzní.<\/annotation><pubtime>2021-10-31 21:29:59<\/pubtime><changetime>2021-10-31 22:43:57<\/changetime><gallery-count>29<\/gallery-count><primary-image-type>photo<\/primary-image-type><link>\/fotbal\/ceska-liga\/fotbal-banik-sparta-slavia-plzen\/r~fa565df43a7f11ec8fa20cc47ab5f122\/<\/link><link-absolute>https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbal-banik-sparta-slavia-plzen\/r~fa565df43a7f11ec8fa20cc47ab5f122\/<\/link-absolute><\/blackbox:object><\/idClanok>\n  \t<\/widgetClanek>\n  \n    <obrUvod>\n  \t\t<obr\/>\n  \t<\/obrUvod>\n\n    <widgetClanek cislo=\"6.\"\/>\n\n<boxKola zacatek=\"\" konec=\"\">\n\n  <kolo cislo=\"1.\" od=\"\">\n    <itemKolo domaci=\"JAB\" hoste=\"OVA\" skore=\"1:0\" datum=\"so 24.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jablonec-srazil-ostravu-az-v-zaveru-hradec-se-vratil-do-ligy\/r~30937738ec9911ebbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3BB1F6d\"\/>\n    <itemKolo domaci=\"PCE\" hoste=\"KAR\" skore=\"2:2\" datum=\"so 24.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jablonec-srazil-ostravu-az-v-zaveru-hradec-se-vratil-do-ligy\/r~30937738ec9911ebbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3rA8zUO\"\/>\n    <itemKolo domaci=\"HKR\" hoste=\"BOH\" skore=\"1:1\" datum=\"so 24.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jablonec-srazil-ostravu-az-v-zaveru-hradec-se-vratil-do-ligy\/r~30937738ec9911ebbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/36UWlMH\"\/>\n    <itemKolo domaci=\"SPA\" hoste=\"OLO\" skore=\"3:2\" datum=\"so 24.07.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-olomouc-letensti-vstupuji-do-nove-sezony-plni-ocekava\/r~d265bd4ee94411eba7d3ac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-dostala-nejrychlejsi-branku-po-temer-50-letech-duel-s\/r~6301dcd6ecb311eba7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3BEMitE\"\/>\n    <itemKolo domaci=\"LIB\" hoste=\"SLO\" skore=\"0:1\" datum=\"ne 25.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/plzni-stacil-k-vyhre-polocas-slovacko-poprve-v-historii-vyhr\/r~0b1436d4ed6411eb966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3i3oNCJ\"\/>\n    <itemKolo domaci=\"CEB\" hoste=\"TEP\" skore=\"1:0\" datum=\"ne 25.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/plzni-stacil-k-vyhre-polocas-slovacko-poprve-v-historii-vyhr\/r~0b1436d4ed6411eb966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3zJAJzB\"\/>\n    <itemKolo domaci=\"PLZ\" hoste=\"MBL\" skore=\"2:1\" datum=\"ne 25.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/plzni-stacil-k-vyhre-polocas-slovacko-poprve-v-historii-vyhr\/r~0b1436d4ed6411eb966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3704mjw\"\/>\n    <itemKolo domaci=\"ZLN\" hoste=\"SLA\" skore=\"0:1\" datum=\"ne 25.07.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga-zive-zlin-slavia\/r~4954545ae84711ebad06ac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/mistra-vysvobodil-strelec-kuchta-slavia-veze-ze-zlina-tri-bo\/r~815a99f6ed7c11ebb91a0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3i74G6J\"\/>\n   \n\n    <boxTabulka>\n<tabItem poradi=\"1.\" zkratkaID=\"SPA\" Z=\"1\" V=\"1\" R=\"0\" P=\"0\" skore=\"3:2\" body=\"3\"\/>\n<tabItem poradi=\"2.\" zkratkaID=\"PLZ\" Z=\"1\" V=\"1\" R=\"0\" P=\"0\" skore=\"2:1\" body=\"3\"\/>\n<tabItem poradi=\"3.\" zkratkaID=\"JAB\" Z=\"1\" V=\"1\" R=\"0\" P=\"0\" skore=\"1:0\" body=\"3\"\/>\n<tabItem poradi=\"4.\" zkratkaID=\"CEB\" Z=\"1\" V=\"1\" R=\"0\" P=\"0\" skore=\"1:0\" body=\"3\"\/>\n<tabItem poradi=\"5.\" zkratkaID=\"SLA\" Z=\"1\" V=\"1\" R=\"0\" P=\"0\" skore=\"1:0\" body=\"3\"\/>\n<tabItem poradi=\"6.\" zkratkaID=\"SLO\" Z=\"1\" V=\"1\" R=\"0\" P=\"0\" skore=\"1:0\" body=\"3\"\/>         \n<tabItem poradi=\"7.\" zkratkaID=\"PCE\" Z=\"1\" V=\"0\" R=\"1\" P=\"0\" skore=\"2:2\" body=\"1\"\/>\n<tabItem poradi=\"8.\" zkratkaID=\"KAR\" Z=\"1\" V=\"0\" R=\"1\" P=\"0\" skore=\"2:2\" body=\"1\"\/>\n<tabItem poradi=\"9.\" zkratkaID=\"HKR\" Z=\"1\" V=\"0\" R=\"1\" P=\"0\" skore=\"1:1\" body=\"1\"\/>\n<tabItem poradi=\"10.\" zkratkaID=\"BOH\" Z=\"1\" V=\"0\" R=\"1\" P=\"0\" skore=\"1:1\" body=\"1\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"OLO\" Z=\"1\" V=\"0\" R=\"0\" P=\"1\" skore=\"2:3\" body=\"0\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"MBL\" Z=\"1\" V=\"0\" R=\"0\" P=\"1\" skore=\"1:2\" body=\"0\"\/>      \n<tabItem poradi=\"13.\" zkratkaID=\"OVA\" Z=\"1\" V=\"0\" R=\"0\" P=\"1\" skore=\"0:1\" body=\"0\"\/>\n<tabItem poradi=\"14.\" zkratkaID=\"ZLN\" Z=\"1\" V=\"0\" R=\"0\" P=\"1\" skore=\"0:1\" body=\"0\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"LIB\" Z=\"1\" V=\"0\" R=\"0\" P=\"1\" skore=\"0:1\" body=\"0\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"TEP\" Z=\"1\" V=\"0\" R=\"0\" P=\"1\" skore=\"0:1\" body=\"0\"\/> \n\n\n    <\/boxTabulka>\n  <\/kolo>\n  <kolo cislo=\"2.\" od=\"\">\n    \n    <itemKolo domaci=\"TEP\" hoste=\"SLA\" skore=\"1:3\" datum=\"pá 30.07.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga-zive-teplice-slavia\/r~ffdd0a18eeec11ebb02dac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-teplice-fotbal-cesko\/r~c9f747c0f16611ebb91a0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3x2pIr5\"\/>\n    <itemKolo domaci=\"KAR\" hoste=\"HKR\" skore=\"1:1\" datum=\"so 31.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-olomouce-porazili-pardubice-3-2-a-ziskali-prvni-b\/r~23509a72f22211eba1070cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3kWsWKB\"\/>\n    <itemKolo domaci=\"MBL\" hoste=\"JAB\" skore=\"3:0\" datum=\"so 31.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-olomouce-porazili-pardubice-3-2-a-ziskali-prvni-b\/r~23509a72f22211eba1070cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3iLsKL8\"\/>\n    <itemKolo domaci=\"OLO\" hoste=\"PCE\" skore=\"3:2\" datum=\"so 31.07.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-olomouce-porazili-pardubice-3-2-a-ziskali-prvni-b\/r~23509a72f22211eba1070cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3iYvW6D\"\/>\n    <itemKolo domaci=\"LIB\" hoste=\"SPA\" skore=\"0:5\" datum=\"so 31.07.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liberec-sparta-prazany-ceka-v-druhem-ligovem-kole-vylet-na-s\/r~346f4656ed5d11eb94d2ac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-olomouce-porazili-pardubice-3-2-a-ziskali-prvni-b\/r~23509a72f22211eba1070cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3y2ge0z\"\/>\n    <itemKolo domaci=\"OVA\" hoste=\"ZLN\" skore=\"5:1\" datum=\"ne 01.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-ostravy-po-povedene-prvni-puli-rozdrtili-zlin-5-1\/r~77feba78f2e911eb8fa20cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3BzFHAs\"\/>\n    <itemKolo domaci=\"SLO\" hoste=\"CEB\" skore=\"1:0\" datum=\"ne 01.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-ostravy-po-povedene-prvni-puli-rozdrtili-zlin-5-1\/r~77feba78f2e911eb8fa20cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3hZ9jPR\"\/>\n    <itemKolo domaci=\"BOH\" hoste=\"PLZ\" skore=\"1:2\" datum=\"ne 01.08.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/plzen-otocila-zapas-v-dolicku-ctvrtou-soutezni-vyhru-zajisti\/r~868b124af2fc11eb9106ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3BAeq0G\"\/>\n   \n\n      <boxTabulka>\n\n<tabItem poradi=\"1.\" zkratkaID=\"SPA\" Z=\"2\" V=\"2\" R=\"0\" P=\"0\" skore=\"8:2\" body=\"6\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SLA\" Z=\"2\" V=\"2\" R=\"0\" P=\"0\" skore=\"4:1\" body=\"6\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"PLZ\" Z=\"2\" V=\"2\" R=\"0\" P=\"0\" skore=\"4:2\" body=\"6\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"SLO\" Z=\"2\" V=\"2\" R=\"0\" P=\"0\" skore=\"2:0\" body=\"6\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"OVA\" Z=\"2\" V=\"1\" R=\"0\" P=\"1\" skore=\"5:2\" body=\"3\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"MBL\" Z=\"2\" V=\"1\" R=\"0\" P=\"1\" skore=\"4:2\" body=\"3\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"OLO\" Z=\"2\" V=\"1\" R=\"0\" P=\"1\" skore=\"5:5\" body=\"3\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"CEB\" Z=\"2\" V=\"1\" R=\"0\" P=\"1\" skore=\"1:1\" body=\"3\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"JAB\" Z=\"2\" V=\"1\" R=\"0\" P=\"1\" skore=\"1:3\" body=\"3\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"KAR\" Z=\"2\" V=\"0\" R=\"2\" P=\"0\" skore=\"3:3\" body=\"2\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"HKR\" Z=\"2\" V=\"0\" R=\"2\" P=\"0\" skore=\"2:2\" body=\"2\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"PCE\" Z=\"2\" V=\"0\" R=\"1\" P=\"1\" skore=\"4:5\" body=\"1\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"BOH\" Z=\"2\" V=\"0\" R=\"1\" P=\"1\" skore=\"2:3\" body=\"1\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"TEP\" Z=\"2\" V=\"0\" R=\"0\" P=\"2\" skore=\"1:4\" body=\"0\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"ZLN\" Z=\"2\" V=\"0\" R=\"0\" P=\"2\" skore=\"1:6\" body=\"0\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"LIB\" Z=\"2\" V=\"0\" R=\"0\" P=\"2\" skore=\"0:6\" body=\"0\"\/> \n \n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"3.\" od=\"\">\n \n<itemKolo domaci=\"CEB\" hoste=\"OVA\" skore=\"1:3\" datum=\"so 07.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-si-po-golech-hlozka-a-pavelky-poradila-s-karvinou-ale\/r~994ac0e8f79711eba7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3x8zk3G\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"LIB\" skore=\"1:1\" datum=\"so 07.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-si-po-golech-hlozka-a-pavelky-poradila-s-karvinou-ale\/r~994ac0e8f79711eba7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3xhqosK\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"KAR\" skore=\"2:0\" datum=\"so 07.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-karvina-letensti-chteji-potvrdit-skvely-vstup-do-sezo\/r~67d1bc94f2ef11eb966d0cc47ab5f122\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-si-po-golech-hlozka-a-pavelky-poradila-s-karvinou-ale\/r~994ac0e8f79711eba7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3iauVZI\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"TEP\" skore=\"3:0\" datum=\"so 07.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-si-po-golech-hlozka-a-pavelky-poradila-s-karvinou-ale\/r~994ac0e8f79711eba7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3zSUm8d\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"OLO\" skore=\"1:0\" datum=\"st 27.10.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-slavie-v-dohravce-udolali-olomouc-1-0-a-dotahli-s\/r~9e66a8a6375911ec94d2ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3GjF9B1\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"BOH\" skore=\"2:2\" datum=\"ne 08.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jablonec-prisel-o-vyhru-v-nastaveni-mlade-boleslavi-vystreli\/r~acfab7c0f86311ebb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3f8NKL5\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"MBL\" skore=\"1:1\" datum=\"ne 08.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jablonec-prisel-o-vyhru-v-nastaveni-mlade-boleslavi-vystreli\/r~acfab7c0f86311ebb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3y9Csh3\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"SLO\" skore=\"2:1\" datum=\"ne 08.08.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jablonec-prisel-o-vyhru-v-nastaveni-mlade-boleslavi-vystreli\/r~acfab7c0f86311ebb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/378GAC3\"\/>\n\n      \n    <boxTabulka>\n<tabItem poradi=\"1.\" zkratkaID=\"SPA\" Z=\"3\" V=\"3\" R=\"0\" P=\"0\" skore=\"10:2\" body=\"9\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"PLZ\" Z=\"3\" V=\"3\" R=\"0\" P=\"0\" skore=\"6:3\" body=\"9\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"OVA\" Z=\"3\" V=\"2\" R=\"0\" P=\"1\" skore=\"8:3\" body=\"6\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"SLA\" Z=\"2\" V=\"2\" R=\"0\" P=\"0\" skore=\"4:1\" body=\"6\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"SLO\" Z=\"3\" V=\"2\" R=\"0\" P=\"1\" skore=\"3:2\" body=\"6\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"MBL\" Z=\"3\" V=\"1\" R=\"1\" P=\"1\" skore=\"5:3\" body=\"4\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"JAB\" Z=\"3\" V=\"1\" R=\"1\" P=\"1\" skore=\"3:5\" body=\"4\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"OLO\" Z=\"2\" V=\"1\" R=\"0\" P=\"1\" skore=\"5:5\" body=\"3\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"HKR\" Z=\"3\" V=\"0\" R=\"3\" P=\"0\" skore=\"3:3\" body=\"3\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"ZLN\" Z=\"3\" V=\"1\" R=\"0\" P=\"2\" skore=\"4:6\" body=\"3\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"CEB\" Z=\"3\" V=\"1\" R=\"0\" P=\"2\" skore=\"2:4\" body=\"3\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"PCE\" Z=\"3\" V=\"0\" R=\"2\" P=\"1\" skore=\"5:6\" body=\"2\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"BOH\" Z=\"3\" V=\"0\" R=\"2\" P=\"1\" skore=\"4:5\" body=\"2\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"KAR\" Z=\"3\" V=\"0\" R=\"2\" P=\"1\" skore=\"3:5\" body=\"2\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"LIB\" Z=\"3\" V=\"0\" R=\"1\" P=\"2\" skore=\"1:7\" body=\"1\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"TEP\" Z=\"3\" V=\"0\" R=\"0\" P=\"3\" skore=\"1:7\" body=\"0\"\/>   \n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"4.\" od=\"\">\n\n<itemKolo domaci=\"OLO\" hoste=\"CEB\" skore=\"3:3\" datum=\"so 14.08.2021\" cas=\"14:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/prestrelka-bez-viteze-olomouc-zachranila-bod-s-jihocechy-v-s\/r~3ccc4926fd0b11eb966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/37DFfnf\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"ZLN\" skore=\"2:3\" datum=\"so 14.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/prestrelka-bez-viteze-olomouc-zachranila-bod-s-jihocechy-v-s\/r~3ccc4926fd0b11eb966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3fEsjBT\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"SLA\" skore=\"0:2\" datum=\"so 14.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/mlada-boleslav-slavia-sesivani-hraji-znovu-venku-proti-stoji\/r~84636ef0f90911eb94d2ac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/prestrelka-bez-viteze-olomouc-zachranila-bod-s-jihocechy-v-s\/r~3ccc4926fd0b11eb966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3Cjz3yG\"\/>\n<itemKolo domaci=\"BOH\" hoste=\"SPA\" skore=\"1:1\" datum=\"so 14.08.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-poprve-ztratila-v-dolicku-dotahovala-ztratu-bitva-s-b\/r~2f4ae19afd3311eb878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3fyGSGP\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"PCE\" skore=\"3:1\" datum=\"so 15.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/cervenou-videli-uspesny-strelec-i-kouc-svedik-presto-slovack\/r~947c9b7cfde611ebbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/37oXBIm\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"HKR\" skore=\"1:0\" datum=\"so 15.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/cervenou-videli-uspesny-strelec-i-kouc-svedik-presto-slovack\/r~947c9b7cfde611ebbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/37r0ckW\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"JAB\" skore=\"1:0\" datum=\"so 15.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/cervenou-videli-uspesny-strelec-i-kouc-svedik-presto-slovack\/r~947c9b7cfde611ebbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3yxnv8S\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"PLZ\" skore=\"0:1\" datum=\"so 15.08.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/cervenou-videli-uspesny-strelec-i-kouc-svedik-presto-slovack\/r~947c9b7cfde611ebbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3jwxpkv\"\/>\n\n      <boxTabulka>\n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"4\" V=\"4\" R=\"0\" P=\"0\" skore=\"7:3\" body=\"12\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SPA\" Z=\"4\" V=\"3\" R=\"1\" P=\"0\" skore=\"11:3\" body=\"10\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"OVA\" Z=\"4\" V=\"3\" R=\"0\" P=\"1\" skore=\"11:4\" body=\"9\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"SLA\" Z=\"3\" V=\"3\" R=\"0\" P=\"0\" skore=\"6:1\" body=\"9\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"SLO\" Z=\"4\" V=\"3\" R=\"0\" P=\"1\" skore=\"4:2\" body=\"9\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"ZLN\" Z=\"4\" V=\"2\" R=\"0\" P=\"2\" skore=\"7:8\" body=\"6\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"OLO\" Z=\"3\" V=\"1\" R=\"1\" P=\"1\" skore=\"8:8\" body=\"4\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"MBL\" Z=\"4\" V=\"1\" R=\"1\" P=\"2\" skore=\"5:5\" body=\"4\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"CEB\" Z=\"4\" V=\"1\" R=\"1\" P=\"2\" skore=\"5:7\" body=\"4\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"JAB\" Z=\"4\" V=\"1\" R=\"1\" P=\"2\" skore=\"3:6\" body=\"4\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"BOH\" Z=\"4\" V=\"0\" R=\"3\" P=\"1\" skore=\"5:6\" body=\"3\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"HKR\" Z=\"4\" V=\"0\" R=\"3\" P=\"1\" skore=\"3:4\" body=\"3\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"TEP\" Z=\"4\" V=\"1\" R=\"0\" P=\"3\" skore=\"2:7\" body=\"3\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"PCE\" Z=\"4\" V=\"0\" R=\"2\" P=\"2\" skore=\"6:9\" body=\"2\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"KAR\" Z=\"4\" V=\"0\" R=\"2\" P=\"2\" skore=\"5:8\" body=\"2\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"LIB\" Z=\"4\" V=\"0\" R=\"1\" P=\"3\" skore=\"1:8\" body=\"1\"\/> \n\n\n\n\n      <\/boxTabulka>\n  \n    <\/kolo>\n\n  <kolo cislo=\"5.\" od=\"\">\n \n<itemKolo domaci=\"MBL\" hoste=\"TEP\" skore=\"3:1\" datum=\"so 21.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/pardubice-bohemians-ceska-liga\/r~505fd87c028d11ec98380cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3fZp6wX\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"BOH\" skore=\"3:0\" datum=\"so 21.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/pardubice-bohemians-ceska-liga\/r~505fd87c028d11ec98380cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3m4g8SK\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"OLO\" skore=\"1:4\" datum=\"so 21.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/pardubice-bohemians-ceska-liga\/r~505fd87c028d11ec98380cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3sbRDnP\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"HKR\" skore=\"4:0\" datum=\"so 21.08.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-diky-vynikajicimu-druhemu-polocasu-porazila-hradec-dv\/r~277d0db002b211eca7d3ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2UfBOQv\"\/>\n<itemKolo domaci=\"CEB\" hoste=\"LIB\" skore=\"1:0\" datum=\"ne 22.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liga-ceka\/r~b3bc33fe036211ec966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3iILLiQ\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"SLO\" skore=\"1:1\" datum=\"ne 22.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liga-ceka\/r~b3bc33fe036211ec966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3AJEZ2t\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"KAR\" skore=\"2:0\" datum=\"ne 22.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liga-ceka\/r~b3bc33fe036211ec966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3iJL9JE\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"OVA\" skore=\"4:0\" datum=\"ne 22.08.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/slavia-banik-sesivane-ceka-nejtezsi-ligova-zkouska-do-edenu\/r~5a542094fe7e11eba7d3ac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-pred-odvetou-s-legii-dala-ctyri-goly-baniku-kolar-udr\/r~978891d2037b11ec966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3k8lxWz\"\/>\n   \n      \n      <boxTabulka>\n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"5\" V=\"5\" R=\"0\" P=\"0\" skore=\"9:3\" body=\"15\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SPA\" Z=\"5\" V=\"4\" R=\"1\" P=\"0\" skore=\"15:3\" body=\"13\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SLA\" Z=\"4\" V=\"4\" R=\"0\" P=\"0\" skore=\"10:1\" body=\"12\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"SLO\" Z=\"5\" V=\"3\" R=\"1\" P=\"1\" skore=\"5:3\" body=\"10\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"OVA\" Z=\"5\" V=\"3\" R=\"0\" P=\"2\" skore=\"11:8\" body=\"9\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"OLO\" Z=\"4\" V=\"2\" R=\"1\" P=\"1\" skore=\"12:9\" body=\"7\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"MBL\" Z=\"5\" V=\"2\" R=\"1\" P=\"2\" skore=\"8:6\" body=\"7\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"CEB\" Z=\"5\" V=\"2\" R=\"1\" P=\"2\" skore=\"6:7\" body=\"7\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"ZLN\" Z=\"5\" V=\"2\" R=\"0\" P=\"3\" skore=\"8:12\" body=\"6\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"PCE\" Z=\"5\" V=\"1\" R=\"2\" P=\"2\" skore=\"9:9\" body=\"5\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"JAB\" Z=\"5\" V=\"1\" R=\"2\" P=\"2\" skore=\"4:7\" body=\"5\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"BOH\" Z=\"5\" V=\"0\" R=\"3\" P=\"2\" skore=\"5:9\" body=\"3\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"HKR\" Z=\"5\" V=\"0\" R=\"3\" P=\"2\" skore=\"3:8\" body=\"3\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"TEP\" Z=\"5\" V=\"1\" R=\"0\" P=\"4\" skore=\"3:10\" body=\"3\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"KAR\" Z=\"5\" V=\"0\" R=\"2\" P=\"3\" skore=\"5:10\" body=\"2\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"LIB\" Z=\"5\" V=\"0\" R=\"1\" P=\"4\" skore=\"1:9\" body=\"1\"\/> \n\n\n<\/boxTabulka>\n\n  <\/kolo>\n\n  <kolo cislo=\"6.\" od=\"\">\n  \n<itemKolo domaci=\"LIB\" hoste=\"ZLN\" skore=\"0:1\" datum=\"so 28.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/dalsi-vylouceni-dalsi-porazka-krize-liberce-pokracuje-padl-i\/r~04d61926081d11eca7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3mjvD9q\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"MBL\" skore=\"1:0\" datum=\"so 28.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/dalsi-vylouceni-dalsi-porazka-krize-liberce-pokracuje-padl-i\/r~04d61926081d11eca7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3D0V3Ph\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"PCE\" skore=\"2:1\" datum=\"so 28.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/dalsi-vylouceni-dalsi-porazka-krize-liberce-pokracuje-padl-i\/r~04d61926081d11eca7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/380izO8\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"CEB\" skore=\"1:0\" datum=\"so 28.08.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/dalsi-vylouceni-dalsi-porazka-krize-liberce-pokracuje-padl-i\/r~04d61926081d11eca7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3z2WB8U\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"JAB\" skore=\"4:0\" datum=\"ne 29.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/trapeni-plzne-pokracuje-i-v-lize-po-kolapsu-v-sofii-prohrala\/r~f144490a08e411ec94d2ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2WeDZEG\"\/>\n<itemKolo domaci=\"BOH\" hoste=\"TEP\" skore=\"4:2\" datum=\"ne 29.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/trapeni-plzne-pokracuje-i-v-lize-po-kolapsu-v-sofii-prohrala\/r~f144490a08e411ec94d2ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2W2fJWB\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"PLZ\" skore=\"1:0\" datum=\"ne 29.08.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/trapeni-plzne-pokracuje-i-v-lize-po-kolapsu-v-sofii-prohrala\/r~f144490a08e411ec94d2ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3ydT8mZ\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"SLA\" skore=\"3:3\" datum=\"ne 29.08.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/trapeni-plzne-pokracuje-i-v-lize-po-kolapsu-v-sofii-prohrala\/r~f144490a08e411ec94d2ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2XHln0G\"\/>\n\n      \n      \n    <boxTabulka>\n<tabItem poradi=\"1.\" zkratkaID=\"SPA\" Z=\"6\" V=\"5\" R=\"1\" P=\"0\" skore=\"16:3\" body=\"16\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"PLZ\" Z=\"6\" V=\"5\" R=\"0\" P=\"1\" skore=\"9:4\" body=\"15\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SLA\" Z=\"5\" V=\"4\" R=\"1\" P=\"0\" skore=\"13:4\" body=\"13\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"SLO\" Z=\"6\" V=\"4\" R=\"1\" P=\"1\" skore=\"7:4\" body=\"13\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"OVA\" Z=\"6\" V=\"4\" R=\"0\" P=\"2\" skore=\"12:8\" body=\"12\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"OLO\" Z=\"5\" V=\"3\" R=\"1\" P=\"1\" skore=\"16:9\" body=\"10\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"ZLN\" Z=\"6\" V=\"3\" R=\"0\" P=\"3\" skore=\"9:12\" body=\"9\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"MBL\" Z=\"6\" V=\"2\" R=\"1\" P=\"3\" skore=\"8:7\" body=\"7\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"CEB\" Z=\"6\" V=\"2\" R=\"1\" P=\"3\" skore=\"6:8\" body=\"7\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"BOH\" Z=\"6\" V=\"1\" R=\"3\" P=\"2\" skore=\"9:11\" body=\"6\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"HKR\" Z=\"6\" V=\"1\" R=\"3\" P=\"2\" skore=\"4:8\" body=\"6\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"PCE\" Z=\"6\" V=\"1\" R=\"2\" P=\"3\" skore=\"10:11\" body=\"5\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"JAB\" Z=\"6\" V=\"1\" R=\"2\" P=\"3\" skore=\"4:11\" body=\"5\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"KAR\" Z=\"6\" V=\"0\" R=\"3\" P=\"3\" skore=\"8:13\" body=\"3\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"TEP\" Z=\"6\" V=\"1\" R=\"0\" P=\"5\" skore=\"5:14\" body=\"3\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"LIB\" Z=\"6\" V=\"0\" R=\"1\" P=\"5\" skore=\"1:10\" body=\"1\"\/> \n\n<\/boxTabulka>\n  <\/kolo>\n\n\n  <kolo cislo=\"7.\" od=\"\">\n\n<itemKolo domaci=\"TEP\" hoste=\"OVA\" skore=\"1:2\" datum=\"so 11.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/banik-veze-vyhru-z-teplic-zato-posledni-liberec-neudrzel-dvo\/r~5c9e31a2131c11ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3Bqup0q\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"BOH\" skore=\"1:3\" datum=\"so 11.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/banik-veze-vyhru-z-teplic-zato-posledni-liberec-neudrzel-dvo\/r~5c9e31a2131c11ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3BpeTC5\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"LIB\" skore=\"2:2\" datum=\"so 11.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/banik-veze-vyhru-z-teplic-zato-posledni-liberec-neudrzel-dvo\/r~5c9e31a2131c11ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3gHIu1y\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"SPA\" skore=\"3:2\" datum=\"so 11.09.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/plzen-sparta-v-slagru-7-kola-pujde-i-o-prvni-misto-v-tabulce\/r~eceeea120e6c11ec878fac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-nezvladla-slagr-v-plzni-viktoria-ji-dala-tri-goly-a-v\/r~5ee2ee52133611ec9322ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3zucxRX\"\/>\n<itemKolo domaci=\"CEB\" hoste=\"HKR\" skore=\"0:1\" datum=\"ne 12.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/ceske-budejovice-hradec-kralove-0-1-0-0\/r~1d32778813d211ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3Bjgj0M\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"KAR\" skore=\"1:0\" datum=\"ne 12.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/ceske-budejovice-hradec-kralove-0-1-0-0\/r~1d32778813d211ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3sVQelI\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"OLO\" skore=\"3:3\" datum=\"ne 12.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/ceske-budejovice-hradec-kralove-0-1-0-0\/r~1d32778813d211ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3sVQfWO\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"SLO\" skore=\"2:1\" datum=\"ne 12.09.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-slovacko-sesivane-uz-s-tencim-kadrem-ceka-boj-se-siln\/r~31efe6440e6c11ec9322ac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-vs-slovacko\/r~1f63016613fb11eca824ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3ysKbGg\"\/>\n\n      \n      <boxTabulka>\n\n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"7\" V=\"6\" R=\"0\" P=\"1\" skore=\"12:6\" body=\"18\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SPA\" Z=\"7\" V=\"5\" R=\"1\" P=\"1\" skore=\"18:6\" body=\"16\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SLA\" Z=\"6\" V=\"5\" R=\"1\" P=\"0\" skore=\"15:5\" body=\"16\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"OVA\" Z=\"7\" V=\"5\" R=\"0\" P=\"2\" skore=\"14:9\" body=\"15\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"SLO\" Z=\"7\" V=\"4\" R=\"1\" P=\"2\" skore=\"8:6\" body=\"13\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"OLO\" Z=\"6\" V=\"3\" R=\"2\" P=\"1\" skore=\"19:12\" body=\"11\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"BOH\" Z=\"7\" V=\"2\" R=\"3\" P=\"2\" skore=\"12:12\" body=\"9\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"HKR\" Z=\"7\" V=\"2\" R=\"3\" P=\"2\" skore=\"5:8\" body=\"9\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"ZLN\" Z=\"7\" V=\"3\" R=\"0\" P=\"4\" skore=\"10:15\" body=\"9\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"MBL\" Z=\"7\" V=\"2\" R=\"2\" P=\"3\" skore=\"11:10\" body=\"8\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"JAB\" Z=\"7\" V=\"2\" R=\"2\" P=\"3\" skore=\"5:11\" body=\"8\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"CEB\" Z=\"7\" V=\"2\" R=\"1\" P=\"4\" skore=\"6:9\" body=\"7\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"PCE\" Z=\"7\" V=\"1\" R=\"3\" P=\"3\" skore=\"12:13\" body=\"6\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"KAR\" Z=\"7\" V=\"0\" R=\"3\" P=\"4\" skore=\"8:14\" body=\"3\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"TEP\" Z=\"7\" V=\"1\" R=\"0\" P=\"6\" skore=\"6:16\" body=\"3\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"LIB\" Z=\"7\" V=\"0\" R=\"2\" P=\"5\" skore=\"3:12\" body=\"2\"\/> \n\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"8.\" od=\"\">\n    \n<itemKolo domaci=\"HKR\" hoste=\"PCE\" skore=\"2:0\" datum=\"pá 17.09.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~a3bbdab817da11ecbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3EoSO8Z\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"OVA\" skore=\"1:1\" datum=\"pá 17.09.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~a3bbdab817da11ecbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3EsXj2k\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"MBL\" skore=\"2:1\" datum=\"so 18.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liberec-v-zaveru-otocil-bitvu-s-boleslavi-slovacko-si-poradi\/r~09b55b60189d11ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3CkBzDV\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"ZLN\" skore=\"3:0\" datum=\"so 18.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liberec-v-zaveru-otocil-bitvu-s-boleslavi-slovacko-si-poradi\/r~09b55b60189d11ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3CpX7PL\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"CEB\" skore=\"2:1\" datum=\"so 18.09.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liberec-v-zaveru-otocil-bitvu-s-boleslavi-slovacko-si-poradi\/r~09b55b60189d11ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2YZSmhb\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"TEP\" skore=\"1:1\" datum=\"ne 19.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-ve-slagru-kola-jen-remizovala-s-jabloncem-a-na-plzen\/r~e6d089a4196311eca7d3ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2Xyj7sS\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"JAB\" skore=\"1:1\" datum=\"ne 19.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-ve-slagru-kola-jen-remizovala-s-jabloncem-a-na-plzen\/r~e6d089a4196311eca7d3ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3CzTzKX\"\/>\n<itemKolo domaci=\"BOH\" hoste=\"SLA\" skore=\"1:5\" datum=\"ne 19.09.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga-zive-bohemians-slavia\/r~fde2e35a151011ec8fa20cc47ab5f122\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/polocas-hruzy-pak-demolice-slavia-ovladla-vrsovicke-derby-ko\/r~3e189ad0197d11eca7d80cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3lvdsvD\"\/>\n  \n      \n      <boxTabulka>\n\n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"8\" V=\"7\" R=\"0\" P=\"1\" skore=\"14:7\" body=\"21\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SLA\" Z=\"7\" V=\"6\" R=\"1\" P=\"0\" skore=\"20:6\" body=\"19\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SPA\" Z=\"8\" V=\"5\" R=\"2\" P=\"1\" skore=\"19:7\" body=\"17\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"OVA\" Z=\"8\" V=\"5\" R=\"1\" P=\"2\" skore=\"15:10\" body=\"16\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"SLO\" Z=\"8\" V=\"5\" R=\"1\" P=\"2\" skore=\"11:6\" body=\"16\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"OLO\" Z=\"7\" V=\"3\" R=\"3\" P=\"1\" skore=\"20:13\" body=\"12\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"HKR\" Z=\"8\" V=\"3\" R=\"3\" P=\"2\" skore=\"7:8\" body=\"12\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"BOH\" Z=\"8\" V=\"2\" R=\"3\" P=\"3\" skore=\"13:17\" body=\"9\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"JAB\" Z=\"8\" V=\"2\" R=\"3\" P=\"3\" skore=\"6:12\" body=\"9\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"ZLN\" Z=\"8\" V=\"3\" R=\"0\" P=\"5\" skore=\"10:18\" body=\"9\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"MBL\" Z=\"8\" V=\"2\" R=\"2\" P=\"4\" skore=\"12:12\" body=\"8\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"CEB\" Z=\"8\" V=\"2\" R=\"1\" P=\"5\" skore=\"7:11\" body=\"7\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"PCE\" Z=\"8\" V=\"1\" R=\"3\" P=\"4\" skore=\"12:15\" body=\"6\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"LIB\" Z=\"8\" V=\"1\" R=\"2\" P=\"5\" skore=\"5:13\" body=\"5\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"KAR\" Z=\"8\" V=\"0\" R=\"4\" P=\"4\" skore=\"9:15\" body=\"4\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"TEP\" Z=\"8\" V=\"1\" R=\"1\" P=\"6\" skore=\"7:17\" body=\"4\"\/> \n\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"9.\" od=\"\">\n    \n<itemKolo domaci=\"CEB\" hoste=\"KAR\" skore=\"3:1\" datum=\"so 25.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-plzne-diky-hejdovi-udolali-pardubice-1-0-a-upevni\/r~44472a941e1d11ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3ErQJsX\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"BOH\" skore=\"4:1\" datum=\"so 25.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-plzne-diky-hejdovi-udolali-pardubice-1-0-a-upevni\/r~44472a941e1d11ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3nKOafE\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"PLZ\" skore=\"0:1\" datum=\"so 25.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-plzne-diky-hejdovi-udolali-pardubice-1-0-a-upevni\/r~44472a941e1d11ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2XrOa9r\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"SPA\" skore=\"2:5\" datum=\"so 25.09.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-plzne-diky-hejdovi-udolali-pardubice-1-0-a-upevni\/r~44472a941e1d11ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3nGhaFf\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"LIB\" skore=\"0:1\" datum=\"ne 26.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbalova-liga-vysledky\/r~882b253c1ee311ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3hGvlqc\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"SLO\" skore=\"3:5\" datum=\"ne 26.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbalova-liga-vysledky\/r~882b253c1ee311ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3hH6H8J\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"OLO\" skore=\"0:0\" datum=\"ne 26.09.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbalova-liga-vysledky\/r~882b253c1ee311ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3zdlrSZ\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"HKR\" skore=\"4:1\" datum=\"ne 26.09.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-hradec-sesivani-se-pokusi-navazat-na-golovy-festival\/r~95af017e1b1e11ec878fac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbalova-liga-vysledky\/r~882b253c1ee311ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3tM9fYf\"\/>\n\n    <boxTabulka>\n  \n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"9\" V=\"8\" R=\"0\" P=\"1\" skore=\"15:7\" body=\"24\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SLA\" Z=\"8\" V=\"7\" R=\"1\" P=\"0\" skore=\"24:7\" body=\"22\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SPA\" Z=\"9\" V=\"6\" R=\"2\" P=\"1\" skore=\"24:9\" body=\"20\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"OVA\" Z=\"9\" V=\"6\" R=\"1\" P=\"2\" skore=\"19:11\" body=\"19\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"SLO\" Z=\"9\" V=\"6\" R=\"1\" P=\"2\" skore=\"16:9\" body=\"19\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"OLO\" Z=\"8\" V=\"3\" R=\"4\" P=\"1\" skore=\"20:13\" body=\"13\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"HKR\" Z=\"9\" V=\"3\" R=\"3\" P=\"3\" skore=\"8:12\" body=\"12\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"CEB\" Z=\"9\" V=\"3\" R=\"1\" P=\"5\" skore=\"10:12\" body=\"10\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"BOH\" Z=\"9\" V=\"2\" R=\"3\" P=\"4\" skore=\"14:21\" body=\"9\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"JAB\" Z=\"9\" V=\"2\" R=\"3\" P=\"4\" skore=\"6:13\" body=\"9\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"ZLN\" Z=\"9\" V=\"3\" R=\"0\" P=\"6\" skore=\"12:23\" body=\"9\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"MBL\" Z=\"9\" V=\"2\" R=\"2\" P=\"5\" skore=\"15:17\" body=\"8\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"LIB\" Z=\"9\" V=\"2\" R=\"2\" P=\"5\" skore=\"6:13\" body=\"8\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"PCE\" Z=\"9\" V=\"1\" R=\"3\" P=\"5\" skore=\"12:16\" body=\"6\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"TEP\" Z=\"9\" V=\"1\" R=\"2\" P=\"6\" skore=\"7:17\" body=\"5\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"KAR\" Z=\"9\" V=\"0\" R=\"4\" P=\"5\" skore=\"10:18\" body=\"4\"\/> \n\n    <\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"10.\" od=\"\">\n    \n<itemKolo domaci=\"BOH\" hoste=\"OLO\" skore=\"2:0\" datum=\"so 02.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~76257798238e11ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3CRdq8v\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"TEP\" skore=\"3:2\" datum=\"so 02.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~76257798238e11ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2ZCcAhD\"\/>\n<itemKolo domaci=\"CEB\" hoste=\"PCE\" skore=\"3:1\" datum=\"so 02.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~76257798238e11ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3zIGdK8\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"ZLN\" skore=\"2:1\" datum=\"so 02.10.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~76257798238e11ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3zT2hSN\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"JAB\" skore=\"2:2\" datum=\"ne 03.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~67b4278e245d11eca824ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3ogeFK2\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"MBL\" skore=\"0:1\" datum=\"ne 03.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~67b4278e245d11eca824ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3AKxFUu\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"OVA\" skore=\"0:2\" datum=\"ne 03.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga\/r~67b4278e245d11eca824ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3APl6Yk\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"SLA\" skore=\"1:0\" datum=\"ne 03.10.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga-zive-sparta-slavia\/r~47c6dba6214c11ec8a900cc47ab5f122\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/300-derby-sparta-slavia\/r~94f5ca80247211ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3m2vjtV\"\/>\n   \n\n<boxTabulka>\n        \n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"10\" V=\"9\" R=\"0\" P=\"1\" skore=\"17:8\" body=\"27\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SPA\" Z=\"10\" V=\"7\" R=\"2\" P=\"1\" skore=\"25:9\" body=\"23\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SLA\" Z=\"9\" V=\"7\" R=\"1\" P=\"1\" skore=\"24:8\" body=\"22\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"OVA\" Z=\"10\" V=\"7\" R=\"1\" P=\"2\" skore=\"21:11\" body=\"22\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"SLO\" Z=\"10\" V=\"7\" R=\"1\" P=\"2\" skore=\"19:11\" body=\"22\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"OLO\" Z=\"9\" V=\"3\" R=\"4\" P=\"2\" skore=\"20:15\" body=\"13\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"CEB\" Z=\"10\" V=\"4\" R=\"1\" P=\"5\" skore=\"13:13\" body=\"13\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"HKR\" Z=\"10\" V=\"3\" R=\"4\" P=\"3\" skore=\"10:14\" body=\"13\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"BOH\" Z=\"10\" V=\"3\" R=\"3\" P=\"4\" skore=\"16:21\" body=\"12\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"MBL\" Z=\"10\" V=\"3\" R=\"2\" P=\"5\" skore=\"16:17\" body=\"11\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"JAB\" Z=\"10\" V=\"2\" R=\"4\" P=\"4\" skore=\"8:15\" body=\"10\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"ZLN\" Z=\"10\" V=\"3\" R=\"0\" P=\"7\" skore=\"13:25\" body=\"9\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"LIB\" Z=\"10\" V=\"2\" R=\"2\" P=\"6\" skore=\"6:15\" body=\"8\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"PCE\" Z=\"10\" V=\"1\" R=\"3\" P=\"6\" skore=\"13:19\" body=\"6\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"TEP\" Z=\"10\" V=\"1\" R=\"2\" P=\"7\" skore=\"9:20\" body=\"5\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"KAR\" Z=\"10\" V=\"0\" R=\"4\" P=\"6\" skore=\"10:19\" body=\"4\"\/> \n\n\n<\/boxTabulka>\n\n  <\/kolo>\n\n  <kolo cislo=\"11.\" od=\"\">\n    \n<itemKolo domaci=\"JAB\" hoste=\"CEB\" skore=\"2:2\" datum=\"so 16.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/ostravsky-banik-doma-podlehl-slovacku-boleslav-kanonadou-oto\/r~2a18029e2e9c11ec966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3FgjGs6\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"BOH\" skore=\"4:1\" datum=\"so 16.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/ostravsky-banik-doma-podlehl-slovacku-boleslav-kanonadou-oto\/r~2a18029e2e9c11ec966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/2WBMSZe\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"SLO\" skore=\"1:2\" datum=\"so 16.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/ostravsky-banik-doma-podlehl-slovacku-boleslav-kanonadou-oto\/r~2a18029e2e9c11ec966d0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/2WCMIAS\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"LIB\" skore=\"3:1\" datum=\"so 16.10.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-liberec-sesivani-chteji-pokazene-derby-zahnat-proti-t\/r~fdc3312429ef11ecbc3f0cc47ab5f122\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/neuveritelne-prokleti-stoperu-slavie-pokracuje-i-tak-ale-zap\/r~e19ee68c2eb311ec9106ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2WBidey\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"KAR\" skore=\"2:0\" datum=\"ne 17.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/plzni-uz-to-zase-vyslo-opet-vyhrala-o-gol-v-teplicich-ji-vit\/r~033888fa2f6511ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3BkULRO\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"PLZ\" skore=\"0:1\" datum=\"ne 17.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/plzni-uz-to-zase-vyslo-opet-vyhrala-o-gol-v-teplicich-ji-vit\/r~033888fa2f6511ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3Bb2Ecu\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"HKR\" skore=\"2:3\" datum=\"ne 17.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/plzni-uz-to-zase-vyslo-opet-vyhrala-o-gol-v-teplicich-ji-vit\/r~033888fa2f6511ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3l9ldYY\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"SPA\" skore=\"2:4\" datum=\"ne 17.10.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga-zive-pardubice-sparta\/r~3f536c502a4811ec8fa20cc47ab5f122\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-objevila-novou-hvezdu-vyhru-nad-pardubicemi-ridil-skv\/r~13d947bc2f7e11eca824ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3FeLnBE\"\/>\n\n    <boxTabulka>\n\n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"11\" V=\"10\" R=\"0\" P=\"1\" skore=\"18:8\" body=\"30\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SPA\" Z=\"11\" V=\"8\" R=\"2\" P=\"1\" skore=\"29:11\" body=\"26\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SLA\" Z=\"10\" V=\"8\" R=\"1\" P=\"1\" skore=\"27:9\" body=\"25\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"SLO\" Z=\"11\" V=\"8\" R=\"1\" P=\"2\" skore=\"21:12\" body=\"25\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"OVA\" Z=\"11\" V=\"7\" R=\"1\" P=\"3\" skore=\"22:13\" body=\"22\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"OLO\" Z=\"10\" V=\"4\" R=\"4\" P=\"2\" skore=\"22:15\" body=\"16\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"HKR\" Z=\"11\" V=\"4\" R=\"4\" P=\"3\" skore=\"13:16\" body=\"16\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"MBL\" Z=\"11\" V=\"4\" R=\"2\" P=\"5\" skore=\"20:18\" body=\"14\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"CEB\" Z=\"11\" V=\"4\" R=\"2\" P=\"5\" skore=\"15:15\" body=\"14\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"BOH\" Z=\"11\" V=\"3\" R=\"3\" P=\"5\" skore=\"17:25\" body=\"12\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"JAB\" Z=\"11\" V=\"2\" R=\"5\" P=\"4\" skore=\"10:17\" body=\"11\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"ZLN\" Z=\"11\" V=\"3\" R=\"0\" P=\"8\" skore=\"15:28\" body=\"9\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"LIB\" Z=\"11\" V=\"2\" R=\"2\" P=\"7\" skore=\"7:18\" body=\"8\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"PCE\" Z=\"11\" V=\"1\" R=\"3\" P=\"7\" skore=\"15:23\" body=\"6\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"TEP\" Z=\"11\" V=\"1\" R=\"2\" P=\"8\" skore=\"9:21\" body=\"5\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"KAR\" Z=\"11\" V=\"0\" R=\"4\" P=\"7\" skore=\"10:21\" body=\"4\"\/> \n\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"12.\" od=\"\">\n\n<itemKolo domaci=\"SLO\" hoste=\"BOH\" skore=\"1:0\" datum=\"so 23.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liberec-unika-ze-dna-porazil-olomouc-slovacko-spasil-v-nasta\/r~8935f19a341a11ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3DTpfLE\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"OLO\" skore=\"2:0\" datum=\"so 23.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liberec-unika-ze-dna-porazil-olomouc-slovacko-spasil-v-nasta\/r~8935f19a341a11ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3aO51Xu\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"ZLN\" skore=\"0:0\" datum=\"so 23.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/liberec-unika-ze-dna-porazil-olomouc-slovacko-spasil-v-nasta\/r~8935f19a341a11ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/2Z0Weyp\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"OVA\" skore=\"-:-\" datum=\"Odloženo\" cas=\"\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3AQmlWb\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"TEP\" skore=\"3:0\" datum=\"ne 24.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-po-tragickem-uvodu-zachranila-jen-bod-plzen-se-vzdalu\/r~2bc36cf234e411ecbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3lRe2VN\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"JAB\" skore=\"5:0\" datum=\"ne 24.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-po-tragickem-uvodu-zachranila-jen-bod-plzen-se-vzdalu\/r~2bc36cf234e411ecbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3jcjill\"\/>\n<itemKolo domaci=\"CEB\" hoste=\"SLA\" skore=\"2:2\" datum=\"ne 24.10.2021\" cas=\"16:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-po-tragickem-uvodu-zachranila-jen-bod-plzen-se-vzdalu\/r~2bc36cf234e411ecbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3lRcA5Z\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"MBL\" skore=\"1:0\" datum=\"ne 24.10.2021\" cas=\"19:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fortuna-liga-zive-sparta-mlada-boleslav\/r~f9735450319211ecb91a0cc47ab5f122\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-po-tragickem-uvodu-zachranila-jen-bod-plzen-se-vzdalu\/r~2bc36cf234e411ecbc3f0cc47ab5f122\/\" fortunaUrl=\"https:\/\/bit.ly\/3aMVfEG\"\/>\n\n    <boxTabulka>\n        \n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"12\" V=\"11\" R=\"0\" P=\"1\" skore=\"23:8\" body=\"33\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SPA\" Z=\"12\" V=\"9\" R=\"2\" P=\"1\" skore=\"30:11\" body=\"29\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SLA\" Z=\"12\" V=\"9\" R=\"2\" P=\"1\" skore=\"30:11\" body=\"29\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"SLO\" Z=\"12\" V=\"9\" R=\"1\" P=\"2\" skore=\"22:12\" body=\"28\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"OVA\" Z=\"11\" V=\"7\" R=\"1\" P=\"3\" skore=\"22:13\" body=\"22\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"HKR\" Z=\"12\" V=\"5\" R=\"4\" P=\"3\" skore=\"16:16\" body=\"19\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"OLO\" Z=\"12\" V=\"4\" R=\"4\" P=\"4\" skore=\"22:18\" body=\"16\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"CEB\" Z=\"12\" V=\"4\" R=\"3\" P=\"5\" skore=\"17:17\" body=\"15\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"MBL\" Z=\"12\" V=\"4\" R=\"2\" P=\"6\" skore=\"20:19\" body=\"14\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"BOH\" Z=\"12\" V=\"3\" R=\"3\" P=\"6\" skore=\"17:26\" body=\"12\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"LIB\" Z=\"12\" V=\"3\" R=\"2\" P=\"7\" skore=\"9:18\" body=\"11\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"JAB\" Z=\"12\" V=\"2\" R=\"5\" P=\"5\" skore=\"10:22\" body=\"11\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"ZLN\" Z=\"12\" V=\"3\" R=\"1\" P=\"8\" skore=\"15:28\" body=\"10\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"PCE\" Z=\"12\" V=\"1\" R=\"4\" P=\"7\" skore=\"15:23\" body=\"7\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"TEP\" Z=\"12\" V=\"1\" R=\"2\" P=\"9\" skore=\"9:24\" body=\"5\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"KAR\" Z=\"11\" V=\"0\" R=\"4\" P=\"7\" skore=\"10:21\" body=\"4\"\/> \n  \n\n \n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"13.\" od=\"\">\n\n<itemKolo domaci=\"TEP\" hoste=\"LIB\" skore=\"1:2\" datum=\"so 30.10.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jarosik-se-ani-napoctvrte-bodu-nedockal-liberec-sebral-tepli\/r~2702c596399911ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3jsfa0n\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"CEB\" skore=\"2:0\" datum=\"so 30.10.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jarosik-se-ani-napoctvrte-bodu-nedockal-liberec-sebral-tepli\/r~2702c596399911ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3m4XMRg\"\/>\n<itemKolo domaci=\"BOH\" hoste=\"KAR\" skore=\"-:-\" datum=\"Odloženo\" cas=\"\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"SLO\" skore=\"0:3\" datum=\"so 30.10.2021\" cas=\"18:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/jarosik-se-ani-napoctvrte-bodu-nedockal-liberec-sebral-tepli\/r~2702c596399911ecb02dac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3Gh7I1V\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"PCE\" skore=\"1:1\" datum=\"ne 31.10.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-mlade-boleslavi-prestrileli-hradec-kralove-3-2-ja\/r~de5cabcc3a6511ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3EeTe0Z\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"HKR\" skore=\"3:2\" datum=\"ne 31.10.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/fotbaliste-mlade-boleslavi-prestrileli-hradec-kralove-3-2-ja\/r~de5cabcc3a6511ecad06ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3GjuXbG\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"SPA\" skore=\"2:2\" datum=\"ne 31.10.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/banik-sparta-letenske-ceka-tradicne-vyhroceny-duel-v-ostrave\/r~4d36b04e366811ec9106ac1f6b220ee8\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/sparta-ze-dvou-penalt-vyuzila-jednu-z-nervozniho-utkani-v-os\/r~1bf2a10a3a6411ec94d2ac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3nmCv55\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"PLZ\" skore=\"2:0\" datum=\"ne 31.10.2021\" cas=\"18:00\" logoTV=\"O25\" onlineUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-plzen-slagr-kola-sesivane-ceka-domaci-zapas-s-lidrem\/r~5dada26635c811ecbc3f0cc47ab5f122\/\" reportUrl=\"https:\/\/sport.aktualne.cz\/fotbal\/ceska-liga\/slavia-udolala-rivala-z-plzne-viktoria-dohravala-bez-tri-vyl\/r~122d4b723a8011ec878fac1f6b220ee8\/\" fortunaUrl=\"https:\/\/bit.ly\/3102Uy9\"\/>\n  \n  \n    <boxTabulka>\n\n<tabItem poradi=\"1.\" zkratkaID=\"PLZ\" Z=\"13\" V=\"11\" R=\"0\" P=\"2\" skore=\"23:10\" body=\"33\"\/> \n<tabItem poradi=\"2.\" zkratkaID=\"SLA\" Z=\"13\" V=\"10\" R=\"2\" P=\"1\" skore=\"32:11\" body=\"32\"\/> \n<tabItem poradi=\"3.\" zkratkaID=\"SLO\" Z=\"13\" V=\"10\" R=\"1\" P=\"2\" skore=\"25:12\" body=\"31\"\/> \n<tabItem poradi=\"4.\" zkratkaID=\"SPA\" Z=\"13\" V=\"9\" R=\"3\" P=\"1\" skore=\"32:13\" body=\"30\"\/> \n<tabItem poradi=\"5.\" zkratkaID=\"OVA\" Z=\"12\" V=\"7\" R=\"2\" P=\"3\" skore=\"24:15\" body=\"23\"\/> \n<tabItem poradi=\"6.\" zkratkaID=\"HKR\" Z=\"13\" V=\"5\" R=\"4\" P=\"4\" skore=\"18:19\" body=\"19\"\/> \n<tabItem poradi=\"7.\" zkratkaID=\"MBL\" Z=\"13\" V=\"5\" R=\"2\" P=\"6\" skore=\"23:21\" body=\"17\"\/> \n<tabItem poradi=\"8.\" zkratkaID=\"OLO\" Z=\"13\" V=\"4\" R=\"4\" P=\"5\" skore=\"22:21\" body=\"16\"\/> \n<tabItem poradi=\"9.\" zkratkaID=\"CEB\" Z=\"13\" V=\"4\" R=\"3\" P=\"6\" skore=\"17:19\" body=\"15\"\/> \n<tabItem poradi=\"10.\" zkratkaID=\"LIB\" Z=\"13\" V=\"4\" R=\"2\" P=\"7\" skore=\"11:19\" body=\"14\"\/> \n<tabItem poradi=\"11.\" zkratkaID=\"ZLN\" Z=\"13\" V=\"4\" R=\"1\" P=\"8\" skore=\"17:28\" body=\"13\"\/> \n<tabItem poradi=\"12.\" zkratkaID=\"BOH\" Z=\"12\" V=\"3\" R=\"3\" P=\"6\" skore=\"17:26\" body=\"12\"\/> \n<tabItem poradi=\"13.\" zkratkaID=\"JAB\" Z=\"13\" V=\"2\" R=\"6\" P=\"5\" skore=\"11:23\" body=\"12\"\/> \n<tabItem poradi=\"14.\" zkratkaID=\"PCE\" Z=\"13\" V=\"1\" R=\"5\" P=\"7\" skore=\"16:24\" body=\"8\"\/> \n<tabItem poradi=\"15.\" zkratkaID=\"TEP\" Z=\"13\" V=\"1\" R=\"2\" P=\"10\" skore=\"10:26\" body=\"5\"\/> \n<tabItem poradi=\"16.\" zkratkaID=\"KAR\" Z=\"11\" V=\"0\" R=\"4\" P=\"7\" skore=\"10:21\" body=\"4\"\/> \n \n \n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"14.\" od=\"\">\n    \n<itemKolo domaci=\"CEB\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 06.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3BsYzQx\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"OVA\" skore=\"-:-\" datum=\"so 06.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3Cy8o0U\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"BOH\" skore=\"-:-\" datum=\"so 06.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3brsBte\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"OLO\" skore=\"-:-\" datum=\"so 06.11.2021\" cas=\"18:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3jUGHbd\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"JAB\" skore=\"-:-\" datum=\"ne 07.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/318Id2P\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"SLA\" skore=\"-:-\" datum=\"ne 07.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3pUnMB7\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"SLO\" skore=\"-:-\" datum=\"ne 07.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3pWwSxq\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"TEP\" skore=\"-:-\" datum=\"ne 07.11.2021\" cas=\"18:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/2ZFOrXS\"\/>\n\n    <boxTabulka>\n\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"15.\" od=\"\">\n\n<itemKolo domaci=\"BOH\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 20.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3EArSTa\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 20.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3CAmoXW\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"HKR\" skore=\"-:-\" datum=\"so 20.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3bstHF5\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 20.11.2021\" cas=\"18:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3pVY7I8\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"LIB\" skore=\"-:-\" datum=\"ne 21.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/2Y74ahK\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"SPA\" skore=\"-:-\" datum=\"ne 21.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3jVuVNM\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"PCE\" skore=\"-:-\" datum=\"ne 21.11.2021\" cas=\"15:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3CujJPr\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"JAB\" skore=\"-:-\" datum=\"ne 21.11.2021\" cas=\"18:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\" fortunaUrl=\"https:\/\/bit.ly\/3CNQXcV\"\/>\n\n      <boxTabulka>\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"16.\" od=\"\">\n    \n<itemKolo domaci=\"CEB\" hoste=\"SLO\" skore=\"-:-\" datum=\"so 27.11.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"KAR\" skore=\"-:-\" datum=\"so 27.11.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 27.11.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"OLO\" skore=\"-:-\" datum=\"so 27.11.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"BOH\" skore=\"-:-\" datum=\"so 27.11.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"TEP\" skore=\"-:-\" datum=\"so 27.11.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"LIB\" skore=\"-:-\" datum=\"so 27.11.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"OVA\" skore=\"-:-\" datum=\"so 27.11.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n      <boxTabulka>\n\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"17.\" od=\"\">\n    \n<itemKolo domaci=\"BOH\" hoste=\"JAB\" skore=\"-:-\" datum=\"so 04.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"SPA\" skore=\"-:-\" datum=\"so 04.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"HKR\" skore=\"-:-\" datum=\"so 04.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"PCE\" skore=\"-:-\" datum=\"so 04.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 04.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"SLA\" skore=\"-:-\" datum=\"so 04.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 04.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 04.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n    <boxTabulka>\n       \n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"18.\" od=\"\">\n\n<itemKolo domaci=\"CEB\" hoste=\"OLO\" skore=\"-:-\" datum=\"so 11.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"SLO\" skore=\"-:-\" datum=\"so 11.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"TEP\" skore=\"-:-\" datum=\"so 11.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"OVA\" skore=\"-:-\" datum=\"so 11.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"LIB\" skore=\"-:-\" datum=\"so 11.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 11.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"BOH\" skore=\"-:-\" datum=\"so 11.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"KAR\" skore=\"-:-\" datum=\"so 11.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n    <boxTabulka> \n \n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"19.\" od=\"\">\n    \n<itemKolo domaci=\"BOH\" hoste=\"PCE\" skore=\"-:-\" datum=\"so 18.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"SPA\" skore=\"-:-\" datum=\"so 18.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 18.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 18.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"SLA\" skore=\"-:-\" datum=\"so 18.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 18.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"JAB\" skore=\"-:-\" datum=\"so 18.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 18.12.2021\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n   \n\n    <boxTabulka>\n\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"20.\" od=\"\">\n    \n<itemKolo domaci=\"CEB\" hoste=\"SPA\" skore=\"-:-\" datum=\"so 05.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"OLO\" skore=\"-:-\" datum=\"so 05.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"OVA\" skore=\"-:-\" datum=\"so 05.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"SLO\" skore=\"-:-\" datum=\"so 05.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"HKR\" skore=\"-:-\" datum=\"so 05.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"KAR\" skore=\"-:-\" datum=\"so 05.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"BOH\" skore=\"-:-\" datum=\"so 05.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"LIB\" skore=\"-:-\" datum=\"so 05.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n    \n      \n      \n    <boxTabulka>\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"21.\" od=\"\">\n    \n<itemKolo domaci=\"BOH\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 12.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 12.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"JAB\" skore=\"-:-\" datum=\"so 12.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"PCE\" skore=\"-:-\" datum=\"so 12.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"TEP\" skore=\"-:-\" datum=\"so 12.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 12.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"SLA\" skore=\"-:-\" datum=\"so 12.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 12.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n    \n      \n      <boxTabulka>\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"22.\" od=\"\">\n\n<itemKolo domaci=\"CEB\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 19.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"SPA\" skore=\"-:-\" datum=\"so 19.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"LIB\" skore=\"-:-\" datum=\"so 19.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"OLO\" skore=\"-:-\" datum=\"so 19.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"HKR\" skore=\"-:-\" datum=\"so 19.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"BOH\" skore=\"-:-\" datum=\"so 19.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"KAR\" skore=\"-:-\" datum=\"so 19.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"SLO\" skore=\"-:-\" datum=\"so 19.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n      <boxTabulka>\n\n\n  \n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"23.\" od=\"\">\n   \n<itemKolo domaci=\"BOH\" hoste=\"OVA\" skore=\"-:-\" datum=\"so 26.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"SLA\" skore=\"-:-\" datum=\"so 26.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 26.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"JAB\" skore=\"-:-\" datum=\"so 26.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"PCE\" skore=\"-:-\" datum=\"so 26.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"TEP\" skore=\"-:-\" datum=\"so 26.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 26.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 26.02.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n    <boxTabulka>\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"24.\" od=\"\">\n    \n<itemKolo domaci=\"JAB\" hoste=\"HKR\" skore=\"-:-\" datum=\"so 05.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"KAR\" skore=\"-:-\" datum=\"so 05.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"LIB\" skore=\"-:-\" datum=\"so 05.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 05.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"BOH\" skore=\"-:-\" datum=\"so 05.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"SPA\" skore=\"-:-\" datum=\"so 05.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"SLO\" skore=\"-:-\" datum=\"so 05.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 05.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n    \n      \n    <boxTabulka>\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"25.\" od=\"\">\n   \n   \n<itemKolo domaci=\"BOH\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 12.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"CEB\" hoste=\"JAB\" skore=\"-:-\" datum=\"so 12.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 12.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"OLO\" skore=\"-:-\" datum=\"so 12.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"SLA\" skore=\"-:-\" datum=\"so 12.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"TEP\" skore=\"-:-\" datum=\"so 12.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"OVA\" skore=\"-:-\" datum=\"so 12.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"PCE\" skore=\"-:-\" datum=\"so 12.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n      \n    <boxTabulka>\n        \n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"26.\" od=\"\">\n\n<itemKolo domaci=\"BOH\" hoste=\"SLO\" skore=\"-:-\" datum=\"so 19.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 19.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"SPA\" skore=\"-:-\" datum=\"so 19.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"KAR\" skore=\"-:-\" datum=\"so 19.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"LIB\" skore=\"-:-\" datum=\"so 19.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 19.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"HKR\" skore=\"-:-\" datum=\"so 19.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"PCE\" skore=\"-:-\" datum=\"so 19.03.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n    <boxTabulka>\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"27.\" od=\"\">\n   \n<itemKolo domaci=\"CEB\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 02.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 02.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"BOH\" skore=\"-:-\" datum=\"so 02.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"TEP\" skore=\"-:-\" datum=\"so 02.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"JAB\" skore=\"-:-\" datum=\"so 02.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"SLA\" skore=\"-:-\" datum=\"so 02.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"OLO\" skore=\"-:-\" datum=\"so 02.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"OVA\" skore=\"-:-\" datum=\"so 02.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n      <boxTabulka>\n  \n \n \n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"28.\" od=\"\">\n      \n<itemKolo domaci=\"BOH\" hoste=\"LIB\" skore=\"-:-\" datum=\"so 09.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 09.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 09.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"HKR\" skore=\"-:-\" datum=\"so 09.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 09.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"PCE\" skore=\"-:-\" datum=\"so 09.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"KAR\" skore=\"-:-\" datum=\"so 09.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"SPA\" skore=\"-:-\" datum=\"so 09.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n   \n      \n    <boxTabulka>\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"29.\" od=\"\">\n  \n<itemKolo domaci=\"CEB\" hoste=\"BOH\" skore=\"-:-\" datum=\"so 16.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"HKR\" hoste=\"OLO\" skore=\"-:-\" datum=\"so 16.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"JAB\" hoste=\"SLA\" skore=\"-:-\" datum=\"so 16.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"LIB\" hoste=\"KAR\" skore=\"-:-\" datum=\"so 16.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PCE\" hoste=\"TEP\" skore=\"-:-\" datum=\"so 16.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"PLZ\" hoste=\"OVA\" skore=\"-:-\" datum=\"so 16.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SPA\" hoste=\"SLO\" skore=\"-:-\" datum=\"so 16.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"ZLN\" hoste=\"MBL\" skore=\"-:-\" datum=\"so 16.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n   \n    <boxTabulka>\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n  <kolo cislo=\"30.\" od=\"\">\n    \n<itemKolo domaci=\"BOH\" hoste=\"HKR\" skore=\"-:-\" datum=\"so 23.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"KAR\" hoste=\"PCE\" skore=\"-:-\" datum=\"so 23.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"MBL\" hoste=\"PLZ\" skore=\"-:-\" datum=\"so 23.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OVA\" hoste=\"JAB\" skore=\"-:-\" datum=\"so 23.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"OLO\" hoste=\"SPA\" skore=\"-:-\" datum=\"so 23.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLA\" hoste=\"ZLN\" skore=\"-:-\" datum=\"so 23.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"SLO\" hoste=\"LIB\" skore=\"-:-\" datum=\"so 23.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n<itemKolo domaci=\"TEP\" hoste=\"CEB\" skore=\"-:-\" datum=\"so 23.04.2022\" cas=\"17:00\" logoTV=\"O25\" onlineUrl=\"\" reportUrl=\"\"\/>\n\n      \n      <boxTabulka>\n\n\n<\/boxTabulka>\n  <\/kolo>\n\n\n\n\t<\/boxKola>\n\n\n\n\n\n  <boxKluby>\n      \n  \n    <klubItem id=\"1\">\n      <nazev>SK Dynamo České Budějovice<\/nazev>\n      <zkratka>CEB<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"3b91ac8eed0911eb966d0cc47ab5f122\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/e7b125de0208368db56213805930664a_resize=360,240_.png?hash=fc4552e1fd5f0729223f4ae015b0c072\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"3b91ac8eed0911eb966d0cc47ab5f122\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/e7b125de0208368db56213805930664a_extract=122,123,355,355_resize=20,20_.png?hash=9d1b82bfab721428cfab619d5f568a7c\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/sk-dynamo-ceske-budejovice\/l~i:keyword:7072\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1905\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Střelecký ostrov (6 681)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"David Horejš\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Martin Králik\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Vladimír Koubek\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"13.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"https:\/\/www.dynamocb.cz\/\"\/>\n    <\/klubItem>\n  \n    <klubItem id=\"2\">\n      <nazev>FK Jablonec<\/nazev>\n      <zkratka>JAB<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"04eba4982fb211e598af002590604f2e\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/a5ff11893b0734c19f59448c99c5285d_extract=171,0,1000,667_resize=360,240_.png?hash=c7c33cc7c7a25fcce01ab288eef327b0\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"04eba4982fb211e598af002590604f2e\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/a5ff11893b0734c19f59448c99c5285d_extract=211,211,579,579_resize=20,20_.png?hash=31ac1121fd5fbbecfd4f914c249edf7a\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fk-jablonec\/l~i:keyword:9401\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1945\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Stadion Střelnice (6 280)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Petr Rada\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Tomáš Hübschman\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Miroslav Pelta\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"3.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/fkjablonec.cz\/\"\/>\n    <\/klubItem>\n    \n    <klubItem id=\"3\">\n      <nazev>MFK Karviná<\/nazev>\n      <zkratka>KAR<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"41c9d5b83f7b11e6851c002590604f2e\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/0035307640183be588eefbb4e4358168_extract=165,0,1000,667_resize=360,240_.png?hash=7009c40bc3addd11e2763fd30e97037b\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"41c9d5b83f7b11e6851c002590604f2e\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/0035307640183be588eefbb4e4358168_extract=211,208,581,581_resize=20,20_.png?hash=12dedf3f7a3e77801b30d4c99826c57e\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/mfk-karvina\/l~9810af441f7511e68afb002590604f2e\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"2003\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Městský stadion Karviná (8 000)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Bohumil Páník\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Michal Papadopulos\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Město Karviná\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"12.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/http:\/\/www.mfkkarvina.cz\/\"\/>\n    <\/klubItem>\n    \n    <klubItem id=\"4\">\n      <nazev>FC Hradec Králové<\/nazev>\n      <zkratka>HKR<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"28e9b802ec4011eb9106ac1f6b220ee8\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/2949b696e7203d4bbf726fb47ccbec40_resize=360,240_.png?hash=a89ed5684928558d34e6e26736dd40d5\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"28e9b802ec4011eb9106ac1f6b220ee8\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/2949b696e7203d4bbf726fb47ccbec40_extract=122,122,356,356_resize=20,20_.png?hash=10340e0d3415dc4da6d4c9a90a6764f1\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fc-hradec-kralove\/l~i:keyword:112543\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1905\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"1\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"dočasně po dobu stavby Městský stadion Mladá Boleslav\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Miroslav Koubek\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Adam Vlkanova\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Město Hradec Králové\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"Postup z FNL (1.)\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"https:\/\/www.fchk.cz\/\"\/>\n    <\/klubItem>\n    \n    \n    <klubItem id=\"5\">\n      <nazev>FC Slovan Liberec<\/nazev>\n      <zkratka>LIB<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"500c4d1a2fb211e5ae1b002590604f2e\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/f36b879e04c93b08a7189d46924458a0_extract=168,0,1000,667_resize=360,240_.png?hash=113d45dc6a2fb6277eecd32e3ba0b404\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"500c4d1a2fb211e5ae1b002590604f2e\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/f36b879e04c93b08a7189d46924458a0_extract=211,211,579,579_resize=20,20_.png?hash=29ff637045b9c30c02fab660c27d9f9e\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fc-slovan-liberec\/l~i:keyword:5433\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1958\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"3\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Stadion U Nisy (9 900)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Luboš Kozel\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"jan Mikula\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Ludvík Karl\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"6.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.fcslovanliberec.cz\/\"\/>\n    <\/klubItem>\n    \n    <klubItem id=\"6\">\n      <nazev>FK Mladá Boleslav<\/nazev>\n      <zkratka>MBL<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"01829c18938811e1bdfa0050569c55fc\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/78fbd5b15590394187c9376aa5ded34a_extract=164,0,1000,667_resize=360,240_.png?hash=de588ad05996c86c13d0dd22266ecc80\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"01829c18938811e1bdfa0050569c55fc\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/78fbd5b15590394187c9376aa5ded34a_extract=211,208,579,579_resize=20,20_.png?hash=c29b4839c143eb40ee6b9bcebbe7a2a2\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fk-mlada-boleslav\/l~i:keyword:4088\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1902\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Městský stadion Mladá Boleslav (5 000)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Karel Jarolím\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Marek Matějovský\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Josef Dufek\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"11.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.fkmb.cz\/\"\/>\n    <\/klubItem>\n  \n  \n    <klubItem id=\"7\">\n      <nazev>SK Sigma Olomouc<\/nazev>\n      <zkratka>OLO<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"678a7ab22fb111e598af002590604f2e\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/25995d74d5b6386caba98cf568c29cf8_extract=164,0,1000,667_resize=360,240_.png?hash=c67dac129e4504de622668a962b97086\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"678a7ab22fb111e598af002590604f2e\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/25995d74d5b6386caba98cf568c29cf8_extract=211,211,580,580_resize=20,20_.png?hash=b5dd142b6a6ddb330b9241e471697f0f\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/sk-sigma-olomouc\/l~i:keyword:7972\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1919\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Andrův stadion (12 566)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Václav Jílek\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Roman Hubník\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Město Olomouc a spolek SK Olomouc Sigma MŽ\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"9.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.sigmafotbal.cz\/\"\/>\n    <\/klubItem>\n  \n    \n  \n    <klubItem id=\"8\">\n      <nazev>FC Baník Ostrava<\/nazev>\n      <zkratka>OVA<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"01a157d4938811e1bdfa0050569c55fc\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/e7078b6eae723cdb9bebb7ed55ba19a0_extract=164,0,1000,667_resize=360,240_.png?hash=80b1481026f763dd106aabc91bb34a92\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"01a157d4938811e1bdfa0050569c55fc\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/e7078b6eae723cdb9bebb7ed55ba19a0_extract=211,211,579,579_resize=20,20_.png?hash=e2b51fe31c13a11b53443a97bca1e1b2\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fc-banik-ostrava\/l~i:keyword:7511\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1922\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"4\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Městský stadion Vítkovice (15 275)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Ondřej Smetana\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Jan Laštůvka\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Václav Brabec\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"8.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.fcb.cz\/\"\/>\n    <\/klubItem>\n    \n    \n    <klubItem id=\"9\">\n      <nazev>FK Pardubice<\/nazev>\n      <zkratka>PCE<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"80191860ed0911ebb91a0cc47ab5f122\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/b27852e2ee8c3b3b99f401e2dfa545ed_resize=360,240_.png?hash=ac5937dd99338f2c8546feaebfd39891\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"80191860ed0911ebb91a0cc47ab5f122\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/b27852e2ee8c3b3b99f401e2dfa545ed_extract=121,120,352,352_resize=20,20_.png?hash=43b97442765621cbd18e25c9231c3860\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fc-fastav-zlin-fotbalovy-klub\/l~106c0688253111e3a6f7002590604f2e\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"2008\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Pod vinicí (3000), na podzim hrají v Ďolíčku\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Jiří Krejčí a Jaroslav Novotný\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Jan Jeřábek\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\" Vladimír Pitter\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"Postup z FNL (1.)\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/fkpardubice.cz\/\"\/>\n    <\/klubItem>\n  \n    <klubItem id=\"10\">\n      <nazev>FC Viktoria Plzeň<\/nazev>\n      <zkratka>PLZ<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"246844b02fb311e595f70025900fea04\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/40b7d7c0027a345dae97f58e1517a5ff_extract=163,0,1000,667_resize=360,240_.png?hash=b90d27921b7b2f6ee06802c480ba56d2\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"246844b02fb311e595f70025900fea04\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/40b7d7c0027a345dae97f58e1517a5ff_extract=205,208,587,587_resize=20,20_.png?hash=5efad0182502d6ae65cdad3cffc17c12\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fc-viktoria-plzen\/l~i:keyword:6677\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1911\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"5\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Doosan Arena (11 700)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Michal Bílek\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Jakub Brabec\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Adolf Šádek\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"5.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.fcviktoria.cz\/cs\/\"\/>\n    <\/klubItem>\n  \n    <klubItem id=\"11\">\n      <nazev>Bohemians Praha 1905<\/nazev>\n      <zkratka>BOH<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"a8f294442fb111e5989d0025900fea04\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/3925051c38de38be9efaa33fba2d3542_extract=165,0,1000,667_resize=360,240_.png?hash=7bd2d506796b97932869375df4a07904\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"a8f294442fb111e5989d0025900fea04\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/3925051c38de38be9efaa33fba2d3542_extract=213,213,573,573_resize=20,20_.png?hash=b3ad82e048f31f16d7b65a585590f43b\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/bohemians-praha-1905\/l~i:keyword:7551\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1895\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"1\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Ďolíček (5 000)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Luděk Klusáček\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Josef Jindřišek\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Dariusz Jakubowicz\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"13.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.bohemians.cz\/\"\/>\n    <\/klubItem>\n  \n    <klubItem id=\"12\">\n      <nazev>SK Slavia Praha<\/nazev>\n      <zkratka>SLA<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"dba0cf442fb311e593f4002590604f2e\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/a74d24f4dcf035d191324fb2ea65c124_extract=165,0,1000,667_resize=360,240_.png?hash=21beaeac87ad8436c836024c89271702\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"dba0cf442fb311e593f4002590604f2e\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/a74d24f4dcf035d191324fb2ea65c124_extract=209,209,580,580_resize=20,20_.png?hash=d258fc0b35e6bd1bce851deb911ee47e\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/sk-slavia-praha\/l~i:keyword:55794\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1892\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"22\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Sinobo Stadium (19 416)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Jindřich Trpišovský\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Jan Bořil\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"CITIC\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"1.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.slavia.cz\/\"\/>\n    <\/klubItem>\n  \n    <klubItem id=\"13\">\n      <nazev>AC Sparta Praha<\/nazev>\n      <zkratka>SPA<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"bdda6552ec3f11eb9106ac1f6b220ee8\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/d7b67cbf838c3a228f49cfe11f44481f_resize=360,240_.png?hash=e17f9ae692707904cbc8adc48d8e8b37\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"bdda6552ec3f11eb9106ac1f6b220ee8\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/d7b67cbf838c3a228f49cfe11f44481f_extract=125,126,348,348_resize=20,20_.png?hash=6f6c9be963712afceef711815229fbb6\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/ac-sparta-praha\/l~i:keyword:4380\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1893\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"33\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Generali aréna (19 416)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Pavel Vrba\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Bořek Dočkal\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Daniel Křetínský\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"2.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.sparta.cz\/\"\/>\n    <\/klubItem>\n  \n    \n  \n    <klubItem id=\"14\">\n      <nazev>1.FC Slovácko<\/nazev>\n      <zkratka>SLO<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"03c49ef4938811e188ee0050569c55fc\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/4926f0923291395bbf5748eaa5a4c9b8_extract=163,0,1000,667_resize=360,240_.png?hash=b5b1d9bbd2d87e6302c484700f668c82\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"03c49ef4938811e188ee0050569c55fc\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/4926f0923291395bbf5748eaa5a4c9b8_extract=211,211,579,579_resize=20,20_.png?hash=07a4e79d168a24b79beb553b4eca97f2\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/1-fc-slovacko\/l~i:keyword:112881\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"2000\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Městský fotbalový stadion Miroslava Valenty (8 000)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Martin Svědík\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Michal Kadlec\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Zdeněk Zemek\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"4.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.fcslovacko.cz\/\"\/>\n    <\/klubItem>\n  \n  \n    <klubItem id=\"15\">\n      <nazev>FK Teplice<\/nazev>\n      <zkratka>TEP<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"03c73b96938811e1bd270050569c55fc\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/8bdf10d050253a36b987529ae074ffaa_extract=164,0,1000,667_resize=360,240_.png?hash=1bd3cb393f921cd584f565c80212fdff\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"03c73b96938811e1bd270050569c55fc\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/8bdf10d050253a36b987529ae074ffaa_extract=211,211,577,577_resize=20,20_.png?hash=38bc6752f222eb9285fd65ad6c695944\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fk-teplice\/l~i:keyword:5785\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1945\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Na Stínadlech (18 211)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Jiří Jarošík\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"AGC\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"15.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.fkteplice.cz\/\"\/>\n    <\/klubItem>\n  \n    <klubItem id=\"16\">\n      <nazev>FC Fastav Zlín<\/nazev>\n      <zkratka>ZLN<\/zkratka>\n      <obr bbxtype=\"0\" guid=\"ba7ac12c2f9911e586d30025900fea04\" width=\"360\" height=\"240\" ratio=\"3:2\">\n        \/\/cdn.xsd.cz\/resize\/db5315c2f56032a7b1d2a51d74dc84f8_extract=165,0,1000,667_resize=360,240_.png?hash=91f9df91e1c6b46bdca83745aff6f4ae\n      <\/obr>\n      <obrIco bbxtype=\"0\" guid=\"ba7ac12c2f9911e586d30025900fea04\" width=\"20\" height=\"20\" ratio=\"1:1\">\n        \/\/cdn.xsd.cz\/resize\/db5315c2f56032a7b1d2a51d74dc84f8_extract=211,211,579,579_resize=20,20_.png?hash=c9839667add7b6407eb999d6ef2e1c8c\n      <\/obrIco>\n      <url\/>\n      <urlVypis>https:\/\/sport.aktualne.cz\/mrss\/fc-fastav-zlin-fotbalovy-klub\/l~106c0688253111e3a6f7002590604f2e\/<\/urlVypis>\n      <bioItem nazev=\"Založen:\" hodnota=\"1919\"\/>\n      <bioItem nazev=\"Titulů:\" hodnota=\"0\"\/>\n      <bioItem nazev=\"Stadion:\" hodnota=\"Letná (6375)\"\/>\n      <bioItem nazev=\"Trenér:\" hodnota=\"Jan Jelínek\"\/>\n      <bioItem nazev=\"Kapitán:\" hodnota=\"Tomáš Poznar\"\/>\n      <bioItem nazev=\"Majitel:\" hodnota=\"Zdeněk Červenka\"\/>\n      <bioItem nazev=\"Minulá sezona:\" hodnota=\"14.\"\/>\n      <bioItem nazev=\"www:\" hodnota=\"http:\/\/www.fcfastavzlin.cz\"\/>\n    <\/klubItem>\n  \n  \n  \n  \n  \n  \n  <\/boxKluby>\n\n  \t<boxStatistiky>\n\n\t\t<boxTab nazev=\"Góly\" poznamka=\"\">\n      \n<tabItem poradi=\"1.\" jmeno=\"Jean-David Beauguel\" zkratkaID=\"PLZ\" Z=\"13\" Num=\"8\"\/> \n<tabItem poradi=\"2.\" jmeno=\"Martin Hála\" zkratkaID=\"OLO\" Z=\"13\" Num=\"6\"\/> \n<tabItem poradi=\"3.\" jmeno=\"Jakub Pešek\" zkratkaID=\"SPA\" Z=\"13\" Num=\"6\"\/> \n<tabItem poradi=\"4.\" jmeno=\"Ivan Schranz\" zkratkaID=\"SLA\" Z=\"11\" Num=\"6\"\/> \n<tabItem poradi=\"5.\" jmeno=\"Jan Kuchta\" zkratkaID=\"SLA\" Z=\"10\" Num=\"6\"\/> \n<tabItem poradi=\"6.\" jmeno=\"Václav Jurečka\" zkratkaID=\"SLO\" Z=\"13\" Num=\"6\"\/> \n<tabItem poradi=\"7.\" jmeno=\"Jan Chramosta\" zkratkaID=\"BOH\" Z=\"9\" Num=\"5\"\/> \n<tabItem poradi=\"8.\" jmeno=\"Pavel Dvořák\" zkratkaID=\"HKR\" Z=\"13\" Num=\"5\"\/> \n<tabItem poradi=\"9.\" jmeno=\"Paixao da Silva Ewerton\" zkratkaID=\"MBL\" Z=\"13\" Num=\"5\"\/> \n<tabItem poradi=\"10.\" jmeno=\"Ladislav Almási\" zkratkaID=\"OVA\" Z=\"11\" Num=\"5\"\/> \n<tabItem poradi=\"11.\" jmeno=\"Milan Škoda\" zkratkaID=\"MBL\" Z=\"13\" Num=\"4\"\/> \n<tabItem poradi=\"12.\" jmeno=\"Daniel Tetour\" zkratkaID=\"OVA\" Z=\"10\" Num=\"4\"\/> \n<tabItem poradi=\"13.\" jmeno=\"Tomáš Poznar\" zkratkaID=\"ZLN\" Z=\"13\" Num=\"4\"\/> \n<tabItem poradi=\"14.\" jmeno=\"Tomáš Čvančara\" zkratkaID=\"JAB\" Z=\"10\" Num=\"4\"\/> \n<tabItem poradi=\"15.\" jmeno=\"David Puškáč\" zkratkaID=\"BOH\" Z=\"7\" Num=\"4\"\/> \n<tabItem poradi=\"16.\" jmeno=\"Adam Hložek\" zkratkaID=\"SPA\" Z=\"13\" Num=\"4\"\/> \n<tabItem poradi=\"17.\" jmeno=\"Fortune Bassey\" zkratkaID=\"CEB\" Z=\"13\" Num=\"4\"\/> \n<tabItem poradi=\"18.\" jmeno=\"David Tkáč\" zkratkaID=\"ZLN\" Z=\"12\" Num=\"4\"\/> \n<tabItem poradi=\"19.\" jmeno=\"Michal Papadopulos\" zkratkaID=\"KAR\" Z=\"10\" Num=\"3\"\/> \n<tabItem poradi=\"20.\" jmeno=\"Milan Petržela\" zkratkaID=\"SLO\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"21.\" jmeno=\"Radim Řezník\" zkratkaID=\"PLZ\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"22.\" jmeno=\"Jakub Rada\" zkratkaID=\"HKR\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"23.\" jmeno=\"Petr Reinberk\" zkratkaID=\"SLO\" Z=\"12\" Num=\"3\"\/> \n<tabItem poradi=\"24.\" jmeno=\"Jiří Skalák\" zkratkaID=\"MBL\" Z=\"11\" Num=\"3\"\/> \n<tabItem poradi=\"25.\" jmeno=\"Jhon Mosquera\" zkratkaID=\"PLZ\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"26.\" jmeno=\"Ondřej Mihálik\" zkratkaID=\"CEB\" Z=\"12\" Num=\"3\"\/> \n<tabItem poradi=\"27.\" jmeno=\"Adam Vlkanova\" zkratkaID=\"HKR\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"28.\" jmeno=\"David Lischka\" zkratkaID=\"OVA\" Z=\"11\" Num=\"3\"\/> \n<tabItem poradi=\"29.\" jmeno=\"Peter  Olayinka\" zkratkaID=\"SLA\" Z=\"6\" Num=\"3\"\/> \n<tabItem poradi=\"30.\" jmeno=\"Ondřej Lingr\" zkratkaID=\"SLA\" Z=\"11\" Num=\"3\"\/> \n<tabItem poradi=\"31.\" jmeno=\"Jan Král\" zkratkaID=\"HKR\" Z=\"11\" Num=\"3\"\/> \n<tabItem poradi=\"32.\" jmeno=\"Pavel Zifčák\" zkratkaID=\"OLO\" Z=\"12\" Num=\"3\"\/> \n<tabItem poradi=\"33.\" jmeno=\"Pablo González\" zkratkaID=\"OLO\" Z=\"12\" Num=\"3\"\/> \n<tabItem poradi=\"34.\" jmeno=\"Emil Tischler\" zkratkaID=\"PCE\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"35.\" jmeno=\"Martin Minčev\" zkratkaID=\"SPA\" Z=\"8\" Num=\"3\"\/> \n<tabItem poradi=\"36.\" jmeno=\"Daniel Fila\" zkratkaID=\"MBL\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"37.\" jmeno=\"Daniel Samek\" zkratkaID=\"SLA\" Z=\"11\" Num=\"3\"\/> \n<tabItem poradi=\"38.\" jmeno=\"Daniel Vašulín\" zkratkaID=\"HKR\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"39.\" jmeno=\"Jakub Mareš\" zkratkaID=\"TEP\" Z=\"7\" Num=\"2\"\/> \n<tabItem poradi=\"40.\" jmeno=\"Martin Doležal\" zkratkaID=\"JAB\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"41.\" jmeno=\"Lukáš Hejda\" zkratkaID=\"PLZ\" Z=\"8\" Num=\"2\"\/> \n<tabItem poradi=\"42.\" jmeno=\"David Vaněček\" zkratkaID=\"OLO\" Z=\"6\" Num=\"2\"\/> \n<tabItem poradi=\"43.\" jmeno=\"Stanislav Tecl\" zkratkaID=\"SLA\" Z=\"6\" Num=\"2\"\/> \n<tabItem poradi=\"44.\" jmeno=\"Václav Pilař\" zkratkaID=\"JAB\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"45.\" jmeno=\"Jakub Hora\" zkratkaID=\"CEB\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"46.\" jmeno=\"Jiří Fleišman\" zkratkaID=\"OVA\" Z=\"12\" Num=\"2\"\/> \n<tabItem poradi=\"47.\" jmeno=\"Martin Dostál\" zkratkaID=\"BOH\" Z=\"12\" Num=\"2\"\/> \n<tabItem poradi=\"48.\" jmeno=\"Michael Krmenčík\" zkratkaID=\"SLA\" Z=\"9\" Num=\"2\"\/> \n<tabItem poradi=\"49.\" jmeno=\"David Pavelka\" zkratkaID=\"SPA\" Z=\"12\" Num=\"2\"\/> \n<tabItem poradi=\"50.\" jmeno=\"Jan Kopic\" zkratkaID=\"PLZ\" Z=\"8\" Num=\"2\"\/> \n  \n \n      \n    <\/boxTab>\n\n  <boxTab nazev=\"Asistence\" poznamka=\"\">\n      \n<tabItem poradi=\"1.\" jmeno=\"Adam Hložek\" zkratkaID=\"SPA\" Z=\"13\" Num=\"6\"\/> \n<tabItem poradi=\"2.\" jmeno=\"Carlos Eduardo Lopes Cruz Cadu\" zkratkaID=\"PCE\" Z=\"13\" Num=\"6\"\/> \n<tabItem poradi=\"3.\" jmeno=\"Juraj Chvátal\" zkratkaID=\"OLO\" Z=\"10\" Num=\"5\"\/> \n<tabItem poradi=\"4.\" jmeno=\"Adam Vlkanova\" zkratkaID=\"HKR\" Z=\"13\" Num=\"5\"\/> \n<tabItem poradi=\"5.\" jmeno=\"Paixao da Silva Ewerton\" zkratkaID=\"MBL\" Z=\"13\" Num=\"5\"\/> \n<tabItem poradi=\"6.\" jmeno=\"Jan Kalabiška\" zkratkaID=\"SLO\" Z=\"13\" Num=\"4\"\/> \n<tabItem poradi=\"7.\" jmeno=\"Jiří Fleišman\" zkratkaID=\"OVA\" Z=\"12\" Num=\"4\"\/> \n<tabItem poradi=\"8.\" jmeno=\"Ondřej Mihálik\" zkratkaID=\"CEB\" Z=\"12\" Num=\"4\"\/> \n<tabItem poradi=\"9.\" jmeno=\"Roman Květ\" zkratkaID=\"BOH\" Z=\"11\" Num=\"4\"\/> \n<tabItem poradi=\"10.\" jmeno=\"Gigli Ndefe\" zkratkaID=\"OVA\" Z=\"12\" Num=\"4\"\/> \n<tabItem poradi=\"11.\" jmeno=\"Michael Krmenčík\" zkratkaID=\"SLA\" Z=\"9\" Num=\"3\"\/> \n<tabItem poradi=\"12.\" jmeno=\"Daniel Holzer\" zkratkaID=\"SLO\" Z=\"11\" Num=\"3\"\/> \n<tabItem poradi=\"13.\" jmeno=\"Jakub Pešek\" zkratkaID=\"SPA\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"14.\" jmeno=\"Jan Mejdr\" zkratkaID=\"HKR\" Z=\"12\" Num=\"3\"\/> \n<tabItem poradi=\"15.\" jmeno=\"Murphy Dorley Oscar\" zkratkaID=\"SLA\" Z=\"9\" Num=\"3\"\/> \n<tabItem poradi=\"16.\" jmeno=\"Dominik Pleštil\" zkratkaID=\"JAB\" Z=\"12\" Num=\"3\"\/> \n<tabItem poradi=\"17.\" jmeno=\"Martin Chlumecký\" zkratkaID=\"TEP\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"18.\" jmeno=\"Vachtang Čanturišvili\" zkratkaID=\"ZLN\" Z=\"11\" Num=\"3\"\/> \n<tabItem poradi=\"19.\" jmeno=\"Tomáš Čelůstka\" zkratkaID=\"PCE\" Z=\"11\" Num=\"3\"\/> \n<tabItem poradi=\"20.\" jmeno=\"Milan Petržela\" zkratkaID=\"SLO\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"21.\" jmeno=\"Radim Řezník\" zkratkaID=\"PLZ\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"22.\" jmeno=\"Jan Krob\" zkratkaID=\"JAB\" Z=\"12\" Num=\"2\"\/> \n<tabItem poradi=\"23.\" jmeno=\"David Vaněček\" zkratkaID=\"OLO\" Z=\"6\" Num=\"2\"\/> \n<tabItem poradi=\"24.\" jmeno=\"Vojtěch Kubista\" zkratkaID=\"JAB\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"25.\" jmeno=\"Marek Havlík\" zkratkaID=\"SLO\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"26.\" jmeno=\"Tomáš Zahradníček\" zkratkaID=\"OLO\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"27.\" jmeno=\"Marek Hlinka\" zkratkaID=\"ZLN\" Z=\"10\" Num=\"2\"\/> \n<tabItem poradi=\"28.\" jmeno=\"Tomáš Chorý\" zkratkaID=\"PLZ\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"29.\" jmeno=\"Jan Sýkora\" zkratkaID=\"PLZ\" Z=\"8\" Num=\"2\"\/> \n<tabItem poradi=\"30.\" jmeno=\"Ivan Schranz\" zkratkaID=\"SLA\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"31.\" jmeno=\"Tomáš Poznar\" zkratkaID=\"ZLN\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"32.\" jmeno=\"Jan Kuchta\" zkratkaID=\"SLA\" Z=\"10\" Num=\"2\"\/> \n<tabItem poradi=\"33.\" jmeno=\"Mick Van Buren\" zkratkaID=\"CEB\" Z=\"8\" Num=\"2\"\/> \n<tabItem poradi=\"34.\" jmeno=\"Antonín Růsek\" zkratkaID=\"OLO\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"35.\" jmeno=\"Dominik Janošek\" zkratkaID=\"PLZ\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"36.\" jmeno=\"David Douděra\" zkratkaID=\"MBL\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"37.\" jmeno=\"Nicolae Stanciu\" zkratkaID=\"SLA\" Z=\"10\" Num=\"2\"\/> \n<tabItem poradi=\"38.\" jmeno=\"Tomáš  Wiesner\" zkratkaID=\"SPA\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"39.\" jmeno=\"Jiří  Sláma\" zkratkaID=\"PCE\" Z=\"6\" Num=\"2\"\/> \n<tabItem poradi=\"40.\" jmeno=\"Pavel Bucha\" zkratkaID=\"PLZ\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"41.\" jmeno=\"Nemanja Kuzmanovič\" zkratkaID=\"OVA\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"42.\" jmeno=\"David Moberg Karlsson\" zkratkaID=\"SPA\" Z=\"10\" Num=\"2\"\/> \n<tabItem poradi=\"43.\" jmeno=\"David Ledecký\" zkratkaID=\"TEP\" Z=\"8\" Num=\"2\"\/> \n<tabItem poradi=\"44.\" jmeno=\"Eduardo Santos\" zkratkaID=\"KAR\" Z=\"10\" Num=\"2\"\/> \n<tabItem poradi=\"45.\" jmeno=\"David Černý\" zkratkaID=\"TEP\" Z=\"12\" Num=\"2\"\/> \n<tabItem poradi=\"46.\" jmeno=\"Yira Sor\" zkratkaID=\"OVA\" Z=\"10\" Num=\"2\"\/> \n<tabItem poradi=\"47.\" jmeno=\"Daniel Samek\" zkratkaID=\"SLA\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"48.\" jmeno=\"David Jurásek\" zkratkaID=\"MBL\" Z=\"9\" Num=\"2\"\/> \n<tabItem poradi=\"49.\" jmeno=\"Jakub Mareš\" zkratkaID=\"TEP\" Z=\"7\" Num=\"1\"\/> \n<tabItem poradi=\"50.\" jmeno=\"Martin Fillo\" zkratkaID=\"ZLN\" Z=\"10\" Num=\"1\"\/> \n\n \n \n\n\n\t\t<\/boxTab>\n\n\n\t\t<boxTab nazev=\"Brankáři\" poznamka=\"\">\n      \n<tabItem poradi=\"1.\" jmeno=\"Florin Nita\" zkratkaID=\"SPA\" Z=\"13\" Num=\"6\"\/> \n<tabItem poradi=\"2.\" jmeno=\"Filip Nguyen\" zkratkaID=\"SLO\" Z=\"12\" Num=\"5\"\/> \n<tabItem poradi=\"3.\" jmeno=\"Vilém Fendrich\" zkratkaID=\"HKR\" Z=\"12\" Num=\"4\"\/> \n<tabItem poradi=\"4.\" jmeno=\"Matej Rakovan\" zkratkaID=\"ZLN\" Z=\"8\" Num=\"3\"\/> \n<tabItem poradi=\"5.\" jmeno=\"Ondřej Kolář\" zkratkaID=\"SLA\" Z=\"7\" Num=\"3\"\/> \n<tabItem poradi=\"6.\" jmeno=\"Jindřich Staněk\" zkratkaID=\"PLZ\" Z=\"8\" Num=\"3\"\/> \n<tabItem poradi=\"7.\" jmeno=\"Matúš Macík\" zkratkaID=\"OLO\" Z=\"13\" Num=\"3\"\/> \n<tabItem poradi=\"8.\" jmeno=\"Jan Laštůvka\" zkratkaID=\"OVA\" Z=\"11\" Num=\"2\"\/> \n<tabItem poradi=\"9.\" jmeno=\"Jan Šeda\" zkratkaID=\"MBL\" Z=\"9\" Num=\"2\"\/> \n<tabItem poradi=\"10.\" jmeno=\"Aleš Hruška\" zkratkaID=\"PLZ\" Z=\"5\" Num=\"2\"\/> \n<tabItem poradi=\"11.\" jmeno=\"Jan Hanuš\" zkratkaID=\"JAB\" Z=\"12\" Num=\"2\"\/> \n<tabItem poradi=\"12.\" jmeno=\"Aleš Mandous\" zkratkaID=\"SLA\" Z=\"6\" Num=\"2\"\/> \n<tabItem poradi=\"13.\" jmeno=\"Vojtěch Vorel\" zkratkaID=\"CEB\" Z=\"12\" Num=\"2\"\/> \n<tabItem poradi=\"14.\" jmeno=\"Milan Knobloch\" zkratkaID=\"LIB\" Z=\"13\" Num=\"2\"\/> \n<tabItem poradi=\"15.\" jmeno=\"Jan Čtvrtečka\" zkratkaID=\"TEP\" Z=\"7\" Num=\"2\"\/> \n<tabItem poradi=\"16.\" jmeno=\"Stanislav Dostál\" zkratkaID=\"ZLN\" Z=\"4\" Num=\"1\"\/> \n<tabItem poradi=\"17.\" jmeno=\"Marek Boháč\" zkratkaID=\"PCE\" Z=\"5\" Num=\"1\"\/> \n<tabItem poradi=\"18.\" jmeno=\"Hugo Jan Bačkovský\" zkratkaID=\"BOH\" Z=\"8\" Num=\"1\"\/> \n<tabItem poradi=\"19.\" jmeno=\"Jakub Markovič\" zkratkaID=\"PCE\" Z=\"6\" Num=\"1\"\/> \n<tabItem poradi=\"20.\" jmeno=\"Pavol Bajza\" zkratkaID=\"SLO\" Z=\"1\" Num=\"1\"\/> \n<tabItem poradi=\"21.\" jmeno=\"Tomáš Grigar\" zkratkaID=\"TEP\" Z=\"6\" Num=\"0\"\/> \n<tabItem poradi=\"22.\" jmeno=\"Petr Bolek\" zkratkaID=\"KAR\" Z=\"7\" Num=\"0\"\/> \n<tabItem poradi=\"23.\" jmeno=\"Vlastimil Hrubý\" zkratkaID=\"JAB\" Z=\"1\" Num=\"0\"\/> \n<tabItem poradi=\"24.\" jmeno=\"Pavel Halouska\" zkratkaID=\"MBL\" Z=\"4\" Num=\"0\"\/> \n<tabItem poradi=\"25.\" jmeno=\"Viktor Budinský\" zkratkaID=\"OVA\" Z=\"1\" Num=\"0\"\/> \n<tabItem poradi=\"26.\" jmeno=\"Patrik Le Giang\" zkratkaID=\"BOH\" Z=\"4\" Num=\"0\"\/> \n<tabItem poradi=\"27.\" jmeno=\"Jan Šiška\" zkratkaID=\"ZLN\" Z=\"2\" Num=\"0\"\/> \n<tabItem poradi=\"28.\" jmeno=\"Vladimír Neuman\" zkratkaID=\"KAR\" Z=\"5\" Num=\"0\"\/> \n<tabItem poradi=\"29.\" jmeno=\"Jiří Letáček\" zkratkaID=\"PCE\" Z=\"2\" Num=\"0\"\/> \n<tabItem poradi=\"30.\" jmeno=\"Tomáš Vajner\" zkratkaID=\"JAB\" Z=\"1\" Num=\"0\"\/> \n<tabItem poradi=\"31.\" jmeno=\"Patrik Vízek\" zkratkaID=\"HKR\" Z=\"2\" Num=\"0\"\/> \n<tabItem poradi=\"32.\" jmeno=\"Dávid Šípoš\" zkratkaID=\"CEB\" Z=\"1\" Num=\"0\"\/> \n\n  \n\n\n\n\n \t\t<\/boxTab>\n\n\n\n\n\t<\/boxStatistiky>\n\n\t<seznamLogoTV>\n\t\t<item nazev=\"ČT2\" kod=\"CT2\">\n\t\t\t<obr>\/\/cdn.xsd.cz\/resize\/feaa46b4674b3466ac770df9ddc15403_resize=,20_.png?hash=e38dafa98a994d947abb16535ffd8ea1<\/obr>\n\t\t<\/item>\n\t\t<item nazev=\"ČT4 sport\" kod=\"CT4\">\n\t\t\t<obr>\/\/cdn.xsd.cz\/resize\/94286cf96a67306aa423f60a13b47b74_resize=,20_.png?hash=f114da365e8df47998e49dbed4e24e10<\/obr>\n\t\t<\/item>\n\t\t<item nazev=\"O2 TV Sport\" kod=\"O25\">\n\t\t\t<obr>\/\/cdn.xsd.cz\/resize\/8fc58081a782366bbd7940494b3e581f_resize=,20_.png?hash=7d84a178ca8c1b2fe33d2307159ab88e<\/obr>\n\t\t<\/item>\n\t\t<item nazev=\"O2 TV Fotbal\" kod=\"O2F\">\n\t\t\t<obr>\/\/cdn.xsd.cz\/resize\/14b2a3c7fa2d37aeb78ec795022e20dc_resize=,20_.png?hash=c2883f1d7ae505e58d9e80a4d379869b<\/obr>\n\t\t<\/item>\n\t<\/seznamLogoTV>\n\n<\/boxData>", "desktop"]);
+                                        widget.iframe.height = widget.iframe.contentDocument.body.scrollHeight +'px';
+                                    },
+                                    target: target,
+                                    fullscreen: true
+                                    });
+                                    }(document));
+                                    ]]>
+                                    </script>
+                                    <div class="article__end">
+                                        &#160;
+                                    </div>
+                                    <div class="social-share-box social-share-box--article">
+                                        <div onclick="BBX.dropDown(&quot;socialshare-article&quot;, this)" data-evt-label="bottom">
+                                            <a class="social-share-box__share">Sdílet článek </a>
+                                        </div>
+                                        <div id="socialshare-article" class="social-share-box__dropdown hidden">
+                                            <a class="fb" onclick="return !window.open(this.href, '_blank', 'width=550,height=400');" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F" data-evt-active="" data-evt-category="dropdown-share" data-evt-action="fb" data-evt-label="bottom" data-evt-value="1">Facebook</a> <a class="tw" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F&amp;related=Aktualnecz&amp;via=Aktualnecz&amp;text=West%20Ham%20hroz%C3%AD%20gigant%C5%AFm%2C%20okouzlil%20i%20Linekera.%20Sou%C4%8Dka%20je%20snadn%C3%A9%20p%C5%99ehl%C3%A9dnout" data-evt-active="" data-evt-category="dropdown-share" data-evt-action="tw" data-evt-label="bottom" data-evt-value="1"> Twitter</a>
+                                        </div>
+                                    </div>
+                                    <div class="error-report error-report--site-sport">
+                                        <p class="error-report__text">
+                                            Pokud jste v článku zaznamenali chybu nebo překlep, dejte nám, prosím, vědět prostřednictvím <a class="error-report__link" href="https://ankety.aktualne.cz/s3/00310d93156a?utm_source=aktualne.cz&amp;utm_medium=upozorneni&amp;from=https%3A%2F%2Fsport.aktualne.cz%2Ffotbal%2Fzahranici%2Fwest-ham-hrozi-gigantum-okouzlil-i-linekera-souckovu-praci-j%2Fr~8fa032ba3add11ec8a900cc47ab5f122%2F">kontaktního formuláře</a>. Děkujeme!
+                                        </p>
+                                    </div>
+                                    <div id="article-adsense" class="adsense-article-bottom adsense">
+                                        <script>
+                                        <![CDATA[
+                                        SiteAdvert.Queue.adSense(function (device) {
+                                        return device === 'd' ? 'https://i0.cz/reklama/bo/ads/akt-art-bot-lef.js' : 'https://i0.cz/reklama/bo/ads/akt-art-mob.js';
+                                        }, 'article-adsense');
+                                        ]]>
+                                        </script>
+                                    </div>
+                                    <div class="related-wrap">
+                                        <div id="recommendations-replace" class="recommendations-hide">
+                                            <div data-ec-list="article-related-sport" data-vr-zone="article-related-sport">
+                                                <div class="block-title">
+                                                    Související
+                                                </div>
+                                                <div class="related-box clearfix">
+                                                    <a href="/fotbal/ceska-liga/fotbal-banik-sparta-slavia-plzen/r~fa565df43a7f11ec8fa20cc47ab5f122/" data-ec="" data-ec-pid="fa565df43a7f11ec8fa20cc47ab5f122" data-ec-pname="Krmenčík divoce slavil gól &quot;své&quot; Plzni. On je ta největší ostuda, čílil se Limberský" data-ec-pos="dynamic" data-vr-contentbox="Position">
+                                                    <h3 class="related-box__text" data-vr-headline="">
+                                                        Krmenčík divoce slavil gól "své" Plzni. On je ta největší ostuda, čílil se Limberský
+                                                    </h3>
+                                                    <div class="related-box__image">
+                                                        <span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/4c9ea1e129b73b728f92275f0f1838b5_resize=140,93_.jpg?hash=1501fc7536a38434921eb70d5e3c4c24" srcset="//cdn.xsd.cz/resize/4c9ea1e129b73b728f92275f0f1838b5_resize=46,31_.jpg?hash=3c905d6e8ba39b73ddf72e7809781dfb 46w, //cdn.xsd.cz/resize/4c9ea1e129b73b728f92275f0f1838b5_resize=70,47_.jpg?hash=7ce950c133f4fe9acb2ba3b64994ed2e 70w, //cdn.xsd.cz/resize/4c9ea1e129b73b728f92275f0f1838b5_resize=140,93_.jpg?hash=1501fc7536a38434921eb70d5e3c4c24 140w, //cdn.xsd.cz/resize/4c9ea1e129b73b728f92275f0f1838b5_resize=210,140_.jpg?hash=c3056b2a47faae97ea055a513903e2a1 210w, //cdn.xsd.cz/resize/4c9ea1e129b73b728f92275f0f1838b5_resize=280,187_.jpg?hash=ef48ce103310ad1a56545d714b7d7573 280w" sizes="140px" alt="Krmenčík divoce slavil gól &quot;své&quot; Plzni. On je ta největší ostuda, čílil se Limberský" restricted="off" /></span>
+                                                        <div class="box-label box-label--gallery js-ga-gallery-open">
+                                                            29 fotografií
+                                                        </div>
+                                                    </div></a>
+                                                </div>
+                                                <div class="related-box clearfix">
+                                                    <a href="/fotbal/zahranici/silenost-v-argentine-kouce-postrelil-pri-zapase-fanousek-hra/r~117569763adf11ec966d0cc47ab5f122/" data-ec="" data-ec-pid="117569763adf11ec966d0cc47ab5f122" data-ec-pname="Šílenost v Argentině. Kouče postřelil při zápase fanoušek, hráči prchali z trávníku" data-ec-pos="dynamic" data-vr-contentbox="Position">
+                                                    <h3 class="related-box__text" data-vr-headline="">
+                                                        Šílenost v Argentině. Kouče postřelil při zápase fanoušek, hráči prchali z trávníku
+                                                    </h3>
+                                                    <div class="related-box__image">
+                                                        <span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/d196cd1685253862b1c86730803f9441_resize=140,93_.jpg?hash=51b33410b898f6b62de0718a75a3f5dc" srcset="//cdn.xsd.cz/resize/d196cd1685253862b1c86730803f9441_resize=46,31_.jpg?hash=222a59649b126c7dc40453a1d4cc246a 46w, //cdn.xsd.cz/resize/d196cd1685253862b1c86730803f9441_resize=70,47_.jpg?hash=e805026ccf1a4018376c795c4a14be8b 70w, //cdn.xsd.cz/resize/d196cd1685253862b1c86730803f9441_resize=140,93_.jpg?hash=51b33410b898f6b62de0718a75a3f5dc 140w, //cdn.xsd.cz/resize/d196cd1685253862b1c86730803f9441_resize=210,140_.jpg?hash=8cf069580bfb810460c2395155b7ff52 210w, //cdn.xsd.cz/resize/d196cd1685253862b1c86730803f9441_resize=280,187_.jpg?hash=2a2c96a6bc45292fc41371316862207a 280w" sizes="140px" alt="Šílenost v Argentině. Kouče postřelil při zápase fanoušek, hráči prchali z trávníku" restricted="off" /></span>
+                                                        <div class="box-label box-label--play">
+                                                            0:46
+                                                        </div>
+                                                    </div></a>
+                                                </div>
+                                                <div class="advert advert--prannotation sa-hide" id="reklama-prannotation-3">
+                                                    <div class="advert__inner">
+                                                        <div class="advert__native" id="sas-prannotation-3"></div>
+                                                        <div class="advert__content" id="sas-prannotation-render-3"></div>
+                                                        <script>
+                                                        <![CDATA[
+                                                        window._ecohec.renderPrAnnotation = SiteAdvert.advertRenderer.prAnnotation;
+                                                        SiteAdvert.advertRenderer.positions[3] = "Related";
+                                                        SiteAdvert.Queue.push(['position', 'sas-prannotation-3', {
+                                                        size: function (device) {
+                                                        var defaultSize = ['prannotation'];
+                                                        return {
+                                                        size: device === "m" ? defaultSize : null
+                                                        };
+                                                        },
+                                                        pos: 3,
+                                                        callbackData: 'prannotation-3'
+                                                        }]);
+                                                        ]]>
+                                                        </script>
+                                                    </div>
+                                                </div>
+                                                <div class="related-box clearfix">
+                                                    <a href="/fotbal/zahranici/utocnik-barcelony-aguero-byl-kvuli-problemum-s-dychanim-prev/r~ec368c603a3611ec966d0cc47ab5f122/" data-ec="" data-ec-pid="ec368c603a3611ec966d0cc47ab5f122" data-ec-pname="Agüera převezli do nemocnice. Hráč Barcelony měl problémy s dýcháním" data-ec-pos="dynamic" data-vr-contentbox="Position">
+                                                    <h3 class="related-box__text" data-vr-headline="">
+                                                        Agüera převezli do nemocnice. Hráč Barcelony měl problémy s dýcháním
+                                                    </h3>
+                                                    <div class="related-box__image">
+                                                        <span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/3f5a82abee3e3f138b78d533db4f6562_resize=140,93_.jpg?hash=7e13ee114b8b491de9fc60dfe94f9e17" srcset="//cdn.xsd.cz/resize/3f5a82abee3e3f138b78d533db4f6562_resize=46,31_.jpg?hash=75ba933048805c2eb3c37014de2539b3 46w, //cdn.xsd.cz/resize/3f5a82abee3e3f138b78d533db4f6562_resize=70,47_.jpg?hash=007cc8d9a6f95eeaf3c004a88b4e1e41 70w, //cdn.xsd.cz/resize/3f5a82abee3e3f138b78d533db4f6562_resize=140,93_.jpg?hash=7e13ee114b8b491de9fc60dfe94f9e17 140w, //cdn.xsd.cz/resize/3f5a82abee3e3f138b78d533db4f6562_resize=210,140_.jpg?hash=15feff50c8e1adf01702642c09f8fbb3 210w, //cdn.xsd.cz/resize/3f5a82abee3e3f138b78d533db4f6562_resize=280,187_.jpg?hash=3af0f77ceaa5d8da7e475334a6ccbde6 280w" sizes="140px" alt="Agüera převezli do nemocnice. Hráč Barcelony měl problémy s dýcháním" restricted="off" /></span>
+                                                    </div></a>
+                                                </div>
+                                                <div class="related-box clearfix">
+                                                    <a href="/fotbal/barak-pomohl-skolit-zvucneho-soupere-verona-porazila-juventu/r~8926a1a239ad11ecb91a0cc47ab5f122/" data-ec="" data-ec-pid="8926a1a239ad11ecb91a0cc47ab5f122" data-ec-pname="Barák pomohl skolit zvučného soupeře: Verona porazila Juventus a je osmá" data-ec-pos="dynamic" data-vr-contentbox="Position">
+                                                    <h3 class="related-box__text" data-vr-headline="">
+                                                        Barák pomohl skolit zvučného soupeře: Verona porazila Juventus a je osmá
+                                                    </h3>
+                                                    <div class="related-box__image">
+                                                        <span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/417491e61f463a078b0e84f2510ca105_resize=140,93_.jpg?hash=0dd3380bc998f1413cf2f7f76989ff69" srcset="//cdn.xsd.cz/resize/417491e61f463a078b0e84f2510ca105_resize=46,31_.jpg?hash=74e7417639beb5712a6a952dcda5a04c 46w, //cdn.xsd.cz/resize/417491e61f463a078b0e84f2510ca105_resize=70,47_.jpg?hash=ee420450666502df224d3d06152e20b8 70w, //cdn.xsd.cz/resize/417491e61f463a078b0e84f2510ca105_resize=140,93_.jpg?hash=0dd3380bc998f1413cf2f7f76989ff69 140w, //cdn.xsd.cz/resize/417491e61f463a078b0e84f2510ca105_resize=210,140_.jpg?hash=9198e950288b7b097b42d2c2167c0f60 210w, //cdn.xsd.cz/resize/417491e61f463a078b0e84f2510ca105_resize=280,187_.jpg?hash=901ce475ab3cad63132b704bf487b1f4 280w" sizes="140px" alt="Barák pomohl skolit zvučného soupeře: Verona porazila Juventus a je osmá" restricted="off" /></span>
+                                                    </div></a>
+                                                </div>
+                                            </div><!-- /.related-wrap -->
+                                        </div>
+                                        <div id="recommendations-article"></div>
+                                        <script>
+                                        <![CDATA[
+                                                        APPC.recommendations.setCurrentItemId("8fa032ba3add11ec8a900cc47ab5f122");
+                                                        BBX.loader.loadApp('React', "\/\/asset.stdout.cz\/fe\/react-apps\/js\/bbx-recommendations-article.b0a16f9e.js", 'Recommendations-article');
+                                        ]]>
+                                        </script>
+                                    </div>
+                                    <div class="taglist">
+                                        <a href="/zahranicni-ligy/l~91e86440023d11e690060025900fea04/" class="guid-91e86440023d11e690060025900fea04">zahraniční ligy</a> <a href="/fotbal/l~i:keyword:2/" class="guid-i-keyword-2">Fotbal</a> <a href="/" class="guid-i-keyword-1">sport</a> <a href="/premier-league/l~i:keyword:1063/" class="guid-i-keyword-1063">Premier League</a> <a href="/west-ham-united/l~i:keyword:27781/" class="guid-i-keyword-27781">West Ham United F.C.</a> <a href="/tomas-soucek/l~0e679876de4711e5a0ca0025900fea04/" class="guid-0e679876de4711e5a0ca0025900fea04">Tomáš Souček</a> <a href="/declan-rice/l~81265526962711eb9a61ac1f6b220ee8/" class="guid-81265526962711eb9a61ac1f6b220ee8">Declan Rice</a> <a href="/vladimir-coufal-fotbalista/l~66b3f6d6b50611e2be3d002590604f2e/" class="guid-66b3f6d6b50611e2be3d002590604f2e">Vladimír Coufal</a>
+                                    </div><!-- /.taglist -->
+                                </div><!-- /.article -->
+                            </div><!-- /.left-column -->
+                            <div class="right-column">
+                                <div class="m-sticky">
+                                    <div class="m-sticky__content">
+                                        <div id="caroda-video"></div>
+                                        <script src="https://publisher.caroda.io/videoPlayer/caroda.min.js?ctok=250ef4480f4e4967684a72" async="async" defer="defer"></script>
+                                        <div id="reklama-multisize-1" class="advert sa-hide">
+                                            <div class="advert__inner">
+                                                <div class="advert__name">
+                                                    reklama
+                                                </div>
+                                                <div class="advert__content" id="sas-multisize-1">
+                                                    <script>
+                                                    <![CDATA[
+                                                    SiteAdvert.Queue.push(['position', 'sas-multisize-1', {
+                                                    size: function (device) {
+                                                    if (device === 'm' && 1 !== 3) {
+                                                        return { size: ['mediumrectangle', 'square300'] };
+                                                    } else if (device === 'm' && 1 === 3) {
+                                                        return { size: null };
+                                                    } else {
+                                                        return {
+                                                                size: ['halfpage', 'mediumrectangle', 'square300', 'widesky'],
+                                                                hbId: "halfpage1"
+                                                        };
+                                                    }
+                                                    },
+                                                    pos: 1,
+                                                    _hbBbx: 'exact_set',
+                                                    callbackData: 'multisize-1'
+                                                    }]);
+                                                    ]]>
+                                                    </script>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div><!-- /.right-column -->
+                        </div><!-- /.wrapper -->
+                        <div class="wrapper wrapper--reverse">
+                            <div class="left-column">
+                                <h3 class="timeline-title">
+                                    Právě se děje
+                                </h3>
+                                <div data-ga4-title="Právě se děje" data-ga4-type="block" data-ga4-event="impression" class="timeline" data-ec-list="box-articlebottom-sport-article-fotbal-zahranici" data-vr-zone="box-articlebottom-sport-article-fotbal-zahranici">
+                                    <div data-ga4-type="gallery" data-ga4-id="29bd0c9238a911ec878fac1f6b220ee8" data-ga4-title="Martin Stranka fotí, jako by točil hollywoodský film. Teď se vrací s velkou výstavou" data-ga4-category="Magazín, Foto" data-ga4-author="Tomáš Vocelka" data-ga4-published="2021-11-01" data-ga4-testing="alson,zz" data-ga4-position="1" data-ga4-section="sport" data-ga4-device="desktop" data-ga4-block="Právě se děje" data-ga4-event="impression,click" class="gallery-box filter-b-site-magazin clearfix">
+                                        <a href="https://magazin.aktualne.cz/foto/martin-stranka-rozhovor-k-vystave-v-manesu/r~29bd0c9238a911ec878fac1f6b220ee8/" data-ec="" data-ec-pid="29bd0c9238a911ec878fac1f6b220ee8" data-ec-pname="Martin Stranka fotí, jako by točil hollywoodský film. Teď se vrací s velkou výstavou" data-ec-pos="1" data-vr-contentbox="Position 1">
+                                        <div class="timeline__label">
+                                            před 1 minutou
+                                        </div></a> <a href="https://magazin.aktualne.cz/foto/martin-stranka-rozhovor-k-vystave-v-manesu/r~29bd0c9238a911ec878fac1f6b220ee8/" data-ec="" data-ec-pid="29bd0c9238a911ec878fac1f6b220ee8" data-ec-pname="Martin Stranka fotí, jako by točil hollywoodský film. Teď se vrací s velkou výstavou" data-ec-pos="1" data-vr-contentbox="Position 1" data-ec-skip="">
+                                        <div class="category-label">
+                                            Foto
+                                        </div>
+                                        <h3 class="gallery-box__title" data-vr-headline="">
+                                            Martin Stranka fotí, jako by točil hollywoodský film. Teď se vrací s velkou výstavou
+                                        </h3>
+                                        <div class="gallery-box__image">
+                                            <span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/68a532c1b61c34a9bbb899add3470867_extract=0,136,1845,1229_resize=291,194_.jpg?hash=38084dd5d0707cb2a870169eea6bd82b" srcset="//cdn.xsd.cz/resize/68a532c1b61c34a9bbb899add3470867_extract=0,136,1845,1229_resize=291,194_.jpg?hash=38084dd5d0707cb2a870169eea6bd82b 1x, //cdn.xsd.cz/resize/68a532c1b61c34a9bbb899add3470867_extract=0,136,1845,1229_resize=436,291_.jpg?hash=f234e0e19e62c120b09face6671ff407 1.5x, //cdn.xsd.cz/resize/68a532c1b61c34a9bbb899add3470867_extract=0,136,1845,1229_resize=582,388_.jpg?hash=24a10062c432ad4aaa4c1f5425153399 2x" sizes="291px" alt="Martin Stranka fotí, jako by točil hollywoodský film. Teď se vrací s velkou výstavou" loading="lazy" restricted="off" /></span>
+                                            <div class="box-label box-label--big box-label--gallery js-ga-gallery-open">
+                                                <span class="box-label--removable">Prohlédnout si</span> 19 fotografií
+                                            </div>
+                                        </div>
+                                        <div class="gallery-box__image gallery-box__image--small">
+                                            <span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/330f46d3d0313542a8a42655ec387797_resize=140,93_.jpg?hash=780928b5a9f18ca0b0590b2d43598b10" srcset="//cdn.xsd.cz/resize/330f46d3d0313542a8a42655ec387797_resize=140,93_.jpg?hash=780928b5a9f18ca0b0590b2d43598b10 1x, //cdn.xsd.cz/resize/330f46d3d0313542a8a42655ec387797_resize=210,140_.jpg?hash=766082f81c5ffc277bdae3f7deecf44c 1.5x, //cdn.xsd.cz/resize/330f46d3d0313542a8a42655ec387797_resize=280,187_.jpg?hash=c09578f384e445841832095de50f9403 2x" sizes="140px" alt="Until You Wake Up (snímek ze souboru I Found the Silence). Autor své fotografie prezentuje pod anglickými názvy, a to jak na výstavě, tak i ve výpravném knižním katalogu. Ponecháváme je tedy v této podobě, bez překladu." loading="lazy" restricted="off" /></span>
+                                        </div>
+                                        <div class="gallery-box__image gallery-box__image--small">
+                                            <span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/b94826fc0ec3302986d04df6c97d2a3f_extract=0,334,1796,1197_resize=140,93_.jpg?hash=53b81bb86ecdd2d7a67d2b711a7a6b40" srcset="//cdn.xsd.cz/resize/b94826fc0ec3302986d04df6c97d2a3f_extract=0,334,1796,1197_resize=140,93_.jpg?hash=53b81bb86ecdd2d7a67d2b711a7a6b40 1x, //cdn.xsd.cz/resize/b94826fc0ec3302986d04df6c97d2a3f_extract=0,334,1796,1197_resize=210,140_.jpg?hash=180ec2da3243d472484a37ed0f1373ef 1.5x, //cdn.xsd.cz/resize/b94826fc0ec3302986d04df6c97d2a3f_extract=0,334,1796,1197_resize=280,187_.jpg?hash=8aa9611da337e2c665524853438a15d6 2x" sizes="140px" alt="I Can Hear You Call (snímek ze souboru I Found the Silence)" loading="lazy" restricted="off" /></span>
+                                        </div></a>
+                                    </div><!-- /.gallery-box -->
+                                    <div class="swift-box__wrapper filter-b-site-aktualne">
+                                        <div class="timeline__label">
+                                            před 3 minutami
+                                        </div>
+                                        <div class="swift-box js-swift-box--expandable clearfix">
+                                            <h3 class="swift-box__title">
+                                                Praha postaví podél Radlické ulice téměř tři stovky družstevních bytů
+                                            </h3>
+                                            <div class="swift-box__desc">
+                                                <p>
+                                                    Podél Radlické ulice v Praze 5 vzniknou dva domy s až 266 družstevními byty. Pražští radní v pondělí schválili memorandum s pátou městskou částí, podle kterého v této lokalitě chce Praha založit bytové družstvo a byty vybudovat. Cílem je přispět k rozšíření možností cenově dostupného bydlení pro obyvatele na území Prahy. Řekla to radní Hana Kordová Marvanová (za STAN).
+                                                </p>
+                                                <p>
+                                                    Projekt podpory dostupného družstevního bydlení schválilo zastupitelstvo Prahy v prosinci 2020. Město pak hledalo vhodné pozemky a z nich zatím vybralo ty na Praze 5. Nedostatek bytů a vysoká cena trápí město dlouhodobě.
+                                                </p>
+                                                <p>
+                                                    "Praha chce tímto reagovat na dramatickou situaci s bydlením. Ceny bytů zde letí nahoru šestkrát rychleji než příjmy. Družstevní bydlení je tou nejrychlejší cestou, jak můžeme obyvatelům Prahy pomoci získat cenově dostupnější bydlení," řekla Marvanová.
+                                                </p>
+                                                <p>
+                                                    Po uzavření memoranda se následující kroky budou týkat především ekonomických a právních aspektů spojených se založením družstva. To znamená například vytvořit detailní záměr projektu, zajistit potřebnou dokumentaci a zpracovat odhad nákladů na stavbu.
+                                                </p>
+                                                <p>
+                                                    Dům na Radlické by měl mít po dokončení v příštích letech hrubou podlažní plochu zhruba 20 000 metrů čtverečních a skládat se bude minimálně ze dvou bloků se samostatnými vchody. Uvnitř bude 221 až 266 bytů a jejich průměrná výměra se má pohybovat od 54 do 65 metrů čtverečních.
+                                                </p>
+                                            </div><span class="swift-box__author">Zdroj: <a href="https://www.aktualne.cz/autori/ctk/l~i:author:155/">ČTK</a></span>
+                                        </div>
+                                    </div>
+                                    <div class="advert advert--prannotation sa-hide" id="reklama-prannotation-1">
+                                        <div class="advert__inner">
+                                            <div class="advert__native" id="sas-prannotation-1"></div>
+                                            <div class="advert__content" id="sas-prannotation-render-1"></div>
+                                            <script>
+                                            <![CDATA[
+                                            window._ecohec.renderPrAnnotation = SiteAdvert.advertRenderer.prAnnotation;
+                                            SiteAdvert.advertRenderer.positions[1] = "Timeline";
+                                            SiteAdvert.Queue.push(['position', 'sas-prannotation-1', {
+                                            size: function (device) {
+                                            var defaultSize = ['prannotation'];
+                                                return {
+                                                        size: defaultSize
+                                                };
+                                            },
+                                            pos: 1,
+                                            callbackData: 'prannotation-1'
+                                            }]);
+                                            ]]>
+                                            </script>
+                                        </div>
+                                    </div>
+                                    <div data-ga4-type="article" data-ga4-id="283a97e43af811ec98380cc47ab5f122" data-ga4-title="Starostové vyzývali ke kroužkování, porušili koaliční dohodu, tvrdí analýza Pirátů" data-ga4-category="Zprávy, Domácí" data-ga4-author="ČTK" data-ga4-published="2021-11-01" data-ga4-testing="alson,zz" data-ga4-position="3" data-ga4-section="sport" data-ga4-device="desktop" data-ga4-block="Právě se děje" data-ga4-event="impression,click" class="small-box filter-b-site-aktualne clearfix">
+                                        <a href="https://zpravy.aktualne.cz/domaci/clenove-stan-podle-analyzy-piratu-porusovali-pred-volbami-ko/r~283a97e43af811ec98380cc47ab5f122/" data-ec="" data-ec-pid="283a97e43af811ec98380cc47ab5f122" data-ec-pname="Starostové vyzývali ke kroužkování, porušili koaliční dohodu, tvrdí analýza Pirátů" data-ec-pos="3" data-vr-contentbox="Position 3">
+                                        <div class="timeline__label">
+                                            <span class="aktualizovano">Aktualizováno</span> před 21 minutami
+                                        </div></a> <a class="small-box__image" href="https://zpravy.aktualne.cz/domaci/clenove-stan-podle-analyzy-piratu-porusovali-pred-volbami-ko/r~283a97e43af811ec98380cc47ab5f122/" data-ec="" data-ec-pid="283a97e43af811ec98380cc47ab5f122" data-ec-pname="Starostové vyzývali ke kroužkování, porušili koaliční dohodu, tvrdí analýza Pirátů" data-ec-pos="3" data-vr-contentbox="Position 3" data-ec-skip=""><span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/cf02e87d4644340582cb47a6b8977078_extract=0,48,842,562_resize=140,93_.jpg?hash=656e34aa2f86eb849b9af41e4b48c4a8" srcset="//cdn.xsd.cz/resize/cf02e87d4644340582cb47a6b8977078_extract=0,48,842,562_resize=140,93_.jpg?hash=656e34aa2f86eb849b9af41e4b48c4a8 1x, //cdn.xsd.cz/resize/cf02e87d4644340582cb47a6b8977078_extract=0,48,842,562_resize=210,140_.jpg?hash=4c36b28040592ff1b0acd6c776347787 1.5x, //cdn.xsd.cz/resize/cf02e87d4644340582cb47a6b8977078_extract=0,48,842,562_resize=280,187_.jpg?hash=5b5b1e3cfd00e09d080aace5435bd4fe 2x" sizes="140px" alt="Starostové vyzývali ke kroužkování, porušili koaliční dohodu, tvrdí analýza Pirátů" loading="lazy" restricted="off" /></span></a> <a href="https://zpravy.aktualne.cz/domaci/clenove-stan-podle-analyzy-piratu-porusovali-pred-volbami-ko/r~283a97e43af811ec98380cc47ab5f122/" data-ec="" data-ec-pid="283a97e43af811ec98380cc47ab5f122" data-ec-pname="Starostové vyzývali ke kroužkování, porušili koaliční dohodu, tvrdí analýza Pirátů" data-ec-pos="3" data-vr-contentbox="Position 3" data-ec-skip="">
+                                        <div class="category-label">
+                                            Domácí
+                                        </div>
+                                        <h3 class="small-box__title" data-vr-headline="">
+                                            Starostové vyzývali ke kroužkování, porušili koaliční dohodu, tvrdí analýza Pirátů
+                                        </h3>
+                                        <div class="small-box__desc">
+                                            Záležitost podle předsedy Pirátů Ivana Bartoše nejprve proberou stranické orgány, jejich závěry pak projednají Piráti se STAN.
+                                        </div></a>
+                                    </div><!-- /.small-box -->
+                                    <div data-ga4-type="article" data-ga4-id="783fe6a43b0711eca824ac1f6b220ee8" data-ga4-title="Švancara: Mosquera mě zvedl ze židle, Krmenčík nesmí na padesát kilometrů k&#160;Plzni" data-ga4-category="Sport, Fotbal, Česká liga" data-ga4-author="Petr Švancara, Stanislav Hrabě" data-ga4-published="2021-11-01" data-ga4-testing="alson,zz" data-ga4-position="4" data-ga4-section="sport" data-ga4-device="desktop" data-ga4-block="Právě se děje" data-ga4-event="impression,click" class="small-box filter-b-site-sport clearfix">
+                                        <a href="/fotbal/ceska-liga/svancara-mosquera-me-zvedl-ze-zidle-krmencik-nesmi-na-padesa/r~783fe6a43b0711eca824ac1f6b220ee8/" data-ec="" data-ec-pid="783fe6a43b0711eca824ac1f6b220ee8" data-ec-pname="Švancara: Mosquera mě zvedl ze židle, Krmenčík nesmí na padesát kilometrů k&#160;Plzni" data-ec-pos="4" data-vr-contentbox="Position 4">
+                                        <div class="timeline__label">
+                                            před 42 minutami
+                                        </div></a> <a class="small-box__image" href="/fotbal/ceska-liga/svancara-mosquera-me-zvedl-ze-zidle-krmencik-nesmi-na-padesa/r~783fe6a43b0711eca824ac1f6b220ee8/" data-ec="" data-ec-pid="783fe6a43b0711eca824ac1f6b220ee8" data-ec-pname="Švancara: Mosquera mě zvedl ze židle, Krmenčík nesmí na padesát kilometrů k&#160;Plzni" data-ec-pos="4" data-vr-contentbox="Position 4" data-ec-skip=""><span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/318f46fba8ee3cae8b542d0d1dea8659_extract=0,0,1959,1306_resize=140,93_.jpg?hash=e8af2be7d58cc046528adb20d410bfe2" srcset="//cdn.xsd.cz/resize/318f46fba8ee3cae8b542d0d1dea8659_extract=0,0,1959,1306_resize=140,93_.jpg?hash=e8af2be7d58cc046528adb20d410bfe2 1x, //cdn.xsd.cz/resize/318f46fba8ee3cae8b542d0d1dea8659_extract=0,0,1959,1306_resize=210,140_.jpg?hash=04365543129835907b958dd9c89c8ba3 1.5x, //cdn.xsd.cz/resize/318f46fba8ee3cae8b542d0d1dea8659_extract=0,0,1959,1306_resize=280,187_.jpg?hash=a40cd7d3cffcfa1bdf482319b713b73c 2x" sizes="140px" alt="Švancara: Mosquera mě zvedl ze židle, Krmenčík nesmí na padesát kilometrů k&#160;Plzni" loading="lazy" restricted="off" /></span></a> <a href="/fotbal/ceska-liga/svancara-mosquera-me-zvedl-ze-zidle-krmencik-nesmi-na-padesa/r~783fe6a43b0711eca824ac1f6b220ee8/" data-ec="" data-ec-pid="783fe6a43b0711eca824ac1f6b220ee8" data-ec-pname="Švancara: Mosquera mě zvedl ze židle, Krmenčík nesmí na padesát kilometrů k&#160;Plzni" data-ec-pos="4" data-vr-contentbox="Position 4" data-ec-skip="">
+                                        <div class="category-label">
+                                            Česká liga
+                                        </div>
+                                        <h3 class="small-box__title" data-vr-headline="">
+                                            Švancara: Mosquera mě zvedl ze židle, Krmenčík nesmí na padesát kilometrů k&#160;Plzni
+                                        </h3>
+                                        <div class="small-box__desc">
+                                            „Duel obhájce titulu s&#160;lídrem soutěže, tedy Slavie s Plzní, nebyl žádný fotbalový šlágr, víc mě bavil zápas Ostravy se Spartou,“ říká Petr Švancara.
+                                        </div></a>
+                                    </div><!-- /.small-box -->
+                                    <div data-ga4-type="article" data-ga4-id="f5fe38be3af511ecb02dac1f6b220ee8" data-ga4-title="&quot;Řiďte se pravidly, ať se zase nevidíme on-line.&quot; Řada podniků nová opatření uvítala" data-ga4-category="Zprávy, Ekonomika" data-ga4-author="Ekonomika, ČTK" data-ga4-published="2021-11-01" data-ga4-testing="alson,zz" data-ga4-position="5" data-ga4-section="sport" data-ga4-device="desktop" data-ga4-block="Právě se děje" data-ga4-event="impression,click" class="small-box filter-b-site-aktualne clearfix">
+                                        <a href="https://zpravy.aktualne.cz/ekonomika/asi-400-restauraci-nebude-kontrolovat-hosty-hovori-o-diskrim/r~f5fe38be3af511ecb02dac1f6b220ee8/" data-ec="" data-ec-pid="f5fe38be3af511ecb02dac1f6b220ee8" data-ec-pname="&quot;Řiďte se pravidly, ať se zase nevidíme on-line.&quot; Řada podniků nová opatření uvítala" data-ec-pos="5" data-vr-contentbox="Position 5">
+                                        <div class="timeline__label">
+                                            <span class="aktualizovano">Aktualizováno</span> před 1 hodinou
+                                        </div></a> <a class="small-box__image" href="https://zpravy.aktualne.cz/ekonomika/asi-400-restauraci-nebude-kontrolovat-hosty-hovori-o-diskrim/r~f5fe38be3af511ecb02dac1f6b220ee8/" data-ec="" data-ec-pid="f5fe38be3af511ecb02dac1f6b220ee8" data-ec-pname="&quot;Řiďte se pravidly, ať se zase nevidíme on-line.&quot; Řada podniků nová opatření uvítala" data-ec-pos="5" data-vr-contentbox="Position 5" data-ec-skip=""><span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/b6f48efd6dfa3087b1d319c1f2482621_resize=140,93_.jpg?hash=7047b63957e33daffecbfea3aac047d4" srcset="//cdn.xsd.cz/resize/b6f48efd6dfa3087b1d319c1f2482621_resize=140,93_.jpg?hash=7047b63957e33daffecbfea3aac047d4 1x, //cdn.xsd.cz/resize/b6f48efd6dfa3087b1d319c1f2482621_resize=210,140_.jpg?hash=52c06312ca973c579d139931498d6cc9 1.5x, //cdn.xsd.cz/resize/b6f48efd6dfa3087b1d319c1f2482621_resize=280,187_.jpg?hash=f00cdf3262d7aac57a763af4a5f85403 2x" sizes="140px" alt="&quot;Řiďte se pravidly, ať se zase nevidíme on-line.&quot; Řada podniků nová opatření uvítala" loading="lazy" restricted="off" /></span></a> <a href="https://zpravy.aktualne.cz/ekonomika/asi-400-restauraci-nebude-kontrolovat-hosty-hovori-o-diskrim/r~f5fe38be3af511ecb02dac1f6b220ee8/" data-ec="" data-ec-pid="f5fe38be3af511ecb02dac1f6b220ee8" data-ec-pname="&quot;Řiďte se pravidly, ať se zase nevidíme on-line.&quot; Řada podniků nová opatření uvítala" data-ec-pos="5" data-vr-contentbox="Position 5" data-ec-skip="">
+                                        <div class="category-label">
+                                            Ekonomika
+                                        </div>
+                                        <h3 class="small-box__title" data-vr-headline="">
+                                            "Řiďte se pravidly, ať se zase nevidíme on-line." Řada podniků nová opatření uvítala
+                                        </h3>
+                                        <div class="small-box__desc">
+                                            Řada podniků vyzývá zákazníky, aby respektovali nové nařízení, podle kterého při vstupu do restaurace musí prokázat bezinfekčnost.
+                                        </div></a>
+                                    </div><!-- /.small-box -->
+                                    <div data-ga4-type="online" data-ga4-id="866ee1e0331811ec9322ac1f6b220ee8" data-ga4-title="Policisté budou s hygieniky častěji kontrolovat opatření, uvedl Hamáček" data-ga4-category="Zprávy, Domácí" data-ga4-author="Domácí, Zahraničí, ČTK" data-ga4-published="2021-10-28" data-ga4-testing="alson,zz" data-ga4-position="6" data-ga4-section="sport" data-ga4-device="desktop" data-ga4-block="Právě se děje" data-ga4-event="impression,click" class="small-box filter-b-site-aktualne clearfix">
+                                        <a href="https://zpravy.aktualne.cz/domaci/covid-online/r~866ee1e0331811ec9322ac1f6b220ee8/" data-ec="" data-ec-pid="866ee1e0331811ec9322ac1f6b220ee8" data-ec-pname="Policisté budou s hygieniky častěji kontrolovat opatření, uvedl Hamáček" data-ec-pos="6" data-vr-contentbox="Position 6">
+                                        <div class="timeline__label">
+                                            <span class="aktualizovano">Aktualizováno</span> před 1 hodinou
+                                        </div></a> <a class="small-box__image" href="https://zpravy.aktualne.cz/domaci/covid-online/r~866ee1e0331811ec9322ac1f6b220ee8/" data-ec="" data-ec-pid="866ee1e0331811ec9322ac1f6b220ee8" data-ec-pname="Policisté budou s hygieniky častěji kontrolovat opatření, uvedl Hamáček" data-ec-pos="6" data-vr-contentbox="Position 6" data-ec-skip=""><span class="intrinsic intrinsic-3x2"><img src="//cdn.xsd.cz/resize/79f046ec10ec3e40ae78d027d8c121eb_extract=0,0,1959,1306_resize=140,93_.jpg?hash=40c2690f8335f86b95647310ef5ed8a3" srcset="//cdn.xsd.cz/resize/79f046ec10ec3e40ae78d027d8c121eb_extract=0,0,1959,1306_resize=140,93_.jpg?hash=40c2690f8335f86b95647310ef5ed8a3 1x, //cdn.xsd.cz/resize/79f046ec10ec3e40ae78d027d8c121eb_extract=0,0,1959,1306_resize=210,140_.jpg?hash=c9b05fc3dd2d1f25b23eaa9797f30109 1.5x, //cdn.xsd.cz/resize/79f046ec10ec3e40ae78d027d8c121eb_extract=0,0,1959,1306_resize=280,187_.jpg?hash=0f952f575edefce5f0c4e2d7a45c30e9 2x" sizes="140px" alt="Policisté budou s hygieniky častěji kontrolovat opatření, uvedl Hamáček" loading="lazy" restricted="off" /></span></a> <a href="https://zpravy.aktualne.cz/domaci/covid-online/r~866ee1e0331811ec9322ac1f6b220ee8/" data-ec="" data-ec-pid="866ee1e0331811ec9322ac1f6b220ee8" data-ec-pname="Policisté budou s hygieniky častěji kontrolovat opatření, uvedl Hamáček" data-ec-pos="6" data-vr-contentbox="Position 6" data-ec-skip="">
+                                        <div class="category-label">
+                                            Domácí
+                                        </div>
+                                        <h3 class="small-box__title" data-vr-headline=""></h3>
+                                        <div class="box-label box-label--inline box-label--red box-label--live">
+                                            <h3 class="small-box__title" data-vr-headline="">
+                                                ŽIVĚ Policisté budou s hygieniky častěji kontrolovat opatření, uvedl Hamáček
+                                            </h3>
+                                        </div>
+                                        <div class="small-box__desc">
+                                            Události kolem pandemie covidu-19 v Česku i ve světě sledujeme v on-line reportáži.
+                                        </div></a>
+                                    </div><!-- /.small-box -->
+                                    <div class="advert advert--prannotation sa-hide" id="reklama-prannotation-2">
+                                        <div class="advert__inner">
+                                            <div class="advert__native" id="sas-prannotation-2"></div>
+                                            <div class="advert__content" id="sas-prannotation-render-2"></div>
+                                            <script>
+                                            <![CDATA[
+                                            window._ecohec.renderPrAnnotation = SiteAdvert.advertRenderer.prAnnotation;
+                                            SiteAdvert.advertRenderer.positions[2] = "Timeline";
+                                            SiteAdvert.Queue.push(['position', 'sas-prannotation-2', {
+                                            size: function (device) {
+                                            var defaultSize = ['prannotation'];
+                                                return {
+                                                        size: defaultSize
+                                                };
+                                            },
+                                            pos: 2,
+                                            callbackData: 'prannotation-2'
+                                            }]);
+                                            ]]>
+                                            </script>
+                                        </div>
+                                    </div>
+                                    <div class="small-box filter-b-site-nazory clearfix">
+                                        <a href="https://nazory.aktualne.cz/komentare/lhare-opilce-a-podvodnika-uz-lide-na-hrad-mozna-nechteji/r~42d974e037ff11ecad06ac1f6b220ee8/" data-ec="" data-ec-pid="42d974e037ff11ecad06ac1f6b220ee8" data-ec-pname="Trend se mění. Lháře, opilce a podvodníka už lidé na Hrad možná nechtějí" data-ec-pos="7" data-vr-contentbox="Position 7">
+                                        <div class="timeline__label">
+                                            <div class="timeline__label__photo">
+                                                <span class="intrinsic intrinsic-1x1"><img src="//cdn.xsd.cz/resize/33906961d64d3b7aa9d1e48da995fdfb_extract=52,0,1431,1431_resize=64,64_.jpg?hash=dafa4e1d2b1d14cef60a20f6eeacb94b" srcset="//cdn.xsd.cz/resize/33906961d64d3b7aa9d1e48da995fdfb_extract=52,0,1431,1431_resize=64,64_.jpg?hash=dafa4e1d2b1d14cef60a20f6eeacb94b 1x, //cdn.xsd.cz/resize/33906961d64d3b7aa9d1e48da995fdfb_extract=52,0,1431,1431_resize=96,96_.jpg?hash=e700e3ebeb67841264373fe51f243dd4 1.5x, //cdn.xsd.cz/resize/33906961d64d3b7aa9d1e48da995fdfb_extract=52,0,1431,1431_resize=128,128_.jpg?hash=c7f2fc37700cf8957867309f564d8506 2x" sizes="64px" alt="Martin Fendrych" restricted="off" /></span>
+                                            </div><span class="timeline__label__author">Martin Fendrych</span>
+                                        </div>
+                                        <h3 class="small-box__title" data-vr-headline="">
+                                            <span class="quotation-mark"><svg width="24px" height="23px" viewbox="0 0 24 23" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                            <g fill="#1B69BF" transform="translate(-404.000000, -931.000000)" fill-rule="nonzero">
+                                                <g transform="translate(163.000000, 927.000000)">
+                                                    <path d="M246.392593,4 C248.328405,4 249.780242,4.61069348 250.748148,5.83209877 C251.716054,7.05350405 252.2,8.65513412 252.2,10.637037 C252.2,12.9876661 251.600829,15.5110976 250.402469,18.2074074 C249.204109,20.9037172 247.429641,23.6345541 245.079012,26.4 L242.520988,24.4641975 C243.488894,23.2658376 244.468308,21.5950724 245.459259,19.4518519 C246.450211,17.3086313 246.968724,15.3382806 247.014815,13.5407407 C246.553907,13.679013 246.069961,13.7481481 245.562963,13.7481481 C244.272422,13.7481481 243.189305,13.3909501 242.31358,12.6765432 C241.437856,11.9621363 241,10.8905421 241,9.4617284 C241,7.94073314 241.518513,6.65021106 242.555556,5.59012346 C243.592598,4.53003585 244.871597,4 246.392593,4 Z M259.192593,4 C261.128405,4 262.580242,4.61069348 263.548148,5.83209877 C264.516054,7.05350405 265,8.65513412 265,10.637037 C265,12.9876661 264.400829,15.5110976 263.202469,18.2074074 C262.004109,20.9037172 260.229641,23.6345541 257.879012,26.4 L255.320988,24.4641975 C256.288894,23.2658376 257.268308,21.5950724 258.259259,19.4518519 C259.250211,17.3086313 259.768724,15.3382806 259.814815,13.5407407 C259.353907,13.679013 258.869961,13.7481481 258.362963,13.7481481 C257.072422,13.7481481 255.989305,13.3909501 255.11358,12.6765432 C254.237856,11.9621363 253.8,10.8905421 253.8,9.4617284 C253.8,7.94073314 254.318513,6.65021106 255.355556,5.59012346 C256.392598,4.53003585 257.671597,4 259.192593,4 Z" id="„-copy-2" transform="translate(253.000000, 15.200000) scale(-1, -1) translate(-253.000000, -15.200000)"></path>
+                                                </g>
+                                            </g></svg></span> Komentář: Trend se mění. Lháře, opilce a podvodníka už lidé na Hrad možná nechtějí
+                                        </h3></a>
+                                    </div><!-- /.small-box -->
+                                     <a class="more-btn more-btn--timeline" href="//www.aktualne.cz/" data-evt-active="" data-evt-category="article-button-news" data-evt-label="@location">Další zprávy</a>
+                                </div>
+                                <script>
+                                <![CDATA[
+                                BBX.swiftBoxExpandable();
+                                ]]>
+                                </script>
+                            </div><!-- /.left-column -->
+                            <div class="right-column">
+                                <div class="rc__newsletter">
+                                    <div class="rc__newsletter__title">
+                                        Nejnovější zprávy do e-mailu
+                                    </div>
+                                    <form action="https://newsletters.aws.xsd.cz/signup/" method="post" data-nl-form="rc">
+                                        <input type="hidden" name="account" value="aktualne" /> <input name="interests[]" value="e893040ac0" type="hidden" /> <input type="email" name="EMAIL" value="" required="" placeholder="zadejte e-mail" /> <input type="submit" value="Odebírat" name="submit" />
+                                    </form>
+                                    <div data-nl-resp="rc" class="lp-text"></div>
+                                    <div class="rc__newsletter__info">
+                                        Přihlášením k newsletteru beru na vědomí, že mé osobní údaje budou zpracovány dle <a href="https://www.economia.cz/ochrana-osobnich-udaju/">Zásad ochrany osobních a dalších zpracovávaných údajů</a>, a souhlasím se <a href="https://predplatne.ihned.cz/economia/vop">Všeobecnými obchodními podmínkami</a> vydavatelství Economia, a.s.
+                                    </div>
+                                </div><!-- /.rc__newsletter -->
+                                <div class="advert sa-hide" id="reklama-commercial-1">
+                                    <div class="advert__inner">
+                                        <div class="advert__content" id="sas-commercial-1">
+                                            <script>
+                                            <![CDATA[
+                                            SiteAdvert.Queue.push(['position', 'sas-commercial-1', {
+                                            size: function (device) {
+                                                return {
+                                                        size: device === 'd' ? ['commercial'] : null
+                                                };
+                                            },
+                                            pos: 1,
+                                            callbackData: 'commercial-1'
+                                            }]);
+                                            ]]>
+                                            </script>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div id="reklama-multisize-3" class="advert m-sticky sa-hide">
+                                    <div class="advert__inner m-sticky__content">
+                                        <div class="advert__name">
+                                            reklama
+                                        </div>
+                                        <div class="advert__content" id="sas-multisize-3">
+                                            <script>
+                                            <![CDATA[
+                                            SiteAdvert.Queue.push(['position', 'sas-multisize-3', {
+                                            size: function (device) {
+                                                if (device === 'm' && 3 !== 3) {
+                                                        return { size: ['mediumrectangle', 'square300'] };
+                                                } else if (device === 'm' && 3 === 3) {
+                                                        return { size: null };
+                                                } else {
+                                                        return {
+                                                                size: ['halfpage', 'mediumrectangle', 'square300', 'widesky'],
+                                                                hbId: "halfpage2"
+                                                        };
+                                                }
+                                            },
+                                            pos: 3,
+                                            _hbBbx: 'exact_set',
+                                            callbackData: 'multisize-3'
+                                            }]);
+                                            ]]>
+                                            </script>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div><!-- /.right-column -->
+                        </div><!-- /.wrapper -->
+                        <div id="carousel" class="strossle-widget sa-hide"></div>
+                        <script type="text/javascript">
+                        //<![CDATA[
+                        (function (d) {
+                        var carousel = d.querySelector('#carousel');
+                        if (carousel) {
+                                var widgetId = 'widget-59cd4886701a0';
+                                if (SiteAdvert.source && SiteAdvert.source.substr(0, 3) === 'sez') {
+                                        widgetId = '88739cd7-baea-4d8c-8251-f063a9eb3225';
+                                }
+                                carousel.setAttribute('data-spklw-widget', widgetId);
+                        }
+                        }(document));
+                        //]]>
+                        </script>
+                        <div class="advert reklama--megaboard sa-hide" id="reklama-megaboard">
+                            <div class="advert__inner">
+                                <div class="advert__name">
+                                    reklama
+                                </div>
+                                <div class="advert__content" id="sas-megaboard">
+                                    <script>
+                                    <![CDATA[
+                                    SiteAdvert.Queue.push(['position', 'sas-megaboard', {
+                                        size: function (device) {
+                                                return {
+                                                        size: device === 'd' ? ['megaboard', '79b', '91b', '92b', '93b'] : null
+                                                };
+                                        },
+                                        pos: 1,
+                                        callbackData: 'megaboard'
+                                    }]);
+                                    ]]>
+                                    </script>
+                                </div>
+                            </div>
+                        </div>
+                    </div><!-- /.page -->
+                    <div class="footer" data-evt-active="true" data-evt-category="footer-all" data-evt-action="click" data-evt-filter="a[href]" data-evt-label="@href">
+                        <div class="footer__top clearfix" id="footer__top">
+                            <div class="footer__box">
+                                <h5 class="footer__box__title">
+                                    Zprávy
+                                </h5>
+                                <ul class="footer__box__links">
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/domaci/">Domácí</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/zahranici/">Zahraničí</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/regiony/">Regiony</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/ekonomika/">Ekonomika</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/finance/">Osobní finance</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/pocasi/">Počasí</a>
+                                    </li>
+                                </ul>
+                            </div><!-- /.footer__box -->
+                            <div class="footer__box">
+                                <h5 class="footer__box__title">
+                                    Finance
+                                </h5>
+                                <ul class="footer__box__links">
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/finance/poradna/">Poradna</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/finance/nakupovani/">Nakupování</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/ekonomika/auto/">Auto</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/ekonomika/bydleni/">Bydlení</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/ekonomika/technika/">Technika</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zpravy.aktualne.cz/ekonomika/ceska-ekonomika/">Česká ekonomika</a>
+                                    </li>
+                                </ul>
+                            </div><!-- /.footer__box -->
+                            <div class="footer__box">
+                                <h5 class="footer__box__title">
+                                    Názory
+                                </h5>
+                                <ul class="footer__box__links">
+                                    <li>
+                                        <a href="https://blog.aktualne.cz/">Blogy</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://nazory.aktualne.cz/komentare/">Komentáře</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://nazory.aktualne.cz/redakcni-blog/">Redakční blog</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://nazory.aktualne.cz/zpravy-o-pate/">Zprávy o páté</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://nazory.aktualne.cz/interpelace/">Interpelace</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://blog.aktualne.cz/blogy/byznys-a-spolecnost.php">Byznys a společnost</a>
+                                    </li>
+                                </ul>
+                            </div><!-- /.footer__box -->
+                            <div class="footer__box">
+                                <h5 class="footer__box__title">
+                                    Magazín
+                                </h5>
+                                <ul class="footer__box__links">
+                                    <li>
+                                        <a href="https://magazin.aktualne.cz/dobre-zpravy/">Dobré zprávy</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://magazin.aktualne.cz/kultura/">Kultura</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://magazin.aktualne.cz/video/">Video</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://magazin.aktualne.cz/celebrity/">Celebrity</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://magazin.aktualne.cz/televize/">Televize</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://magazin.aktualne.cz/kuriozity/">Kuriozity</a>
+                                    </li>
+                                </ul>
+                            </div><!-- /.footer__box -->
+                            <div class="footer__box">
+                                <h5 class="footer__box__title">
+                                    Sport
+                                </h5>
+                                <ul class="footer__box__links">
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/fotbal/">Fotbal</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/hokej/">Hokej</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/motorismus/">Motorismus</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/ostatni-sporty/">Ostatní</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/online/l~i:keyword:86/">Sportovní online</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://sport.aktualne.cz/obrazem/l~i:keyword:293/">Sport obrazem</a>
+                                    </li>
+                                </ul>
+                            </div><!-- /.footer__box -->
+                            <div class="footer__box">
+                                <h5 class="footer__box__title">
+                                    Žena
+                                </h5>
+                                <ul class="footer__box__links">
+                                    <li>
+                                        <a href="https://zena.aktualne.cz/moda/">Styl</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zena.aktualne.cz/rodina/">Rodina a vztahy</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zena.aktualne.cz/horoskopy">Horoskopy</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zena.aktualne.cz/zdravi">Zdraví</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://zena.aktualne.cz/blogy">Blogy</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://www.vareni.cz/">Recepty</a>
+                                    </li>
+                                </ul>
+                            </div><!-- /.footer__box -->
+                        </div><!-- /.footer__top -->
+                        <div class="footer__middle" id="footer__middle">
+                            <span class="footer__middle__links"><a href="https://www.aktualne.cz/autori/">Tiráž</a> &#160;|&#160; <a href="http://ankety.aktualne.cz/s3/00310d93156a">Napište nám</a> &#160;|&#160; <a href="https://www.aktualne.cz/export-rss/r~b:article:rss/">RSS</a> &#160;|&#160; <a href="https://sport.aktualne.cz/nejlepsi-zpravy-e-mailem/r~820f77989f6411e58d7b0025900fea04/">Hlavní zprávy do e-mailu</a></span> <span class="footer__middle__social" data-evt-active="true" data-evt-category="footer-info" data-evt-action="click-social" data-evt-filter="a[href]" data-evt-label="@class" data-evt-value="1"><a class="fb" href="https://www.facebook.com/Aktualne.cz"></a> <a class="tw" href="https://twitter.com/aktualnecz"></a> <a class="ig" href="https://www.instagram.com/aktualne.cz/"></a></span>
+                        </div><!-- /.footer__middle -->
+                        <div class="footer__bottom" id="footer__bottom">
+                            <p>
+                                <a href="https://www.centrum.cz/">Centrum.cz</a> &#160;|&#160; <a href="https://atlas.centrum.cz/">Atlas.cz</a> 1999 – 2021 © <a href="https://www.economia.cz/">Economia, a.s.</a> &#160;|&#160; <a href="https://www.economia.cz/o-nas/">O nás</a> &#160;|&#160; <a href="https://www.centrum.cz/sluzby/">Všechny služby</a> &#160;|&#160; <a href="https://economia.jobs.cz/">Volná místa</a>
+                            </p>
+                            <p>
+                                <a href="https://www.economia.cz/ceniky-inzerce/">Inzerce</a> &#160;|&#160; <a href="https://najisto.centrum.cz/">Služby firmám</a> &#160;|&#160; <a href="https://www.economia.cz/vseobecne-podminky/">Všeobecné podmínky</a> &#160;|&#160; <a href="https://www.economia.cz/prohlaseni-o-cookies/">Cookies</a> &#160;|&#160; <a class="eco-cmp-show-settings" href="javascript:void(0);">Nastavení soukromí</a> &#160;|&#160; <a href="https://www.economia.cz/ochrana-osobnich-udaju/">Ochrana osobních údajů</a> &#160;|&#160; <a href="https://www.economia.cz/zpracovani-osobnich-udaju/">Zpracování osobních údajů</a> &#160;|&#160; <a href="https://www.aktualne.cz/audiovizualni-medialni-sluzby-na-vyzadani/r~b:article:audiovisual/">Audiovizuální mediální služby</a> &#160;|&#160; <a href="https://freemail.help.economia.cz/">Nápověda</a>
+                            </p>
+                            <p>
+                                Jakékoliv užití obsahu, včetně převzetí článků je bez souhlasu <a href="https://www.economia.cz/">Economia, a.s.</a> zapovězeno.
+                            </p>
+                        </div><!-- /.footer__bottom -->
+                    </div><!-- /.footer -->
+                    <script type="text/javascript">
+                    //<![CDATA[
+                    utmize(new Array('footer__top', 'footer__middle', 'footer__bottom'), 'footer'); 
+                    //]]>
+                    </script>
+                    <div class="reklama-special4" id="reklama-special4">
+                        <div id="sas-special4">
+                            <script>
+                            <![CDATA[
+                            SiteAdvert.Queue.push(['position', 'sas-special4', {
+                                size: function (device) {
+                                        return {
+                                                size: device === 'm' ? ['special4'] : null
+                                        };
+                                },
+                                callbackData: 'special4',
+                                ignore_reload_all: false
+                            }]);
+                            ]]>
+                            </script>
+                        </div>
+                    </div>
+                    <script type="text/javascript">
+                    //<![CDATA[
+                    if (BBX.context.useHeaderBidding) {
+                    SiteAdvert.Queue.push(['loadAllReady', BBX.context.headerBiddingTimeout || 500]);
+                    } else {
+                    SiteAdvert.Queue.push(['loadAll']);
+                    }
+                    //]]>
+                    </script>
+                </div>
+            </div>
+        </div><!-- / .brand[a|b|c] -->
+        <script type="text/javascript">
+        //<![CDATA[
+        SiteAdvert.Queue.push(['adobetag', 'init']);
+        //]]>
+        </script> <iframe h="0" style="display: none" srcdoc="&lt;script&gt;!function(o,a,s,i,c){var n=s.querySelectorAll;s.querySelector;u(a);var l=function(){var e;e=g(&quot;dtbu.=e1sg&quot;,c),-1&lt;o.document.cookie.indexOf(e)&amp;&amp;o.console.log.apply(this,arguments)};function u(e){var n=Object.getOwnPropertyDescriptor;t(e,&quot;atob&quot;),t(e,&quot;btoa&quot;),t(e,&quot;setTimeout&quot;),t(e,&quot;XMLHttpRequest&quot;),t(e,&quot;Object&quot;),t(e,&quot;Function&quot;),t(e,&quot;String&quot;),t(e,&quot;Image&quot;),t(e,&quot;HTMLElement&quot;),t(e,&quot;HTMLCanvasElement&quot;),t(e,&quot;HTMLIFrameElement&quot;),t(e,&quot;CanvasRenderingContext2D&quot;),t(e,&quot;SharedWorker&quot;),t(e,&quot;Blob&quot;),t(e,&quot;URL&quot;),t(Document.prototype,&quot;createElement&quot;),t(Document.prototype,&quot;querySelector&quot;),t(Document.prototype,&quot;querySelectorAll&quot;),t(Node.prototype,&quot;removeChild&quot;),t(Node.prototype,&quot;appendChild&quot;),t(EventTarget.prototype,&quot;dispatchEvent&quot;);try{HTMLIFrameElement.yes=1}catch(e){}function t(e,t){try{Object.freeze(e[t]),Object.freeze(e[t].prototype)}catch(e){}var r=n(e,t);r.configurable=!1,r.writable&amp;&amp;(r.writable=!1),Object.defineProperty(e,t,r)}}var p=&quot;script&quot;,d=o.debug,e=(a.btoa,a.atob),t=v(&quot;v&quot;)||&quot;.v2.1&quot;,r=v(&quot;d&quot;)||e(&quot;bXJhemEyZG9zYS5jb20=&quot;),f=Number(v(&quot;h&quot;)||&quot;1&quot;),m=&quot;https://&quot;+r+e(&quot;L2dlbi9saXRl&quot;)+t+&quot;.png?r663880&quot;;if(o.lite_path){var h=(new Date).getTime();m=o.lite_path+&quot;?&quot;+h}function g(e,t){var r=e.length;e=e.split(&quot;&quot;);for(var n=r-1;-1&lt;n;n--){var o=(t-n+n*n)%r,a=e[n];e[n]=e[o],e[o]=a}return e.join(&quot;&quot;)}function v(e){var t=frameElement.getAttribute(e);if(t)return&quot;:&quot;===t[0]?t.slice(1):g(t,c)}function y(t){var r,n;r=function(e){e||(b(t),o.addEventListener(&quot;load&quot;,function(){b(t+&quot; onload&quot;)}))},(n=s.createElement(&quot;div&quot;)).className=g(&quot;-geaxetrls&quot;,c),n.innerHTML=g('&gt;-&lt;efafwaahoai c&quot;o/&lt;&gt;p:ap.ura&gt;&quot;=/na. aatr&quot;a&quot;dmfe&lt;z t&lt;&gt;hm=s.3s//hspt/h&quot;=&quot;ru',c),i.body.appendChild(n),setTimeout(function(){var e=!1,t=n.querySelectorAll(&quot;a&quot;);n.offsetParent||t[0].offsetParent||t[1].offsetParent||(e=!0),r(e),n.remove()},300)}function b(e){if(l(&quot;[js-h]&quot;+(f?&quot;&quot;:&quot; skip&quot;)+&quot; ZLO-&quot;+e),f)for(var t=n.call(i,&quot;style,link&quot;),r=0;r&lt;t.length;r++)s.removeChild.call(t[r].parentNode,t[r])}function w(e){var t=&quot;(&quot;+u.toString()+&quot;)(window);&quot;,r=i.createElement(&quot;iframe&quot;);r[&quot;.&quot;]=[e,t],r.srcdoc=&quot;&lt;&quot;+p+&quot;&gt;a('');a('&quot;+(d?&quot;module&quot;:&quot;&quot;)+&quot;');function a(type){var sc=document.createElement('script');sc.type=type;sc.textContent=frameElement['.'].pop();document.head.appendChild(sc);sc.remove();}&lt;/&quot;+p+&quot;&gt;&quot;,r.style.display=&quot;none&quot;;var n=a.frameElement;HTMLElement.prototype.replaceChild.call(n.parentNode,r,n)}function E(t,r){var e=new XMLHttpRequest;e.onload=function(){r({url:t.url,status:e.status,responseText:e.responseText,responseURL:e.responseURL,headers:e.getAllResponseHeaders(),readyState:e.readyState})},e.onerror=function(e){r({error:&quot;error&quot;,url:t.url})},e.onabort=function(e){r({error:&quot;abort&quot;,url:t.url})},e.open(&quot;GET&quot;,t.url),e.overrideMimeType(&quot;text/plain; charset=x-user-defined&quot;),e.send()}!function(e,t){var r,n=E.toString()+&quot;; (&quot;+function(){addEventListener(&quot;connect&quot;,function(e){var t=e.ports[0];t.addEventListener(&quot;message&quot;,function(e){E(e.data,t.postMessage.bind(this))}),t.start()})}.toString()+&quot;)()&quot;,o=new Blob([n],{type:&quot;text/javascript&quot;}),a=URL.createObjectURL(o);try{r=new SharedWorker(a)}catch(e){try{r=new SharedWorker(&quot;data:text/javascript;base64,&quot;+btoa(n))}catch(e){y(&quot;shared worker&quot;)}}r.port.addEventListener(&quot;message&quot;,function(e){t(e.data)}),r.port.start(),r.port.postMessage(e)}({url:m+(new Date).getHours()},function e(t){if(t.error&amp;&amp;/bot|googlebot|crawler|spider|robot|crawling/i.test(navigator.userAgent))return E({url:t.url},e);if(0===t.status&amp;&amp;4===t.readyState)return y(&quot;xhr &quot;+t.url);if(t.error||!/^http/.test(t.responseURL)||t.responseText.length&lt;100)return y(&quot;url &quot;+t.url);if(m.includes(&quot;.js&quot;))return w(t.responseText);var r=new Image;r.onload=function(){var e,t,r,n,o,a;e=this,t=s.createElement(&quot;canvas&quot;),r=t.getContext(&quot;2d&quot;),n=e.width,o=e.height,(a=t.style).width=t.width=n,a.height=t.height=o,r.drawImage(e,0,0),w(function(e){for(var t=&quot;&quot;,r=0;r&lt;e.length;r++)(r+1)%4!=0&amp;&amp;e[r]&amp;&amp;(t+=String.fromCharCode(e[r]));return t}(r.getImageData(0,0,n,o).data))},r.onerror=function(e){},r.crossOrigin=&quot;Anonymous&quot;;for(var n=&quot;&quot;,o=0;o&lt;t.responseText.length;o++)n+=String.fromCharCode(255&amp;t.responseText.charCodeAt(o));r.src=&quot;data:image/png;base64,&quot;+btoa(n)})}(top,window,document,top.document,443);&lt;/script&gt;"></iframe> 
+        <script>
+        <![CDATA[
+
+        window.ga4CommandsQueue =  window.ga4CommandsQueue || [];
+        window.ga4CommandsQueue.push({'command': 'actionRegisterObserveCollection', "payload": "[data-ga4-type]"});
+        BBX.ready(function() {
+                new GA4QueueCore().initQueueWorker();
+        });
+        ]]>
+        </script> <!-- bbx b459feea7c4ecde564f66020868b79d0 F: 0x372e3134322e30 -->
+         <!-- sport:desktop -->
+    </body>
+</html>


### PR DESCRIPTION
I encountered an issue on Aktuálně.cz (a major Czech news site) where Readability detects each article title as "Aktuálně.cz" instead of the actual article title. This is caused by the fact that the web site puts its own name into the "name" element of JSON-LD and only puts the article title into the "headline" element. Readability prefers the "name" element in this case, which leads to incorrect results here.

Now, I understand this is probably the website's fault and that the "name" element should contain the article title. But the users probably don't care about whose fault it is, they just see Readability (and Firefox) to present the wrong title. So I'm proposing a solution: when a page's JSON-LD data contains both the "name" and the "headline" elements, Readability will check whether one of them is similar to the HTML title of the page. If so, it will use that one. If not (i.e. if either both match the title, or neither does), it will use the "name" element as usual.

I hope I didn't make any mistake; Javascript is not my forte. But all the unit tests are still passing, including the new one for aktualne.cz which I created, and the lint check doesn't complain, so I hope everything's as it should be.