### PR TITLE
feat: add support for parsely published date, title, and author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ reasonable).
 
 ## [Unreleased]
 
+- [Add Parsely tags as a fallback metadata source](https://github.com/mozilla/readability/pull/865)
 - [Fix the case that jsonld parse process is ignored when context url include the trailing slash](https://github.com/mozilla/readability/pull/833)
 
 ## [0.5.0] - 2023-12-15

--- a/Readability.js
+++ b/Readability.js
@@ -1548,7 +1548,7 @@ Readability.prototype = {
 
     // get article published time
     metadata.publishedTime = jsonld.datePublished ||
-                             values["article:published_time"] || 
+                             values["article:published_time"] ||
                              values["parsely-pub-date"] ||
                              null;
 

--- a/Readability.js
+++ b/Readability.js
@@ -1476,7 +1476,7 @@ Readability.prototype = {
     var propertyPattern = /\s*(article|dc|dcterm|og|twitter)\s*:\s*(author|creator|description|published_time|title|site_name)\s*/gi;
 
     // name is a single value
-    var namePattern = /^\s*(?:(dc|dcterm|og|twitter|weibo:(article|webpage))\s*[\.:]\s*)?(author|creator|description|title|site_name)\s*$/i;
+    var namePattern = /^\s*(?:(dc|dcterm|og|twitter|parsely|weibo:(article|webpage))\s*[-\.:]\s*)?(author|creator|pub-date|description|title|site_name)\s*$/i;
 
     // Find description tags.
     this._forEachNode(metaElements, function(element) {
@@ -1518,7 +1518,8 @@ Readability.prototype = {
                      values["weibo:article:title"] ||
                      values["weibo:webpage:title"] ||
                      values["title"] ||
-                     values["twitter:title"];
+                     values["twitter:title"] ||
+                     values["parsely-title"];
 
     if (!metadata.title) {
       metadata.title = this._getArticleTitle();
@@ -1528,7 +1529,8 @@ Readability.prototype = {
     metadata.byline = jsonld.byline ||
                       values["dc:creator"] ||
                       values["dcterm:creator"] ||
-                      values["author"];
+                      values["author"] ||
+                      values["parsely-author"];
 
     // get description
     metadata.excerpt = jsonld.excerpt ||
@@ -1546,7 +1548,9 @@ Readability.prototype = {
 
     // get article published time
     metadata.publishedTime = jsonld.datePublished ||
-      values["article:published_time"] || null;
+                             values["article:published_time"] || 
+                             values["parsely-pub-date"] ||
+                             null;
 
     // in many sites the meta value is escaped with HTML entities,
     // so here we need to unescape it

--- a/test/test-pages/parsely-metadata/expected-metadata.json
+++ b/test/test-pages/parsely-metadata/expected-metadata.json
@@ -1,0 +1,10 @@
+{
+  "title": "Some Other Title",
+  "byline": "Jane Doe",
+  "dir": null,
+  "lang": null,
+  "excerpt": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  "siteName": null,
+  "publishedTime": "2024-04-20T04:20:00.000Z",
+  "readerable": true
+}

--- a/test/test-pages/parsely-metadata/expected.html
+++ b/test/test-pages/parsely-metadata/expected.html
@@ -1,0 +1,7 @@
+<div id="readability-page-1" class="page">
+    <article>
+        <h2>Test document title</h2>
+        <p> Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. </p>
+        <p> Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. </p>
+    </article>
+</div>

--- a/test/test-pages/parsely-metadata/source.html
+++ b/test/test-pages/parsely-metadata/source.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="parsely-title" content="Some Other Title" />
+    <meta name="parsely-pub-date" content="2024-04-20T04:20:00.000Z" />
+    <meta name="parsely-author" content="Jane Doe" />
+    <!-- Valid parsely metadata, but currently unused by Readability.
+    <meta name="parsely-link" content="https://www.doubleudoubleudoubleu.com" />
+    <meta name="parsely-image-url" content="https://www.doubleudoubleudoubleu.com/image.jpg" />
+    <meta name="parsely-section" content="front-page" />
+    <meta name="parsely-tags" content="tag,tag-with-dashes" />
+    <meta name="parsely-type" content="post" /> 
+    -->
+  </head>
+  <body>
+    <article>
+      <h1>Test document title</h1>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+	    <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+      </article>
+  </body>
+</html>


### PR DESCRIPTION
Adds Parsely tags as a fallback option for metadata. Parsely is a content analytics service aimed at larger publishers running Wordpress, eg: The Verge. 

It's worth noting that Parsely tags are unlikely to exist in isolation and seem to be populated alongside `og` tags and JSONLD data in nearly all cases. I would like to add other tag sets which will be more valuable though and this was a nice simple one to familiarize myself with. I will totally understand if the preference is to keep the regex patterns from growing too large by leaving out less common sources of metadata like this.