### PR TITLE
Make isSingleImage function a loop rather than recursive

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -1867,7 +1867,8 @@ Readability.prototype = {
     while (node) {
       if (node.tagName === "IMG") {
         return true;
-      } else if (node.children.length !== 1 || node.textContent.trim() !== "") {
+      }
+      if (node.children.length !== 1 || node.textContent.trim() !== "") {
         return false;
       }
       node = node.children[0];

--- a/Readability.js
+++ b/Readability.js
@@ -1864,15 +1864,15 @@ Readability.prototype = {
    * @param Element
    **/
   _isSingleImage(node) {
-    if (node.tagName === "IMG") {
-      return true;
+    while (node) {
+      if (node.tagName === "IMG") {
+        return true;
+      } else if (node.children.length !== 1 || node.textContent.trim() !== "") {
+        return false;
+      }
+      node = node.children[0];
     }
-
-    if (node.children.length !== 1 || node.textContent.trim() !== "") {
-      return false;
-    }
-
-    return this._isSingleImage(node.children[0]);
+    return false;
   },
 
   /**


### PR DESCRIPTION
My motivation for this change was to avoid any potential for a stack overflow (though I'm not sure how likely this is in practice or if it's even possible in JavaScript), but it turns out to reduce the time the test suite takes to run on my computer from 20s to 18s, so there does seem to be a practical benefit.

The return at the bottom was added to appease eslint; the conditions in the loop body make it unreachable.