### PR TITLE
Fix articles showing cookie information in reader mode

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1357,87 +1357,88 @@ Readability.prototype = {
   _getJSONLD: function (doc) {
     var scripts = this._getAllNodesWithTag(doc, ["script"]);
 
-    var jsonLdElement = this._findNode(scripts, function(el) {
-      return el.getAttribute("type") === "application/ld+json";
-    });
+    var metadata;
 
-    if (jsonLdElement) {
-      try {
-        // Strip CDATA markers if present
-        var content = jsonLdElement.textContent.replace(/^\s*<!\[CDATA\[|\]\]>\s*$/g, "");
-        var parsed = JSON.parse(content);
-        var metadata = {};
-        if (
-          !parsed["@context"] ||
-          !parsed["@context"].match(/^https?\:\/\/schema\.org$/)
-        ) {
-          return metadata;
-        }
-
-        if (!parsed["@type"] && Array.isArray(parsed["@graph"])) {
-          parsed = parsed["@graph"].find(function(it) {
-            return (it["@type"] || "").match(
-              this.REGEXPS.jsonLdArticleTypes
-            );
-          });
-        }
-
-        if (
-          !parsed ||
-          !parsed["@type"] ||
-          !parsed["@type"].match(this.REGEXPS.jsonLdArticleTypes)
-        ) {
-          return metadata;
-        }
-        if (typeof parsed.name === "string" && typeof parsed.headline === "string" && parsed.name !== parsed.headline) {
-          // we have both name and headline element in the JSON-LD. They should both be the same but some websites like aktualne.cz
-          // put their own name into "name" and the article title to "headline" which confuses Readability. So we try to check if either
-          // "name" or "headline" closely matches the html title, and if so, use that one. If not, then we use "name" by default.
-
-          var title = this._getArticleTitle();
-          var nameMatches = this._textSimilarity(parsed.name, title) > 0.75;
-          var headlineMatches = this._textSimilarity(parsed.headline, title) > 0.75;
-
-          if (headlineMatches && !nameMatches) {
-            metadata.title = parsed.headline;
-          } else {
-            metadata.title = parsed.name;
+    this._forEachNode(scripts, function(jsonLdElement) {
+      if (!metadata && jsonLdElement.getAttribute("type") === "application/ld+json") {
+        try {
+          // Strip CDATA markers if present
+          var content = jsonLdElement.textContent.replace(/^\s*<!\[CDATA\[|\]\]>\s*$/g, "");
+          var parsed = JSON.parse(content);
+          if (
+            !parsed["@context"] ||
+            !parsed["@context"].match(/^https?\:\/\/schema\.org$/)
+          ) {
+            return;
           }
 
-        } else if (typeof parsed.name === "string") {
-          metadata.title = parsed.name.trim();
-        } else if (typeof parsed.headline === "string") {
-          metadata.title = parsed.headline.trim();
-        }
-        if (parsed.author) {
-          if (typeof parsed.author.name === "string") {
-            metadata.byline = parsed.author.name.trim();
-          } else if (Array.isArray(parsed.author) && parsed.author[0] && typeof parsed.author[0].name === "string") {
-            metadata.byline = parsed.author
-              .filter(function(author) {
-                return author && typeof author.name === "string";
-              })
-              .map(function(author) {
-                return author.name.trim();
-              })
-              .join(", ");
+          if (!parsed["@type"] && Array.isArray(parsed["@graph"])) {
+            parsed = parsed["@graph"].find(function(it) {
+              return (it["@type"] || "").match(
+                this.REGEXPS.jsonLdArticleTypes
+              );
+            });
           }
+
+          if (
+            !parsed ||
+            !parsed["@type"] ||
+            !parsed["@type"].match(this.REGEXPS.jsonLdArticleTypes)
+          ) {
+            return;
+          }
+
+          metadata = {};
+
+          if (typeof parsed.name === "string" && typeof parsed.headline === "string" && parsed.name !== parsed.headline) {
+            // we have both name and headline element in the JSON-LD. They should both be the same but some websites like aktualne.cz
+            // put their own name into "name" and the article title to "headline" which confuses Readability. So we try to check if either
+            // "name" or "headline" closely matches the html title, and if so, use that one. If not, then we use "name" by default.
+
+            var title = this._getArticleTitle();
+            var nameMatches = this._textSimilarity(parsed.name, title) > 0.75;
+            var headlineMatches = this._textSimilarity(parsed.headline, title) > 0.75;
+
+            if (headlineMatches && !nameMatches) {
+              metadata.title = parsed.headline;
+            } else {
+              metadata.title = parsed.name;
+            }
+          } else if (typeof parsed.name === "string") {
+            metadata.title = parsed.name.trim();
+          } else if (typeof parsed.headline === "string") {
+            metadata.title = parsed.headline.trim();
+          }
+          if (parsed.author) {
+            if (typeof parsed.author.name === "string") {
+              metadata.byline = parsed.author.name.trim();
+            } else if (Array.isArray(parsed.author) && parsed.author[0] && typeof parsed.author[0].name === "string") {
+              metadata.byline = parsed.author
+                .filter(function(author) {
+                  return author && typeof author.name === "string";
+                })
+                .map(function(author) {
+                  return author.name.trim();
+                })
+                .join(", ");
+            }
+          }
+          if (typeof parsed.description === "string") {
+            metadata.excerpt = parsed.description.trim();
+          }
+          if (
+            parsed.publisher &&
+            typeof parsed.publisher.name === "string"
+          ) {
+            metadata.siteName = parsed.publisher.name.trim();
+          }
+          return;
+        } catch (err) {
+          this.log(err.message);
         }
-        if (typeof parsed.description === "string") {
-          metadata.excerpt = parsed.description.trim();
-        }
-        if (
-          parsed.publisher &&
-          typeof parsed.publisher.name === "string"
-        ) {
-          metadata.siteName = parsed.publisher.name.trim();
-        }
-        return metadata;
-      } catch (err) {
-        this.log(err.message);
       }
-    }
-    return {};
+    });
+    return metadata ? metadata : {};
   },
 
   /**

--- a/Readability.js
+++ b/Readability.js
@@ -2202,7 +2202,9 @@ Readability.prototype = {
     return (!node.style || node.style.display != "none")
       && !node.hasAttribute("hidden")
       //check for "fallback-image" so that wikimedia math images are displayed
-      && (!node.hasAttribute("aria-hidden") || node.getAttribute("aria-hidden") != "true" || (node.className && node.className.indexOf && node.className.indexOf("fallback-image") !== -1));
+      && (!node.hasAttribute("aria-hidden") || node.getAttribute("aria-hidden") != "true" || (node.className && node.className.indexOf && node.className.indexOf("fallback-image") !== -1))
+      // user cannot see element applied with both attribute "aria-modla = true" and "role = dialog"
+      && (!(node.getAttribute("aria-modal") == "true" && node.getAttribute("role") == "dialog"));
   },
 
   /**

--- a/Readability.js
+++ b/Readability.js
@@ -2203,7 +2203,7 @@ Readability.prototype = {
       && !node.hasAttribute("hidden")
       //check for "fallback-image" so that wikimedia math images are displayed
       && (!node.hasAttribute("aria-hidden") || node.getAttribute("aria-hidden") != "true" || (node.className && node.className.indexOf && node.className.indexOf("fallback-image") !== -1))
-      // user cannot see element applied with both attribute "aria-modla = true" and "role = dialog"
+      // user can not see element applied with both attribute "aria-modla = true" and "role = dialog"
       && (!(node.getAttribute("aria-modal") == "true" && node.getAttribute("role") == "dialog"));
   },
 

--- a/Readability.js
+++ b/Readability.js
@@ -904,7 +904,7 @@ Readability.prototype = {
           continue;
         }
 
-        // User is not able to see elements applied with both "aria-modla = true" and "role = dialog"
+        // User is not able to see elements applied with both "aria-modal = true" and "role = dialog"
         if (node.getAttribute("aria-modal") == "true" && node.getAttribute("role") == "dialog") {
           node = this._removeAndGetNext(node);
           continue;
@@ -2208,9 +2208,7 @@ Readability.prototype = {
     return (!node.style || node.style.display != "none")
       && !node.hasAttribute("hidden")
       //check for "fallback-image" so that wikimedia math images are displayed
-      && (!node.hasAttribute("aria-hidden") || node.getAttribute("aria-hidden") != "true" || (node.className && node.className.indexOf && node.className.indexOf("fallback-image") !== -1))
-      // user can not see element applied with both attribute "aria-modla = true" and "role = dialog"
-      && (!(node.getAttribute("aria-modal") == "true" && node.getAttribute("role") == "dialog"));
+      && (!node.hasAttribute("aria-hidden") || node.getAttribute("aria-hidden") != "true" || (node.className && node.className.indexOf && node.className.indexOf("fallback-image") !== -1));
   },
 
   /**

--- a/test/test-pages/engadget/expected-metadata.json
+++ b/test/test-pages/engadget/expected-metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Xbox One X review:  A console that keeps up with gaming PCs",
-  "byline": null,
+  "byline": "Devindra Hardawar",
   "dir": null,
   "excerpt": "The Xbox One X is the most powerful gaming console ever, but it's not for everyone yet.",
   "siteName": "Engadget",


### PR DESCRIPTION
Applying the `aria-modal` property to an element with `role="dialog"` replaces the technique of using `aria-hidden` in the background. So I think this kind of element should also be considered "invisible" to the reader. 