### PR TITLE
Updated Readability Title Parsing

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1443,6 +1443,9 @@ Readability.prototype = {
         }
       }
     });
+    if (metadata && doc.title) {
+      metadata.title = doc.title;
+    }
     return metadata ? metadata : {};
   },
 

--- a/test/test-pages/aclu/expected-metadata.json
+++ b/test/test-pages/aclu/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Facebook Is Tracking Me Even Though I’m Not on Facebook",
+  "title": "Facebook Is Tracking Me Even Though I’m Not on Facebook | American Civil Liberties Union",
   "byline": "Daniel Kahn Gillmor",
   "dir": "ltr",
   "excerpt": "Facebook collects data about people who have never even opted in. But there are ways these non-users can protect themselves.",

--- a/test/test-pages/aktualne/expected-metadata.json
+++ b/test/test-pages/aktualne/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "West Ham hrozí gigantům, okouzlil i Linekera. Součka je snadné přehlédnout",
+  "title": "West Ham hrozí gigantům, okouzlil i Linekera. Součkovu práci je snadné přehlédnout - Aktuálně.cz",
   "byline": "Aleš Vávra",
   "dir": null,
   "excerpt": "Zázrak jedné sezony? West Ham United dává pochybovačům stále pádnější odpovědi.",

--- a/test/test-pages/bbc-1/expected-metadata.json
+++ b/test/test-pages/bbc-1/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Obama admits US gun laws are his 'biggest frustration'",
+  "title": "Obama admits US gun laws are his 'biggest frustration' - BBC News",
   "byline": null,
   "dir": null,
   "excerpt": "President Barack Obama tells the BBC his failure to pass \"common sense gun safety laws\" is the greatest frustration of his presidency.",

--- a/test/test-pages/engadget/expected-metadata.json
+++ b/test/test-pages/engadget/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Xbox One X review:  A console that keeps up with gaming PCs",
+  "title": "Xbox One X review: A console that keeps up with gaming PCs",
   "byline": "Devindra Hardawar",
   "dir": null,
   "excerpt": "The Xbox One X is the most powerful gaming console ever, but it's not for everyone yet.",

--- a/test/test-pages/folha/expected-metadata.json
+++ b/test/test-pages/folha/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Tite diz que errou ao levar taça da Libertadores a Lula em 2012",
+  "title": "Tite diz que errou ao levar taça da Libertadores a Lula em 2012 - 21/12/2018 - Esporte - Folha",
   "byline": "Bruno (Henrique Zecchin) Rodrigues",
   "dir": null,
   "excerpt": "Na ocasião, técnico do Corinthians entregou réplica do troféu ao ex-presidente",

--- a/test/test-pages/medium-3/expected-metadata.json
+++ b/test/test-pages/medium-3/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Samantha and The Great Big Lie - John C. Welch - Medium",
+  "title": "Samantha and The Great Big Lie. How to get shanked doing what people… | by John C. Welch | Medium",
   "byline": "John C. Welch",
   "dir": null,
   "excerpt": "(EDIT: removed the link to Samantha’s post, because the arments and the grubers and the rest of The Deck Clique got what they wanted: a non-proper person driven off the internet lightly capped with a…",

--- a/test/test-pages/toc-missing/expected-metadata.json
+++ b/test/test-pages/toc-missing/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Simple Anomaly Detection Using Plain SQL",
+  "title": "Simple Anomaly Detection Using Plain SQL | Haki Benita",
   "byline": "Haki Benita",
   "dir": null,
   "excerpt": "Many developers think that having a critical bug in their code is the worse thing that can happen. Well, there is something much worst than that: Having a critical bug in your code and not knowing about it! Using some high school level statistics and a fair knowledge of SQL, I implemented a very simple anomaly detection system.",

--- a/test/test-pages/tumblr/expected-metadata.json
+++ b/test/test-pages/tumblr/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Minecraft 1.8 - The Bountiful Update",
+  "title": "Minecraft 1.8 - The Bountiful Update - Minecraft 1.8 - The Bountiful Update - Minecraft Update News",
   "byline": null,
   "dir": null,
   "excerpt": "+ Added Granite, Andesite, and Diorite stone blocks, with smooth versions\n+ Added Slime Block\n+ Added Iron Trapdoor\n+ Added Prismarine and Sea Lantern blocks\n+ Added the Ocean Monument\n+ Added Red...",

--- a/test/test-pages/videos-1/expected-metadata.json
+++ b/test/test-pages/videos-1/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "How to watch the 21 best films of 2017",
+  "title": "How to watch the 21 best films of 2017 - Vox",
   "byline": "Alissa Wilkinson",
   "dir": null,
   "excerpt": "It was an extraordinary year for movies.",

--- a/test/test-pages/videos-2/expected-metadata.json
+++ b/test/test-pages/videos-2/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Screenshot : «Vape Wave», «6 Days», «Alphonse Président»…",
+  "title": "Screenshot : «Vape Wave», «6 Days», «Alphonse Président»… - Culture / Next",
   "byline": "Alexandre Hervaud, Jérémy Piette",
   "dir": null,
   "excerpt": "Séries, documentaires, programmes jeunesse… Retrouvez les recommandations de Libération pour savoir quoi regarder sur vos écrans cette semaine.\nPour dépasser...",

--- a/test/test-pages/wikia/expected-metadata.json
+++ b/test/test-pages/wikia/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "'Star Wars' Original Cuts Might Get Released for 40th Anniversary",
+  "title": "'Star Wars' Original Cuts Might Get Released for 40th Anniversary | Fandom powered by Wikia",
   "byline": "James Akinaka",
   "dir": null,
   "excerpt": "As a 40th birthday present to the Star Wars Saga and its fans, Lucasfilm could re-release the original versions of the original trilogy films.",

--- a/test/test-pages/wikipedia-2/expected-metadata.json
+++ b/test/test-pages/wikipedia-2/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "New Zealand",
+  "title": "New Zealand - Wikipedia",
   "byline": "Contributors to Wikimedia projects",
   "dir": "ltr",
   "excerpt": "Coordinates: 42°S 174°E﻿ / ﻿42°S 174°E",

--- a/test/test-pages/wikipedia-3/expected-metadata.json
+++ b/test/test-pages/wikipedia-3/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Hermitian matrix",
+  "title": "Hermitian matrix - Wikipedia",
   "byline": "Contributors to Wikimedia projects",
   "dir": "ltr",
   "excerpt": "In mathematics, a Hermitian matrix (or self-adjoint matrix) is a complex square matrix that is equal to its own conjugate transpose—that is, the element in the i-th row and j-th column is equal to the complex conjugate of the element in the j-th row and i-th column, for all indices i and j:",


### PR DESCRIPTION
This change updated Readability.js's title parsing to match that of Firefox's standard browser view. The tests files have been updated to reflect this change. 

Related to: https://bugzilla.mozilla.org/show_bug.cgi?id=1134363 and https://phabricator.services.mozilla.com/D139614