### PR TITLE
Consider blockquote in article scoring

### DIFF
--- a/Readability-readerable.js
+++ b/Readability-readerable.js
@@ -63,7 +63,7 @@ function isProbablyReaderable(doc, options = {}) {
   };
   options = Object.assign(defaultOptions, options);
 
-  var nodes = doc.querySelectorAll("p, pre, article");
+  var nodes = doc.querySelectorAll("p, pre, blockquote, article");
 
   // Get <div> nodes which have <br> node(s) and append them into the `nodes` variable.
   // Some articles' DOM structures might look like


### PR DESCRIPTION
Some pages have long quoted sections but only a few lines of commentary or intro. Right now, `isProbablyReaderable` ignores `blockquote`, which can make the examples below score 0 (the default options), whereas including `blockquote` would give a score of 9.

Example from [W3Schools](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_blockquote_test):

```html
<!DOCTYPE html>
<html>
<body>

<h1>The blockquote element</h1>

<p>Here is a quote from WWF's website:</p>

<blockquote cite="http://www.worldwildlife.org/who/index.html">
For 50 years, WWF has been protecting the future of nature. The world's leading conservation organization, WWF works in 100 countries and is supported by 1.2 million members in the United States and close to 5 million globally.
</blockquote>

</body>
</html>
```

I’m thinking it might make sense to factor blockquote into the scoring. If not, I’d love to hear the reasoning—thanks!