### PR TITLE
Ensure pushes go to main repo

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,6 +1,7 @@
 {
   "plugins": {
     "@release-it/keep-a-changelog": {
+      "addUnreleased": true,
       "filename": "CHANGELOG.md"
     }
   },

--- a/.release-it.json
+++ b/.release-it.json
@@ -6,5 +6,9 @@
   },
   "github": {
     "release": false
+  },
+  "git": {
+    "requireBranch": "main",
+    "pushRepo": "https://github.com/mozilla/readability.git"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ may change this output. Patch version increments will only do so in ways that ar
 strict improvements (e.g. from empty strings or exceptions to something more
 reasonable).
 
+## [Unreleased]
+
 ## [0.5.0] - 2023-12-15
 - [Add published time metadata](https://github.com/mozilla/readability/pull/813)
 - [Expanded comma detection to non-Latin commas](https://github.com/mozilla/readability/pull/796)


### PR DESCRIPTION
This also adds the unreleased header back and ensures this is the last time we have to do that manually because it's boring.