### PR TITLE
Add null | undefined to parse results. Fixes #937

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,33 +32,33 @@ export class Readability<T = string> {
 
   parse(): null | {
     /** article title */
-    title: string;
+    title: string | null | undefined;
 
     /** HTML string of processed article content */
-    content: T;
+    content: T | null | undefined;
 
     /** text content of the article, with all the HTML tags removed */
-    textContent: string;
+    textContent: string | null | undefined;
 
     /** length of an article, in characters */
-    length: number;
+    length: number | null | undefined;
 
     /** article description, or short excerpt from the content */
-    excerpt: string;
+    excerpt: string | null | undefined;
 
     /** author metadata */
-    byline: string;
+    byline: string | null | undefined;
 
     /** content direction */
-    dir: string;
+    dir: string | null | undefined;
 
     /** name of the site */
-    siteName: string;
+    siteName: string | null | undefined;
 
     /** content language */
-    lang: string;
+    lang: string | null | undefined;
 
     /** published time */
-    publishedTime: string;
+    publishedTime: string | null | undefined;
   };
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/readability/issues/937.

This PR _might_ be too much of a swing in the opposite direction. The reason I've included null and undefined in all props is because it's difficult to trace exactly which props are always assigned a value versus which might be null versus which might be null _or_ undefined.

I've got a branch locally where I'm slowly annotating everything with types, but that is slow going. In the meantime, erring this way is arguably more appropriate.