### PR TITLE
Use better test for start of base64 payload in _fixLazyImages

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -2315,10 +2315,10 @@ Readability.prototype = {
             }
           }
 
-          // Here we assume if image is less than 100 bytes (or 133B after encoded to base64)
+          // Here we assume if image is less than 100 bytes (or 133 after encoded to base64)
           // it will be too small, therefore it might be placeholder image.
           if (srcCouldBeRemoved) {
-            var b64starts = elem.src.search(/base64\s*/i) + 7;
+            var b64starts = elem.src.indexOf(",") + 1;
             var b64length = elem.src.length - b64starts;
             if (b64length < 133) {
               elem.removeAttribute("src");

--- a/Readability.js
+++ b/Readability.js
@@ -2318,7 +2318,7 @@ Readability.prototype = {
           // Here we assume if image is less than 100 bytes (or 133 after encoded to base64)
           // it will be too small, therefore it might be placeholder image.
           if (srcCouldBeRemoved) {
-            var b64starts = elem.src.indexOf(",") + 1;
+            var b64starts = parts[0].length;
             var b64length = elem.src.length - b64starts;
             if (b64length < 133) {
               elem.removeAttribute("src");


### PR DESCRIPTION
The prior method didn't take into account the whitespace it matches when adding seven to the offset, nor did it consider that the type might itself end in "base64"; looking for the comma which is necessarily the delimiter between metadata and data is both simpler and more accurate.