### PR TITLE
chore: enforce trailing commas

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@
 
 module.exports = {
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 6,
   },
   "env": {
     "es6": true,
@@ -209,5 +209,8 @@ module.exports = {
 
     // Only check typeof against valid results
     "valid-typeof": 2,
+
+    // enforce trailing commas
+    "comma-dangle": ["error", "always-multiline"],
   },
 };

--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -272,7 +272,7 @@
     "meta": true,
     "param": true,
     "source": true,
-    "wbr": true
+    "wbr": true,
   };
 
   var whitespace = [" ", "\t", "\n", "\r"];
@@ -290,7 +290,7 @@
     DOCUMENT_NODE: 9,
     DOCUMENT_TYPE_NODE: 10,
     DOCUMENT_FRAGMENT_NODE: 11,
-    NOTATION_NODE: 12
+    NOTATION_NODE: 12,
   };
 
   function getElementsByTagName(tag) {
@@ -510,7 +510,7 @@
     __proto__: Node.prototype,
 
     nodeName: "#comment",
-    nodeType: Node.COMMENT_NODE
+    nodeType: Node.COMMENT_NODE,
   };
 
   var Text = function () {
@@ -836,7 +836,7 @@
 
       value += " " + styleName + ": " + styleValue + ";";
       this.node.setAttribute("style", value.trim());
-    }
+    },
   };
 
   // For each item in styleMap, define a getter and setter on the style
@@ -1176,7 +1176,7 @@
       }
 
       return doc;
-    }
+    },
   };
 
   // Attach the standard DOM types to the global scope

--- a/Readability.js
+++ b/Readability.js
@@ -145,7 +145,7 @@ Readability.prototype = {
     // see: https://en.wikipedia.org/wiki/Comma#Comma_variants
     commas: /\u002C|\u060C|\uFE50|\uFE10|\uFE11|\u2E41|\u2E34|\u2E32|\uFF0C/g,
     // See: https://schema.org/Article
-    jsonLdArticleTypes: /^Article|AdvertiserContentArticle|NewsArticle|AnalysisNewsArticle|AskPublicNewsArticle|BackgroundNewsArticle|OpinionNewsArticle|ReportageNewsArticle|ReviewNewsArticle|Report|SatiricalArticle|ScholarlyArticle|MedicalScholarlyArticle|SocialMediaPosting|BlogPosting|LiveBlogPosting|DiscussionForumPosting|TechArticle|APIReference$/
+    jsonLdArticleTypes: /^Article|AdvertiserContentArticle|NewsArticle|AnalysisNewsArticle|AskPublicNewsArticle|BackgroundNewsArticle|OpinionNewsArticle|ReportageNewsArticle|ReviewNewsArticle|Report|SatiricalArticle|ScholarlyArticle|MedicalScholarlyArticle|SocialMediaPosting|BlogPosting|LiveBlogPosting|DiscussionForumPosting|TechArticle|APIReference$/,
   },
 
   UNLIKELY_ROLES: [ "menu", "menubar", "complementary", "navigation", "alert", "alertdialog", "dialog" ],
@@ -166,7 +166,7 @@ Readability.prototype = {
     "DATALIST", "DFN", "EM", "EMBED", "I", "IMG", "INPUT", "KBD", "LABEL",
     "MARK", "MATH", "METER", "NOSCRIPT", "OBJECT", "OUTPUT", "PROGRESS", "Q",
     "RUBY", "SAMP", "SCRIPT", "SELECT", "SMALL", "SPAN", "STRONG", "SUB",
-    "SUP", "TEXTAREA", "TIME", "VAR", "WBR"
+    "SUP", "TEXTAREA", "TIME", "VAR", "WBR",
   ],
 
   // These are the classes that readability sets itself.
@@ -406,7 +406,7 @@ Readability.prototype = {
     });
 
     var medias = this._getAllNodesWithTag(articleContent, [
-      "img", "picture", "figure", "video", "audio", "source"
+      "img", "picture", "figure", "video", "audio", "source",
     ]);
 
     this._forEachNode(medias, function(media) {
@@ -2319,9 +2319,9 @@ Readability.prototype = {
       length: textContent.length,
       excerpt: metadata.excerpt,
       siteName: metadata.siteName || this._articleSiteName,
-      publishedTime: metadata.publishedTime
+      publishedTime: metadata.publishedTime,
     };
-  }
+  },
 };
 
 if (typeof module === "object") {

--- a/index.js
+++ b/index.js
@@ -4,5 +4,5 @@ var isProbablyReaderable = require("./Readability-readerable");
 
 module.exports = {
   Readability: Readability,
-  isProbablyReaderable: isProbablyReaderable
+  isProbablyReaderable: isProbablyReaderable,
 };

--- a/test/generate-testcase.js
+++ b/test/generate-testcase.js
@@ -87,7 +87,7 @@ function sanitizeSource(html, callbackFn) {
     "indent-spaces": 4,
     "numeric-entities": true,
     "output-xhtml": true,
-    "wrap": 0
+    "wrap": 0,
   }, callbackFn);
 }
 

--- a/test/test-isProbablyReaderable.js
+++ b/test/test-isProbablyReaderable.js
@@ -75,7 +75,7 @@ describe("isProbablyReaderable", function () {
       visibilityChecker() {
         called = true;
         return false;
-      }
+      },
     };
     expect(isProbablyReaderable(veryLargeDoc, options)).to.be.false;
     expect(called).to.be.true;
@@ -87,7 +87,7 @@ describe("isProbablyReaderable", function () {
       visibilityChecker() {
         called = true;
         return true;
-      }
+      },
     };
     expect(isProbablyReaderable(veryLargeDoc, options)).to.be.true;
     expect(called).to.be.true;

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -281,7 +281,7 @@ describe("Readability API", function() {
       var content = new Readability(dom.window.document, {
         serializer: function(el) {
           return xml.serializeToString(el.firstChild);
-        }
+        },
       }).parse().content;
       expect(content).eql(expected_xhtml);
     });
@@ -297,7 +297,7 @@ describe("Readability API", function() {
         "</div>";
       var content = new Readability(dom.window.document, {
         charThreshold: 20,
-        allowedVideoRegex: /.*mycustomdomain.com.*/
+        allowedVideoRegex: /.*mycustomdomain.com.*/,
       }).parse().content;
       expect(content).eql(expected_xhtml);
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -37,6 +37,6 @@ exports.prettyPrint = function(html) {
     "unescape_strings": false,
     "wrap_line_length": 0,
     "wrap_attributes": "auto",
-    "wrap_attributes_indent_size": 4
+    "wrap_attributes_indent_size": 4,
   });
 };


### PR DESCRIPTION
adds the `comma-dangle` rule to eslint to enforce trailing commas