### PR TITLE
Fix DomException when simplifying nested elements caused by invalid attribute names

### DIFF
--- a/JSDOMParser.js
+++ b/JSDOMParser.js
@@ -542,6 +542,10 @@
     getEncodedValue() {
       return encodeHTML(this._value);
     },
+    // Cheat horribly. This is fine for our usecases.
+    cloneNode() {
+      return this;
+    },
   };
 
   var Comment = function () {
@@ -821,6 +825,10 @@
         }
       }
       this.attributes.push(new Attribute(name, value));
+    },
+
+    setAttributeNode(node) {
+      this.setAttribute(node.name, node.value);
     },
 
     removeAttribute(name) {

--- a/Readability.js
+++ b/Readability.js
@@ -538,10 +538,19 @@ Readability.prototype = {
         ) {
           var child = node.children[0];
           for (var i = 0; i < node.attributes.length; i++) {
-            child.setAttribute(
-              node.attributes[i].name,
-              node.attributes[i].value
-            );
+            try {
+              child.setAttribute(
+                node.attributes[i].name,
+                node.attributes[i].value
+              );
+            } catch (ex) {
+              /* it's possible for setAttribute() to throw if the attribute name
+               * isn't a valid XML Name. Such attributes can however be parsed from
+               * source in HTML docs, see https://github.com/whatwg/html/issues/4275,
+               * so we can hit them here and then throw. We don't care about such
+               *  attributes so we ignore them.
+               */
+            }
           }
           node.parentNode.replaceChild(child, node);
           node = child;

--- a/Readability.js
+++ b/Readability.js
@@ -538,19 +538,7 @@ Readability.prototype = {
         ) {
           var child = node.children[0];
           for (var i = 0; i < node.attributes.length; i++) {
-            try {
-              child.setAttribute(
-                node.attributes[i].name,
-                node.attributes[i].value
-              );
-            } catch (ex) {
-              /* it's possible for setAttribute() to throw if the attribute name
-               * isn't a valid XML Name. Such attributes can however be parsed from
-               * source in HTML docs, see https://github.com/whatwg/html/issues/4275,
-               * so we can hit them here and then throw. We don't care about such
-               *  attributes so we ignore them.
-               */
-            }
+            child.setAttributeNode(node.attributes[i].cloneNode());
           }
           node.parentNode.replaceChild(child, node);
           node = child;
@@ -764,19 +752,7 @@ Readability.prototype = {
     }
 
     for (var i = 0; i < node.attributes.length; i++) {
-      try {
-        replacement.setAttribute(
-          node.attributes[i].name,
-          node.attributes[i].value
-        );
-      } catch (ex) {
-        /* it's possible for setAttribute() to throw if the attribute name
-         * isn't a valid XML Name. Such attributes can however be parsed from
-         * source in HTML docs, see https://github.com/whatwg/html/issues/4275,
-         * so we can hit them here and then throw. We don't care about such
-         * attributes so we ignore them.
-         */
-      }
+      replacement.setAttributeNode(node.attributes[i].cloneNode());
     }
     return replacement;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "mocha": "10.1.0",
         "prettier": "^3.3.2",
         "release-it": "17.0.1",
-        "sinon": "14.0.2"
+        "sinon": "14.0.2",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4570,6 +4571,16 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -7737,6 +7748,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -8140,12 +8161,13 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/xmlchars": {
@@ -11478,6 +11500,14 @@
         "whatwg-url": "^11.0.0",
         "ws": "^8.9.0",
         "xml-name-validator": "^4.0.0"
+      },
+      "dependencies": {
+        "xml-name-validator": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+          "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+          "dev": true
+        }
       }
     },
     "json-buffer": {
@@ -13786,6 +13816,14 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^4.0.0"
+      },
+      "dependencies": {
+        "xml-name-validator": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+          "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+          "dev": true
+        }
       }
     },
     "wcwidth": {
@@ -14074,9 +14112,9 @@
       "dev": true
     },
     "xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true
     },
     "xmlchars": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mocha": "10.1.0",
     "prettier": "^3.3.2",
     "release-it": "17.0.1",
-    "sinon": "14.0.2"
+    "sinon": "14.0.2",
+    "xml-name-validator": "^5.0.0"
   }
 }

--- a/test/test-pages/invalid-attributes/expected-metadata.json
+++ b/test/test-pages/invalid-attributes/expected-metadata.json
@@ -1,0 +1,9 @@
+{
+  "title": "Lorem Ipsum",
+  "byline": null,
+  "dir": null,
+  "excerpt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  "siteName": null,
+  "publishedTime": null,
+  "readerable": false
+}

--- a/test/test-pages/invalid-attributes/expected.html
+++ b/test/test-pages/invalid-attributes/expected.html
@@ -1,0 +1,7 @@
+<div id="readability-page-1" class="page">
+  <div "="">
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </p>
+  </div>
+</div>

--- a/test/test-pages/invalid-attributes/source.html
+++ b/test/test-pages/invalid-attributes/source.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Lorem Ipsum</title>
+    </head>
+    <body>
+        <main>
+            <section>
+                <div "="">
+                    <div>
+                        <div>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </body>
+</html>


### PR DESCRIPTION
Copies the same fix for copying invalid property names (such as `"`) used in `_setNodeTag` to `_simplifyNestedElements`.

You can reproduce this error running the following code in node (with `jsdom` installed):

```javascript
const { JSDOM } = require("jsdom");
const Readability = require("./Readability.js");

const sampleHTML = '<div "=""><div><div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div></div></div>';
const dom = new JSDOM(sampleHTML, { contentType: "text/html" });
const readability = new Readability(dom.window.document);
const parsed = readability.parse();
console.log(parsed.textContent);
```

Without the fix:

```console
$ node demo.js  

./readability/node_modules/jsdom/lib/jsdom/living/helpers/validate-names.js:10
    throw DOMException.create(globalObject, [`"${name}" did not match the Name production`, "InvalidCharacterError"]);
    ^
[DOMException [InvalidCharacterError]: """ did not match the Name production]

Node.js v20.18.0
```

With the fix:

```console
$ node demo.js
Lorem ipsum dolor sit amet, consectetur adipiscing elit.
```
