### PR TITLE
fix: ensure short strings of legitimate content are not excluded

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -209,8 +209,5 @@ module.exports = {
 
     // Only check typeof against valid results
     "valid-typeof": 2,
-
-    // enforce trailing commas
-    "comma-dangle": ["error", "always"],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -211,6 +211,6 @@ module.exports = {
     "valid-typeof": 2,
 
     // enforce trailing commas
-    "comma-dangle": ["error", "never"],
+    "comma-dangle": ["error", "always"],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -209,5 +209,8 @@ module.exports = {
 
     // Only check typeof against valid results
     "valid-typeof": 2,
+
+    // enforce trailing commas
+    "comma-dangle": ["error", "never"],
   },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ reasonable).
 
 - [Add Parsely tags as a fallback metadata source](https://github.com/mozilla/readability/pull/865)
 - [Fix the case that jsonld parse process is ignored when context url include the trailing slash](https://github.com/mozilla/readability/pull/833)
+- [Fixed situations where short paragraphs of legitimate content would be excluded](https://github.com/mozilla/readability/pull/867)
 
 ## [0.5.0] - 2023-12-15
 

--- a/Readability.js
+++ b/Readability.js
@@ -160,7 +160,7 @@ Readability.prototype = {
   PRESENTATIONAL_ATTRIBUTES: [ "align", "background", "bgcolor", "border", "cellpadding", "cellspacing", "frame", "hspace", "rules", "style", "valign", "vspace" ],
 
   DEPRECATED_SIZE_ATTRIBUTE_ELEMS: [ "TABLE", "TH", "TD", "HR", "PRE" ],
-  
+
   // The commented out elements qualify as phrasing content but tend to be
   // removed by readability when put into paragraphs, so we ignore them here.
   PHRASING_ELEMS: [

--- a/Readability.js
+++ b/Readability.js
@@ -148,18 +148,8 @@ Readability.prototype = {
     jsonLdArticleTypes: /^Article|AdvertiserContentArticle|NewsArticle|AnalysisNewsArticle|AskPublicNewsArticle|BackgroundNewsArticle|OpinionNewsArticle|ReportageNewsArticle|ReviewNewsArticle|Report|SatiricalArticle|ScholarlyArticle|MedicalScholarlyArticle|SocialMediaPosting|BlogPosting|LiveBlogPosting|DiscussionForumPosting|TechArticle|APIReference$/,
     // used to see if a node's content matches words commonly used for ad blocks or loading indicators
     adWords: /^(ad(vertising|vertisement)?|pub(licité)?|werb(ung)?|广告|Реклама|Anuncio)$/iu,
-    loadingWords: /^((loading|正在加载|Загрузка|chargement|cargando)(\.\.\.)?)$/iu
-  },
-
-  UNLIKELY_ROLES: [ "menu", "menubar", "complementary", "navigation", "alert", "alertdialog", "dialog" ],
-
-  DIV_TO_P_ELEMS: new Set([ "BLOCKQUOTE", "DL", "DIV", "IMG", "OL", "P", "PRE", "TABLE", "UL" ]),
-
-  ALTER_TO_DIV_EXCEPTIONS: ["DIV", "ARTICLE", "SECTION", "P"],
-
-  PRESENTATIONAL_ATTRIBUTES: [ "align", "background", "bgcolor", "border", "cellpadding", "cellspacing", "frame", "hspace", "rules", "style", "valign", "vspace" ],
-
-  DEPRECATED_SIZE_ATTRIBUTE_ELEMS: [ "TABLE", "TH", "TD", "HR", "PRE" ],
+    loadingWords: /^((loading|正在加载|Загрузка|chargement|cargando)(…|\.\.\.)?)$/iu,
+    },
 
   // The commented out elements qualify as phrasing content but tend to be
   // removed by readability when put into paragraphs, so we ignore them here.

--- a/Readability.js
+++ b/Readability.js
@@ -149,7 +149,7 @@ Readability.prototype = {
     // used to see if a node's content matches words commonly used for ad blocks or loading indicators
     adWords: /^(ad(vertising|vertisement)?|pub(licité)?|werb(ung)?|广告|Реклама|Anuncio)$/iu,
     loadingWords: /^((loading|正在加载|Загрузка|chargement|cargando)(…|\.\.\.)?)$/iu,
-    },
+  },
 
   // The commented out elements qualify as phrasing content but tend to be
   // removed by readability when put into paragraphs, so we ignore them here.

--- a/Readability.js
+++ b/Readability.js
@@ -151,6 +151,16 @@ Readability.prototype = {
     loadingWords: /^((loading|正在加载|Загрузка|chargement|cargando)(…|\.\.\.)?)$/iu,
   },
 
+  UNLIKELY_ROLES: [ "menu", "menubar", "complementary", "navigation", "alert", "alertdialog", "dialog" ],
+
+  DIV_TO_P_ELEMS: new Set([ "BLOCKQUOTE", "DL", "DIV", "IMG", "OL", "P", "PRE", "TABLE", "UL" ]),
+
+  ALTER_TO_DIV_EXCEPTIONS: ["DIV", "ARTICLE", "SECTION", "P"],
+
+  PRESENTATIONAL_ATTRIBUTES: [ "align", "background", "bgcolor", "border", "cellpadding", "cellspacing", "frame", "hspace", "rules", "style", "valign", "vspace" ],
+
+  DEPRECATED_SIZE_ATTRIBUTE_ELEMS: [ "TABLE", "TH", "TD", "HR", "PRE" ],
+  
   // The commented out elements qualify as phrasing content but tend to be
   // removed by readability when put into paragraphs, so we ignore them here.
   PHRASING_ELEMS: [

--- a/Readability.js
+++ b/Readability.js
@@ -2157,14 +2157,52 @@ Readability.prototype = {
         var linkDensity = this._getLinkDensity(node);
         var contentLength = this._getInnerText(node).length;
 
-        var haveToRemove =
-          (img > 1 && p / img < 0.5 && !this._hasAncestorTag(node, "figure")) ||
-          (!isList && li > p) ||
-          (input > Math.floor(p/3)) ||
-          (!isList && headingDensity < 0.9 && contentLength < 25 && (img === 0 || img > 2) && !this._hasAncestorTag(node, "figure")) ||
-          (!isList && weight < 25 && linkDensity > 0.2) ||
-          (weight >= 25 && linkDensity > 0.5) ||
-          ((embedCount === 1 && contentLength < 75) || embedCount > 1);
+        const shouldRemoveNode = () => {
+          if (img > 1 && p / img < 0.5 && !this._hasAncestorTag(node, "figure")) {
+            this.log(`Removing node: img > 1 && p / img < 0.5 && !this._hasAncestorTag(node, 'figure') (img=${img}, p=${p}, node=${node})`);
+            return true;
+          }
+          if (!isList && li > p) {
+            this.log(`Removing node: !isList && li > p (li=${li}, p=${p})`);
+            return true;
+          }
+          if (input > Math.floor(p/3)) {
+            this.log(`Removing node: input > Math.floor(p/3) (input=${input}, p=${p})`);
+            return true;
+          }
+          if (!isList && headingDensity < 0.9 && contentLength < 25 && (img === 0 || img > 2) && linkDensity > 0 && !this._hasAncestorTag(node, "figure")) {
+            this.log(`Removing node: !isList && headingDensity < 0.9 && contentLength < 25 && (img === 0 || img > 2) && !this._hasAncestorTag(node, 'figure') (headingDensity=${headingDensity}, contentLength=${contentLength}, img=${img})`);
+            return true;
+          }
+          if (!isList && weight < 25 && linkDensity > 0.2) {
+            this.log(`Removing node: !isList && weight < 25 && linkDensity > 0.2 (weight=${weight}, linkDensity=${linkDensity})`);
+            return true;
+          }
+          if (weight >= 25 && linkDensity > 0.5) {
+            this.log(`Removing node: weight >= 25 && linkDensity > 0.5 (weight=${weight}, linkDensity=${linkDensity})`);
+            return true;
+          }
+          if ((embedCount === 1 && contentLength < 75) || embedCount > 1) {
+            this.log(`Removing node: (embedCount === 1 && contentLength < 75) || embedCount > 1 (embedCount=${embedCount}, contentLength=${contentLength})`);
+            return true;
+          }
+          if (this._getTextDensity(node, ["SPAN", "LI", "TD"].concat(Array.from(this.DIV_TO_P_ELEMS))) === 0) {
+            this.log("Removing node: textDensity of children === 0");
+            return true;
+          }
+          return false;
+        }
+        
+        var haveToRemove = shouldRemoveNode();
+
+        // var haveToRemove = 
+        //   (img > 1 && p / img < 0.5 && !this._hasAncestorTag(node, "figure")) ||
+        //   (!isList && li > p) ||
+        //   (input > Math.floor(p/3)) ||
+        //   (!isList && headingDensity < 0.9 && contentLength < 25 && (img === 0 || img > 2) && !this._hasAncestorTag(node, "figure")) ||
+        //   (!isList && weight < 25 && linkDensity > 0.2) ||
+        //   (weight >= 25 && linkDensity > 0.5) ||
+        //   ((embedCount === 1 && contentLength < 75) || embedCount > 1);
         // Allow simple lists of images to remain in pages
         if (isList && haveToRemove) {
           for (var x = 0; x < node.children.length; x++) {

--- a/test/debug-testcase.js
+++ b/test/debug-testcase.js
@@ -1,0 +1,17 @@
+var Readability = require('../Readability');
+var {JSDOM} = require("jsdom");
+var fs = require("fs");
+var path = require("path");
+
+var testcaseRoot = path.join(__dirname, "test-pages");
+
+if (process.argv.length < 3) {
+console.log("No testcase provided.");
+process.exit(1);
+}
+
+var src = fs.readFileSync(`${testcaseRoot}/${process.argv[2]}/source.html`, {encoding: "utf-8"}).trim();
+
+var doc = new JSDOM(src, {url: "http://fakehost/test/page.html"}).window.document;
+
+new Readability(doc, {debug: true}).parse();

--- a/test/debug-testcase.js
+++ b/test/debug-testcase.js
@@ -1,4 +1,6 @@
-var Readability = require('../Readability');
+/* eslint-env node */
+
+var Readability = require("../Readability");
 var {JSDOM} = require("jsdom");
 var fs = require("fs");
 var path = require("path");
@@ -6,8 +8,8 @@ var path = require("path");
 var testcaseRoot = path.join(__dirname, "test-pages");
 
 if (process.argv.length < 3) {
-console.log("No testcase provided.");
-process.exit(1);
+  console.log("No testcase provided.");
+  process.exit(1);
 }
 
 var src = fs.readFileSync(`${testcaseRoot}/${process.argv[2]}/source.html`, {encoding: "utf-8"}).trim();

--- a/test/test-pages/bug-1255978/expected.html
+++ b/test/test-pages/bug-1255978/expected.html
@@ -14,6 +14,32 @@
         <p>1. Take any blankets or duvets off the bed</p>
         <p>Forrest Jones said that anything that comes into contact with any of the previous guest’s skin should be taken out and washed every time the room is made, but that even the fanciest hotels don’t always do so. "Hotels are getting away from comforters. Blankets are here to stay, however. But some hotels are still hesitant about washing them every day if they think they can get out of it," he said.</p>
         <div>
+            <div data-video-id="4685984084001" data-embed="default" data-player="2d3d4a83-ba40-464e-9bfb-2804b076bf67" data-account="624246174001" id="4685984084001" role="region" aria-label="video player"><video id="4685984084001_html5_api" data-account="624246174001" data-player="2d3d4a83-ba40-464e-9bfb-2804b076bf67" data-embed="default" data-video-id="4685984084001" preload="none" poster="http://brightcove.vo.llnwd.net/e1/pd/624246174001/624246174001_4685986878001_4685984084001-vs.jpg?pubId=624246174001&amp;videoId=4685984084001" src="blob:http://www.independent.co.uk/112e1cb2-b0b1-e146-be22-fc6d052f7ddd"></video>
+                <p><span>Play Video</span></p>
+                <div dir="ltr" role="group">
+                    <p><span>Play</span></p>
+                    <div>
+                        <p><span>Current Time </span>0:00</p>
+                    </div>
+                    <div>
+                        <p><span>/</span></p>
+                    </div>
+                    <div>
+                        <p><span>Duration Time</span> 0:00</p>
+                    </div>
+                    <div tabindex="0" role="slider" aria-valuenow="NaN" aria-valuemin="0" aria-valuemax="100" aria-label="progress bar" aria-valuetext="0:00">
+                        <p><span><span>Loaded</span>: 0%</span>
+                        </p>
+                        <p><span><span>Progress</span>: 0%</span>
+                        </p>
+                    </div>
+                    <div>
+                        <p><span>Remaining Time</span> -0:00</p>
+                    </div>
+                    <p><span>Share</span></p>
+                    <p><span>Fullscreen</span></p>
+                </div>
+            </div>
             <p>Video shows bed bug infestation at New York hotel</p>
         </div>
         <div>

--- a/test/test-pages/citylab-1/expected.html
+++ b/test/test-pages/citylab-1/expected.html
@@ -20,6 +20,10 @@
         </figure>
         <div>
             <h2 itemprop="headline"> Why Neon Is the Ultimate Symbol of the 20th Century </h2>
+            <div>
+                <p><span><time>1:39 PM ET</time></span>
+                </p>
+            </div>
         </div>
         <h2 itemprop="description"> The once-ubiquitous form of lighting was novel when it first emerged in the early 1900s, though it has since come to represent decline. </h2>
         <section id="article-section-1">

--- a/test/test-pages/ehow-1/expected.html
+++ b/test/test-pages/ehow-1/expected.html
@@ -1,16 +1,14 @@
 <div id="readability-page-1" class="page">
     <div>
         <header>
+            <div>
+                <p><span></span> <span></span> <span>Found This Helpful</span> </p>
+            </div>
         </header>
         <div>
             <p>Glass cloche terrariums are not only appealing to the eye, but they also preserve a bit of nature in your home and serve as a simple, yet beautiful, piece of art. Closed terrariums are easy to care for, as they retain much of their own moisture and provide a warm environment with a consistent level of humidity. You won’t have to water the terrariums unless you see that the walls are not misting up. Small growing plants that don’t require a lot of light work best such as succulents, ferns, moss, even orchids.</p>
             <figure> <img src="http://img-aws.ehowcdn.com/640/cme/photography.prod.demandstudios.com/16149374-814f-40bc-baf3-ca20f149f0ba.jpg" alt="Glass cloche terrariums" title="Glass cloche terrariums" data-credit="Lucy Akins " longdesc="http://s3.amazonaws.com/photography.prod.demandstudios.com/16149374-814f-40bc-baf3-ca20f149f0ba.jpg" /> </figure>
             <figcaption class="caption"> Glass cloche terrariums (Lucy Akins) </figcaption>
-        </div>
-        <div id="relatedContentUpper" data-module="rcp_top">
-            <header>
-                <h3>Other People Are Reading</h3>
-            </header>
         </div>
         <div>
             <p><span>What You'll Need:</span></p>

--- a/test/test-pages/ehow-2/expected.html
+++ b/test/test-pages/ehow-2/expected.html
@@ -1,16 +1,22 @@
 <div id="readability-page-1" class="page">
-    <div data-type="AuthorProfile">
-        <div>
-            <p><a id="img-follow-tip" href="http://fakehost/contributor/gina_robertsgrey/" target="_top">
-                    <img src="http://img-aws.ehowcdn.com/60x60/cme/cme_public_images/www_demandstudios_com/sitelife.studiod.com/ver1.0/Content/images/store/9/2/d9dd6f61-b183-4893-927f-5b540e45be91.Small.jpg" data-failover="//img-aws.ehowcdn.com/60x60/ehow-cdn-assets/test15/media/images/authors/missing-author-image.png" onerror="var failover = this.getAttribute(&apos;data-failover&apos;);
+    <div>
+        <div data-type="AuthorProfile">
+            <div>
+                <p><a id="img-follow-tip" href="http://fakehost/contributor/gina_robertsgrey/" target="_top">
+                        <img src="http://img-aws.ehowcdn.com/60x60/cme/cme_public_images/www_demandstudios_com/sitelife.studiod.com/ver1.0/Content/images/store/9/2/d9dd6f61-b183-4893-927f-5b540e45be91.Small.jpg" data-failover="//img-aws.ehowcdn.com/60x60/ehow-cdn-assets/test15/media/images/authors/missing-author-image.png" onerror="var failover = this.getAttribute(&apos;data-failover&apos;);
                 if (failover) failover = failover.replace(/^https?:/,&apos;&apos;);
                 var src = this.src ? this.src.replace(/^https?:/,&apos;&apos;) : &apos;&apos;;
                 if (src != failover){
                     this.src = failover;
                 }" /> </a></p>
+            </div>
+            <p><time datetime="2016-09-14T07:07:00-04:00" itemprop="dateModified">Last updated September 14, 2016</time>
+            </p>
         </div>
-        <p><time datetime="2016-09-14T07:07:00-04:00" itemprop="dateModified">Last updated September 14, 2016</time>
-        </p>
+        <div data-score="true" data-url="http://www.ehow.com/how_4851888_throw-graduation-party-budget.html">
+            <p><span> Save</span>
+            </p>
+        </div>
     </div>
     <div>
         <article data-type="article">
@@ -115,11 +121,6 @@
                             <img src="http://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/35/B4/DD5FD05A-B631-4AFE-BC8F-FDACAD1EB435/DD5FD05A-B631-4AFE-BC8F-FDACAD1EB435.jpg" alt="A brunch gathering will cost less than a dinner party." data-credit="Mark Stout/iStock/Getty Images" data-pin-ehow-hover="true" data-pin-no-hover="true" />
                         </figure>
                         <figcaption class="caption"> Mark Stout/iStock/Getty Images </figcaption>
-                    </div>
-                    <div id="relatedContentUpper" data-module="rcp_top">
-                        <header>
-                            <h3>Other People Are Reading</h3>
-                        </header>
                     </div>
                 </span>
             </span>

--- a/test/test-pages/engadget/expected.html
+++ b/test/test-pages/engadget/expected.html
@@ -13,6 +13,15 @@
     <div>
         <div>
             <div>
+                <p><span>from</span>&nbsp;<span>$610.00</span>
+                </p>
+            </div>
+            <div>
+                <p> 87 </p>
+            </div>
+        </div>
+        <div>
+            <div>
                 <ul>
                     <li>Most powerful hardware ever in a home console </li>
                     <li>Solid selection of enhanced titles </li>

--- a/test/test-pages/firefox-nightly-blog/expected.html
+++ b/test/test-pages/firefox-nightly-blog/expected.html
@@ -246,9 +246,6 @@
                     </p>
                 </li>
             </ol>
-            <div id="respond">
-                <h3 id="reply-title"> Leave a Reply </h3>
-            </div>
         </div>
     </div>
 </div>

--- a/test/test-pages/mercurial/expected.html
+++ b/test/test-pages/mercurial/expected.html
@@ -90,6 +90,10 @@
                     <a href="#id7">Setting up</a><a href="#setting-up" title="Permalink to this headline">¶</a>
                 </h3>
                 <p> We’ll work through an example with three local repositories, although in the real world they’d most likely be on three different computers. First, the <tt><span>public</span></tt> repository is where tested, polished changesets live, and it is where you synchronize with the rest of your team. </p>
+                <div>
+                    <pre>$ hg init public
+</pre>
+                </div>
                 <p> We’ll need two clones where work gets done, <tt><span>test-repo</span></tt> and <tt><span>dev-repo</span></tt>: </p>
                 <div>
                     <pre>$ hg clone public test-repo
@@ -124,6 +128,11 @@ evolve =
 </pre>
                 </div>
                 <p> and add </p>
+                <div>
+                    <pre>[extensions]
+evolve =
+</pre>
+                </div>
                 <p> Keep in mind that in real life, these repositories would probably be on separate computers, so you’d have to login to each one to configure each repository. </p>
                 <p> To start things off, let’s make one public, immutable changeset: </p>
                 <div>
@@ -228,6 +237,11 @@ updating to branch default
 </pre>
                 </div>
                 <p> and add </p>
+                <div>
+                    <pre>[extensions]
+evolve =
+</pre>
+                </div>
                 <p> Then edit Bob’s repository configuration: </p>
                 <div>
                     <pre>$ hg -R bob config --edit --local
@@ -523,6 +537,10 @@ $ hg pull -q -u
                     <p> [figure SG07: 2:e011 now public not obsolete, 4:fe88 now bumped] </p>
                 </blockquote>
                 <p> As usual when there’s trouble in your repository, the solution is to evolve it: </p>
+                <div>
+                    <pre>$ hg evolve --all
+</pre>
+                </div>
                 <p> Figure 8 illustrates Bob’s repository after evolving away the bumped changeset. Ignoring the obsolete changesets, Bob now has a nice, clean, simple history. His amendment of Alice’s bug fix lives on, as changeset 5:227d—albeit with a software-generated commit message. (Bob should probably amend that changeset to improve the commit message.) But the important thing is that his repository no longer has any troubled changesets, thanks to <tt><span>evolve</span></tt>. </p>
                 <blockquote>
                     <p> [figure SG08: 5:227d is new, formerly bumped changeset 4:fe88 now hidden] </p>

--- a/test/test-pages/qq/expected.html
+++ b/test/test-pages/qq/expected.html
@@ -1,5 +1,8 @@
 <div id="readability-page-1" class="page">
     <div id="C-Main-Article-QQ">
+        <div bosszone="titleDown">
+            <p><span><span bosszone="jgname">TNW中文站</span></span><span>2016年10月14日07:17</span></p>
+        </div>
         <div id="Cnt-Main-Article-QQ" bosszone="content" accesskey="3" tabindex="-1">
             <div>
                 <p><span>转播到腾讯微博</span></p>

--- a/test/test-pages/royal-road/expected-metadata.json
+++ b/test/test-pages/royal-road/expected-metadata.json
@@ -1,0 +1,10 @@
+{
+  "title": "ONE HUNDRED TWO: What kind of wordchain? - Super Supportive",
+  "byline": "Follow Author",
+  "dir": null,
+  "lang": "en",
+  "excerpt": "102 “Were you expecting the competition for the showers to be the highest drama part of gym class?” Alden asked Haoyu as the two of them headed (...)",
+  "siteName": "Royal Road",
+  "publishedTime": null,
+  "readerable": true
+}

--- a/test/test-pages/royal-road/expected.html
+++ b/test/test-pages/royal-road/expected.html
@@ -1,0 +1,892 @@
+<div id="readability-page-1" class="page">
+    <div tabindex="1" spellcheck="false">
+        <div>
+            <p><span>102</span>
+            </p>
+            <p><span>“Were you expecting the competition for the showers to be the highest drama part of gym class?” Alden asked Haoyu as the two of them headed down a broad avenue toward North of North gym. It was a ten minute walk from the MPE building, right on the edge of campus, and apparently, they had both had the same idea when they discovered they were going to have to wait for their turns anyway.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu was gulping from a water bottle. “I’m glad my group was getting along well. I think the one with the speedsters in it had some kind of issue. They seemed tense.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Finlay <span>had</span> looked pretty mad. It was the first time Alden had seen the Scottish boy in anything but a cheerful mood.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I didn’t have the attention span to watch them and run from Snake’s tennis ball pitches.</span> <span>It somehow adds insult to injury that he makes you chase the balls down after they hit you.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>When they reached the airy glass building that Alden thought of as the main gym, the same girl in lime green yoga pants who’d been protecting the entrance from riffraff and gawkers on his first visit greeted them both warmly. She was giving out cups of some of the liquefied salads that the spa upstairs bottled and sold as drinks.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>They both took one.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>As they headed toward the showers, Haoyu sipped the black pepper beet juice he’d chosen and wrinkled his nose. “I don’t think I’m old enough to drink this.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden raised an eyebrow at him.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I’m trying!” Haoyu said. “Being friends with Lexi’s <span>hard</span>. He got really serious about nutrition in the past year or two. I saw him cut a single piece of chocolate in half once. And there I was stuffing six in my mouth at a time. I want to eat healthy, but I like candy <span>so</span> much. And anything fried.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Is that why you bought the slow cooker?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu nodded. “That, and because my mom kept telling me I shouldn’t buy it because I wouldn’t ever use it. I’m going to use it every day. And send her pictures. Starting tonight. The bouncing oatmeal was just a temporary setback. It didn’t even taste that bad.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He looked curiously at a man casting spells on a section of the climbing wall as they passed it. “I’m so glad you’ve got a membership here, too. I really wanted one, and my parents wanted me to have it. But I almost told them not to buy it for me because it’s so…um…”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Richy?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“<span>Yes.</span> Mom and Dad both come here, but they have to. They need the facilities in the heavy gym. I could probably have used the school equipment until I was halfway through uni. But everything here is <span>so</span> much nicer, and I used to play on the rock wall in the onsite daycare and just imagine how great it was going to be when I was finally fifteen and I could use the real one. They can set it to have high winds, floods, and earthquakes! I went for it. And you’re here, too! We’ll both look richy together, and it won’t be as awkward when we leave school to use the better stuff.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Happy to spoil myself with you.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>They walked past an attendant into the room with the big rainfall showers and the ridiculously fluffy scented towels.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu beamed at him. “Soooo, since you’re here with me, and you’re not going to freak out about it…I’ll confess that I actually already have potion therapy sauna slots booked for a few days a week until the end of term. I was always planning to come here instead of using the student showers.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden blinked at him. The potions saunas had been a part of his facilities tour. For a hundred argold—or more depending on which sauna you chose—you could sweat and inhale magical substances that did rather out-there sounding things.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Are you having your spirit waxed or…?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“No!” Haoyu laughed. “Is that even real? I’m using the recovery sauna. Potions aren’t as good as healers, obviously, but if I sit in there for ninety minutes or so, I don’t really need to rest on my rest days, and I don’t get too sore. I’m just going to do my homework in there instead of sitting through study halls. My mom did sauna homework her whole last year of uni. It was her idea, and since I wasn’t saying no to the gym membership I wasn’t going to say no to something like this.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>He’s basically turning the two hour study hall into recovery time.</span> Alden wondered if Mrs. Zhang-Demir had been attempting to balance out Haoyu’s lifestyle when she tried to set a dorm decorating budget.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“That’s very efficient,” said Alden.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I’m telling you so you can book a slot tonight, if you want to do homework together. And so you’re not like, ‘Where did Haoyu go? Is he trying to get away from me?’ when I jump straight out of the shower and run off to the sauna instead of heading back to the dorms with you.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Gotcha.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Do you want to come?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“…isn’t it a lot of famous people sitting around in towels together, talking about superhero stuff?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>That sounded like a high pressure environment to do homework in unless your parents were famous superheroes and you were used to them.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I’ve only used it a few times so far. It’s not that many people, and they’re all zoned out watching videos or working on their interfaces. They don’t talk and interrupt my studying, so it’s good.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Let me think about it.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>******</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden had a couple of minutes to debate it while they both rinsed off.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Pro: doing homework with Haoyu was in line with his mission to be a great roommate.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Con: shirtlessness.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Pro: trying the new magic thing with someone his own age for backup instead of facing down a bunch of forty-year-olds who could create waterspouts and pitch railcars by himself.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Con: money.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Pro: feeling good tomorrow instead of feeling ouch tomorrow.</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>The cons aren’t really cons.</span></span>
+            </p>
+        </div>
+        <div>
+            <p><span>He didn’t want to be shy about the tattoo forever with the people he actually <span>lived</span> with. And as for the money…</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden had given half of it to Boe so that his family and friends would be taken care of no matter where he was. He’d be spending half of what he had left on supplies, gear, and calling fees to make himself the most absurdly well-equipped and well-connected Rabbit on the Triplanets the next time he was summoned.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>A little would be set aside in his <span>backup</span> backup emergency fund.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>But all the rest of it…</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He’d just about talked himself into spending a million dollars however he wanted. As fast as he felt like. When the mood struck him.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Neha had told him to save it for a downpayment on his future immortality, and everything on the internet was about preparing for retirement. Meanwhile, the tiny remnants of the person he’d been in January kept shouting that this much money should last him until he was a <span>wrinkly old man</span>.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He thought all of them were overconfident in his ability to make it to the wrinkly stage of life.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Besides, even if he did live to a ripe old age, two or three short summonings a year would make for a decent salary by his standards. He’d be absolutely floored if he only got summoned twice a year.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Mind made up, he flicked through his interface and booked a recovery sauna slot. Then he quickly checked the North of North website to make sure he actually understood what you were supposed to <span>do</span> in potion saunas.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Just sit there. No clothes or shoes. Towels. Shower first. No noisy, bright, or smelly spells. No food. Respect the tranquility of the environment.</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>Gee they don’t tell you where to hide your auriad. That’s an oversight.</span></span>
+            </p>
+        </div>
+        <div>
+            <p><span>He could go with under the wrist cuff or on a thigh. The auriad was getting more and more helpful every day about staying put comfortably wherever he wanted it to.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>A couple of minutes later, towel around his waist, he was stepping into the sauna.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>It was hot and spacious with soft lighting and steam. Five women, three men, and Haoyu each had plenty of room to themselves on the two tiers of pale wood benches. Alden assumed it was all normal enough…for Apex anyway. The adults mostly had that fit-and-flawless look about them that was so common in this gym he hardly ever noticed it anymore. And there was a little bitty cauldron on a pedestal in the middle of the floor. The clear substance inside was <span>blub-blubbing</span>, and he thought it was the source of the watermelonish scent.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu smiled brightly and waved him over. “I’m going to watch all the drone footage of my rescues first,” he said quietly. “And then we have that reading assignment on ‘outsmarting enemies’ for offense.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden sat down beside him. By the time he’d started to sweat, he’d gotten over the inherent oddness of doing homework in such an uncommon environment—mostly because Haoyu was a dedicated student. Alden couldn’t stay hung up on towel etiquette while they were having a serious texting conversation about whether saving two of the sandbags at once would increase rescue speed enough to justify the difficulty, risk, and/or talent strain.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>The time went by quickly. A gym employee brought water for them and a refill potion for the tiny cauldron just as he finished up the reading for Instructor Klein. It had already been an hour. His homework was half done. He felt tired, but a little less so than when he’d sat down. Either his body liked saunas or it liked inhaling magic steam.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Most of the people who’d been here to start with were gone. There was just one woman wearing cucumbers over her eyes while she lounged on the top bench…which was technically having food in the sauna, wasn’t it?</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He glanced over at Haoyu. His dark hair was stuck to his forehead, and his mouth was moving slightly. He was one of those people who did that even when they were reading silently.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden kept at his own homework.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Cucumber lady left about fifteen minutes later. Alden was busy watching a video, so he wouldn’t have noticed. But as soon as she closed the door behind her, Haoyu said, “Why can she wear food, but we can’t eat food?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I was thinking the same thing.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu looked over at him. “Thanks for studying with me. I didn’t beg too much, did I? I know it’s expensive. I just got excited to have a gym buddy. The only other people I know of who are even close to our age here are a couple of uni first years.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“This is fun. I probably wouldn’t ever have tried it if you hadn’t asked, so I’m glad you did,” Alden said. “I was more worried about wearing my towel backwards than the money.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu looked thoughtful. “I don’t think you <span>can</span> wear a towel backward.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“What if I got here and everyone else had turned theirs into a toga? Or they were supposed to be for our heads instead of our waists?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu snorted.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“It could happen. You Anesidorans have weird customs. Spas have weird customs. Magic has weird customs. All three combined in one location? If I’d walked in and found out we all had to remove our towels and bow to the cauldron, I wouldn’t have been very surprised.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“You were supposed to do that.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden stared at him.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>The other boy’s expression was sincere. “It’s all right that you didn’t do it. Since it was your first time, nobody expected you to know—”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Lexi’s right about you! You do deliver jokes in the exact same tone as serious material.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu grinned.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“What if you do that to someone…you can’t do that! Someone like Jeffy will totally get naked and worship a wizard soup pot!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Jokes are funnier when they’re subtle.” He lifted an arm up and over his head to start a shoulder stretch. “I’m glad you wanted to try it. I was a lot more focused knowing someone else was doing the same assignments.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>Haoyu’s not going to mention it.</span> Alden was gratified but not really surprised. <span>He’s so good-natured. And his mom…</span></span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden decided he wasn’t going to get a better chance to bring it up himself. “Do you think our classmates will make a big deal about the tattoo when they see it?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Arm still bent behind his head, Haoyu cut his eyes toward him. “It’s real, right?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Yes.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“You just have to ignore them,” Haoyu said. “You’re rooming with me and Lexi and <span>Lute</span>… Plus everyone’s already talking about how something crazy happened to you. And you’re a Rabbit. The purity people have already slotted you in with the rest of us. They’re stupid and they just repeat whatever their parents say, so who cares?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden felt like he was missing at least a couple of social factors that Haoyu was treating as obvious. “The purity people?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“You know, the ones who are like, ‘Anyone who wants to work for the Artonans is an alien bumkisser. Anyone who gets summoned all the time cares more about money than human pride.’ Those people. I think there are only one or two in our whole class who are seriously that way.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He dropped his arm and shrugged.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I haven’t noticed,” said Alden.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Sometimes it’s someone who’s lost a family member to an emergency summons, and then, I understand. They’re grieving and angry. But <span>usually</span> it’s just the kids of Contract refusers, or people who’ve never been called at all for some reason, and they want to act like not being a part of that aspect of Avowed life somehow makes them better than everyone else.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“So they’re assholes?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Mostly. Those people are going to be terrible no matter what, so I say don’t worry about them. Everyone else…”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu’s brows suddenly lowered. “Maybe I wouldn’t flash it around the locker room, after all? Even if most of them don’t really have a problem with private contracts, they’re still going to say stupid things and gossip about it. It’s the same reason I don’t tell most people when my parents are doing something dangerous.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He nodded once, as if to settle the matter, then added, “And obviously don’t worry about me. Or any <span>mature</span> people. Mom and dad both have tattoos. From Triplanets work and from the demon suppression. Everyone who helps with that gets a secrecy one. And Lexi’s little sister has eight now!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Half of them are turtles,” said Alden.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu laughed. “Lexi won’t admit it, but he’s <span>super</span> worried that his parents are wrong and they won’t actually wash off. I think he’s already planning to murder anyone who says anything about the fact that Irina is blue.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>******</span>
+            </p>
+        </div>
+        <div>
+            <p><span>They headed back to the dorm in the dark, and they met a rolling cafeteria delivery drone on the way that had half of Haoyu’s supper in it.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Listen,” Haoyu said, walking backward while he pleaded with the slowly trundling box, “that’s <span>my</span> vegetable rice. I’m Haoyu Zhang-Demir, Garden Hall, Suite 208. That’s me! My name’s on your lid display. Give it to me, and I’ll get to eat it sooner and you’ll get to go back to the cafeteria sooner. It makes sense!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>Beeeeep,</span> the drone said angrily when Haoyu moved to block its way again.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Not <span>beep</span>! Rice. My rice. I want it!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden was trying not to lose it. “I don’t think it understands you. It probably can’t give it to you until it reaches the room.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“It’s such a slow, dumb one! Why does CNH have slow, dumb drones?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden coughed. “You want me to pick it up?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“They make a huge racket and report you to drone operations if you interfere with their delivery for more than a second or two, and then an operator <span>scolds</span> you,” said Haoyu, stepping out of the drone’s path and rolling his eyes.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“No, I mean…tell me to pick it up.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu blinked. “You mean with your skill?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I recover from fatigue quickly, so it will work for this. And the drone can’t beep or report if it’s preserved, right? We’re just going to help it get to our room faster.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“That’s crazy. Drone operations is going to think it learned to teleport…let’s do it! Pick it up!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden swooped down on the drone.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>A few minutes later, laughing like dumbasses, they set the rolling box down in front of the doors to Garden Hall then hid behind a planter watching it.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“It’s so freaked out,” Haoyu whispered, watching the box sit there silently.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“How did I get here?” Alden whispered back. “Where am I? I am full of rice and confusion.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“You’re so weird.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Shut up. You’re hiding behind a pepper plant with me.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Peppers! Are these ones we can take? Oh, it’s figured it out. I’m getting a delivery notice.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He bounced over to the drone, and it’s lid popped open.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“You two look happy,” Lute said when they stepped into the room shortly after that. He was lying on the chesterfield, reading one of Haoyu’s Chinese comic books. “Downright <span>vibrant</span> compared to Lexi. He staggered in, ate some of the food in the cooker, and he’s been in the tub ever since. Does he bathe with his whip?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Maybe. He’s a Meister. They do things like that,” said Haoyu, setting his container of rice on the counter and lifting the lid on the chicken-onion dish he’d concocted. “This doesn’t look bad!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“It’s really good with ramen,” said Lute.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“It is?! I have to call my mom!” Alden told himself he was content with the liquid salad he’d bought on the way out of the gym and the bean burgers he was microwaving. He carried his plate into the living room and took Lexi’s favorite armchair.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“The self-mastery wordchain was fantastic,” he told Lute between bites of burger.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lute dropped the comic book on the ottoman and rolled over to look at him. “It’s <span>cool,</span> right?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I don’t think I’d want to use it every day, since this shirt now has a hole burned into the back of it that seemed like a completely reasonable thing to do at the time. But it was so good in the gym. It ran out about the time Big Snake started pelting me with deathballs.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Deathballs?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Tennis balls at deadly speeds!” Haoyu called.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I know I was only my normal self again, and my normal self is pretty good at running around and ducking. But I felt so awkward all of the sudden. Like my limbs got stupider.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Yeah, I’m always disappointed in my natural state of being when it fizzles out, too. Do you still want to learn it?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I need to pay the debt. Can we do that tonight?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lute looked at the plate on Alden’s lap. “Sure. But not while you’re eating. I bit my own finger doing that once.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu sat down with them a minute later, with a pile of food he’d very obviously tried to make photogenic. “We’ve done it. Our first official day of school.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“You cute little first years,” said Lute.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“You’re a first year, too!” said Haoyu.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Yeah, but I’m a grizzled old veteran first year. I bet you two don’t even know which of the toilets on campus have spells and gag flushes on them.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu and Alden exchanged looks.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I feel like we need more details,” said Alden.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Absolutely not. It’s a right of passage to figure it out yourself.” He looked at Alden’s plate again. “You finished your burgers. How much fun can Haoyu and I have at your expense?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“What do you mean?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“As a friend, I should tell you to go get in bed for the night before I drop the debt on you. But…as a friend…I think you should let us observe you a while instead.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Is he going to be funny?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“He’s going to be <span>so</span> funny.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lute was grinning. Haoyu looked excited.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>******</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden Thorn was pretty sure he’d done it. He’d just become a great roommate.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Would a <span>not</span> great roommate let two teenage boys who were laughing like hyenas watch him try to wash dishes when he was in this state?</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He didn’t think so.</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>The feet are more important,</span> he told himself. <span>Pay attention to your balance.</span></span>
+            </p>
+        </div>
+        <div>
+            <p><span>He stood firm.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>The cup he’d been washing fell out of his hand into the small sink and sent soapy water splashing onto the floor. For the third time.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“What the hell?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>It came out sounding like “Whadell?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>His tongue now had a disturbing habit of skipping over sounds. He accessed their roommate group chat.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: Lute, did you somehow give me a triple dose of this shit!?]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Haoyu was on the floor mopping spills with a kitchen towel they only owned thanks to his mother and her assistant explaining that kitchen towels were a must-have item. Lute was lying on his back on the table, clutching his stomach. They were both howling.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: I can’t even talk! This can’t be normal.]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>It wasn’t exactly that he couldn’t talk. With careful effort, he could talk, stand up safely, or move his hands the way he wanted to. But doing all three at once was suddenly rocket science.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lute had even insisted on checking the water temperature before he put his hands in the sink. Apparently with this half of the wordchain, you could be minimally aware of the fact that you were boiling yourself.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I p-promise it’s only one!” Lute gasped. “After you finish the dishes, let’s…let’s try brushing your teeth!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: If there’s a fire tonight, I’ll die. I’ll never make it down the stairs.]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“We’d carry you!” Haoyu said from the floor as another stream of bubbles slopped over the edge toward him.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lexi, scowling, stepped into the kitchen right then. He was in pajama pants. He crossed his arms over his bare chest. “Why are you three so loud, and what did you do to—?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Hi,” said Alden. “I’m fine.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>His arm overshot the drainboard by a mile, and a fork clattered across the tile counter.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Don’t fall!” Haoyu shouted.</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>I’m not falling,</span> thought Alden.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>But Haoyu was on his feet suddenly and Alden was being caught and set upright, so he <span>must</span> have been falling.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lexi walked over to the sink, his eyes wide. “Are you drunk?” he hissed in Alden’s ear. “Did you two get him drunk?!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Yeah that’s it,” said Lute. “Just look at all this booze we’ve got lying around.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I’mnah drunk! I’m jethnah master now.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Probably “I’m just not the master of myself right now” <span>was</span> an overly ambitious sentence.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“He <span>is</span> drunk! He looks just like a drunk person on television! He sounds just like a drunk person.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“He’s not drunk,” said Haoyu, trying to square Alden’s shoulders from behind like he was straightening an unruly shelf.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Are niffing?” Alden asked as Lexi leaned toward him and inhaled.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: He’s sniffing me. Stop it, Lexi. I don’t have beer breath. ]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lute started cackling again.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“It’s a clumsines<span>s</span> wordchain,” Haoyu said. “That’s why he sounds fine on the room chat but not with his mouth. It seems pretty strong. Lute gave it to him.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“<span>Pretty</span> strong?” Lexi asked, staring as another tricky fork made a bid for freedom.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“We aren’t letting him wash knives.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lexi frowned. “Should you be letting him stand up?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: I’m a good roommate. I’m washing all the dishes by myself!]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Haoyu’s keeping you upright.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: He’s a good roommate, too.]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Haoyu: Thank you! That’s not a dish you’re washing though. It’s the pear you knocked in the sink earlier.]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden looked down to see himself scrubbing the peel off a green pear with the dish brush. He set the fruit aside with as much dignity as he could.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lexi looked at them all, then he sighed and went to fetch the forks.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>After the dishes, they all three followed Alden around while he attempted to go through his nighttime routine. Equal amounts of teasing and mother-henning were involved. They wouldn’t let him trip over the edges of the rugs—maybe he shouldn’t have bought <span>quite</span> such thick ones—and bust his face. But they absolutely all stood there snickering while he tried to get toothpaste out of the tube onto his brush.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Don’t waste it!” said Haoyu as Alden stared down at the tablespoonful of green paste oozing down the sides of the brush onto his hand. “Put it all in your mouth.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“It’s not a mistake, you guys!” Lute said. “He wanted that much. You should have seen what he ate for lunch.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Anesidoran social dynamic,” said Lexi. “Spit goes in the sink.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: <span>Et tu</span>, Lexi?]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Why do we randomly say ‘Anesidoran social dynamic’ to Alden sometimes?” Lute asked as he finished brushing.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden glanced at them all in the mirror.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lexi’s expression was neutral.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: Because I whined about Lexi keeping Anesidoran social dynamics to himself when he knew I was ignorant. I was being a dick.]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>About Lute. He felt <span>even worse</span> about that now.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Compared to <span>Lexi</span>?” Lute asked. .</span>
+            </p>
+        </div>
+        <div>
+            <p><span>[Alden: That time I was.]</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lute gasped in mock horror. “Cool! Anesidoran social dynamic—remember you have to pee before bed. <span>For real</span>.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Lexi and Haoyu both looked startled.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“What kind of wordchain <span>is</span> this?” Lexi asked for the third time.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>******</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden wasn’t sure about the lack of bodily awareness being great for sleeping. He might just have been tired after the day he’d had. But he was drifting off easily, right on the brink of unconsciousness, when the notification came in:</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>[Video call from Twenty-seven Hundred and Sixty-third General Evul-art’h, Artona I. Connection fee waived.]</span></span>
+            </p>
+        </div>
+        <div>
+            <p><span>Alden stared at it.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Stuart was calling. Early. It shouldn’t have been much of a surprise. Alden was up in the middle of the night a lot, and Stuart knew that.</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>But I’m in bed. And my tongue is broken.</span></span>
+            </p>
+        </div>
+        <div>
+            <p><span>He reached up and slapped at the switch for the reading light over his bunk. When he finally got it on, he accepted the call with a thought.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Evul-art’h’s black hair and pale pink eyes appeared. She was in her cushioned window seat again.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“The human is very &lt;&lt;loosey-goosey&gt;&gt;today, Stu,” she reported. “He’s in bed.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span><span>Loosey-goosey?</span> Alden was going to have to look into the word that was being translated that way.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Did we wake him up?” Stuart inserted his face between his sister and the tablet. “Did we wake you up? I’m sorry. I called as soon as I got home. I wasn’t thinking about the time as much as I should have been.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Evul-art’h gave them both a curious look.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“It’s all right,” Alden said slowly in the least loosey-goosey Artonan he could manage. <span>Think only about the tongue. Only the tongue.</span> “I’m on the bad half of a wordchain now. Do you mind if we send text messages instead? Or talk in the morning? My mouth—”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>Stuart smiled. “Go to sleep. I’ll call back later.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“He means <span>I’ll</span> call back later,” his sister said dryly.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Thank you. Both of you. We can talk all day tomorrow, Stuart. If you want. Night-night.”</span>
+            </p>
+        </div>
+        <div>
+            <hr />
+            <p>
+                <span>This tale has been unlawfully lifted without the author's consent. Report any appearances on Amazon.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“The human just said <span>night-night</span> and hung up on you. And me,” said Evul-art’h in an intrigued voice. “Mostly me, since it’s officially me calling.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“He has a name.” Stu-art’h perched on the edge of the lounger beside her.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I <span>know</span>. It’s your fault for naming your pet after him. Now I don’t know what to call either of them!”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Alden. And…Other Alden.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“The Ryeh-b’t and the other ryeh-b’t. Not confusing in the slightest.” She shoved herself back into her cushions. After a moment, she said, “Stu, are you all right these days?”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He sighed. “I would be much more all right if you would all stop wanting things for me that I don’t want for myself.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>She smiled. “You’re still angry with me. I don’t know why you thought I wouldn’t side with the others. It’s only the small matters I allow myself to be careless about. You are not a small matter.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>One of her hands rummaged under a golden yellow pillow and pulled out one of her lungsticks. She held the dark tube out to him, and he lit it with a flick of his fingers.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“You’ve always been such a beautiful caster, Stu.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>He stood.</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“Thank you for calling Alden,” he said stiffly. “I would appreciate it if you did me the favor again when he has finished resting.”</span>
+            </p>
+        </div>
+        <div>
+            <p><span>“I’ll do all manner of favors for you, baby brother.” She drew on the stick and sent a cloud of blue smoke toward the ceiling. “Consider doing just <span>one</span> for me in return.”</span>
+            </p>
+        </div>
+    </div>
+</div>

--- a/test/test-pages/royal-road/source.html
+++ b/test/test-pages/royal-road/source.html
@@ -1,0 +1,2440 @@
+<!DOCTYPE html>
+<!--[if IE 8]> <html lang="en" class="ie8 no-js"> <![endif]--><!--[if IE 9]> <html lang="en" class="ie9 no-js"> <![endif]--><!--[if !IE]><!-->
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <!--<![endif]-->
+    <head>
+        <meta charset="utf-8" />
+        <title>
+            ONE HUNDRED TWO: What kind of wordchain? - Super Supportive | Royal Road
+        </title>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="keywords" content="Super Supportive ; Sleyca; ONE HUNDRED TWO: What kind of wordchain?; free books online; webnovel; web novel; web fiction; free; book; novel; royal road; royalroadl; rrl; legends; fiction" />
+        <meta name="description" content="102 “Were you expecting the competition for the showers to be the highest drama part of gym class?” Alden asked Haoyu as the two of them headed (...)" />
+        <meta property="fb:app_id" content="1585608748421060" />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://www.royalroad.com/fiction/63759/super-supportive/chapter/1449598/one-hundred-two-what-kind-of-wordchain" />
+        <meta property="og:image" content="https://www.royalroadcdn.com/public/covers-large/63759-super-supportive.jpg?time=1691780497" />
+        <meta property="og:site_name" content="Royal Road" />
+        <meta property="og:title" content="ONE HUNDRED TWO: What kind of wordchain? - Super Supportive" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="@RoyalRoadL" />
+        <meta name="twitter:creator" content="Sleyca" />
+        <meta name="twitter:title" content="ONE HUNDRED TWO: What kind of wordchain? - Super Supportive" />
+        <meta name="twitter:description" content="102 “Were you expecting the competition for the showers to be the highest drama part of gym class?” Alden asked Haoyu as the two of them headed down a broad avenue toward North of North gym. It (...)" />
+        <meta name="twitter:image" content="https://www.royalroadcdn.com/public/covers-large/63759-super-supportive.jpg?time=1691780497" />
+        <link rel="canonical" href="https://www.royalroad.com/fiction/63759/super-supportive/chapter/1449598/one-hundred-two-what-kind-of-wordchain" />
+        <link rel="prev" href="/fiction/63759/super-supportive/chapter/1446199/one-hundred-one-anesidora-time-0715-pm" />
+        <link rel="next" href="/fiction/63759/super-supportive/chapter/1453643/one-hundred-three-artonan-conversations" />
+        <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;1,400&amp;display=swap" rel="stylesheet" />
+        <link type="text/css" rel="stylesheet" href="/dist/vendor.css?v=dk6Lx2FNSWiQrI59cVd1k4LY4MC0xZ1k6_QX6wgREKU" />
+        <link type="text/css" rel="stylesheet" href="/dist/site-light.css?v=MGMxGOS-fyxJZ54gBrl575MgesbOIbAq6Ydi7LXg5no" />
+        <link rel="stylesheet" href="https://use.typekit.net/jlx5azg.css" />
+        <style>
+        <![CDATA[
+            .cmUyMmY2ODgwNWE4MzRiODJiNjVkMTkxZDVhMDg2N2Qz{
+                display: none;
+                speak: never;
+            }
+        ]]>
+        </style>
+        <link rel="icon" href="/icons/android-chrome-192x192.png?v=20200125" sizes="192x192" />
+        <link rel="shortcut icon" href="/icons/favicon.ico?v=20200125" sizes="16x16 24x24 32x32" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-icon-180x180.png?v=20200125" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png?v=20200125" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png?v=20200125" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="msapplication-TileColor" content="#ffffff" />
+        <meta name="msapplication-TileImage" content="/icons/ms-icon-144x144.png" />
+        <meta name="theme-color" content="#FFFFFF" />
+        <meta name="sentry-trace" content="41d42e6298324f9c9264253f548e2b8b-faa9233724006047" />
+        <meta name="baggage" content="sentry-trace_id=41d42e6298324f9c9264253f548e2b8b, sentry-public_key=de5ce8f509e7458780cbb83f5b040bf0, sentry-release=RoyalRoad.Web.Website%404.1.20240426.6, sentry-environment=production" />
+        <script type="text/javascript">
+        //<![CDATA[
+        window.royalroad = window.royalroad || {init: []};
+        window.royalroad.isPremium = false;
+        window.royalroad.version = "RoyalRoad.Web.Website@"+"4.1.20240426.6";
+        window.royalroad.userId = 0;
+        window.royalroad.environment = "Production";
+        window.royalroad.actionRoute = "Chapter.Index";
+        window.royalroad.username = "";
+        window.royalroad.betaFeatures = false;
+
+        window.dateFormat = "yyyy-MM-dd";
+        window.dateTimeFormat = "yyyy-MM-dd HH:mm";
+        //]]>
+        </script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default%2Ces6"></script>
+        <script>
+        <![CDATA[
+        ('WeakMap' in window && 'IntersectionObserver' in window && 'assign' in Object && 'fetch' in window||document.write("\u003Cscript type=\u0022text/javascript\u0022 src=\u0022/dist/polyfill.js?v=E2dlGu3Twkt6Aze41fk1aiKDLNTwuhu8UQJ891oOdik\u0022\u003E\u003C/script\u003E"));
+        ]]>
+        </script>
+        <script type="text/javascript">
+        //<![CDATA[
+        var AdblockPlus=new function(){this.detect=function(n,e){var o=!1,r=2,c=!1,t=!1;if("function"==typeof e){n+="?ch=*&rn=*";var a=11*Math.random(),i=new Image;i.onload=u,i.onerror=function(){c=!0,u()},i.src=n.replace(/\*/,1).replace(/\*/,a);var f=new Image;f.onload=u,f.onerror=function(){t=!0,u()},f.src=n.replace(/\*/,2).replace(/\*/,a),function n(e,c){0==r||c>1e3?e(0==r&&o):setTimeout(function(){n(e,2*c)},2*c)}(e,250)}function u(){--r||(o=!c&&t)}}};
+        //]]>
+        </script>
+        <script type="text/javascript">
+        //<![CDATA[
+        window.nitroAds=window.nitroAds||{createAd:function(){return new Promise(e=>{window.nitroAds.queue.push(["createAd",arguments,e])})},addUserToken:function(){window.nitroAds.queue.push(["addUserToken",arguments])},queue:[]};
+        //]]>
+        </script>
+        <script async="async" src="https://s.nitropay.com/ads-137.js" type="text/javascript"></script>
+    </head>
+    <body class="page-container-bg-solid light-theme chapter-page-body">
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async="async" src="https://www.googletagmanager.com/gtag/js?id=G-DZHTJVDKRZ"></script> 
+        <script>
+        <![CDATA[
+
+        function createGa() {
+            function adBlockEnabled() {
+                var ad = document.createElement('ins');
+                ad.className = 'AdSense';
+                ad.style.display = 'block';
+                ad.style.position = 'absolute';
+                ad.style.top = '-1px';
+                ad.style.height = '1px';
+                document.body.appendChild(ad);
+                var isAdBlockEnabled = !ad.clientHeight;
+                document.body.removeChild(ad);
+                return isAdBlockEnabled;
+            }
+
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('set', {
+                "dimension4": adBlockEnabled()
+            });
+
+            gtag('set', {"dimension1":"63759","dimension3":"1449598","dimension5":"NotLoggedIn","dimension6":"NitroPay"});
+            function getCookie(name) {
+                var value = "; " + document.cookie;
+                var parts = value.split("; " + name + "=");
+                if (parts.length == 2) return parts.pop().split(";").shift();
+            }
+            
+            if (false){
+                gtag('set', { 'anonymize_ip': true });
+            }
+            if (false) {
+                gtag('consent', 'default', {
+                  'ad_storage': 'denied',
+                  'analytics_storage': 'denied'
+                });
+            }
+            gtag('config', 'G-DZHTJVDKRZ');
+        }
+
+        createGa();
+        ]]>
+        </script>
+        <div class="background-overlay"></div>
+        <div class="page-header">
+            <!-- BEGIN HEADER TOP -->
+            <div class="page-header-top">
+                <div class="container">
+                    <!-- BEGIN LOGO -->
+                    <div class="page-logo">
+                        <a href="/home"><img src="/dist/img/logo/rr-logo-gold-white-small-min.png" alt="Royal Road" title="Royal Road" class="logo-default" /></a>
+                    </div><!-- END LOGO -->
+                    <!-- BEGIN RESPONSIVE MENU TOGGLER -->
+                    <a href="javascript:;" class="menu-toggler" aria-label="Toggle Menu" role="button"></a> <!-- END RESPONSIVE MENU TOGGLER -->
+                     <!-- BEGIN TOP NAVIGATION MENU -->
+                    <div class="top-menu">
+                        <ul class="nav navbar-nav pull-right">
+                            <!-- BEGIN NOTIFICATION DROPDOWN -->
+                            <li class="dropdown dropdown-extended dropdown-notification dropdown-dark" id="header_notification_bar">
+                                <a href="javascript:;" class="dropdown-toggle notifications" data-toggle="dropdown" data-close-others="true" aria-label="Notifications - 0 new"><span class="badge badge-danger alert no-announcement" data-count="0" style="display:none">0</span></a>
+                                <ul class="dropdown-menu notifications">
+                                    <li class="external">
+                                        <h3>
+                                            You have <strong><span class="nr-announcement">no</span> pending</strong> notifications
+                                        </h3><a href="/notifications/list">View all</a>
+                                    </li>
+                                    <li>
+                                        <ul class="dropdown-menu-list scroller" style="height: 250px;" data-handle-color="#637283">
+                                            <li style="overflow: hidden">
+                                                <div class="loader spinner">
+                                                    Loading...
+                                                </div>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li><!-- END NOTIFICATION DROPDOWN -->
+                            <li>
+                                <a href="/account/login?returnurl=%2Ffiction%2F63759%2Fsuper-supportive%2Fchapter%2F1449598%2Fone-hundred-two-what-kind-of-wordchain">Log In</a>
+                            </li>
+                        </ul>
+                    </div><!-- END TOP NAVIGATION MENU -->
+                </div>
+            </div><!-- END HEADER TOP -->
+            <div class="page-header-menu">
+                <div class="container">
+                    <form class="search-form" action="/fictions/search" method="get">
+                        <div class="input-group">
+                            <input type="text" class="form-control" placeholder="Search title..." name="title" aria-label="Fiction search" /> <span class="input-group-btn"><a href="javascript:;" class="btn submit" aria-label="Search" role="button"></a> <a class="btn btn-icon-only btn-primary popovers adv-search" data-trigger="hover" data-container="body" data-placement="bottom" data-content="Advanced Search" aria-label="Advanced Search" href="/fictions/search?advanced=true"></a></span>
+                        </div>
+                    </form>
+                    <div class="hor-menu">
+                        <ul class="nav navbar-nav">
+                            <li class="dropdown menu-dropdown classic-menu-dropdown">
+                                <a href="javascript:;" aria-label="Read" role="button" aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="dropdown-toggle">Read</a>
+                                <ul class="dropdown-menu pull-left">
+                                    <li class="">
+                                        <a href="/fictions/best-rated" class="nav-link" rel="">Best Rated</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/trending" class="nav-link" rel="">Trending</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/active-popular" class="nav-link" rel="">Ongoing Fictions</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/complete" class="nav-link" rel="">Complete</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/weekly-popular" class="nav-link" rel="">Popular this week</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/latest-updates" class="nav-link" rel="">Latest Updates</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/new" class="nav-link" rel="">Newest Fictions</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/rising-stars" class="nav-link" rel="">Rising Stars</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/writathon" class="nav-link" rel="">Writathon</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fictions/search" class="nav-link" rel="">Search</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/fiction/random" class="nav-link" rel="noreferrer noopener">Surprise me!</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="dropdown menu-dropdown classic-menu-dropdown">
+                                <a href="/author-dashboard" aria-label="Write" role="link">Write</a>
+                            </li>
+                            <li class="dropdown menu-dropdown classic-menu-dropdown">
+                                <a href="/forums" aria-label="Forums" role="link">Forums</a>
+                            </li>
+                            <li class="dropdown menu-dropdown classic-menu-dropdown">
+                                <a href="/user/memberlist" aria-label="Member List" role="link">Member List</a>
+                            </li>
+                            <li class="dropdown menu-dropdown classic-menu-dropdown">
+                                <a href="javascript:;" aria-label="Support" role="button" aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="dropdown-toggle">Support</a>
+                                <ul class="dropdown-menu pull-left">
+                                    <li class="">
+                                        <a href="/support/knowledgebase" class="nav-link" rel="">Knowledge Base</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/ideas" class="nav-link" rel="">Suggestions</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="https://www.royalroad.com/forums/1124" class="nav-link" rel="">Community Help</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="/support" class="nav-link" rel="">Support Tickets</a>
+                                    </li>
+                                    <li class="">
+                                        <a href="https://status.royalroad.com" class="nav-link" rel="">Status</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="dropdown menu-dropdown classic-menu-dropdown">
+                                <a href="/premium" aria-label="Premium" role="link">Premium</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="page-container">
+            <div class="page-content-wrapper">
+                <div class="page-content">
+                    <div class="container chapter-page">
+                        <div>
+                            <div class="row fic-header margin-bottom-40">
+                                <div class="row no-space">
+                                    <div class="col-md-2 col-md-push-1 hidden-sm hidden-xs">
+                                        <img class="img-offset" data-type="cover" onload="this.dataset.loaded = 1" onerror="this.onerror=null; this.src='/dist/img/nocover-new-min.png'" alt="Super Supportive " src="https://www.royalroadcdn.com/public/covers-large/63759-super-supportive.jpg?time=1691780497" />
+                                    </div>
+                                    <div class="col-md-5 col-lg-6 col-md-offset-1 text-center md-text-left">
+                                        <a href="/fiction/63759/super-supportive">
+                                        <h2 style="font-size: 24px" class="font-white inline-block">
+                                            Super Supportive
+                                        </h2></a> <span class="font-white">by</span>
+                                        <h3 style="font-size: 21px" class="font-white inline-block">
+                                            <a href="/profile/338123" class="font-white">Sleyca</a>
+                                        </h3>
+                                        <h4 class="font-red-thunderbird star star-48"></h4>
+                                        <h1 style="margin-top: 10px" class="font-white break-word">
+                                            ONE HUNDRED TWO: What kind of wordchain?
+                                        </h1>
+                                    </div>
+                                    <div class="col-md-4 col-lg-3 fic-buttons text-center md-text-left">
+                                        <a class="btn btn-block btn-primary margin-bottom-5" href="/fiction/63759/super-supportive">Fiction Page</a>
+                                        <div class="btn-group" style="width: 100%">
+                                            <a class="btn btn-block btn-default popovers margin-bottom-5 dropdown-toggle" data-toggle="dropdown" aria-expanded="false" data-trigger="hover" data-container="body" data-placement="top" data-original-title="Donations" data-content="All donations to the authors go through their own PayPal or Patreon account; Royal Road takes absolutely no part of your donations." href="javascript:;">Donate</a>
+                                            <ul class="dropdown-menu" style="width: 100%">
+                                                <li>
+                                                    <a href="https://www.patreon.com/Sleyca">Patreon</a>
+                                                </li>
+                                            </ul>
+                                        </div><a class="btn btn-block red-thunderbird margin-bottom-5" href="/report/chapter/1449598"> Report Chapter</a>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="portlet light chapter">
+                                <div class="portlet-title">
+                                    <div class="caption"></div>
+                                    <div class="actions">
+                                        <button data-target="#settings" data-toggle="modal" class="btn btn-circle red"><span class="hidden-xs">Reader</span> Preferences</button>
+                                    </div>
+                                </div>
+                                <div class="portlet-body">
+                                    <div class="row nav-buttons">
+                                        <div class="col-xs-6 col-md-4 col-lg-3 col-xl-2">
+                                            <a class="btn btn-primary col-xs-12" href="/fiction/63759/super-supportive/chapter/1446199/one-hundred-one-anesidora-time-0715-pm">Previous<br class="visible-xs-block" />
+                                            Chapter</a>
+                                        </div>
+                                        <div class="col-xs-6 col-md-4 col-md-offset-4 col-lg-3 col-lg-offset-6">
+                                            <a class="btn btn-primary col-xs-12" href="/fiction/63759/super-supportive/chapter/1453643/one-hundred-three-artonan-conversations">Next<br class="visible-xs-block" />
+                                            Chapter </a>
+                                        </div>
+                                    </div>
+                                    <hr />
+                                    <div class="margin-bottom-20 portlet light t-center-3" style="padding-top: 5px !important;position: relative">
+                                        <div class="bold uppercase">
+                                            Advertisement
+                                        </div><span style="position: absolute; top: 10px;right:10px"><a class="btn btn-default btn-xs" target="_blank" href="/premium/subscription"> Remove</a></span>
+                                        <div class="square const text-center">
+                                            <div class="row">
+                                                <div class="col-md-6">
+                                                    <div id="Chapter_Top_Desktop_1"></div>
+                                                </div>
+                                                <div class="col-md-6 hidden-xs hidden-sm">
+                                                    <div id="Chapter_Top_Desktop_2"></div>
+                                                </div>
+                                            </div>
+                                            <div id="Chapter_Top_Mobile"></div>
+                                        </div>
+                                    </div>
+                                    <div class="chapter-inner chapter-content">
+                                        <div style="caret-color: #000000; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-indent: 0; text-transform: none; word-spacing: 0; text-decoration: none; display: block">
+                                            <div style="direction: ltr; min-height: 350px" tabindex="1" spellcheck="false">
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr; text-align: center">
+                                                        &#160;
+                                                    </div>
+                                                    <div style="direction: ltr; text-align: center">
+                                                        <span style="font-family: arial, sans-serif">102</span>
+                                                    </div>
+                                                    <div style="direction: ltr; text-align: center">
+                                                        &#160;
+                                                    </div>
+                                                    <div style="direction: ltr">
+                                                        &#160;
+                                                    </div>
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Were you expecting the competition for the showers to be the highest drama part of gym class?” Alden asked Haoyu as the two of them headed down a broad avenue toward North of North gym. It was a ten minute walk from the MPE building, right on the edge of campus, and apparently, they had both had the same idea when they discovered they were going to have to wait for their turns anyway.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu was gulping from a water bottle. “I’m glad my group was getting along well. I think the one with the speedsters in it had some kind of issue. They seemed tense.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Finlay <span style="font-style: italic">had</span> looked pretty mad. It was the first time Alden had seen the Scottish boy in anything but a cheerful mood.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I didn’t have the attention span to watch them and run from Snake’s tennis ball pitches.</span> <span style="font-family: arial, sans-serif">It somehow adds insult to injury that he makes you chase the balls down after they hit you.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">When they reached the airy glass building that Alden thought of as the main gym, the same girl in lime green yoga pants who’d been protecting the entrance from riffraff and gawkers on his first visit greeted them both warmly. She was giving out cups of some of the liquefied salads that the spa upstairs bottled and sold as drinks.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">They both took one.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">As they headed toward the showers, Haoyu sipped the black pepper beet juice he’d chosen and wrinkled his nose. “I don’t think I’m old enough to drink this.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden raised an eyebrow at him.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I’m trying!” Haoyu said. “Being friends with Lexi’s <span style="font-style: italic">hard</span>. He got really serious about nutrition in the past year or two. I saw him cut a single piece of chocolate in half once. And there I was stuffing six in my mouth at a time. I want to eat healthy, but I like candy <span style="font-style: italic">so</span> much. And anything fried.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Is that why you bought the slow cooker?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu nodded. “That, and because my mom kept telling me I shouldn’t buy it because I wouldn’t ever use it. I’m going to use it every day. And send her pictures. Starting tonight. The bouncing oatmeal was just a temporary setback. It didn’t even taste that bad.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He looked curiously at a man casting spells on a section of the climbing wall as they passed it. “I’m so glad you’ve got a membership here, too. I really wanted one, and my parents wanted me to have it. But I almost told them not to buy it for me because it’s so…um…”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Richy?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“<span style="font-style: italic">Yes.</span> Mom and Dad both come here, but they have to. They need the facilities in the heavy gym. I could probably have used the school equipment until I was halfway through uni. But everything here is <span style="font-style: italic">so</span> much nicer, and I used to play on the rock wall in the onsite daycare and just imagine how great it was going to be when I was finally fifteen and I could use the real one. They can set it to have high winds, floods, and earthquakes! I went for it. And you’re here, too! We’ll both look richy together, and it won’t be as awkward when we leave school to use the better stuff.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Happy to spoil myself with you.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">They walked past an attendant into the room with the big rainfall showers and the ridiculously fluffy scented towels.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu beamed at him. “Soooo, since you’re here with me, and you’re not going to freak out about it…I’ll confess that I actually already have potion therapy sauna slots booked for a few days a week until the end of term. I was always planning to come here instead of using the student showers.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden blinked at him. The potions saunas had been a part of his facilities tour. For a hundred argold—or more depending on which sauna you chose—you could sweat and inhale magical substances that did rather out-there sounding things.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Are you having your spirit waxed or…?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“No!” Haoyu laughed. “Is that even real? I’m using the recovery sauna. Potions aren’t as good as healers, obviously, but if I sit in there for ninety minutes or so, I don’t really need to rest on my rest days, and I don’t get too sore. I’m just going to do my homework in there instead of sitting through study halls. My mom did sauna homework her whole last year of uni. It was her idea, and since I wasn’t saying no to the gym membership I wasn’t going to say no to something like this.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif"><span style="font-style: italic">He’s basically turning the two hour study hall into recovery time.</span> Alden wondered if Mrs. Zhang-Demir had been attempting to balance out Haoyu’s lifestyle when she tried to set a dorm decorating budget.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“That’s very efficient,” said Alden.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I’m telling you so you can book a slot tonight, if you want to do homework together. And so you’re not like, ‘Where did Haoyu go? Is he trying to get away from me?’ when I jump straight out of the shower and run off to the sauna instead of heading back to the dorms with you.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Gotcha.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Do you want to come?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“…isn’t it a lot of famous people sitting around in towels together, talking about superhero stuff?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">That sounded like a high pressure environment to do homework in unless your parents were famous superheroes and you were used to them.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I’ve only used it a few times so far. It’s not that many people, and they’re all zoned out watching videos or working on their interfaces. They don’t talk and interrupt my studying, so it’s good.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Let me think about it.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr; text-align: center">
+                                                        <span style="font-family: arial, sans-serif">******</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden had a couple of minutes to debate it while they both rinsed off.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Pro: doing homework with Haoyu was in line with his mission to be a great roommate.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Con: shirtlessness.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Pro: trying the new magic thing with someone his own age for backup instead of facing down a bunch of forty-year-olds who could create waterspouts and pitch railcars by himself.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Con: money.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Pro: feeling good tomorrow instead of feeling ouch tomorrow.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-style: italic"><span style="font-family: arial, sans-serif">The cons aren’t really cons.</span></span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He didn’t want to be shy about the tattoo forever with the people he actually <span style="font-style: italic">lived</span> with. And as for the money…</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden had given half of it to Boe so that his family and friends would be taken care of no matter where he was. He’d be spending half of what he had left on supplies, gear, and calling fees to make himself the most absurdly well-equipped and well-connected Rabbit on the Triplanets the next time he was summoned.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">A little would be set aside in his <span style="font-style: italic">backup</span> backup emergency fund.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">But all the rest of it…</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He’d just about talked himself into spending a million dollars however he wanted. As fast as he felt like. When the mood struck him.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Neha had told him to save it for a downpayment on his future immortality, and everything on the internet was about preparing for retirement. Meanwhile, the tiny remnants of the person he’d been in January kept shouting that this much money should last him until he was a <span style="font-style: italic">wrinkly old man</span>.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He thought all of them were overconfident in his ability to make it to the wrinkly stage of life.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Besides, even if he did live to a ripe old age, two or three short summonings a year would make for a decent salary by his standards. He’d be absolutely floored if he only got summoned twice a year.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Mind made up, he flicked through his interface and booked a recovery sauna slot. Then he quickly checked the North of North website to make sure he actually understood what you were supposed to <span style="font-style: italic">do</span> in potion saunas.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Just sit there. No clothes or shoes. Towels. Shower first. No noisy, bright, or smelly spells. No food. Respect the tranquility of the environment.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-style: italic"><span style="font-family: arial, sans-serif">Gee they don’t tell you where to hide your auriad. That’s an oversight.</span></span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He could go with under the wrist cuff or on a thigh. The auriad was getting more and more helpful every day about staying put comfortably wherever he wanted it to.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">A couple of minutes later, towel around his waist, he was stepping into the sauna.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">It was hot and spacious with soft lighting and steam. Five women, three men, and Haoyu each had plenty of room to themselves on the two tiers of pale wood benches. Alden assumed it was all normal enough…for Apex anyway. The adults mostly had that fit-and-flawless look about them that was so common in this gym he hardly ever noticed it anymore. And there was a little bitty cauldron on a pedestal in the middle of the floor. The clear substance inside was <span style="font-style: italic">blub-blubbing</span>, and he thought it was the source of the watermelonish scent.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu smiled brightly and waved him over. “I’m going to watch all the drone footage of my rescues first,” he said quietly. “And then we have that reading assignment on ‘outsmarting enemies’ for offense.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden sat down beside him. By the time he’d started to sweat, he’d gotten over the inherent oddness of doing homework in such an uncommon environment—mostly because Haoyu was a dedicated student. Alden couldn’t stay hung up on towel etiquette while they were having a serious texting conversation about whether saving two of the sandbags at once would increase rescue speed enough to justify the difficulty, risk, and/or talent strain.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">The time went by quickly. A gym employee brought water for them and a refill potion for the tiny cauldron just as he finished up the reading for Instructor Klein. It had already been an hour. His homework was half done. He felt tired, but a little less so than when he’d sat down. Either his body liked saunas or it liked inhaling magic steam.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Most of the people who’d been here to start with were gone. There was just one woman wearing cucumbers over her eyes while she lounged on the top bench…which was technically having food in the sauna, wasn’t it?</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He glanced over at Haoyu. His dark hair was stuck to his forehead, and his mouth was moving slightly. He was one of those people who did that even when they were reading silently.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden kept at his own homework.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Cucumber lady left about fifteen minutes later. Alden was busy watching a video, so he wouldn’t have noticed. But as soon as she closed the door behind her, Haoyu said, “Why can she wear food, but we can’t eat food?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I was thinking the same thing.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu looked over at him. “Thanks for studying with me. I didn’t beg too much, did I? I know it’s expensive. I just got excited to have a gym buddy. The only other people I know of who are even close to our age here are a couple of uni first years.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“This is fun. I probably wouldn’t ever have tried it if you hadn’t asked, so I’m glad you did,” Alden said. “I was more worried about wearing my towel backwards than the money.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu looked thoughtful. “I don’t think you <span style="font-style: italic">can</span> wear a towel backward.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“What if I got here and everyone else had turned theirs into a toga? Or they were supposed to be for our heads instead of our waists?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu snorted.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“It could happen. You Anesidorans have weird customs. Spas have weird customs. Magic has weird customs. All three combined in one location? If I’d walked in and found out we all had to remove our towels and bow to the cauldron, I wouldn’t have been very surprised.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“You were supposed to do that.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden stared at him.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">The other boy’s expression was sincere. “It’s all right that you didn’t do it. Since it was your first time, nobody expected you to know—”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Lexi’s right about you! You do deliver jokes in the exact same tone as serious material.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu grinned.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“What if you do that to someone…you can’t do that! Someone like Jeffy will totally get naked and worship a wizard soup pot!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Jokes are funnier when they’re subtle.” He lifted an arm up and over his head to start a shoulder stretch. “I’m glad you wanted to try it. I was a lot more focused knowing someone else was doing the same assignments.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif"><span style="font-style: italic">Haoyu’s not going to mention it.</span> Alden was gratified but not really surprised. <span style="font-style: italic">He’s so good-natured. And his mom…</span></span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden decided he wasn’t going to get a better chance to bring it up himself. “Do you think our classmates will make a big deal about the tattoo when they see it?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Arm still bent behind his head, Haoyu cut his eyes toward him. “It’s real, right?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Yes.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“You just have to ignore them,” Haoyu said. “You’re rooming with me and Lexi and <span style="font-style: italic">Lute</span>… Plus everyone’s already talking about how something crazy happened to you. And you’re a Rabbit. The purity people have already slotted you in with the rest of us. They’re stupid and they just repeat whatever their parents say, so who cares?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden felt like he was missing at least a couple of social factors that Haoyu was treating as obvious. “The purity people?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“You know, the ones who are like, ‘Anyone who wants to work for the Artonans is an alien bumkisser. Anyone who gets summoned all the time cares more about money than human pride.’ Those people. I think there are only one or two in our whole class who are seriously that way.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He dropped his arm and shrugged.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I haven’t noticed,” said Alden.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Sometimes it’s someone who’s lost a family member to an emergency summons, and then, I understand. They’re grieving and angry. But <span style="font-style: italic">usually</span> it’s just the kids of Contract refusers, or people who’ve never been called at all for some reason, and they want to act like not being a part of that aspect of Avowed life somehow makes them better than everyone else.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“So they’re assholes?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Mostly. Those people are going to be terrible no matter what, so I say don’t worry about them. Everyone else…”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu’s brows suddenly lowered. “Maybe I wouldn’t flash it around the locker room, after all? Even if most of them don’t really have a problem with private contracts, they’re still going to say stupid things and gossip about it. It’s the same reason I don’t tell most people when my parents are doing something dangerous.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He nodded once, as if to settle the matter, then added, “And obviously don’t worry about me. Or any <span style="font-style: italic">mature</span> people. Mom and dad both have tattoos. From Triplanets work and from the demon suppression. Everyone who helps with that gets a secrecy one. And Lexi’s little sister has eight now!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Half of them are turtles,” said Alden.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu laughed. “Lexi won’t admit it, but he’s <span style="font-style: italic">super</span> worried that his parents are wrong and they won’t actually wash off. I think he’s already planning to murder anyone who says anything about the fact that Irina is blue.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr; text-align: center">
+                                                        <span style="font-family: arial, sans-serif">******</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">They headed back to the dorm in the dark, and they met a rolling cafeteria delivery drone on the way that had half of Haoyu’s supper in it.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Listen,” Haoyu said, walking backward while he pleaded with the slowly trundling box, “that’s <span style="font-style: italic">my</span> vegetable rice. I’m Haoyu Zhang-Demir, Garden Hall, Suite 208. That’s me! My name’s on your lid display. Give it to me, and I’ll get to eat it sooner and you’ll get to go back to the cafeteria sooner. It makes sense!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif"><span style="font-style: italic">Beeeeep,</span> the drone said angrily when Haoyu moved to block its way again.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Not <span style="font-style: italic">beep</span>! Rice. My rice. I want it!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden was trying not to lose it. “I don’t think it understands you. It probably can’t give it to you until it reaches the room.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“It’s such a slow, dumb one! Why does CNH have slow, dumb drones?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden coughed. “You want me to pick it up?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“They make a huge racket and report you to drone operations if you interfere with their delivery for more than a second or two, and then an operator <span style="font-style: italic">scolds</span> you,” said Haoyu, stepping out of the drone’s path and rolling his eyes.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“No, I mean…tell me to pick it up.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu blinked. “You mean with your skill?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I recover from fatigue quickly, so it will work for this. And the drone can’t beep or report if it’s preserved, right? We’re just going to help it get to our room faster.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“That’s crazy. Drone operations is going to think it learned to teleport…let’s do it! Pick it up!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden swooped down on the drone.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">A few minutes later, laughing like dumbasses, they set the rolling box down in front of the doors to Garden Hall then hid behind a planter watching it.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“It’s so freaked out,” Haoyu whispered, watching the box sit there silently.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“How did I get here?” Alden whispered back. “Where am I? I am full of rice and confusion.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“You’re so weird.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Shut up. You’re hiding behind a pepper plant with me.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Peppers! Are these ones we can take? Oh, it’s figured it out. I’m getting a delivery notice.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He bounced over to the drone, and it’s lid popped open.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“You two look happy,” Lute said when they stepped into the room shortly after that. He was lying on the chesterfield, reading one of Haoyu’s Chinese comic books. “Downright <span style="font-style: italic">vibrant</span> compared to Lexi. He staggered in, ate some of the food in the cooker, and he’s been in the tub ever since. Does he bathe with his whip?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Maybe. He’s a Meister. They do things like that,” said Haoyu, setting his container of rice on the counter and lifting the lid on the chicken-onion dish he’d concocted. “This doesn’t look bad!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“It’s really good with ramen,” said Lute.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“It is?! I have to call my mom!” Alden told himself he was content with the liquid salad he’d bought on the way out of the gym and the bean burgers he was microwaving. He carried his plate into the living room and took Lexi’s favorite armchair.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“The self-mastery wordchain was fantastic,” he told Lute between bites of burger.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lute dropped the comic book on the ottoman and rolled over to look at him. “It’s <span style="font-style: italic">cool,</span> right?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I don’t think I’d want to use it every day, since this shirt now has a hole burned into the back of it that seemed like a completely reasonable thing to do at the time. But it was so good in the gym. It ran out about the time Big Snake started pelting me with deathballs.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Deathballs?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Tennis balls at deadly speeds!” Haoyu called.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I know I was only my normal self again, and my normal self is pretty good at running around and ducking. But I felt so awkward all of the sudden. Like my limbs got stupider.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Yeah, I’m always disappointed in my natural state of being when it fizzles out, too. Do you still want to learn it?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I need to pay the debt. Can we do that tonight?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lute looked at the plate on Alden’s lap. “Sure. But not while you’re eating. I bit my own finger doing that once.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu sat down with them a minute later, with a pile of food he’d very obviously tried to make photogenic. “We’ve done it. Our first official day of school.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“You cute little first years,” said Lute.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“You’re a first year, too!” said Haoyu.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Yeah, but I’m a grizzled old veteran first year. I bet you two don’t even know which of the toilets on campus have spells and gag flushes on them.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu and Alden exchanged looks.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I feel like we need more details,” said Alden.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Absolutely not. It’s a right of passage to figure it out yourself.” He looked at Alden’s plate again. “You finished your burgers. How much fun can Haoyu and I have at your expense?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“What do you mean?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“As a friend, I should tell you to go get in bed for the night before I drop the debt on you. But…as a friend…I think you should let us observe you a while instead.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Is he going to be funny?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“He’s going to be <span style="font-style: italic">so</span> funny.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lute was grinning. Haoyu looked excited.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr; text-align: center">
+                                                        <span style="font-family: arial, sans-serif">******</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden Thorn was pretty sure he’d done it. He’d just become a great roommate.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Would a <span style="font-style: italic">not</span> great roommate let two teenage boys who were laughing like hyenas watch him try to wash dishes when he was in this state?</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He didn’t think so.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif"><span style="font-style: italic">The feet are more important,</span> he told himself. <span style="font-style: italic">Pay attention to your balance.</span></span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He stood firm.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">The cup he’d been washing fell out of his hand into the small sink and sent soapy water splashing onto the floor. For the third time.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“What the hell?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">It came out sounding like “Whadell?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">His tongue now had a disturbing habit of skipping over sounds. He accessed their roommate group chat.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: Lute, did you somehow give me a triple dose of this shit!?]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Haoyu was on the floor mopping spills with a kitchen towel they only owned thanks to his mother and her assistant explaining that kitchen towels were a must-have item. Lute was lying on his back on the table, clutching his stomach. They were both howling.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: I can’t even talk! This can’t be normal.]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">It wasn’t exactly that he couldn’t talk. With careful effort, he could talk, stand up safely, or move his hands the way he wanted to. But doing all three at once was suddenly rocket science.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lute had even insisted on checking the water temperature before he put his hands in the sink. Apparently with this half of the wordchain, you could be minimally aware of the fact that you were boiling yourself.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I p-promise it’s only one!” Lute gasped. “After you finish the dishes, let’s…let’s try brushing your teeth!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: If there’s a fire tonight, I’ll die. I’ll never make it down the stairs.]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“We’d carry you!” Haoyu said from the floor as another stream of bubbles slopped over the edge toward him.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lexi, scowling, stepped into the kitchen right then. He was in pajama pants. He crossed his arms over his bare chest. “Why are you three so loud, and what did you do to—?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Hi,” said Alden. “I’m fine.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">His arm overshot the drainboard by a mile, and a fork clattered across the tile counter.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Don’t fall!” Haoyu shouted.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif"><span style="font-style: italic">I’m not falling,</span> thought Alden.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">But Haoyu was on his feet suddenly and Alden was being caught and set upright, so he <span style="font-style: italic">must</span> have been falling.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lexi walked over to the sink, his eyes wide. “Are you drunk?” he hissed in Alden’s ear. “Did you two get him drunk?!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Yeah that’s it,” said Lute. “Just look at all this booze we’ve got lying around.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I’mnah drunk! I’m jethnah master now.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Probably “I’m just not the master of myself right now” <span style="font-style: italic">was</span> an overly ambitious sentence.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“He <span style="font-style: italic">is</span> drunk! He looks just like a drunk person on television! He sounds just like a drunk person.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“He’s not drunk,” said Haoyu, trying to square Alden’s shoulders from behind like he was straightening an unruly shelf.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Are niffing?” Alden asked as Lexi leaned toward him and inhaled.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: He’s sniffing me. Stop it, Lexi. I don’t have beer breath. ]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lute started cackling again.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“It’s a clumsines<span style="font-style: italic">s</span> wordchain,” Haoyu said. “That’s why he sounds fine on the room chat but not with his mouth. It seems pretty strong. Lute gave it to him.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“<span style="font-style: italic">Pretty</span> strong?” Lexi asked, staring as another tricky fork made a bid for freedom.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“We aren’t letting him wash knives.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lexi frowned. “Should you be letting him stand up?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: I’m a good roommate. I’m washing all the dishes by myself!]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Haoyu’s keeping you upright.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: He’s a good roommate, too.]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Haoyu: Thank you! That’s not a dish you’re washing though. It’s the pear you knocked in the sink earlier.]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden looked down to see himself scrubbing the peel off a green pear with the dish brush. He set the fruit aside with as much dignity as he could.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lexi looked at them all, then he sighed and went to fetch the forks.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">After the dishes, they all three followed Alden around while he attempted to go through his nighttime routine. Equal amounts of teasing and mother-henning were involved. They wouldn’t let him trip over the edges of the rugs—maybe he shouldn’t have bought <span style="font-style: italic">quite</span> such thick ones—and bust his face. But they absolutely all stood there snickering while he tried to get toothpaste out of the tube onto his brush.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Don’t waste it!” said Haoyu as Alden stared down at the tablespoonful of green paste oozing down the sides of the brush onto his hand. “Put it all in your mouth.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“It’s not a mistake, you guys!” Lute said. “He wanted that much. You should have seen what he ate for lunch.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Anesidoran social dynamic,” said Lexi. “Spit goes in the sink.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: <span style="font-style: italic">Et tu</span>, Lexi?]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Why do we randomly say ‘Anesidoran social dynamic’ to Alden sometimes?” Lute asked as he finished brushing.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden glanced at them all in the mirror.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lexi’s expression was neutral.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: Because I whined about Lexi keeping Anesidoran social dynamics to himself when he knew I was ignorant. I was being a dick.]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">About Lute. He felt <span style="font-style: italic">even worse</span> about that now.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Compared to <span style="font-style: italic">Lexi</span>?” Lute asked. .</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">[Alden: That time I was.]</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lute gasped in mock horror. “Cool! Anesidoran social dynamic—remember you have to pee before bed. <span style="font-style: italic">For real</span>.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Lexi and Haoyu both looked startled.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“What kind of wordchain <span style="font-style: italic">is</span> this?” Lexi asked for the third time.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr; text-align: center">
+                                                        <span style="font-family: arial, sans-serif">******</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden wasn’t sure about the lack of bodily awareness being great for sleeping. He might just have been tired after the day he’d had. But he was drifting off easily, right on the brink of unconsciousness, when the notification came in:</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-weight: bold"><span style="font-family: arial, sans-serif">[Video call from Twenty-seven Hundred and Sixty-third General Evul-art’h, Artona I. Connection fee waived.]</span></span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Alden stared at it.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Stuart was calling. Early. It shouldn’t have been much of a surprise. Alden was up in the middle of the night a lot, and Stuart knew that.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-style: italic"><span style="font-family: arial, sans-serif">But I’m in bed. And my tongue is broken.</span></span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He reached up and slapped at the switch for the reading light over his bunk. When he finally got it on, he accepted the call with a thought.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Evul-art’h’s black hair and pale pink eyes appeared. She was in her cushioned window seat again.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“The human is very &lt;&lt;loosey-goosey&gt;&gt;today, Stu,” she reported. “He’s in bed.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif"><span style="font-style: italic">Loosey-goosey?</span> Alden was going to have to look into the word that was being translated that way.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Did we wake him up?” Stuart inserted his face between his sister and the tablet. “Did we wake you up? I’m sorry. I called as soon as I got home. I wasn’t thinking about the time as much as I should have been.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Evul-art’h gave them both a curious look.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“It’s all right,” Alden said slowly in the least loosey-goosey Artonan he could manage. <span style="font-style: italic">Think only about the tongue. Only the tongue.</span> “I’m on the bad half of a wordchain now. Do you mind if we send text messages instead? Or talk in the morning? My mouth—”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">Stuart smiled. “Go to sleep. I’ll call back later.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“He means <span style="font-style: italic">I’ll</span> call back later,” his sister said dryly.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Thank you. Both of you. We can talk all day tomorrow, Stuart. If you want. Night-night.”</span>
+                                                    </div>
+                                                    <div style="direction: ltr">
+                                                        &#160;
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr; text-align: center">
+                                                        <hr />
+                                                        <p class="cmUyMmY2ODgwNWE4MzRiODJiNjVkMTkxZDVhMDg2N2Qz">
+                                                            <span style="font-family: arial, sans-serif">This tale has been unlawfully lifted without the author's consent. Report any appearances on Amazon.</span>
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“The human just said <span style="font-style: italic">night-night</span> and hung up on you. And me,” said Evul-art’h in an intrigued voice. “Mostly me, since it’s officially me calling.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“He has a name.” Stu-art’h perched on the edge of the lounger beside her.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I <span style="font-style: italic">know</span>. It’s your fault for naming your pet after him. Now I don’t know what to call either of them!”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Alden. And…Other Alden.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“The Ryeh-b’t and the other ryeh-b’t. Not confusing in the slightest.” She shoved herself back into her cushions. After a moment, she said, “Stu, are you all right these days?”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He sighed. “I would be much more all right if you would all stop wanting things for me that I don’t want for myself.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">She smiled. “You’re still angry with me. I don’t know why you thought I wouldn’t side with the others. It’s only the small matters I allow myself to be careless about. You are not a small matter.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">One of her hands rummaged under a golden yellow pillow and pulled out one of her lungsticks. She held the dark tube out to him, and he lit it with a flick of his fingers.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“You’ve always been such a beautiful caster, Stu.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">He stood.</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“Thank you for calling Alden,” he said stiffly. “I would appreciate it if you did me the favor again when he has finished resting.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr">
+                                                        <span style="font-family: arial, sans-serif">“I’ll do all manner of favors for you, baby brother.” She drew on the stick and sent a cloud of blue smoke toward the ceiling. “Consider doing just <span style="font-style: italic">one</span> for me in return.”</span>
+                                                    </div>
+                                                </div>
+                                                <div style="margin: 1em 0; caret-color: #000000">
+                                                    <div style="direction: ltr"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="portlet light t-center-3" style="padding-top: 5px !important;position: relative">
+                                        <div class="bold uppercase">
+                                            Advertisement
+                                        </div><span style="position: absolute; top: 10px;right:10px"><a class="btn btn-default btn-xs" target="_blank" href="/premium/subscription"> Remove</a></span>
+                                        <div class="square text-center">
+                                            <div class="row">
+                                                <div class="col-md-6">
+                                                    <div id="Content_Mid"></div>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <div id="Chapter_Bottom_Desktop"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="portlet solid author-note-portlet">
+                                        <div class="portlet-title">
+                                            <div class="caption">
+                                                <span class="caption-subject bold uppercase">A note from Sleyca</span>
+                                            </div>
+                                        </div>
+                                        <div class="portlet-body author-note">
+                                            <p>
+                                                <span style="font-family: arial, sans-serif">*****Notes*****</span>
+                                            </p>
+                                            <p>
+                                                <span style="font-family: arial, sans-serif">** Not really a note, but do you guys know how different sauna and locker room etiquette can be from country to country...or in the US, at least, from school to school and gym to gym? And generational differences, too. It's one of those weird things I never think about, and then I have to all of the sudden for the story. **</span>
+                                            </p>
+                                            <p>
+                                                <span style="font-family: arial, sans-serif"><span style="font-weight: bold">Other Alden</span> -- the most important character that never gets screentime. Other Alden is a red female ryeh-b't. She looks like a cross between a dragon and a bipedal dinosaur. Only small. Stu-art'h bought her egg after First Alden's assumed death. He turned his bathroom into a terrarium-like habitat for her. She has her own little splashing pool in there. Many Artonan children train ryeh-b'ts for flight, message carrying, and hunting competitions; Stuart says he's giving OA the same training even though he doesn't plan to let her compete.</span>
+                                            </p>
+                                            <p>
+                                                <span style="font-family: arial, sans-serif"><span style="font-weight: bold">Art'h</span> -- The surname used by the Primary's family. It sounds almost like "art" with a nearly silent exhalation on the end. So technically there is a difference in "Stuart" and "Stu-art'h" as far as pronunciation goes.</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <hr />
+                                    <a id="donate"></a>
+                                    <h5 class="uppercase bold margin-bottom-20">
+                                        Support "Super Supportive "
+                                    </h5>
+                                    <div class="row">
+                                        <div class="text-center col-xs-6 col-xs-collapse">
+                                            <button style="width: 100%" class="btn yellow-gold" disabled="disabled">PayPal</button>
+                                        </div>
+                                        <div class="text-center col-xs-6 col-xs-collapse">
+                                            <a style="width: 100%" target="_blank" class="btn yellow-gold" href="https://www.patreon.com/Sleyca">Patreon</a>
+                                        </div>
+                                    </div>
+                                    <hr />
+                                    <div class="row margin-bottom-10 margin-left-0 margin-right-0">
+                                        <a class="btn btn-primary col-xs-4" href="/fiction/63759/super-supportive/chapter/1446199/one-hundred-one-anesidora-time-0715-pm">Previous<br class="visible-xs" />
+                                        Chapter</a> <a class="btn btn-primary col-xs-4" href="/fiction/63759/super-supportive">Fiction<br class="visible-xs" />
+                                        Index</a> <a class="btn btn-primary col-xs-4" href="/fiction/63759/super-supportive/chapter/1453643/one-hundred-three-artonan-conversations">Next<br class="visible-xs" />
+                                        Chapter</a>
+                                    </div>
+                                    <div class="portlet-footer text-right">
+                                        <ul class="list-inline">
+                                            <li class="list-item">
+                                                <a href="/fiction/syndication/63759" rel="nofollow" class="btn btn-sm yellow-gold" style="border-radius: 4px !important">RSS</a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="hidden-lg hidden-md portlet light t-center-3" style="padding-top: 5px !important;position: relative">
+                                <span style="position: absolute; top: 10px;right:10px"><a class="btn btn-default btn-xs" target="_blank" href="/premium/subscription"> Remove</a></span>
+                                <div class="wide text-center mobile-only">
+                                    <div id="Chapter_Bottom_Mobile"></div>
+                                </div>
+                            </div>
+                            <div class="portlet light">
+                                <div class="portlet-title">
+                                    <div class="caption">
+                                        About the author
+                                    </div>
+                                </div>
+                                <div class="portlet-body profile">
+                                    <div class="row">
+                                        <div class="col-md-2">
+                                            <div class="margin-bottom-10">
+                                                <div class="avatar-container-general">
+                                                    <img alt="Sleyca" class="img-circle" data-type="avatar" onerror="this.onerror=null; this.src='/dist/img/anon.jpg'" onload="this.dataset.loaded = 1" src="https://www.royalroadcdn.com/public/avatars/avatar-338123-AAAANTBZ5hI.png?time=1676302774" />
+                                                    <div class="avatar-border dia dia-2"></div>
+                                                    <div class="gem gem-16 dia dia-2" title="Reputation Level 16"></div>
+                                                </div>
+                                            </div>
+                                            <div class="user-stats row no-margin">
+                                                <a href="/profile/338123/fictions" class="margin-bottom-10 btn btn-sm btn-primary col-xs-12 col-sm-4 col-md-12"><strong>1</strong> Fictions</a> <a href="/profile/338123/posts" class="margin-bottom-10 btn btn-sm btn-primary col-xs-6 col-sm-4 col-md-12"> <strong>8</strong> Posts</a> <a href="/profile/338123/threads" class="margin-bottom-10 btn btn-sm btn-primary col-xs-6 col-sm-4 col-md-12"> <strong>0</strong> Threads</a>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-10">
+                                            <div class="row">
+                                                <div class="col-md-8 profile-info">
+                                                    <h1 class="font-blue bold">
+                                                        <a href="/profile/338123" class="font-blue-dark" style="word-break: break-word">Sleyca</a>
+                                                    </h1>
+                                                    <form class="inline-block follow-author-form" action="/user/follow/338123" method="post">
+                                                        <input type="hidden" name="returnUrl" value="/fiction/63759/super-supportive/chapter/1449598/one-hundred-two-what-kind-of-wordchain" /> <button type="submit" class="btn btn-sm btn-primary popovers" data-trigger="hover" data-placement="top" data-title="Follow Author" data-content="Notify me when this author releases a new fiction">Follow Author</button> <input name="__RequestVerificationToken" type="hidden" value="CfDJ8A9BKn47R9pFo4csx6R_elP1Pr3KOw4KSGhTA8wLk6hCkagsShJ0Ber1eyJ4LPk3gl3J0txK0828EWW3qo3wSEhCq9GiVCgd_unVoMcsIBicgg-yYI6ij89ML91ORe0V5FQVLimpE8T-VNbifVlQ2q0" />
+                                                    </form>
+                                                    <ul class="list-inline">
+                                                        <li>
+                                                            <time unixtime="1703102996" datetime="2023-12-20T20:09:56.0000000Z" format="U">Wednesday, December 20, 2023 8:09:56 PM</time>
+                                                        </li>
+                                                    </ul>
+                                                    <p>
+                                                        <strong>Bio:</strong> I write things. I hope you like them.
+                                                    </p>
+                                                </div><!--end col-md-8-->
+                                                <div class="col-md-4">
+                                                    <div class="portlet sale-summary">
+                                                        <div class="portlet-title">
+                                                            <div class="caption font-red sbold">
+                                                                Achievements
+                                                            </div>
+                                                        </div>
+                                                        <div class="portlet-body">
+                                                            <div class="row no-gutter">
+                                                                <div class="col-xs-3" style="margin-top: 3px;">
+                                                                    <img style="width: 32px; height: 32px" src="https://www.royalroadcdn.com/public/achievements/i-am-flying-ix-small-AABA3lcHIw0.png" alt="" class="img-responsive popovers" data-container="body" data-trigger="hover" data-placement="top" data-original-title="10,000,000 Views" data-content="Awarded for achieving 10,000,000 total views on a single fiction" />
+                                                                </div>
+                                                                <div class="col-xs-3" style="margin-top: 3px;">
+                                                                    <img style="width: 32px; height: 32px" src="https://www.royalroadcdn.com/public/achievements/20000-followers-small-AADAkHCyIg0.png" alt="" class="img-responsive popovers" data-container="body" data-trigger="hover" data-placement="top" data-original-title="20,000 Followers" data-content="Achievement awarded for reaching 20,000 Followers for a single fiction" />
+                                                                </div>
+                                                                <div class="col-xs-3" style="margin-top: 3px;">
+                                                                    <img style="width: 32px; height: 32px" src="https://www.royalroadcdn.com/public/achievements/1st-anniversary-small-AACAVydbIQ0.png" alt="" class="img-responsive popovers" data-container="body" data-trigger="hover" data-placement="top" data-original-title="1st Anniversary" data-content="You have been with us for 1 year now! Thank you for being part of our journey" />
+                                                                </div>
+                                                                <div class="col-xs-3" style="margin-top: 3px;">
+                                                                    <img style="width: 32px; height: 32px" src="https://www.royalroadcdn.com/public/achievements/word-count-15-small-AABAaRomIg0.png" alt="" class="img-responsive popovers" data-container="body" data-trigger="hover" data-placement="top" data-original-title="Word Count (15)" data-content="Awarded for publishing at least 500,000 words" />
+                                                                </div>
+                                                                <div class="col-xs-3" style="margin-top: 3px;">
+                                                                    <img style="width: 32px; height: 32px" src="https://www.royalroadcdn.com/public/achievements/100-comments-small-AADAWt2zIg0.png" alt="" class="img-responsive popovers" data-container="body" data-trigger="hover" data-placement="top" data-original-title="100 Comments" data-content="Achievement awarded for posting 100 comments" />
+                                                                </div>
+                                                                <div class="col-xs-3" style="margin-top: 3px;">
+                                                                    <img style="width: 32px; height: 32px" src="https://www.royalroadcdn.com/public/achievements/now-the-shiny-trophy-is-mine-guess-i-won-yay-small-AAAAM7GCIQ0.png" alt="" class="img-responsive popovers" data-container="body" data-trigger="hover" data-placement="top" data-original-title="Royal Bloodline" data-content="Achievement awarded for reaching the top of the Best Rated ranking" />
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div><!--end col-md-4-->
+                                            </div><!--end row-->
+                                        </div>
+                                    </div>
+                                </div>
+                            </div><!-- BEGIN COMMENTS -->
+                            <a id="comments"></a>
+                            <div class="portlet light comments-container">
+                                <div class="portlet-title">
+                                    <div class="caption">
+                                        <div class="caption-subject">
+                                            Comments(301)
+                                        </div>
+                                    </div>
+                                    <div class="actions">
+                                        <button class="btn btn-default btn-circle comment-display-toggle" data-compact="false">Set Compact</button>
+                                    </div>
+                                </div>
+                                <div class="text-center margin-top-20 margin-bottom-20">
+                                    Log in to comment<br />
+                                    <a class="btn btn-primary margin-top-10" href="/account/login?ReturnUrl=https%3A%2F%2Fwww.royalroad.com%2Ffiction%2F63759%2Fsuper-supportive%2Fchapter%2F1449598%2Fone-hundred-two-what-kind-of-wordchain"> Log In</a>
+                                </div>
+                                <hr />
+                                <div class="portlet-body comments comment-container">
+                                    <div id="comment-loader" class="text-center margin-top-20 margin-bottom-20">
+                                        <button class="btn btn-primary" onclick="loadComments(1, 1449598, null);">Load Comments</button>
+                                    </div><noscript>Please enable JavaScript to load the comments!</noscript>
+                                </div>
+                                <div class="text-center margin-top-20 margin-bottom-20">
+                                    Log in to comment<br />
+                                    <a class="btn btn-primary margin-top-10" href="/account/login?ReturnUrl=https%3A%2F%2Fwww.royalroad.com%2Ffiction%2F63759%2Fsuper-supportive%2Fchapter%2F1449598%2Fone-hundred-two-what-kind-of-wordchain"> Log In</a>
+                                </div>
+                                <hr />
+                            </div>
+                            <div class="modal custom-modal" id="settings" data-backdrop="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h4 class="modal-title">
+                                                Settings
+                                            </h4>
+                                        </div>
+                                        <div class="modal-body">
+                                            <div>
+                                                <div class="row">
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label>Theme (Entire Website)</label> <select name="style" id="style" class="style-select form-control">
+                                                                <option value="dark">
+                                                                    Dark
+                                                                </option>
+                                                                <option value="light" selected="selected">
+                                                                    Light
+                                                                </option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label>Dim background</label> <select class="dim-dropdown form-control" data-reader-preference-binding="dimBackground" id="dim-dropdown" name="dim-dropdown">
+                                                                <option selected="selected" value="0">
+                                                                    0%
+                                                                </option>
+                                                                <option value="0.2">
+                                                                    20%
+                                                                </option>
+                                                                <option value="0.4">
+                                                                    40%
+                                                                </option>
+                                                                <option value="0.5">
+                                                                    50%
+                                                                </option>
+                                                                <option value="0.6">
+                                                                    60%
+                                                                </option>
+                                                                <option value="0.8">
+                                                                    80%
+                                                                </option>
+                                                                <option value="1">
+                                                                    100%
+                                                                </option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="row">
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label>Font Size</label> <select class="font-size form-control" data-reader-preference-binding="fontSize">
+                                                                <option>
+                                                                    10
+                                                                </option>
+                                                                <option>
+                                                                    11
+                                                                </option>
+                                                                <option>
+                                                                    12
+                                                                </option>
+                                                                <option>
+                                                                    13
+                                                                </option>
+                                                                <option selected="selected">
+                                                                    14
+                                                                </option>
+                                                                <option>
+                                                                    15
+                                                                </option>
+                                                                <option>
+                                                                    16
+                                                                </option>
+                                                                <option>
+                                                                    17
+                                                                </option>
+                                                                <option>
+                                                                    18
+                                                                </option>
+                                                                <option>
+                                                                    20
+                                                                </option>
+                                                                <option>
+                                                                    22
+                                                                </option>
+                                                                <option>
+                                                                    24
+                                                                </option>
+                                                                <option>
+                                                                    28
+                                                                </option>
+                                                                <option>
+                                                                    32
+                                                                </option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-6">
+                                                        <div class="form-group">
+                                                            <label>Reader Width</label> <select class="reader-width form-control" data-reader-preference-binding="readerWidth">
+                                                                <option selected="selected" value="1">
+                                                                    Max
+                                                                </option>
+                                                                <option value="0.9">
+                                                                    90%
+                                                                </option>
+                                                                <option value="0.8">
+                                                                    80%
+                                                                </option>
+                                                                <option value="0.7">
+                                                                    70%
+                                                                </option>
+                                                                <option value="0.6">
+                                                                    60%
+                                                                </option>
+                                                                <option value="0.5">
+                                                                    50%
+                                                                </option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="row">
+                                                    <div class="col-xs-12 col-12 col-sm-10 col-md-10">
+                                                        <div class="form-group">
+                                                            <label>Font Family</label>
+                                                            <div class="font-family-dropdown-container">
+                                                                <select class="font-family form-control" data-reader-preference-binding="fontFamily">
+                                                                    <option selected="selected" value="default" style="font-family: Helvetica Neue, Helvetica, Roboto, Arial, sans-serif">
+                                                                        Default
+                                                                    </option>
+                                                                    <option disabled="disabled">
+                                                                        —————
+                                                                    </option>
+                                                                    <option value="opendyslexic" style="font-family: opendyslexic">
+                                                                        Open Dyslexic
+                                                                    </option>
+                                                                    <option value="atkinson-hyperlegible" style="font-family: 'Atkinson Hyperlegible'">
+                                                                        Atkinson Hyperlegible
+                                                                    </option>
+                                                                    <option disabled="disabled">
+                                                                        —————
+                                                                    </option>
+                                                                    <option value="Arial" style="font-family: Arial">
+                                                                        Arial
+                                                                    </option>
+                                                                    <option value="Roboto" style="font-family: Roboto">
+                                                                        Roboto
+                                                                    </option>
+                                                                    <option value="Open Sans" style="font-family: 'Open Sans', 'open sans', open-sans, sans-serif">
+                                                                        Open Sans
+                                                                    </option>
+                                                                    <option value="System Default" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'">
+                                                                        OS Default
+                                                                    </option>
+                                                                    <option value="Comic Sans MS, Comic Sans" style="font-family: 'Comic Sans MS', Comic Sans, sans-serif">
+                                                                        Comic Sans
+                                                                    </option>
+                                                                    <option value="Lucida" style="font-family: 'Lucida Grande', 'Lucida Sans', Arial, sans-serif">
+                                                                        Lucida
+                                                                    </option>
+                                                                    <option value="Verdana" style="font-family: Verdana">
+                                                                        Verdana
+                                                                    </option>
+                                                                    <option value="Ubuntu" style="font-family: Ubuntu">
+                                                                        Ubuntu
+                                                                    </option>
+                                                                    <option value="Ubuntu Condensed" style="font-family: Ubuntu Condensed">
+                                                                        Ubuntu Condensed
+                                                                    </option>
+                                                                    <option value="Franklin Gothic" style="font-family: Franklin Gothic">
+                                                                        Franklin Gothic
+                                                                    </option>
+                                                                    <option value="adobe-garamond-pro" style="font-family: adobe-garamond-pro">
+                                                                        Garamond
+                                                                    </option>
+                                                                    <option value="adobe-caslon-pro" style="font-family: adobe-caslon-pro">
+                                                                        Caslon
+                                                                    </option>
+                                                                    <option value="minion-pro" style="font-family: minion-pro">
+                                                                        Minion
+                                                                    </option>
+                                                                </select>
+                                                            </div>
+                                                            <div class="override-font-family-container">
+                                                                <input type="checkbox" id="font-override" class="font-override hidden" data-reader-preference-binding="fontFamilyOverride" />
+                                                            </div>
+                                                            <div class="clearfix"></div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-sm-2 col-xs-3 col-3 col-md-2 col-xs-push-9 col-sm-push-0 text-center">
+                                                        <div class="form-group">
+                                                            <label><span class="hidden-xs">Font</span> Color</label>
+                                                            <div class="form-group">
+                                                                <input type="checkbox" id="color-override" class="color-override hidden" data-reader-preference-binding="stripFontColor" />
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-4 col-sm-6 col-xs-9 col-xs-pull-3 col-sm-pull-0">
+                                                        <label>Indent</label>
+                                                        <div class="form-group">
+                                                            <input type="radio" name="indent-override" id="indent-override-remove" class="indent-override hidden" value="remove" data-reader-preference-binding="indent" /> <input type="radio" name="indent-override" id="indent-override-default" class="indent-override hidden" value="default" data-reader-preference-binding="indent" /> <input type="radio" name="indent-override" id="indent-override-force" class="indent-override hidden" value="force" data-reader-preference-binding="indent" />
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-4 col-sm-6 col-xs-12">
+                                                        <label>Color Scheme</label>
+                                                        <div class="form-group">
+                                                            <select class="background-color form-control" data-reader-preference-binding="bgColor">
+                                                                <option selected="selected" value="default">
+                                                                    Theme Default
+                                                                </option>
+                                                                <option value="black">
+                                                                    OLED Black
+                                                                </option>
+                                                                <option value="rrdark">
+                                                                    Royal Road Dark
+                                                                </option>
+                                                                <option value="darkgray">
+                                                                    Dark Gray
+                                                                </option>
+                                                                <option value="gray">
+                                                                    Gray
+                                                                </option>
+                                                                <option value="lightgray">
+                                                                    Light Gray
+                                                                </option>
+                                                                <option value="sepia">
+                                                                    Sepia
+                                                                </option>
+                                                                <option value="white">
+                                                                    White
+                                                                </option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-4 col-xs-12">
+                                                        <label>Paragraph Spacing</label>
+                                                        <div class="form-group">
+                                                            <div class="input-group">
+                                                                <input name="paragraph-spacing" id="paragraph-spacing" class="form-control text-center" value="30" type="number" data-reader-preference-binding="paragraphSpacing" />
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" data-dismiss="modal" class="btn dark btn-outline">Close</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="modal fade" id="rep-modal" tabindex="-1" role="dialog">
+                                <div class="modal-dialog" role="document">
+                                    <div class="portlet">
+                                        <form method="post" class="form" id="give-reputation-form" action="/forums/givereputation" name="give-reputation-form">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                                                    <h4 class="modal-title">
+                                                        Give Reputation to User: <span id="rep-username"></span>
+                                                    </h4>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <input type="hidden" name="uid" id="rep-uid" /> <input type="hidden" name="cid" id="rep-cid" />
+                                                    <div class="form-group">
+                                                        <label for="amount" class="control-label">Points</label> <input class="form-control" type="number" min="0" max="0" name="amount" id="rep-amount" value="0" /> <span class="hint small" id="rep-hint">You can specify how many points you want to give (minimum: 0, maximum: 0).</span>
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <label for="c" class="control-label">Comment <small>(optional)</small></label> 
+                                                        <textarea class="form-control" type="text" name="comment" id="c" rows="3"></textarea> <span class="hint small">Why are you giving this user reputation?</span>
+                                                    </div>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="submit" class="btn btn-primary">Give Reputation</button> <button type="button" data-dismiss="modal" class="btn dark btn-outline">Close</button>
+                                                </div>
+                                            </div><input name="__RequestVerificationToken" type="hidden" value="CfDJ8A9BKn47R9pFo4csx6R_elP1Pr3KOw4KSGhTA8wLk6hCkagsShJ0Ber1eyJ4LPk3gl3J0txK0828EWW3qo3wSEhCq9GiVCgd_unVoMcsIBicgg-yYI6ij89ML91ORe0V5FQVLimpE8T-VNbifVlQ2q0" />
+                                        </form>
+                                    </div>
+                                    <div style="position: absolute; top: 0; left: 0; bottom: 0; right: 0; background: rgba(0, 0, 0, .5); display: none" id="rep-modal-loader">
+                                        <div style="position: absolute; left: calc(50% - 40px); top: calc(50% - 140px);">
+                                            <div class="loading spinner">
+                                                <div class="cube1 bg-blue"></div>
+                                                <div class="cube2 bg-blue"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="page-prefooter">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-3 col-sm-6 col-xs-12 footer-block">
+                        <h2>
+                            About
+                        </h2>
+                        <p>
+                            Royal Road® is the home of web novels and fan fictions! In our amazing community, you can find various talented individuals who write as a hobby or even professionally, artists who create art for them, and many, many readers who provide valuable feedback and encouragement.
+                        </p>
+                    </div>
+                    <div class="col-md-3 col-sm-6 col-xs12 footer-block">
+                        <h2>
+                            Amazon Affiliate
+                        </h2>
+                        <div class="smalltext">
+                            Royal Road® as an Amazon Associate earns from qualifying purchases.
+                        </div>
+                    </div>
+                    <div class="col-md-3 col-sm-6 col-xs-12 footer-block">
+                        <h2>
+                            <label for="style" style="font-weight: inherit; color: inherit">Theme Select</label>
+                        </h2>
+                        <div class="subscribe-form">
+                            <select name="style" id="style" class="style-select form-control">
+                                <option value="dark">
+                                    Dark
+                                </option>
+                                <option value="light" selected="selected">
+                                    Light
+                                </option>
+                            </select>
+                        </div><br />
+                        <h2>
+                            Follow Us On
+                        </h2>
+                        <ul class="social-icons">
+                            <li>
+                                <a href="https://facebook.com/royalroadl" target="_blank" rel="noopener noreferrer" data-original-title="facebook" class="facebook" aria-label="Our Facebook Page"></a>
+                            </li>
+                            <li>
+                                <a href="https://twitter.com/royalroadl" target="_blank" rel="noopener noreferrer" data-original-title="twitter" class="twitter" aria-label="Our Twitter Page"></a>
+                            </li>
+                            <li>
+                                <a href="https://www.pinterest.co.uk/royalroadofficial/" target="_blank" rel="noopener noreferrer" data-original-title="pinterest" class="pintrest" aria-label="Our Pinterest Page"></a>
+                            </li>
+                            <li>
+                                <a href="https://www.instagram.com/royalroad.official" target="_blank" rel="noopener noreferrer" data-original-title="instagram" class="instagram" aria-label="Our Instagram Page"></a>
+                            </li>
+                            <li>
+                                <a href="https://www.tiktok.com/@royalroadofficial" target="_blank" rel="noopener noreferrer" data-original-title="tiktok" class="tiktok" aria-label="Our Tiktok Page"></a>
+                            </li>
+                        </ul>
+                    </div><!--sse-->
+                    <div class="col-md-3 col-sm-6 col-xs-12 footer-block">
+                        <h2>
+                            Need some help?
+                        </h2>
+                        <div>
+                            <a href="/support">Create a support ticket</a>
+                        </div>
+                        <div>
+                            <div id="ncmp-consent-link"></div>
+                        </div><br />
+                        <div>
+                            <h2>
+                                Contact
+                            </h2><a href="/contact">Contact Us by Email</a>
+                        </div><br />
+                        <h2>
+                            Advertising
+                        </h2>
+                        <div>
+                            <a href="/pages/advertising-faq">Ads for Authors</a><br />
+                            <a href="/cdn-cgi/l/email-protection#3645575a53457651514559504241574453185f59">Programmatic Advertising</a>
+                        </div>
+                    </div><!--/sse-->
+                </div>
+            </div>
+        </div><!-- END PRE-FOOTER -->
+        <!-- BEGIN INNER FOOTER -->
+        <div class="page-footer footer">
+            <div class="container">
+                <div class="pull-left">
+                    Royal Road® © 2024
+                </div>
+                <div class="pull-right">
+                    <a href="/tos">Terms of Service</a> | <a title="Privacy Policy" href="/privacypolicy">Privacy Policy</a> | <a title="Cookie Policy" href="/cookiepolicy">Cookie Policy</a> | <a title="DMCA" href="/dmca">DMCA</a> | <a href="/blog">Blog</a> | <a href="https://status.royalroad.com" rel="noopener noreferrer">Status</a>
+                </div>
+            </div>
+        </div>
+        <div class="scroll-to-top"></div>
+        <div class="scroll-to-top-tooltip" style="display: none">
+            Tap again to scroll to the top!
+        </div>
+        <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script>
+        <script type="text/javascript" src="/dist/site.js?v=yF8l1klsXVKx0QoRPjauzkYOV4Z7xDX-aRiVlFZFBCQ"></script> 
+        <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script> 
+        <script>
+        <![CDATA[
+
+        WebFont.load({
+            google: {
+                families: ['Ubuntu', 'Ubuntu Condensed', 'Roboto:300,400,500,600,700', 'Merriweather:300,400,500,600,700']
+            }
+        });
+        ]]>
+        </script> 
+        <script>
+        <![CDATA[
+
+            var chapterId = 1449598;
+            var fictionId = 63759;
+        ]]>
+        </script>
+        <link type="text/css" rel="stylesheet" href="/users/borders.css?v=TAuhJTOTF6Au5UIesJ/x/A==" />
+        <script type="text/javascript">
+        //<![CDATA[
+        var npAd = {
+        "refreshLimit": 0,
+        "refreshTime": 30,
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        100
+        ]
+        ],
+        "renderVisibleOnly": true,
+        "refreshVisibleOnly": true,
+        "acceptable": false
+        }
+        if(window.innerWidth < 748 && npAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAd.sizes = Array.from(npAd.sizes.filter(function(x){return x[0] < 728}));
+        npAd.sizes.push([320, 50]);
+        npAd.sizes.push([320, 100]);
+        }
+        var npAAd = {
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        100
+        ]
+        ],
+        "renderVisibleOnly": false,
+        "refreshVisibleOnly": false,
+        "acceptable": true
+        }
+        if(window.innerWidth < 748 && npAAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAAd.sizes = Array.from(npAAd.sizes.filter(function(x){return x[0] < 728}));
+        npAAd.sizes.push([320, 50]);
+        npAAd.sizes.push([320, 100]);
+        }
+        if(window.innerWidth >= 991) {window['nitroAds'].createAd('Chapter_Top_Desktop_1', npAd);}
+        if(window.innerWidth >= 991) {window['nitroAds'].createAd('Chapter_Top_Desktop_1', npAAd);}
+        var npAd = {
+        "refreshLimit": 0,
+        "refreshTime": 30,
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        100
+        ]
+        ],
+        "renderVisibleOnly": true,
+        "refreshVisibleOnly": true,
+        "acceptable": false
+        }
+        if(window.innerWidth < 748 && npAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAd.sizes = Array.from(npAd.sizes.filter(function(x){return x[0] < 728}));
+        npAd.sizes.push([320, 50]);
+        npAd.sizes.push([320, 100]);
+        }
+        var npAAd = {
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        100
+        ]
+        ],
+        "renderVisibleOnly": false,
+        "refreshVisibleOnly": false,
+        "acceptable": true
+        }
+        if(window.innerWidth < 748 && npAAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAAd.sizes = Array.from(npAAd.sizes.filter(function(x){return x[0] < 728}));
+        npAAd.sizes.push([320, 50]);
+        npAAd.sizes.push([320, 100]);
+        }
+        if(window.innerWidth >= 991) {window['nitroAds'].createAd('Chapter_Top_Desktop_2', npAd);}
+        if(window.innerWidth >= 991) {window['nitroAds'].createAd('Chapter_Top_Desktop_2', npAAd);}
+        var npAd = {
+        "refreshLimit": 0,
+        "refreshTime": 30,
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        320,
+        50
+        ],
+        [
+        320,
+        100
+        ],
+        [
+        300,
+        250
+        ]
+        ],
+        "renderVisibleOnly": true,
+        "refreshVisibleOnly": true,
+        "acceptable": false
+        }
+        if(window.innerWidth < 748 && npAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAd.sizes = Array.from(npAd.sizes.filter(function(x){return x[0] < 728}));
+        npAd.sizes.push([320, 50]);
+        npAd.sizes.push([320, 100]);
+        }
+        var npAAd = {
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        320,
+        50
+        ],
+        [
+        320,
+        100
+        ],
+        [
+        300,
+        250
+        ]
+        ],
+        "renderVisibleOnly": false,
+        "refreshVisibleOnly": false,
+        "acceptable": true
+        }
+        if(window.innerWidth < 748 && npAAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAAd.sizes = Array.from(npAAd.sizes.filter(function(x){return x[0] < 728}));
+        npAAd.sizes.push([320, 50]);
+        npAAd.sizes.push([320, 100]);
+        }
+        if(window.innerWidth < 991) {window['nitroAds'].createAd('Chapter_Top_Mobile', npAd);}
+        if(window.innerWidth < 991) {window['nitroAds'].createAd('Chapter_Top_Mobile', npAAd);}
+        var npAd = {
+        "refreshLimit": 0,
+        "refreshTime": 30,
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        50
+        ],
+        [
+        320,
+        100
+        ]
+        ],
+        "renderVisibleOnly": true,
+        "refreshVisibleOnly": true,
+        "acceptable": false
+        }
+        if(window.innerWidth < 748 && npAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAd.sizes = Array.from(npAd.sizes.filter(function(x){return x[0] < 728}));
+        npAd.sizes.push([320, 50]);
+        npAd.sizes.push([320, 100]);
+        }
+        var npAAd = {
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        50
+        ],
+        [
+        320,
+        100
+        ]
+        ],
+        "renderVisibleOnly": false,
+        "refreshVisibleOnly": false,
+        "acceptable": true
+        }
+        if(window.innerWidth < 748 && npAAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAAd.sizes = Array.from(npAAd.sizes.filter(function(x){return x[0] < 728}));
+        npAAd.sizes.push([320, 50]);
+        npAAd.sizes.push([320, 100]);
+        }
+        window['nitroAds'].createAd('Content_Mid', npAd);
+        window['nitroAds'].createAd('Content_Mid', npAAd);
+        var npAd = {
+        "refreshLimit": 0,
+        "refreshTime": 30,
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        50
+        ],
+        [
+        320,
+        100
+        ]
+        ],
+        "renderVisibleOnly": true,
+        "refreshVisibleOnly": true,
+        "acceptable": false
+        }
+        if(window.innerWidth < 748 && npAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAd.sizes = Array.from(npAd.sizes.filter(function(x){return x[0] < 728}));
+        npAd.sizes.push([320, 50]);
+        npAd.sizes.push([320, 100]);
+        }
+        var npAAd = {
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        50
+        ],
+        [
+        320,
+        100
+        ]
+        ],
+        "renderVisibleOnly": false,
+        "refreshVisibleOnly": false,
+        "acceptable": true
+        }
+        if(window.innerWidth < 748 && npAAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAAd.sizes = Array.from(npAAd.sizes.filter(function(x){return x[0] < 728}));
+        npAAd.sizes.push([320, 50]);
+        npAAd.sizes.push([320, 100]);
+        }
+        if(window.innerWidth >= 991) {window['nitroAds'].createAd('Chapter_Bottom_Desktop', npAd);}
+        if(window.innerWidth >= 991) {window['nitroAds'].createAd('Chapter_Bottom_Desktop', npAAd);}
+        var npAd = {
+        "refreshLimit": 0,
+        "refreshTime": 30,
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        50
+        ],
+        [
+        320,
+        100
+        ],
+        [
+        300,
+        600
+        ]
+        ],
+        "renderVisibleOnly": true,
+        "refreshVisibleOnly": true,
+        "acceptable": false
+        }
+        if(window.innerWidth < 748 && npAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAd.sizes = Array.from(npAd.sizes.filter(function(x){return x[0] < 728}));
+        npAd.sizes.push([320, 50]);
+        npAd.sizes.push([320, 100]);
+        }
+        var npAAd = {
+        "report": {
+        "enabled": true,
+        "wording": "Report",
+        "position": "fixed-bottom-right"
+        },
+        "sizes": [
+        [
+        300,
+        250
+        ],
+        [
+        320,
+        50
+        ],
+        [
+        320,
+        100
+        ],
+        [
+        300,
+        600
+        ]
+        ],
+        "renderVisibleOnly": false,
+        "refreshVisibleOnly": false,
+        "acceptable": true
+        }
+        if(window.innerWidth < 748 && npAAd.sizes.map(function(x){ return x[0] == 728}).reduce(function(x, y) { return x || y}))
+        {
+        npAAd.sizes = Array.from(npAAd.sizes.filter(function(x){return x[0] < 728}));
+        npAAd.sizes.push([320, 50]);
+        npAAd.sizes.push([320, 100]);
+        }
+        if(window.innerWidth < 991) {window['nitroAds'].createAd('Chapter_Bottom_Mobile', npAd);}
+        if(window.innerWidth < 991) {window['nitroAds'].createAd('Chapter_Bottom_Mobile', npAAd);}
+        //]]>
+        </script> 
+        <script>
+        <![CDATA[
+        (function(){if (!document.body) return;var js = "window['__CF$cv$params']={r:'87ea132a1a9510e3',t:'MTcxNDg0MjMxOC41NTIwMDA='};_cpo=document.createElement('script');_cpo.nonce='',_cpo.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js',document.getElementsByTagName('head')[0].appendChild(_cpo);";var _0xh = document.createElement('iframe');_0xh.height = 1;_0xh.width = 1;_0xh.style.position = 'absolute';_0xh.style.top = 0;_0xh.style.left = 0;_0xh.style.border = 'none';_0xh.style.visibility = 'hidden';document.body.appendChild(_0xh);function handler() {var _0xi = _0xh.contentDocument || _0xh.contentWindow.document;if (_0xi) {var _0xj = _0xi.createElement('script');_0xj.innerHTML = js;_0xi.getElementsByTagName('head')[0].appendChild(_0xj);}}if (document.readyState !== 'loading') {handler();} else if (window.addEventListener) {document.addEventListener('DOMContentLoaded', handler);} else {var prev = document.onreadystatechange || function () {};document.onreadystatechange = function (e) {prev(e);if (document.readyState !== 'loading') {document.onreadystatechange = prev;handler();}};}})();
+        ]]>
+        </script><!--
+ ___               _   ___              _
+| _ \___ _  _ __ _| | | _ \___  __ _ __| |
+|   / _ \ || / _` | | |   / _ \/ _` / _` |
+|_|_\___/\_, \__,_|_| |_|_\___/\__,_\__,_|
+       |__/
+-->
+    </body>
+</html>

--- a/test/test-pages/toc-missing/expected.html
+++ b/test/test-pages/toc-missing/expected.html
@@ -82,6 +82,9 @@
             </div>
         </details>
         <hr />
+        <div>
+            <p> Interactive Editor </p>
+        </div>
         <hr />
         <h2 id="detecting-anomalies">
             <a href="#detecting-anomalies">Detecting Anomalies</a>

--- a/test/test-pages/wikipedia/expected.html
+++ b/test/test-pages/wikipedia/expected.html
@@ -141,6 +141,9 @@
         </h2>
         <div>
             <p><a href="http://fakehost/wiki/File:Mozilla_Firefox_logo_2013.svg"><img alt="" src="http://upload.wikimedia.org/wikipedia/commons/thumb/7/76/Mozilla_Firefox_logo_2013.svg/220px-Mozilla_Firefox_logo_2013.svg.png" width="220" height="233" srcset="http://upload.wikimedia.org/wikipedia/commons/thumb/7/76/Mozilla_Firefox_logo_2013.svg/330px-Mozilla_Firefox_logo_2013.svg.png 1.5x, http://upload.wikimedia.org/wikipedia/commons/thumb/7/76/Mozilla_Firefox_logo_2013.svg/440px-Mozilla_Firefox_logo_2013.svg.png 2x" data-file-width="352" data-file-height="373" /></a></p>
+            <div>
+                <p> Firefox logo</p>
+            </div>
         </div>
         <h3><span id="Firefox">Firefox</span><span><span>[</span><a href="http://fakehost/w/index.php?title=Mozilla&amp;action=edit&amp;section=6" title="Edit section: Firefox">edit</a><span>]</span></span>
         </h3>
@@ -164,6 +167,9 @@
         </h3>
         <div>
             <p><a href="http://fakehost/wiki/File:SeaMonkey.png"><img alt="" src="http://upload.wikimedia.org/wikipedia/commons/0/0d/SeaMonkey.png" width="128" height="128" data-file-width="128" data-file-height="128" /></a></p>
+            <div>
+                <p> SeaMonkey logo</p>
+            </div>
         </div>
         <p><a href="http://fakehost/wiki/SeaMonkey" title="SeaMonkey">SeaMonkey</a> (formerly the Mozilla Application Suite) is a free and open source cross platform suite of Internet software components including a web browser component, a client for sending and receiving email and <a href="http://fakehost/wiki/USENET" title="USENET">USENET</a> newsgroup messages, an HTML editor (<a href="http://fakehost/wiki/Mozilla_Composer" title="Mozilla Composer">Mozilla Composer</a>) and the <a href="http://fakehost/wiki/ChatZilla" title="ChatZilla">ChatZilla</a> IRC client.</p>
         <p>On March 10, 2005, <a href="http://fakehost/wiki/The_Mozilla_Foundation" title="The Mozilla Foundation">the Mozilla Foundation</a> announced that it would not release any official versions of Mozilla Application Suite beyond 1.7.x, since it had now focused on the standalone applications <a href="http://fakehost/wiki/Mozilla_Firefox" title="Mozilla Firefox">Firefox</a> and <a href="http://fakehost/wiki/Mozilla_Thunderbird" title="Mozilla Thunderbird">Thunderbird</a>.<sup id="cite_ref-57"><a href="#cite_note-57">[57]</a></sup> SeaMonkey is now maintained by the SeaMonkey Council, which has <a href="http://fakehost/wiki/Trademark" title="Trademark">trademarked</a> the SeaMonkey name with help from the Mozilla Foundation.<sup id="cite_ref-58"><a href="#cite_note-58">[58]</a></sup> The Mozilla Foundation provides project hosting for the SeaMonkey developers.</p>
@@ -171,6 +177,9 @@
         </h3>
         <div>
             <p><a href="http://fakehost/wiki/File:Buggie.svg"><img alt="" src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Buggie.svg/220px-Buggie.svg.png" width="220" height="289" srcset="http://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Buggie.svg/330px-Buggie.svg.png 1.5x, http://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Buggie.svg/440px-Buggie.svg.png 2x" data-file-width="95" data-file-height="125" /></a></p>
+            <div>
+                <p> Bugzilla logo</p>
+            </div>
         </div>
         <p><a href="http://fakehost/wiki/Bugzilla" title="Bugzilla">Bugzilla</a> is a <a href="http://fakehost/wiki/World_Wide_Web" title="World Wide Web">web</a>-based general-purpose <a href="http://fakehost/wiki/Bug_tracking_system" title="Bug tracking system">bug tracking system</a>, which was released as <a href="http://fakehost/wiki/Open_source_software" title="Open source software">open source software</a> by <a href="http://fakehost/wiki/Netscape_Communications" title="Netscape Communications">Netscape Communications</a> in 1998 along with the rest of the Mozilla codebase, and is currently stewarded by Mozilla. It has been adopted by a variety of organizations for use as a <a href="http://fakehost/wiki/Bug_tracking_system" title="Bug tracking system">bug tracking system</a> for both <a href="http://fakehost/wiki/Free_and_open_source_software" title="Free and open source software">free and open source software</a> and <a href="http://fakehost/wiki/Proprietary_software" title="Proprietary software">proprietary</a> projects and products, including the <a href="http://fakehost/wiki/The_Mozilla_Foundation" title="The Mozilla Foundation">Mozilla Foundation</a>, the <a href="http://fakehost/wiki/Linux_kernel" title="Linux kernel">Linux kernel</a>, <a href="http://fakehost/wiki/GNOME" title="GNOME">GNOME</a>, <a href="http://fakehost/wiki/KDE" title="KDE">KDE</a>, <a href="http://fakehost/wiki/Red_Hat" title="Red Hat">Red Hat</a>, <a href="http://fakehost/wiki/Novell" title="Novell">Novell</a>, <a href="http://fakehost/wiki/Eclipse_(software)" title="Eclipse (software)">Eclipse</a> and <a href="http://fakehost/wiki/LibreOffice" title="LibreOffice">LibreOffice</a>.<sup id="cite_ref-59"><a href="#cite_note-59">[59]</a></sup></p>
         <h3><span id="Components">Components</span><span><span>[</span><a href="http://fakehost/w/index.php?title=Mozilla&amp;action=edit&amp;section=12" title="Edit section: Components">edit</a><span>]</span></span>
@@ -227,12 +236,18 @@
         </h3>
         <div>
             <p><a href="http://fakehost/wiki/File:London_Mozilla_Workspace.jpg"><img alt="" src="http://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/London_Mozilla_Workspace.jpg/220px-London_Mozilla_Workspace.jpg" width="220" height="146" srcset="http://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/London_Mozilla_Workspace.jpg/330px-London_Mozilla_Workspace.jpg 1.5x, http://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/London_Mozilla_Workspace.jpg/440px-London_Mozilla_Workspace.jpg 2x" data-file-width="2500" data-file-height="1656" /></a></p>
+            <div>
+                <p> Mozilla spaces, London</p>
+            </div>
         </div>
         <p>There are a number of sub-communities that exist based on their geographical locations, where contributors near each other work together on particular activities, such as localization, marketing, PR and user support.</p>
         <h3><span id="Mozilla_Reps">Mozilla Reps</span><span><span>[</span><a href="http://fakehost/w/index.php?title=Mozilla&amp;action=edit&amp;section=29" title="Edit section: Mozilla Reps">edit</a><span>]</span></span>
         </h3>
         <div>
             <p><a href="http://fakehost/wiki/File:Mozilla_Reps.png"><img alt="" src="http://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Mozilla_Reps.png/220px-Mozilla_Reps.png" width="220" height="101" srcset="http://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Mozilla_Reps.png/330px-Mozilla_Reps.png 1.5x, http://upload.wikimedia.org/wikipedia/commons/0/0b/Mozilla_Reps.png 2x" data-file-width="400" data-file-height="183" /></a></p>
+            <div>
+                <p> Mozilla Reps logo</p>
+            </div>
         </div>
         <p>The Mozilla Reps program aims to empower and support volunteer Mozillians who want to become official representatives of Mozilla in their region/locale.</p>
         <p>The program provides a simple framework and a specific set of tools to help Mozillians to organize and/or attend events, recruit and mentor new contributors, document and share activities, and support their local communities better.</p>


### PR DESCRIPTION
This PR changes one of the `haveToRemove` checks to allow for short paragraphs, such as the written dialog in the linked issue, by adding `linkDensity` to the primary "short content" check. The rationale being that short strings which don't contain any links are likely to be text the user would want to read, provided that the initial preprocessing has already removed the bulk of the page elements.

I regenerated all test cases to check for regressions and added a couple of new checks to deal with those:

* `adWords` and `loadingWords` regexes to help identify ad blocks and loading indicators.
* `textDensity` + image count to exclude elements without useful content.

Test case changes:

* `citylab-1` now includes the published time in the Readability content.
* `ehow-1` lost an extraneous "Other People Are Reading" header but gained an extraneous "Found This Helpful" header
* `ehow-2` lost its "Other People Are Reading" header and gained the word "Save" previously used for a button
* `engadget` now shows the base price and score originally present in the product review
* `firefox-nightly-blog` no longer shows "Leave a Reply"
* `mercurial` now correctly shows a previously excluded code snippets and commands
* `qq` now shows the page header with published date
* `toc-missing` now *incorrectly* shows "Interactive Editor"
* `wikipedia` now shows image captions wrapped in `<div><p>...</p></div>`

The changes which are definitely regressions seem like an acceptable trade for the improvements gained. I would like some input on whether the `adWords` and `loadingWords` regexes are acceptable though. They are scoped so that they will only produce a match against a node's entire `innerText` string, so it's unlikely to impact real content, but it still feels like a slippery slope.

Closes #861