### PR TITLE
fix: resolve the bug of checkByline when there is a byline attribute in metadata

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -2273,7 +2273,7 @@ Readability.prototype = {
     this._prepDocument();
 
     var metadata = this._getArticleMetadata(jsonLd);
-    this._metadata = metadata
+    this._metadata = metadata;
     this._articleTitle = metadata.title;
 
     var articleContent = this._grabArticle();

--- a/Readability.js
+++ b/Readability.js
@@ -41,6 +41,7 @@ function Readability(doc, options) {
   this._articleDir = null;
   this._articleSiteName = null;
   this._attempts = [];
+  this._metadata = {};
 
   // Configurable options
   this._debug = !!options.debug;
@@ -837,7 +838,7 @@ Readability.prototype = {
   },
 
   _checkByline: function(node, matchString) {
-    if (this._articleByline) {
+    if (this._articleByline || this._metadata.byline) {
       return false;
     }
 
@@ -2272,6 +2273,7 @@ Readability.prototype = {
     this._prepDocument();
 
     var metadata = this._getArticleMetadata(jsonLd);
+    this._metadata = metadata
     this._articleTitle = metadata.title;
 
     var articleContent = this._grabArticle();

--- a/test/test-pages/ietf-1/expected.html
+++ b/test/test-pages/ietf-1/expected.html
@@ -1100,7 +1100,7 @@ charset=UTF-8","Content-Length":106}}}
         M. Jones, D. Hardt, "The OAuth 2.0 Authorization Framework:
         Bearer Token Usage", <a href="http://fakehost/test/rfc6750">RFC6750</a>, October 2012.
 
-    []
+    [<a name="ref-AUTHORING" id="ref-AUTHORING">AUTHORING</a>]
         "Using remoteStorage for web authoring", reSite wiki, retrieved
         September 2014. <a href="https://github.com/michielbdejong/resite/wiki">https://github.com/michielbdejong/resite/wiki</a>
         /Using-remoteStorage-for-web-authoring


### PR DESCRIPTION
Resolve the issue where `<meta name="og: article: author" content="xxxx">` when there is author information in the meta tag of the head, and if there is also the following content in the body `<strong id="timeline">yyyy</strong>`  calling checkByline returns incorrect results and the yyyy information is not displayed in the content
