### PR TITLE
Avoid unnecessary copying while unwrapping single-image noscripts

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1910,6 +1910,9 @@ Readability.prototype = {
     var noscripts = Array.from(doc.getElementsByTagName("noscript"));
     this._forEachNode(noscripts, function (noscript) {
       // Parse content of noscript and make sure it only contains image
+      if (!this._isSingleImage(noscript)) {
+        return;
+      }
       var tmp = doc.createElement("div");
       // We're running in the document context, and using unmodified
       // document contents, so doing this should be safe.
@@ -1917,9 +1920,6 @@ Readability.prototype = {
       // run at all in this document...)
       // eslint-disable-next-line no-unsanitized/property
       tmp.innerHTML = noscript.innerHTML;
-      if (!this._isSingleImage(tmp)) {
-        return;
-      }
 
       // If noscript has previous sibling and it only contains image,
       // replace it with noscript content. However we also keep old


### PR DESCRIPTION
This patch reorders two operations in the `_unwrapNoscriptImages` function to avoid making a clone of the `<noscript>` if it is not a single-image wrapper. I expect the difference is minuscule, but it is the order in which things should be done, as far as I can tell. 