### PR TITLE
Use array reduction when cleaning paragraphs

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -832,15 +832,18 @@ Readability.prototype = {
     );
 
     // Remove extra paragraphs
+    // At this point, nasty iframes have been removed; only embedded video
+    // ones remain.
+    var contentTags = ["img", "embed", "object", "iframe"];
     this._removeNodes(
       this._getAllNodesWithTag(articleContent, ["p"]),
       function (paragraph) {
-        var imgCount = paragraph.getElementsByTagName("img").length;
-        var embedCount = paragraph.getElementsByTagName("embed").length;
-        var objectCount = paragraph.getElementsByTagName("object").length;
-        // At this point, nasty iframes have been removed, only remain embedded video ones.
-        var iframeCount = paragraph.getElementsByTagName("iframe").length;
-        var totalCount = imgCount + embedCount + objectCount + iframeCount;
+        // We use an array reduction here so the counts of elements are summed
+        // without anyone having to make further code edits if the list of
+        // content tags is changed.
+        var totalCount = contentTags.reduce(function (total, tag) {
+          return total + paragraph.getElementsByTagName(tag).length;
+        }, 0);
 
         return totalCount === 0 && !this._getInnerText(paragraph, false);
       }


### PR DESCRIPTION
The current code for cleaning non-content paragraphs is straightforward, but brittle against change: one must remember to modifiy both the list of element counts as well as `totalCount`. This change removes the need to modify `totalCount` (or indeed to set any more variables) by instead having a list of tag names `reduce()`d into `totalCount` in one operation. It's slightly less readable, but it seemed worth it to me.