### PR TITLE
Prevent "visibility: hidden" nodes from contributing to output.

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -2233,6 +2233,7 @@ Readability.prototype = {
   _isProbablyVisible: function(node) {
     // Have to null-check node.style and node.className.indexOf to deal with SVG and MathML nodes.
     return (!node.style || node.style.display != "none")
+      && (!node.style || node.style.visibility != "hidden")
       && !node.hasAttribute("hidden")
       //check for "fallback-image" so that wikimedia math images are displayed
       && (!node.hasAttribute("aria-hidden") || node.getAttribute("aria-hidden") != "true" || (node.className && node.className.indexOf && node.className.indexOf("fallback-image") !== -1));

--- a/test/test-pages/visibility-hidden/expected-metadata.json
+++ b/test/test-pages/visibility-hidden/expected-metadata.json
@@ -1,0 +1,8 @@
+{
+  "title": "Basic tag cleaning test",
+  "byline": null,
+  "dir": null,
+  "excerpt": "Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n      consequat.",
+  "siteName": null,
+  "readerable": true
+}

--- a/test/test-pages/visibility-hidden/expected-metadata.json
+++ b/test/test-pages/visibility-hidden/expected-metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Basic tag cleaning test",
+  "title": "Visibility hidden test",
   "byline": null,
   "dir": null,
   "excerpt": "Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n      consequat.",

--- a/test/test-pages/visibility-hidden/expected.html
+++ b/test/test-pages/visibility-hidden/expected.html
@@ -1,0 +1,6 @@
+<div id="readability-page-1" class="page">
+    <div>
+        <p>Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+</div>

--- a/test/test-pages/visibility-hidden/source.html
+++ b/test/test-pages/visibility-hidden/source.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Basic tag cleaning test</title>
+</head>
+<body>
+  <article>
+    <h1>Lorem</h1>
+    <div style="visibility: hidden;">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat.</p>
+      <iframe src="about:blank">Iframe fallback test</iframe>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <h2>Foo</h2>
+    <div>
+      <p>Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat.</p>
+      <object data="foo.swf" type="application/x-shockwave-flash" width="88" height="31">
+        <param movie="foo.swf" />
+      </object>
+      <embed src="foo.swf"/>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+  </article>
+</body>
+</html>

--- a/test/test-pages/visibility-hidden/source.html
+++ b/test/test-pages/visibility-hidden/source.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8"/>
-  <title>Basic tag cleaning test</title>
+  <title>Visibility hidden test</title>
 </head>
 <body>
   <article>


### PR DESCRIPTION
This PR should address https://github.com/mozilla/readability/issues/816, https://github.com/mozilla/readability/issues/769, and https://bugzilla.mozilla.org/show_bug.cgi?id=1799239.

Note that the test is just a copy of the pre-existing [basic-tags-cleaning](https://github.com/mozilla/readability/tree/main/test/test-pages/basic-tags-cleaning) test, but with the first div (which primarily contributes to the resulting content and excerpt) styled with `visibility: hidden` such that the second div is now taken for the content/excerpt.

All tests pass and the linter has been run.