### PR TITLE
Improve character reference unescaping

### DIFF
--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -60,26 +60,23 @@
       .replace(/&(quot|amp|apos|lt|gt);/g, function (match, tag) {
         return entityTable[tag];
       })
-      .replace(
-        /&#(?:x([0-9a-f]+)|([0-9]+));/gi,
-        function (_, hex, numStr) {
-          var num = parseInt(hex || numStr, hex ? 16 : 10);
-          
-          // these character references are replaced by a conforming HTML parser
-          if (num == 0 || num > 0x10FFFF || (num >= 0xD800 && num <= 0xDFFF)) {
-            num = 0xFFFD;
-          }
-          
-          // code points beyond the BMP must be converted to a surrogate pair when using String.fromCharCode
-          if (num > 0xFFFF) {
-            var high = 0xD800 + (((num - 0x10000) & 0xFFC00) >> 10);
-            var low = 0xDC00 + ((num - 0x10000) & 0x3FF);
-            return String.fromCharCode(high) + String.fromCharCode(low);
-          }
+      .replace(/&#(?:x([0-9a-f]+)|([0-9]+));/gi, function (match, hex, numStr) {
+        var num = parseInt(hex || numStr, hex ? 16 : 10);
 
-          return String.fromCharCode(num);
+        // these character references are replaced by a conforming HTML parser
+        if (num == 0 || num > 0x10ffff || (num >= 0xd800 && num <= 0xdfff)) {
+          num = 0xfffd;
         }
-      );
+
+        // code points beyond the BMP must be converted to a surrogate pair when using String.fromCharCode
+        if (num > 0xffff) {
+          var high = 0xd800 + (((num - 0x10000) & 0xffc00) >> 10);
+          var low = 0xdc00 + ((num - 0x10000) & 0x3ff);
+          return String.fromCharCode(high) + String.fromCharCode(low);
+        }
+
+        return String.fromCharCode(num);
+      });
   }
 
   // When a style is set in JS, map it to the corresponding CSS attribute

--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -68,14 +68,7 @@
           num = 0xfffd;
         }
 
-        // code points beyond the BMP must be converted to a surrogate pair when using String.fromCharCode
-        if (num > 0xffff) {
-          var high = 0xd800 + (((num - 0x10000) & 0xffc00) >> 10);
-          var low = 0xdc00 + ((num - 0x10000) & 0x3ff);
-          return String.fromCharCode(high) + String.fromCharCode(low);
-        }
-
-        return String.fromCharCode(num);
+        return String.fromCodePoint(num);
       });
   }
 

--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -61,9 +61,22 @@
         return entityTable[tag];
       })
       .replace(
-        /&#(?:x([0-9a-z]{1,4})|([0-9]{1,4}));/gi,
-        function (match, hex, numStr) {
-          var num = parseInt(hex || numStr, hex ? 16 : 10); // read num
+        /&#(?:x([0-9a-f]+)|([0-9]+));/gi,
+        function (_, hex, numStr) {
+          var num = parseInt(hex || numStr, hex ? 16 : 10);
+          
+          // these character references are replaced by a conforming HTML parser
+          if (num == 0 || num > 0x10FFFF || (num >= 0xD800 && num <= 0xDFFF)) {
+            num = 0xFFFD;
+          }
+          
+          // code points beyond the BMP must be converted to a surrogate pair when using String.fromCharCode
+          if (num > 0xFFFF) {
+            var high = 0xD800 + (((num - 0x10000) & 0xFFC00) >> 10);
+            var low = 0xDC00 + ((num - 0x10000) & 0x3FF);
+            return String.fromCharCode(high) + String.fromCharCode(low);
+          }
+
           return String.fromCharCode(num);
         }
       );

--- a/Readability.js
+++ b/Readability.js
@@ -1616,26 +1616,23 @@ Readability.prototype = {
       .replace(/&(quot|amp|apos|lt|gt);/g, function (_, tag) {
         return htmlEscapeMap[tag];
       })
-      .replace(
-        /&#(?:x([0-9a-f]+)|([0-9]+));/gi,
-        function (_, hex, numStr) {
-          var num = parseInt(hex || numStr, hex ? 16 : 10);
-          
-          // these character references are replaced by a conforming HTML parser
-          if (num == 0 || num > 0x10FFFF || (num >= 0xD800 && num <= 0xDFFF)) {
-            num = 0xFFFD;
-          }
-          
-          // code points beyond the BMP must be converted to a surrogate pair when using String.fromCharCode
-          if (num > 0xFFFF) {
-            var high = 0xD800 + (((num - 0x10000) & 0xFFC00) >> 10);
-            var low = 0xDC00 + ((num - 0x10000) & 0x3FF);
-            return String.fromCharCode(high) + String.fromCharCode(low);
-          }
+      .replace(/&#(?:x([0-9a-f]+)|([0-9]+));/gi, function (_, hex, numStr) {
+        var num = parseInt(hex || numStr, hex ? 16 : 10);
 
-          return String.fromCharCode(num);
+        // these character references are replaced by a conforming HTML parser
+        if (num == 0 || num > 0x10ffff || (num >= 0xd800 && num <= 0xdfff)) {
+          num = 0xfffd;
         }
-      );
+
+        // code points beyond the BMP must be converted to a surrogate pair when using String.fromCharCode
+        if (num > 0xffff) {
+          var high = 0xd800 + (((num - 0x10000) & 0xffc00) >> 10);
+          var low = 0xdc00 + ((num - 0x10000) & 0x3ff);
+          return String.fromCharCode(high) + String.fromCharCode(low);
+        }
+
+        return String.fromCharCode(num);
+      });
   },
 
   /**

--- a/Readability.js
+++ b/Readability.js
@@ -1624,14 +1624,7 @@ Readability.prototype = {
           num = 0xfffd;
         }
 
-        // code points beyond the BMP must be converted to a surrogate pair when using String.fromCharCode
-        if (num > 0xffff) {
-          var high = 0xd800 + (((num - 0x10000) & 0xffc00) >> 10);
-          var low = 0xdc00 + ((num - 0x10000) & 0x3ff);
-          return String.fromCharCode(high) + String.fromCharCode(low);
-        }
-
-        return String.fromCharCode(num);
+        return String.fromCodePoint(num);
       });
   },
 

--- a/test/test-pages/005-unescape-html-entities/expected-metadata.json
+++ b/test/test-pages/005-unescape-html-entities/expected-metadata.json
@@ -1,0 +1,9 @@
+{
+  "title": "",
+  "byline": null,
+  "dir": null,
+  "excerpt": "&#xg; 😭 😭 � �",
+  "siteName": null,
+  "publishedTime": null,
+  "readerable": false
+}

--- a/test/test-pages/005-unescape-html-entities/expected.html
+++ b/test/test-pages/005-unescape-html-entities/expected.html
@@ -1,0 +1,1 @@
+<div id="readability-page-1" class="page"> Test </div>

--- a/test/test-pages/005-unescape-html-entities/source.html
+++ b/test/test-pages/005-unescape-html-entities/source.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta property="dc:description og:description" content="&amp;#xg; &amp;#x1F62D; &amp;#128557; &amp;#xFFFFFFFF; &amp;#x0;"/>
+    </head>
+    <body>
+        Test
+    </body>
+</html>


### PR DESCRIPTION
This improves the entity unescaping such that:

1. Null characters are no longer emitted
2. Characters beyond four digits are handled properly

This is only an improvement, not a complete fix. Two exceptions to correctness remain:
1. Most named entities are not converted (a documented limitation)
2. Character references to C1 controls are not mapped to windows-1252 chracters

The best way to really do this correctly is to write to a temporary element's `innerHTML` (after escaping any `<`) and then read back its `textContent`. However this would require enhancing JSDOMParser such that it handles all entities and character references correctly, so that all tests may pass consistently. If there's any appetite for this I'd be happy to do the work.