### PR TITLE
Correct title word-count comment

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -601,8 +601,7 @@ Readability.prototype = {
       titleHadHierarchicalSeparators = / [\\\/>»] /.test(curTitle);
       curTitle = origTitle.replace(/(.*)[\|\-\\\/>»] .*/gi, "$1");
 
-      // If the resulting title is too short (3 words or fewer), remove
-      // the first part instead:
+      // If the resulting title is too short, remove the first part instead:
       if (wordCount(curTitle) < 3) {
         curTitle = origTitle.replace(/[^\|\-\\\/>»]*[\|\-\\\/>»](.*)/gi, "$1");
       }


### PR DESCRIPTION
This is just an editorial change. There was a contradictory comment in the `_getArticleTitle` function:

```js
 // If the resulting title is too short (3 words or fewer), remove
 // the first part instead:
 if (wordCount(curTitle) < 3) {
```

The comment states "three or fewer", but the comparison is actually "less than three" i.e. two or fewer.

It took me a little time to figure out whether it was the comment or the comparison which was in error. In fact the comparison dates from [the earliest commit](https://github.com/mozilla/readability/blob/55587d91ac5b333ca6bf968e5504f3083c59cf6c/Readability.js#L168) and the comment was added much later. I considered correcting the parenthetical to read "fewer than three" or similar, but given that it might conceivably fall out of sync if the condition changes, I thought it better to simply remove the parenthetical.