### PR TITLE
fix linkedom svg parse

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -347,7 +347,10 @@ Readability.prototype = {
     }
 
     for (node = node.firstElementChild; node; node = node.nextElementSibling) {
-      this._cleanClasses(node);
+      if (typeof attr === "string") {
+        var nodeClassNAme = node.getAttribute("class");
+        this._cleanClasses(nodeClassNAme);
+      }
     }
   },
 

--- a/Readability.js
+++ b/Readability.js
@@ -348,8 +348,8 @@ Readability.prototype = {
 
     for (node = node.firstElementChild; node; node = node.nextElementSibling) {
       if (typeof attr === "string") {
-        var nodeClassNAme = node.getAttribute("class");
-        this._cleanClasses(nodeClassNAme);
+        var nodeClassName = node.getAttribute("class");
+        this._cleanClasses(nodeClassName);
       }
     }
   },


### PR DESCRIPTION
Using in conjunction with [linkedom](https://github.com/WebReflection/linkedom/) there is a problem sometimes

```
Trace: TypeError: (node.getAttribute(...) || "").split is not a function
    at Readability._cleanClasses (/Users/andremacola/Work/Lab/article-parser/node_modules/@mozilla/readability/Readability.js:337:8)
    at Readability._cleanClasses (/Users/andremacola/Work/Lab/article-parser/node_modules/@mozilla/readability/Readability.js:354:14)
    at Readability._cleanClasses (/Users/andremacola/Work/Lab/article-parser/node_modules/@mozilla/readability/Readability.js:354:14)
    at Readability._cleanClasses (/Users/andremacola/Work/Lab/article-parser/node_modules/@mozilla/readability/Readability.js:354:14)
    at Readability._cleanClasses (/Users/andremacola/Work/Lab/article-parser/node_modules/@mozilla/readability/Readability.js:354:14)
    at Readability._cleanClasses (/Users/andremacola/Work/Lab/article-parser/node_modules/@mozilla/readability/Readability.js:354:14)
    at Readability._postProcessContent (/Users/andremacola/Work/Lab/article-parser/node_modules/@mozilla/readability/Readability.js:194:12)
    at Readability.parse (/Users/andremacola/Work/Lab/article-parser/node_modules/@mozilla/readability/Readability.js:2259:10)
```

linkedom seems to do something with classNames in SVG tags that mozilla readability read the class name as object

https://github.com/WebReflection/linkedom/blob/2145416c314c5de23c1f1d87fa3b111db7253eaa/cjs/svg/element.js#L27

More information here: https://github.com/ndaidong/article-parser/issues/235

This pull request fix this problem