### PR TITLE
Add S and U phrasing elements

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -168,8 +168,8 @@ Readability.prototype = {
     "ABBR", "AUDIO", "B", "BDO", "BR", "BUTTON", "CITE", "CODE", "DATA",
     "DATALIST", "DFN", "EM", "EMBED", "I", "IMG", "INPUT", "KBD", "LABEL",
     "MARK", "MATH", "METER", "NOSCRIPT", "OBJECT", "OUTPUT", "PROGRESS", "Q",
-    "RUBY", "SAMP", "SCRIPT", "SELECT", "SMALL", "SPAN", "STRONG", "SUB",
-    "SUP", "TEXTAREA", "TIME", "VAR", "WBR",
+    "RUBY", "S", "SAMP", "SCRIPT", "SELECT", "SMALL", "SPAN", "STRONG", "SUB",
+    "SUP", "TEXTAREA", "TIME", "U", "VAR", "WBR",
   ],
 
   // These are the classes that readability sets itself.


### PR DESCRIPTION
**S** and **U** should be part of the phrasing elements list:
https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content

Leaving them out causes `<p>` elements to be placed within `<u>` or `<s>` like in the _hukumusume_ test case, which is invalid.
