### PR TITLE
Preserve images within figure elements

### DIFF
--- a/Readability.js
+++ b/Readability.js
@@ -2506,6 +2506,11 @@ Readability.prototype = {
         return false;
       }
 
+      // Handle <img> buried inside nested <div> layers in <figure>.
+      if (tag === "div" && this._hasAncestorTag(node, "figure") && this._isSingleImage(node)) {
+        return false;
+      }
+
       var weight = this._getClassWeight(node);
 
       this.log("Cleaning Conditionally", node);

--- a/test/test-pages/allrecipes-1/expected-metadata.json
+++ b/test/test-pages/allrecipes-1/expected-metadata.json
@@ -1,0 +1,10 @@
+{
+  "title": "Hot Honey Brussels Sprouts",
+  "byline": "Nicole Russell",
+  "dir": null,
+  "lang": "en",
+  "excerpt": "These hot honey Brussels sprouts are a simple side dish with all the elements you'll ever need in a side. They're sweet, spicy, crispy, and melt in your mouth.",
+  "siteName": "Allrecipes",
+  "publishedTime": null,
+  "readerable": true
+}

--- a/test/test-pages/allrecipes-1/expected.html
+++ b/test/test-pages/allrecipes-1/expected.html
@@ -1,0 +1,291 @@
+<div id="readability-page-1" class="page">
+    <div id="main" role="main">
+        <article id="allrecipes-article_1-0" data-content-graph-id="none" data-tracking-container="true">
+            <div id="article-header--recipe_1-0">
+                <div id="mm-recipes-review-bar_1-0">
+                    <p> 1 Photo </p>
+                </div>
+                <p> These hot honey Brussels sprouts are a simple side dish with all the elements you'll ever need in a side. They're sweet, spicy, crispy, and melt in your mouth. I like to pair this with pork chops but it goes great with chicken or wild game. </p>
+                <div id="mntl-article-meta-dynamic_1-0" data-tracking-container="true">
+                    <div id="mntl-bylines__item_1-0">
+                        <p><span>By</span></p>
+                        <div data-tooltip="Nicole Russell is a prolific contributor to Allrecipes and an avid member of the Allrecipes Allstars." tabindex="0" data-inline-tooltip="true">
+                            <p><a href="https://www.allrecipes.com/nicole-russell-7113592" rel="nocaes" data-trigger-link="true" tabindex="-1">Nicole Russell</a></p>
+                            <div id="mntl-author-tooltip_1-0">
+                                <div>
+                                    <p><img src="https://www.allrecipes.com/thmb/uYVcXCSJ-dbRVP6aENNapCfLdlY=/75x75/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg" width="75" height="75" srcset="https://www.allrecipes.com/thmb/Trlj084IC3wBi4LKJPIKHEidK_Y=/40x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 40w, https://www.allrecipes.com/thmb/PjK7K3x5635tX12yHK_IGTJCha8=/58x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 58w, https://www.allrecipes.com/thmb/r4I1SWydIlNIwza6llxnx6EUpZ4=/76x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 76w, https://www.allrecipes.com/thmb/pp0xDFVleEUku7amHGoSEAIxVdw=/94x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 94w, https://www.allrecipes.com/thmb/XIiaJQ1BUWIDHcE9XW8jQyRKIBQ=/112x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 112w" sizes="80px" alt="Nicole Russell" data-src="https://www.allrecipes.com/thmb/uYVcXCSJ-dbRVP6aENNapCfLdlY=/75x75/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg" data-srcset="https://www.allrecipes.com/thmb/Trlj084IC3wBi4LKJPIKHEidK_Y=/40x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 40w, https://www.allrecipes.com/thmb/PjK7K3x5635tX12yHK_IGTJCha8=/58x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 58w, https://www.allrecipes.com/thmb/r4I1SWydIlNIwza6llxnx6EUpZ4=/76x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 76w, https://www.allrecipes.com/thmb/pp0xDFVleEUku7amHGoSEAIxVdw=/94x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 94w, https://www.allrecipes.com/thmb/XIiaJQ1BUWIDHcE9XW8jQyRKIBQ=/112x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 112w" /></p>
+                                </div>
+                                <p> Nicole Russell is a prolific contributor to Allrecipes and an avid member of the Allrecipes Allstars. </p>
+                            </div>
+                        </div>
+                    </div>
+                    <p> Published on November 3, 2025 </p>
+                </div>
+            </div>
+            <div>
+                <figure id="figure-article_1-0" data-click-tracked="false">
+                    <div>
+                        <p><img src="https://www.allrecipes.com/thmb/RDigrCswgpVoo9dPZxanUuRIudI=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg" width="4000" height="3000" srcset="https://www.allrecipes.com/thmb/LNvP40zVI2ZbS5O3gRnmmadoMEM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg 750w" sizes="750px" alt="Dish of roasted brussels sprouts with crumbled cheese and garnish" /></p>
+                    </div>
+                </figure>
+                <div id="article-content_1-0">
+                    <div id="mm-recipes-details_1-0">
+                        <div>
+                            <p> Prep Time: </p>
+                            <p> 10 mins </p>
+                        </div>
+                        <div>
+                            <p> Cook Time: </p>
+                            <p> 20 mins </p>
+                        </div>
+                        <div>
+                            <p> Total Time: </p>
+                            <p> 30 mins </p>
+                        </div>
+                        <div>
+                            <p> Servings: </p>
+                            <p> 4 </p>
+                        </div>
+                    </div>
+                    <div id="mm-recipes-lrs-ingredients_1-0" data-content-modified-date="2025-11-03T18:00:00.000Z" data-load-offset="300">
+                        <p> <span>Keep Screen Awake</span></p>
+                        <p>
+                        <h2 id="mm-recipes-structured-ingredients__heading_1-0"> Ingredients </h2>
+                        </p>
+                        <div id="mm-recipes-serving-size-adjuster_1-0">
+                            <div>
+                                <p> <label id="serving-adjuster-multiplier-button-1-0-0.5x" for="serving-size-0.5x_1-0" data-click-tracked="false"><svg>
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-check" href="#icon-check"></use>
+                                        </svg> <span>1/2x</span></label></p>
+                                <p> <label id="serving-adjuster-multiplier-button-1-0-1x" for="serving-size-1x_1-0" data-click-tracked="false"><svg>
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-check" href="#icon-check"></use>
+                                        </svg> <span>1x</span></label></p>
+                                <p> <label id="serving-adjuster-multiplier-button-1-0-2x" for="serving-size-2x_1-0" data-click-tracked="false"><svg>
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-check" href="#icon-check"></use>
+                                        </svg> <span>2x</span></label></p>
+                            </div>
+                            <p> Original recipe (1X) yields 4 servings </p>
+                        </div>
+                        <ul>
+                            <li data-nutritionix-id="440">
+                                <p>
+                                    <span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">pound</span> <span data-ingredient-name="true">Brussels sprouts</span>, trimmed and halved lengthwise
+                                </p>
+                            </li>
+                            <li data-nutritionix-id="42">
+                                <p>
+                                    <span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">tablespoon</span> <span data-ingredient-name="true">olive oil</span>
+                                </p>
+                            </li>
+                            <li data-nutritionix-id="20">
+                                <p>
+                                    <span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">tablespoons</span> <span data-ingredient-name="true">hot honey</span>, such as Mike's® Original Hot Honey
+                                </p>
+                            </li>
+                            <li data-nutritionix-id="12822">
+                                <p>
+                                    <span data-ingredient-name="true">salt and freshly ground black pepper to taste</span>
+                                </p>
+                            </li>
+                            <li data-nutritionix-id="551">
+                                <p>
+                                    <span data-ingredient-quantity="true">1/4</span> <span data-ingredient-unit="true">cup</span> crumbled <span data-ingredient-name="true">feta cheese</span>
+                                </p>
+                            </li>
+                            <li data-nutritionix-id="1916">
+                                <p>
+                                    <span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">tablespoon</span> chopped <span data-ingredient-name="true">scallions</span>
+                                </p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div id="mm-recipes-steps_1-0">
+                        <h2 id="mm-recipes-steps__heading_1-0"> Directions </h2>
+                        <div id="mm-recipes-steps__content_1-0">
+                            <ol id="mntl-sc-block_1-0">
+                                <li id="mntl-sc-block_2-0">
+                                    <p id="mntl-sc-block_3-0"> Gather all ingredients. Preheat the oven to 400 degrees F (200 degrees C). Line a large baking sheet with aluminum foil. </p>
+                                    <figure id="mntl-sc-block_4-0">
+                                        <div>
+                                            <p><img src="https://www.allrecipes.com/thmb/aqdax3V1v0dM1iYGEdk80SuiUW4=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg" width="4000" height="3000" srcset="https://www.allrecipes.com/thmb/YgfY5c5ZN8GjWNeoWQQ5ALoNWhM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg 750w" sizes="750px" alt="Ingredients for a recipe including Brussels sprouts oil honey cheese and seasonings arranged in bowls on a marble surface" data-src="https://www.allrecipes.com/thmb/aqdax3V1v0dM1iYGEdk80SuiUW4=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg" data-srcset="https://www.allrecipes.com/thmb/YgfY5c5ZN8GjWNeoWQQ5ALoNWhM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg 750w" data-hi-res-src="https://www.allrecipes.com/thmb/aqdax3V1v0dM1iYGEdk80SuiUW4=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg" /></p>
+                                        </div>
+                                        <figcaption id="mntl-figure-caption_1-0">
+                                            <p>
+                                                <span>Allrecipes / Julia Hartbeck</span>
+                                            </p>
+                                        </figcaption>
+                                    </figure>
+                                </li>
+                                <li id="mntl-sc-block_7-0">
+                                    <p id="mntl-sc-block_8-0"> Place Brussels sprouts in a bowl. Add oil, hot honey, salt, and pepper. Stir to combine and transfer to the baking sheet. </p>
+                                    <figure id="mntl-sc-block_9-0">
+                                        <div>
+                                            <p><img src="https://www.allrecipes.com/thmb/eUPioUqRphcDxRjTsAyjPzwxZJc=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg" width="4000" height="3000" srcset="https://www.allrecipes.com/thmb/MABSZFZSQiMH9-AAdON6zeW12Xc=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg 750w" sizes="750px" alt="A baking sheet with halved Brussels sprouts arranged on foil prepared for cooking" data-src="https://www.allrecipes.com/thmb/eUPioUqRphcDxRjTsAyjPzwxZJc=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg" data-srcset="https://www.allrecipes.com/thmb/MABSZFZSQiMH9-AAdON6zeW12Xc=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg 750w" data-hi-res-src="https://www.allrecipes.com/thmb/eUPioUqRphcDxRjTsAyjPzwxZJc=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg" /></p>
+                                        </div>
+                                        <figcaption id="mntl-figure-caption_2-0">
+                                            <p>
+                                                <span>Allrecipes / Julia Hartbeck</span>
+                                            </p>
+                                        </figcaption>
+                                    </figure>
+                                </li>
+                                <li id="mntl-sc-block_12-0">
+                                    <p id="mntl-sc-block_13-0"> Roast in the preheated oven for 20 minutes. </p>
+                                    <figure id="mntl-sc-block_14-0">
+                                        <div>
+                                            <p><img src="https://www.allrecipes.com/thmb/UB3Jz-pfoXewTAcjSJz4RBjrigY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg" width="4000" height="3000" srcset="https://www.allrecipes.com/thmb/2eqyp1WAanqlJ_UvmyL7dRxlfoM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg 750w" sizes="750px" alt="Roasted Brussels sprouts on a foillined baking sheet" data-src="https://www.allrecipes.com/thmb/UB3Jz-pfoXewTAcjSJz4RBjrigY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg" data-srcset="https://www.allrecipes.com/thmb/2eqyp1WAanqlJ_UvmyL7dRxlfoM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg 750w" data-hi-res-src="https://www.allrecipes.com/thmb/UB3Jz-pfoXewTAcjSJz4RBjrigY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg" /></p>
+                                        </div>
+                                        <figcaption id="mntl-figure-caption_3-0">
+                                            <p>
+                                                <span>Allrecipes / Julia Hartbeck</span>
+                                            </p>
+                                        </figcaption>
+                                    </figure>
+                                </li>
+                                <li id="mntl-sc-block_17-0">
+                                    <p id="mntl-sc-block_18-0"> Transfer sprouts to a bowl. Top with feta and scallions. Toss to combine. Serve immediately. </p>
+                                    <figure id="mntl-sc-block_19-0">
+                                        <div>
+                                            <p><img src="https://www.allrecipes.com/thmb/TKyvsRHU4FOU6HJ50w5StS_jOqk=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg" width="4000" height="3000" srcset="https://www.allrecipes.com/thmb/lUcNGpjFIbAT1nndRb9huLaamgo=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg 750w" sizes="750px" alt="Bowl of roasted Brussels sprouts garnished with toppings and a spoon on the side" data-src="https://www.allrecipes.com/thmb/TKyvsRHU4FOU6HJ50w5StS_jOqk=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg" data-srcset="https://www.allrecipes.com/thmb/lUcNGpjFIbAT1nndRb9huLaamgo=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg 750w" data-hi-res-src="https://www.allrecipes.com/thmb/TKyvsRHU4FOU6HJ50w5StS_jOqk=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg" /></p>
+                                        </div>
+                                        <figcaption id="mntl-figure-caption_4-0">
+                                            <p>
+                                                <span>Allrecipes / Julia Hartbeck</span>
+                                            </p>
+                                        </figcaption>
+                                    </figure>
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                    <div id="mm-recipes-nutrition-facts_1-0">
+                        <div id="mm-recipes-nutrition-facts-summary_1-0">
+                            <h2 colspan="2"> Nutrition Facts <span>(per serving)</span>
+                            </h2>
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td> 132 </td>
+                                        <td> Calories </td>
+                                    </tr>
+                                    <tr>
+                                        <td> 6g </td>
+                                        <td> Fat </td>
+                                    </tr>
+                                    <tr>
+                                        <td> 18g </td>
+                                        <td> Carbs </td>
+                                    </tr>
+                                    <tr>
+                                        <td> 5g </td>
+                                        <td> Protein </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="mm-recipes-nutrition-facts-label_1-0" data-click-tracked="freemarker.template.FalseTemplateBooleanModel@1d3b7044">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th colspan="2"> Nutrition Facts </th>
+                                    </tr>
+                                    <tr>
+                                        <th colspan="2">
+                                            <span>Servings Per Recipe</span> <span>4</span>
+                                        </th>
+                                    </tr>
+                                    <tr>
+                                        <th colspan="2">
+                                            <span>Calories</span> <span>132</span>
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td colspan="2"> % Daily Value * </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Total Fat</span> 6g
+                                        </td>
+                                        <td> 8% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Saturated Fat</span> 2g
+                                        </td>
+                                        <td> 10% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Cholesterol</span> 8mg
+                                        </td>
+                                        <td> 3% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Sodium</span> 185mg
+                                        </td>
+                                        <td> 8% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Total Carbohydrate</span> 18g
+                                        </td>
+                                        <td> 7% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Dietary Fiber</span> 3g
+                                        </td>
+                                        <td> 11% </td>
+                                    </tr>
+                                    <tr>
+                                        <td colspan="2">
+                                            <span>Total Sugars</span> 12g
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Protein</span> 5g
+                                        </td>
+                                        <td> 9% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Vitamin C</span> 98mg
+                                        </td>
+                                        <td> 109% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Calcium</span> 91mg
+                                        </td>
+                                        <td> 7% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Iron</span> 2mg
+                                        </td>
+                                        <td> 9% </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span>Potassium</span> 414mg
+                                        </td>
+                                        <td> 9% </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            <div id="mm-recipes-nutrition-facts-label-disclaimer_1-0">
+                                <p id="disclaimer-1_1-0"> * Percent Daily Values are based on a 2,000 calorie diet. Your daily values may be higher or lower depending on your calorie needs. </p>
+                                <p id="mntl-text-block_2-0"> ** Nutrient information is not available for all ingredients. Amount is based on available nutrient data. </p>
+                                <p id="mntl-text-block_3-0"> (-) Information is not currently available for this nutrient. If you are following a medically restrictive diet, please consult your doctor or registered dietitian before preparing this recipe for personal consumption. </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </article>
+    </div>
+</div>

--- a/test/test-pages/allrecipes-1/source.html
+++ b/test/test-pages/allrecipes-1/source.html
@@ -1,0 +1,3349 @@
+<!DOCTYPE html>
+<html id="recipeScTemplate_1-0" class="comp recipeScTemplate html mntl-html no-js taxlevel-4" data-mm-ads-resource-version="2.2.80" data-ddm-standard-video="true" data-mm-video-resource-version="3.0.20" data-mm-myrecipes-resource-version="3.3.29" data-mantle-resource-version="4.2.231" data-allrecipes-resource-version="4.110.0" data-lazy-offset="200.0" data-ab="99,99,99,99,99,50,99,99,99,77,99,99,99,99,99,99,99,99,58,78,99,64,62" data-mm-transactional-resource-version="3.1.21" data-mm-digital-issues-resource-version="3.0.10" lang="en" data-tracking-container="true" data-resource-version="4.110.0" data-ddm-standard-tracking="true" data-mm-recipes-resource-version="3.1.6" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <!--
+<globe-environment environment="k8s-prod" application="allrecipes" dataCenter="us-east-1"/>
+-->
+    <head class="loc head">
+        <meta charset="utf-8" />
+        <script type="text/javascript">
+        //<![CDATA[
+        var MMads = window.MMads || {};
+        var MMAds = window.MMAds || {};
+        //]]>
+        </script>
+        <link rel="preconnect" href="//c.amazon-adsystem.com" />
+        <link rel="preconnect" href="//securepubads.g.doubleclick.net" />
+        <link rel="preconnect" href="//allrecipes.groceryserver.com" />
+        <link rel="preconnect" href="//products.polaris.me" />
+        <link rel="preconnect" href="//calvera-telemetry.polaris.me" />
+        <link rel="preconnect" href="//live.polaris.me" />
+        <link rel="dnsprefetch" href="//www.google-analytics.com" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="robots" content="max-image-preview:large, NOODP, NOYDIR" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="canonical" href="https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010" />
+        <title>
+            Hot Honey Brussels Sprouts Recipe
+        </title>
+        <meta name="description" content="These hot honey Brussels sprouts are a simple side dish with all the elements you'll ever need in a side. They're sweet, spicy, crispy, and melt in your mouth." itemprop="description" />
+        <meta name="parsely-section" content="Recipes" />
+        <meta name="parsely-tags" content="Recipes,Roasted Vegetable Recipes,Everyday Cooking,Allrecipes Allstar Recipes,Special Collections,Side Dish,Vegetables,Brussels Sprouts,Vegetables" /><!-- Pinterest Pins -->
+        <meta itemprop="name" content="Hot Honey Brussels Sprouts" />
+        <meta property="article:section" content="Allrecipes" /><!-- Facebook Open Graph Tags -->
+        <meta property="og:type" content="article" />
+        <meta property="og:site_name" content="Allrecipes" />
+        <meta property="og:url" content="https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010" />
+        <meta property="og:title" content="Hot Honey Brussels Sprouts" />
+        <meta property="og:description" content="These hot honey Brussels sprouts are a simple side dish with all the elements you'll ever need in a side. They're sweet, spicy, crispy, and melt in your mouth." />
+        <meta property="og:image" content="https://www.allrecipes.com/thmb/98UmG-syGtguOt28Gn9vOtux90I=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-2x1-12acfcb60eef41e3b9cc996aa684c46a.jpg" />
+        <meta property="article:opinion" content="false" />
+        <meta property="article:author" content="https://www.facebook.com/allrecipes" /><!-- Twitter Cards -->
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@allrecipes" />
+        <meta name="twitter:title" content="Hot Honey Brussels Sprouts" />
+        <meta name="twitter:description" content="These hot honey Brussels sprouts are a simple side dish with all the elements you'll ever need in a side. They're sweet, spicy, crispy, and melt in your mouth." />
+        <meta name="twitter:image" content="https://www.allrecipes.com/thmb/fUO0_hGNPi-LwQtQ2u-MqlLr-h0=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc():focal(1913x901:1915x903)/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-2x1-12acfcb60eef41e3b9cc996aa684c46a.jpg" />
+        <link rel="alternate" type="application/rss+xml" href="https://feeds-api.dotdashmeredith.com/v1/rss/google/b41abeb9-87a0-4c32-b4db-c8d3f41e7934" />
+        <link type="text/css" rel="stylesheet" data-glb-css="top" href="/static/4.110.0/cache/eNqtWFGaoyAMvtDyeYh93UsgRM0UoQtop3v6DWhbaZHBzjy0kpD_hwAh0cZ57lE0I9deQSOca4IGfjWvHTjyHthZcQGDURJszmgEixK5blBL-LxbxC6O-gVixrPRoL1rWsu1JKurDT92I3ogjJwUuC3EclRsRgkmDhBbJfuWu9VHwbh0j9k9TEjd7HTNoKWxzXlyg7quj4I_F5Q90HMA7Af_e-C6hz_oPGiwWWWBq1em5YpQXEYw365-rd0rreYz9tRndDN5VOivjFTb9teDbIwZo4371nCRgXXGyAJNZ-xIWwjcioEFYdsu4EZwLpzgluuwBalYN-3F5zjrR7MO2k1KOWEBdISn4g9QHFh8ZwRyFTliMNzF3G7ncRlMLj5B4BnYdrNfVdkotKSg-a9PJoymEPEr-iBvZmLjGFYrQhzr-Gwseshrf4iGMa4sQSsuDG08dijimt8Oa9injP4bbC5MioyAbS1ym5G3PEAQ7lQVw6U13MrSim7M4iyzsL3rke4NT94tj8LNlbcrh160XcLu3jwEVahPLhHq4NJ4yd3AJo0zWLfGX1ZbIKRMqky_PqqPNFLUWefRE2y_hz2zvroDF6fAB8_XibxoCtt1BP069u0qCadpbRdvHKVuPj5bZ1YrVhzs40JF0ZUm01rDZZOK9fA7sOCN83YSfrIg73diLMuW_wJwsQqL0GOXW4ARaClXs7Olp72ylHTHuMOe5sMEPyfxXzzUraW4FnYaW7dtM0pnRqmM6lu0FafjlmjWoiYVazJUGXh44BE8T4RS4Xyl6yQcLHdvl2Z8Mz9gyic_GMu8McrjueSV9xbbKWxGIjDKFTWpbx2hqRgpmdIS3Tuz3KtL6GwtVYwbuIWs8v3aJEOdZ95fjIQivkCR5Q7Jvo8WZoQLZX6bUeX8S_3I2BYGS9fiLr-_jKn2-3ySQgmVexJrXEuR7giUkqU1IX8mihJSU8e8bPrSrBlG2cDcU27Akr4qMB5pJseY764iXt5XLvwEOV0VBdiZRmUO_wG9xX9MLhRzxd5jCXXwo4p_R47Z-mStMuLkHt9LqjziMwUap3KaEu8mep7075_6F-4ca2GCI-UmusKf5RqonigJxBTQcbGvZ24aQ8nxk5SKt6DeWLRn_jJvbqLh2w4LH6fiOXiIJZD7O93ueaqrxenKFk0tJjWu8Fah8xR7y2vW0s7Bz4Px5lZ4b4UDxc3zkIXhpl6E35p3Ns2q73qdgk9sVYj8UsyDiOVi2G8rWF4s4AW9jbLgw6P1hXX8q_hSEvli7fesqACTgQ2BTddfRvUfvGZ0kg.min.css" />
+        <style type="text/css">
+        /*<![CDATA[*/
+        #onetrust-banner-sdk .onetrust-vendors-list-handler{cursor:pointer;color:#1f96db;font-size:inherit;font-weight:bold;text-decoration:none;margin-left:5px;white-space:normal;word-wrap:break-word;text-align:left}#onetrust-banner-sdk .onetrust-vendors-list-handler:hover{color:#1f96db}#onetrust-banner-sdk:focus{outline:2px solid #000;outline-offset:-2px}#onetrust-banner-sdk a:focus{outline:2px solid #000}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{outline-offset:1px}#onetrust-banner-sdk.ot-bnr-w-logo .ot-bnr-logo{height:64px;width:64px}#onetrust-banner-sdk #onetrust-policy svg,#onetrust-banner-sdk .banner-option svg{height:13px;width:13px;margin-left:1px}#onetrust-banner-sdk .ot-tcf2-vendor-count.ot-text-bold{font-weight:bold}#onetrust-banner-sdk .ot-button-order-0{order:0}#onetrust-banner-sdk .ot-button-order-1{order:1}#onetrust-banner-sdk .ot-button-order-2{order:2}#onetrust-banner-sdk #onetrust-close-btn-container svg{height:10px;width:10px;pointer-events:none}#onetrust-banner-sdk .ot-close-icon,#onetrust-pc-sdk .ot-close-icon,#ot-sync-ntfy .ot-close-icon{background-size:contain;background-repeat:no-repeat;background-position:center;height:12px;width:12px}#onetrust-banner-sdk .powered-by-logo,#onetrust-banner-sdk .ot-pc-footer-logo a,#onetrust-pc-sdk .powered-by-logo,#onetrust-pc-sdk .ot-pc-footer-logo a,#ot-sync-ntfy .powered-by-logo,#ot-sync-ntfy .ot-pc-footer-logo a{background-size:contain;background-repeat:no-repeat;background-position:center;height:25px;width:152px;display:block;text-decoration:none;font-size:.75em}#onetrust-banner-sdk .powered-by-logo:hover,#onetrust-banner-sdk .ot-pc-footer-logo a:hover,#onetrust-pc-sdk .powered-by-logo:hover,#onetrust-pc-sdk .ot-pc-footer-logo a:hover,#ot-sync-ntfy .powered-by-logo:hover,#ot-sync-ntfy .ot-pc-footer-logo a:hover{color:#565656}#onetrust-banner-sdk h3 *,#onetrust-banner-sdk h4 *,#onetrust-banner-sdk h6 *,#onetrust-banner-sdk button *,#onetrust-banner-sdk a[data-parent-id] *,#onetrust-banner-sdk p[role=heading] *,#onetrust-pc-sdk h3 *,#onetrust-pc-sdk h4 *,#onetrust-pc-sdk h6 *,#onetrust-pc-sdk button *,#onetrust-pc-sdk a[data-parent-id] *,#onetrust-pc-sdk p[role=heading] *,#ot-sync-ntfy h3 *,#ot-sync-ntfy h4 *,#ot-sync-ntfy h6 *,#ot-sync-ntfy button *,#ot-sync-ntfy a[data-parent-id] *,#ot-sync-ntfy p[role=heading] *{font-size:inherit;font-weight:inherit;color:inherit}#onetrust-banner-sdk .ot-hide,#onetrust-pc-sdk .ot-hide,#ot-sync-ntfy .ot-hide{display:none !important}#onetrust-banner-sdk button.ot-link-btn:hover,#onetrust-pc-sdk button.ot-link-btn:hover,#ot-sync-ntfy button.ot-link-btn:hover{text-decoration:underline;opacity:1}#onetrust-pc-sdk .ot-sdk-row .ot-sdk-column{padding:0}#onetrust-pc-sdk .ot-sdk-container{padding-right:0}#onetrust-pc-sdk .ot-sdk-row{flex-direction:initial;width:100%}#onetrust-pc-sdk [type=checkbox]:checked,#onetrust-pc-sdk [type=checkbox]:not(:checked){pointer-events:initial}#onetrust-pc-sdk [type=checkbox]:disabled+label::before,#onetrust-pc-sdk [type=checkbox]:disabled+label:after,#onetrust-pc-sdk [type=checkbox]:disabled+label{pointer-events:none;opacity:.8}#onetrust-pc-sdk #vendor-list-content{transform:translate3d(0, 0, 0)}#onetrust-pc-sdk li input[type=checkbox]{z-index:1}#onetrust-pc-sdk li .ot-checkbox label{z-index:2}#onetrust-pc-sdk li .ot-checkbox input[type=checkbox]{height:auto;width:auto}#onetrust-pc-sdk li .host-title a,#onetrust-pc-sdk li .ot-host-name a,#onetrust-pc-sdk li .accordion-text,#onetrust-pc-sdk li .ot-acc-txt{z-index:2;position:relative}#onetrust-pc-sdk input{margin:3px .1ex}#onetrust-pc-sdk .pc-logo,#onetrust-pc-sdk .ot-pc-logo{height:60px;width:180px;background-position:center;background-size:contain;background-repeat:no-repeat;display:inline-flex;justify-content:center;align-items:center}#onetrust-pc-sdk .pc-logo img,#onetrust-pc-sdk .ot-pc-logo img{max-height:100%;max-width:100%}#onetrust-pc-sdk .pc-logo svg,#onetrust-pc-sdk .ot-pc-logo svg{height:60px;width:180px}#onetrust-pc-sdk #close-pc-btn-handler>svg{margin:auto;display:block;height:12px;width:12px}#onetrust-pc-sdk #ot-pc-desc svg{height:13px;width:13px;margin-left:-7px;vertical-align:baseline;margin-right:3px}#onetrust-pc-sdk .screen-reader-only,#onetrust-pc-sdk .ot-scrn-rdr,.ot-sdk-cookie-policy .screen-reader-only,.ot-sdk-cookie-policy .ot-scrn-rdr{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}#onetrust-pc-sdk.ot-fade-in,.onetrust-pc-dark-filter.ot-fade-in,#onetrust-banner-sdk.ot-fade-in,.ot-confirm-dialog-overlay.ot-fade-in{animation-name:onetrust-fade-in;animation-duration:400ms;animation-timing-function:ease-in-out}#onetrust-pc-sdk.ot-hide{display:none !important}.onetrust-pc-dark-filter.ot-hide{display:none !important}#ot-sdk-btn.ot-sdk-show-settings,#ot-sdk-btn.optanon-show-settings{color:#fff;background-color:#468254;height:auto;white-space:normal;word-wrap:break-word;padding:.8em 2em;font-size:.8em;line-height:1.2;cursor:pointer;-moz-transition:.1s ease;-o-transition:.1s ease;-webkit-transition:1s ease;transition:.1s ease}#ot-sdk-btn.ot-sdk-show-settings:hover,#ot-sdk-btn.optanon-show-settings:hover{color:#fff;background-color:#2c6415}#ot-sdk-btn.ot-sdk-show-settings:active,#ot-sdk-btn.optanon-show-settings:active{color:#fff;background-color:#2c6415;border:1px solid rgba(162,192,169,.5)}.onetrust-pc-dark-filter{background:rgba(0,0,0,.5);z-index:2147483646;width:100%;height:100%;overflow:hidden;position:fixed;top:0;bottom:0;left:0}@keyframes onetrust-fade-in{0%{opacity:0}100%{opacity:1}}.ot-cookie-label{text-decoration:underline}@media only screen and (min-width: 426px)and (max-width: 896px)and (orientation: landscape){#onetrust-pc-sdk p{font-size:.75em}}#onetrust-banner-sdk .banner-option-input:focus+label{outline:1px solid #000;outline-style:auto}.category-vendors-list-handler+a:focus,.category-vendors-list-handler+a:focus-visible{outline:2px solid #000}#onetrust-pc-sdk .ot-userid-title{margin-top:10px}#onetrust-pc-sdk .ot-userid-title>span,#onetrust-pc-sdk .ot-userid-timestamp>span{font-weight:700}#onetrust-pc-sdk .ot-userid-desc{font-style:italic}#onetrust-pc-sdk .ot-host-desc a{pointer-events:initial}#onetrust-pc-sdk .ot-ven-hdr>p a{position:relative;z-index:2;pointer-events:initial}#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info a,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info a{margin-right:auto}#onetrust-pc-sdk .ot-pc-footer-logo svg,#onetrust-pc-sdk .ot-pc-footer-logo img{width:136px;height:16px}#onetrust-pc-sdk .ot-pur-vdr-count{font-weight:400;font-size:.8em;padding-top:3px;display:block}#onetrust-pc-sdk p[role=heading] .ot-pur-vdr-count{font-weight:400 !important;font-size:.8em !important}#onetrust-banner-sdk .ot-optout-signal,#onetrust-pc-sdk .ot-optout-signal{border:1px solid #32ae88;border-radius:3px;padding:5px;margin-bottom:10px;background-color:#f9fffa;font-size:.85rem;line-height:2}#onetrust-banner-sdk .ot-optout-signal .ot-optout-icon,#onetrust-pc-sdk .ot-optout-signal .ot-optout-icon{display:inline;margin-right:5px}#onetrust-banner-sdk .ot-optout-signal svg,#onetrust-pc-sdk .ot-optout-signal svg{height:20px;width:30px}#onetrust-banner-sdk .ot-optout-signal svg.ot-source-sprite,#onetrust-pc-sdk .ot-optout-signal svg.ot-source-sprite{position:relative;bottom:-3px}#onetrust-banner-sdk .ot-optout-signal svg:not(.ot-source-sprite),#onetrust-pc-sdk .ot-optout-signal svg:not(.ot-source-sprite){transform:scale(0.5)}#onetrust-banner-sdk .ot-optout-signal svg:not(.ot-source-sprite) path,#onetrust-pc-sdk .ot-optout-signal svg:not(.ot-source-sprite) path{fill:#32ae88}#onetrust-consent-sdk .ot-general-modal{overflow:hidden;position:fixed;margin:0 auto;top:50%;left:50%;width:40%;padding:1.5rem;max-width:575px;min-width:575px;z-index:2147483647;border-radius:2.5px;transform:translate(-50%, -50%)}#onetrust-consent-sdk .ot-signature-health-group{margin-top:1rem;padding-left:1.25rem;padding-right:1.25rem;margin-bottom:.625rem;width:calc(100% - 2.5rem)}#onetrust-consent-sdk .ot-signature-health-group .ot-signature-health-form{gap:.5rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-health-form{width:70%;gap:.35rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-input{height:38px;padding:6px 10px;background-color:#fff;border:1px solid #d1d1d1;border-radius:4px;box-shadow:none;box-sizing:border-box}#onetrust-consent-sdk .ot-signature-health .ot-signature-subtitle{font-size:1.125rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-group-title{font-size:1.25rem;font-weight:bold}#onetrust-consent-sdk .ot-signature-health,#onetrust-consent-sdk .ot-signature-health-group{display:flex;flex-direction:column;gap:1rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-cont,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-cont{display:flex;flex-direction:column;gap:.25rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-paragraph,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-paragraph{margin:0;line-height:20px;font-size:max(14px,.875rem)}#onetrust-consent-sdk .ot-signature-health .ot-health-signature-error,#onetrust-consent-sdk .ot-signature-health-group .ot-health-signature-error{color:#4d4d4d;font-size:min(12px,.75rem)}#onetrust-consent-sdk .ot-signature-health .ot-signature-buttons-cont,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-buttons-cont{margin-top:max(.75rem,2%);gap:1rem;display:flex;justify-content:flex-end}#onetrust-consent-sdk .ot-signature-health .ot-signature-button,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-button{flex:1;height:auto;color:#fff;cursor:pointer;line-height:1.2;min-width:125px;font-weight:600;font-size:.813em;border-radius:2px;padding:12px 10px;white-space:normal;word-wrap:break-word;word-break:break-word;background-color:#68b631;border:2px solid #68b631}#onetrust-consent-sdk .ot-signature-health .ot-signature-button.reject,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-button.reject{background-color:#fff}#onetrust-consent-sdk .ot-input-field-cont{display:flex;flex-direction:column;gap:.5rem}#onetrust-consent-sdk .ot-input-field-cont .ot-signature-input{width:65%}#onetrust-consent-sdk .ot-signature-health-form{display:flex;flex-direction:column}#onetrust-consent-sdk .ot-signature-health-form .ot-signature-label{margin-bottom:0;line-height:20px;font-size:max(14px,.875rem)}#onetrust-consent-sdk #onetrust-sprite-svg{display:none}@media only screen and (max-width: 600px){#onetrust-consent-sdk .ot-general-modal{min-width:100%}#onetrust-consent-sdk .ot-signature-health .ot-signature-health-form{width:100%}#onetrust-consent-sdk .ot-input-field-cont .ot-signature-input{width:100%}}#onetrust-banner-sdk,#onetrust-pc-sdk,#ot-sdk-cookie-policy,#ot-sync-ntfy{font-size:16px}#onetrust-banner-sdk *,#onetrust-banner-sdk ::after,#onetrust-banner-sdk ::before,#onetrust-pc-sdk *,#onetrust-pc-sdk ::after,#onetrust-pc-sdk ::before,#ot-sdk-cookie-policy *,#ot-sdk-cookie-policy ::after,#ot-sdk-cookie-policy ::before,#ot-sync-ntfy *,#ot-sync-ntfy ::after,#ot-sync-ntfy ::before{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}#onetrust-banner-sdk div,#onetrust-banner-sdk span,#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-banner-sdk p,#onetrust-banner-sdk img,#onetrust-banner-sdk svg,#onetrust-banner-sdk button,#onetrust-banner-sdk section,#onetrust-banner-sdk a,#onetrust-banner-sdk label,#onetrust-banner-sdk input,#onetrust-banner-sdk ul,#onetrust-banner-sdk li,#onetrust-banner-sdk nav,#onetrust-banner-sdk table,#onetrust-banner-sdk thead,#onetrust-banner-sdk tr,#onetrust-banner-sdk td,#onetrust-banner-sdk tbody,#onetrust-banner-sdk .ot-main-content,#onetrust-banner-sdk .ot-toggle,#onetrust-banner-sdk #ot-content,#onetrust-banner-sdk #ot-pc-content,#onetrust-banner-sdk .checkbox,#onetrust-pc-sdk div,#onetrust-pc-sdk span,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#onetrust-pc-sdk p,#onetrust-pc-sdk img,#onetrust-pc-sdk svg,#onetrust-pc-sdk button,#onetrust-pc-sdk section,#onetrust-pc-sdk a,#onetrust-pc-sdk label,#onetrust-pc-sdk input,#onetrust-pc-sdk ul,#onetrust-pc-sdk li,#onetrust-pc-sdk nav,#onetrust-pc-sdk table,#onetrust-pc-sdk thead,#onetrust-pc-sdk tr,#onetrust-pc-sdk td,#onetrust-pc-sdk tbody,#onetrust-pc-sdk .ot-main-content,#onetrust-pc-sdk .ot-toggle,#onetrust-pc-sdk #ot-content,#onetrust-pc-sdk #ot-pc-content,#onetrust-pc-sdk .checkbox,#ot-sdk-cookie-policy div,#ot-sdk-cookie-policy span,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6,#ot-sdk-cookie-policy p,#ot-sdk-cookie-policy img,#ot-sdk-cookie-policy svg,#ot-sdk-cookie-policy button,#ot-sdk-cookie-policy section,#ot-sdk-cookie-policy a,#ot-sdk-cookie-policy label,#ot-sdk-cookie-policy input,#ot-sdk-cookie-policy ul,#ot-sdk-cookie-policy li,#ot-sdk-cookie-policy nav,#ot-sdk-cookie-policy table,#ot-sdk-cookie-policy thead,#ot-sdk-cookie-policy tr,#ot-sdk-cookie-policy td,#ot-sdk-cookie-policy tbody,#ot-sdk-cookie-policy .ot-main-content,#ot-sdk-cookie-policy .ot-toggle,#ot-sdk-cookie-policy #ot-content,#ot-sdk-cookie-policy #ot-pc-content,#ot-sdk-cookie-policy .checkbox,#ot-sync-ntfy div,#ot-sync-ntfy span,#ot-sync-ntfy h1,#ot-sync-ntfy h2,#ot-sync-ntfy h3,#ot-sync-ntfy h4,#ot-sync-ntfy h5,#ot-sync-ntfy h6,#ot-sync-ntfy p,#ot-sync-ntfy img,#ot-sync-ntfy svg,#ot-sync-ntfy button,#ot-sync-ntfy section,#ot-sync-ntfy a,#ot-sync-ntfy label,#ot-sync-ntfy input,#ot-sync-ntfy ul,#ot-sync-ntfy li,#ot-sync-ntfy nav,#ot-sync-ntfy table,#ot-sync-ntfy thead,#ot-sync-ntfy tr,#ot-sync-ntfy td,#ot-sync-ntfy tbody,#ot-sync-ntfy .ot-main-content,#ot-sync-ntfy .ot-toggle,#ot-sync-ntfy #ot-content,#ot-sync-ntfy #ot-pc-content,#ot-sync-ntfy .checkbox{font-family:inherit;font-weight:normal;-webkit-font-smoothing:auto;letter-spacing:normal;line-height:normal;padding:0;margin:0;height:auto;min-height:0;max-height:none;width:auto;min-width:0;max-width:none;border-radius:0;border:none;clear:none;float:none;position:static;bottom:auto;left:auto;right:auto;top:auto;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;white-space:normal;background:none;overflow:visible;vertical-align:baseline;visibility:visible;z-index:auto;box-shadow:none}#onetrust-banner-sdk img,#onetrust-pc-sdk img,#ot-sdk-cookie-policy img,#ot-sync-ntfy img{overflow:hidden !important}#onetrust-banner-sdk label:before,#onetrust-banner-sdk label:after,#onetrust-banner-sdk .checkbox:after,#onetrust-banner-sdk .checkbox:before,#onetrust-pc-sdk label:before,#onetrust-pc-sdk label:after,#onetrust-pc-sdk .checkbox:after,#onetrust-pc-sdk .checkbox:before,#ot-sdk-cookie-policy label:before,#ot-sdk-cookie-policy label:after,#ot-sdk-cookie-policy .checkbox:after,#ot-sdk-cookie-policy .checkbox:before,#ot-sync-ntfy label:before,#ot-sync-ntfy label:after,#ot-sync-ntfy .checkbox:after,#ot-sync-ntfy .checkbox:before{content:"";content:none}#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{position:relative;width:100%;max-width:100%;margin:0 auto;padding:0 20px;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{width:100%;float:left;box-sizing:border-box;padding:0;display:initial}@media(min-width: 400px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:90%;padding:0}}@media(min-width: 550px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:100%}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{margin-left:4%}#onetrust-banner-sdk .ot-sdk-column:first-child,#onetrust-banner-sdk .ot-sdk-columns:first-child,#onetrust-pc-sdk .ot-sdk-column:first-child,#onetrust-pc-sdk .ot-sdk-columns:first-child,#ot-sdk-cookie-policy .ot-sdk-column:first-child,#ot-sdk-cookie-policy .ot-sdk-columns:first-child{margin-left:0}#onetrust-banner-sdk .ot-sdk-two.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-two.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-two.ot-sdk-columns{width:13.3333333333%}#onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-three.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-three.ot-sdk-columns{width:22%}#onetrust-banner-sdk .ot-sdk-four.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-four.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-four.ot-sdk-columns{width:30.6666666667%}#onetrust-banner-sdk .ot-sdk-eight.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eight.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eight.ot-sdk-columns{width:65.3333333333%}#onetrust-banner-sdk .ot-sdk-nine.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-nine.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-nine.ot-sdk-columns{width:74%}#onetrust-banner-sdk .ot-sdk-ten.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-ten.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-ten.ot-sdk-columns{width:82.6666666667%}#onetrust-banner-sdk .ot-sdk-eleven.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eleven.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eleven.ot-sdk-columns{width:91.3333333333%}#onetrust-banner-sdk .ot-sdk-twelve.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-twelve.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-twelve.ot-sdk-columns{width:100%;margin-left:0}}#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-banner-sdk p[role=heading],#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#onetrust-pc-sdk p[role=heading],#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6,#ot-sdk-cookie-policy p[role=heading]{margin-top:0;font-weight:600;font-family:inherit}#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem;line-height:1.2}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem;line-height:1.25}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem;line-height:1.3}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem;line-height:1.35}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem;line-height:1.5}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem;line-height:1.6}@media(min-width: 550px){#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem}}#onetrust-banner-sdk p:not([role=heading]),#onetrust-pc-sdk p:not([role=heading]),#ot-sdk-cookie-policy p:not([role=heading]){margin:0 0 1em 0;font-family:inherit;line-height:normal}#onetrust-banner-sdk a,#onetrust-pc-sdk a,#ot-sdk-cookie-policy a{color:#565656;text-decoration:underline}#onetrust-banner-sdk a:hover,#onetrust-pc-sdk a:hover,#ot-sdk-cookie-policy a:hover{color:#565656;text-decoration:none}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{display:inline-block;height:38px;padding:0 30px;color:#555;text-align:center;font-size:.9em;font-weight:400;line-height:38px;letter-spacing:.01em;text-decoration:none;white-space:nowrap;background-color:rgba(0,0,0,0);border-radius:2px;border:1px solid #bbb;cursor:pointer;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container):not(.ot-confirm-dialog-buttons)>button:not(.ot-link-btn):hover,#onetrust-banner-sdk :not(.ot-leg-btn-container):not(.ot-confirm-dialog-buttons)>button:not(.ot-link-btn):focus,#onetrust-pc-sdk .ot-sdk-button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container):not(.ot-confirm-dialog-buttons)>button:not(.ot-link-btn):hover,#onetrust-pc-sdk :not(.ot-leg-btn-container):not(.ot-confirm-dialog-buttons)>button:not(.ot-link-btn):focus,#ot-sdk-cookie-policy .ot-sdk-button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container):not(.ot-confirm-dialog-buttons)>button:not(.ot-link-btn):hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container):not(.ot-confirm-dialog-buttons)>button:not(.ot-link-btn):focus{color:#333;border-color:#888;opacity:.9}#onetrust-banner-sdk .ot-sdk-button:focus,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:focus,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:focus,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{outline:2px solid #000}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-banner-sdk button.ot-sdk-button-primary,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-pc-sdk button.ot-sdk-button-primary,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary,#ot-sdk-cookie-policy button.ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary{color:#fff;background-color:#33c3f0;border-color:#33c3f0}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-banner-sdk button.ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary:hover,#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-banner-sdk button.ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary:focus,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-pc-sdk button.ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary:hover,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-pc-sdk button.ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary:focus{color:#fff;background-color:#1eaedb;border-color:#1eaedb}#onetrust-banner-sdk input[type=text],#onetrust-pc-sdk input[type=text],#ot-sdk-cookie-policy input[type=text]{height:38px;padding:6px 10px;background-color:#fff;border:1px solid #707070;border-radius:4px;box-shadow:none;box-sizing:border-box}#onetrust-banner-sdk input[type=text],#onetrust-pc-sdk input[type=text],#ot-sdk-cookie-policy input[type=text]{-webkit-appearance:none;-moz-appearance:none;appearance:none}#onetrust-banner-sdk input[type=text]:focus,#onetrust-pc-sdk input[type=text]:focus,#ot-sdk-cookie-policy input[type=text]:focus{border:1px solid #000;outline:0}#onetrust-banner-sdk label,#onetrust-pc-sdk label,#ot-sdk-cookie-policy label{display:block;margin-bottom:.5rem;font-weight:600}#onetrust-banner-sdk input[type=checkbox],#onetrust-pc-sdk input[type=checkbox],#ot-sdk-cookie-policy input[type=checkbox]{display:inline}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{list-style:circle inside}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{padding-left:0;margin-top:0}#onetrust-banner-sdk ul ul,#onetrust-pc-sdk ul ul,#ot-sdk-cookie-policy ul ul{margin:1.5rem 0 1.5rem 3rem;font-size:90%}#onetrust-banner-sdk li,#onetrust-pc-sdk li,#ot-sdk-cookie-policy li{margin-bottom:1rem}#onetrust-banner-sdk th,#onetrust-banner-sdk td,#onetrust-pc-sdk th,#onetrust-pc-sdk td,#ot-sdk-cookie-policy th,#ot-sdk-cookie-policy td{padding:12px 15px;text-align:left;border-bottom:1px solid #e1e1e1}#onetrust-banner-sdk button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-container:after,#onetrust-banner-sdk .ot-sdk-row:after,#onetrust-pc-sdk .ot-sdk-container:after,#onetrust-pc-sdk .ot-sdk-row:after,#ot-sdk-cookie-policy .ot-sdk-container:after,#ot-sdk-cookie-policy .ot-sdk-row:after{content:"";display:table;clear:both}#onetrust-banner-sdk .ot-sdk-row,#onetrust-pc-sdk .ot-sdk-row,#ot-sdk-cookie-policy .ot-sdk-row{margin:0;max-width:none;display:block} #onetrust-banner-sdk{box-shadow:0 0 18px rgba(0,0,0,.2)}#onetrust-banner-sdk.otFlat{position:fixed;z-index:2147483645;bottom:0;right:0;left:0;background-color:#fff;max-height:90%;overflow-x:hidden;overflow-y:auto}#onetrust-banner-sdk.otFlat.top{top:0px;bottom:auto}#onetrust-banner-sdk.otRelFont{font-size:1rem}#onetrust-banner-sdk>.ot-sdk-container{overflow:hidden}#onetrust-banner-sdk::-webkit-scrollbar{width:11px}#onetrust-banner-sdk::-webkit-scrollbar-thumb{border-radius:10px;background:#c1c1c1}#onetrust-banner-sdk{scrollbar-arrow-color:#c1c1c1;scrollbar-darkshadow-color:#c1c1c1;scrollbar-face-color:#c1c1c1;scrollbar-shadow-color:#c1c1c1}#onetrust-banner-sdk #onetrust-policy{margin:1.25em 0 .625em 2em;overflow:hidden}#onetrust-banner-sdk #onetrust-policy .ot-gv-list-handler{float:left;font-size:.82em;padding:0;margin-bottom:0;border:0;line-height:normal;height:auto;width:auto}#onetrust-banner-sdk #onetrust-policy-title{font-size:1.2em;line-height:1.3;margin-bottom:10px}#onetrust-banner-sdk #onetrust-group-container{position:relative}#onetrust-banner-sdk #onetrust-policy-text{clear:both;text-align:left;font-size:.88em;line-height:1.4}#onetrust-banner-sdk #onetrust-policy-text *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk #onetrust-policy-text a{font-weight:bold}#onetrust-banner-sdk #onetrust-policy-title,#onetrust-banner-sdk #onetrust-policy-text{color:dimgray;float:left}#onetrust-banner-sdk #onetrust-button-group-parent{min-height:1px;text-align:center}#onetrust-banner-sdk #onetrust-button-group{display:inline-block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{background-color:#68b631;color:#fff;border-color:#68b631;margin-right:1em;min-width:125px;height:auto;white-space:normal;word-break:break-word;word-wrap:break-word;padding:12px 10px;line-height:1.2;font-size:.813em;font-weight:600}#onetrust-banner-sdk #onetrust-pc-btn-handler.cookie-setting-link{background-color:#fff;border:none;color:#68b631;text-decoration:underline;padding-left:0;padding-right:0}#onetrust-banner-sdk .onetrust-close-btn-ui{width:44px;height:44px;background-size:12px;border:none;position:relative;margin:auto;padding:0}#onetrust-banner-sdk .banner_logo{display:none}#onetrust-banner-sdk.ot-bnr-w-logo .ot-bnr-logo{position:absolute;top:50%;transform:translateY(-50%);left:0px;margin-right:5px}#onetrust-banner-sdk.ot-bnr-w-logo #onetrust-policy{margin-left:65px}#onetrust-banner-sdk .ot-b-addl-desc{clear:both;float:left;display:block}#onetrust-banner-sdk #banner-options{float:left;display:table;margin-right:0;margin-left:1em;width:calc(100% - 1em)}#onetrust-banner-sdk .banner-option-input{cursor:pointer;width:auto;height:auto;border:none;padding:0;padding-right:3px;margin:0 0 10px;font-size:.82em;line-height:1.4}#onetrust-banner-sdk .banner-option-input *{pointer-events:none;font-size:inherit;line-height:inherit}#onetrust-banner-sdk .banner-option-input[aria-expanded=true]~.banner-option-details{display:block;height:auto}#onetrust-banner-sdk .banner-option-input[aria-expanded=true] .ot-arrow-container{transform:rotate(90deg)}#onetrust-banner-sdk .banner-option{margin-bottom:12px;margin-left:0;border:none;float:left;padding:0}#onetrust-banner-sdk .banner-option:first-child{padding-left:2px}#onetrust-banner-sdk .banner-option:not(:first-child){padding:0;border:none}#onetrust-banner-sdk .banner-option-header{cursor:pointer;display:inline-block}#onetrust-banner-sdk .banner-option-header :first-child{color:dimgray;font-weight:bold;float:left}#onetrust-banner-sdk .banner-option-header .ot-arrow-container{display:inline-block;border-top:6px solid rgba(0,0,0,0);border-bottom:6px solid rgba(0,0,0,0);border-left:6px solid dimgray;margin-left:10px;vertical-align:middle}#onetrust-banner-sdk .banner-option-details{display:none;font-size:.83em;line-height:1.5;padding:10px 0px 5px 10px;margin-right:10px;height:0px}#onetrust-banner-sdk .banner-option-details *{font-size:inherit;line-height:inherit;color:dimgray}#onetrust-banner-sdk .ot-arrow-container,#onetrust-banner-sdk .banner-option-details{transition:all 300ms ease-in 0s;-webkit-transition:all 300ms ease-in 0s;-moz-transition:all 300ms ease-in 0s;-o-transition:all 300ms ease-in 0s}#onetrust-banner-sdk .ot-dpd-container{float:left}#onetrust-banner-sdk .ot-dpd-title{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-title,#onetrust-banner-sdk .ot-dpd-desc{font-size:.88em;line-height:1.4;color:dimgray}#onetrust-banner-sdk .ot-dpd-title *,#onetrust-banner-sdk .ot-dpd-desc *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text *{margin-bottom:0}#onetrust-banner-sdk.ot-iab-2 .onetrust-vendors-list-handler{display:block;margin-left:0;margin-top:5px;clear:both;margin-bottom:0;padding:0;border:0;height:auto;width:auto}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk.ot-close-btn-link{padding-top:25px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container{top:15px;transform:none;right:15px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container button{padding:0;white-space:pre-wrap;border:none;height:auto;line-height:1.5;text-decoration:underline;font-size:.69em}#onetrust-banner-sdk #onetrust-policy-text,#onetrust-banner-sdk .ot-dpd-desc,#onetrust-banner-sdk .ot-b-addl-desc{font-size:.813em;line-height:1.5}#onetrust-banner-sdk .ot-dpd-desc{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-desc>.ot-b-addl-desc{margin-top:10px;margin-bottom:10px;font-size:1em}@media only screen and (max-width: 425px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:6px;right:2px}#onetrust-banner-sdk #onetrust-policy{margin-left:0;margin-top:3em}#onetrust-banner-sdk #onetrust-button-group{display:block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{width:100%}#onetrust-banner-sdk .onetrust-close-btn-ui{top:auto;transform:none}#onetrust-banner-sdk #onetrust-policy-title{display:inline;float:none}#onetrust-banner-sdk #banner-options{margin:0;padding:0;width:100%}}@media only screen and (max-width: 550px){#onetrust-button-group.ot-button-order-container #onetrust-accept-btn-handler,#onetrust-button-group.ot-button-order-container #onetrust-reject-all-handler,#onetrust-button-group.ot-button-order-container #onetrust-pc-btn-handler{margin-right:0}#onetrust-banner-sdk .has-reject-all-button div#onetrust-button-group.ot-button-order-container #onetrust-accept-btn-handler,#onetrust-banner-sdk .has-reject-all-button div#onetrust-button-group.ot-button-order-container #onetrust-reject-all-handler,#onetrust-banner-sdk .has-reject-all-button div#onetrust-button-group.ot-button-order-container #onetrust-pc-btn-handler{margin-right:0}}@media only screen and (min-width: 426px)and (max-width: 896px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:0;right:0}#onetrust-banner-sdk #onetrust-policy{margin-left:1em;margin-right:1em}#onetrust-banner-sdk .onetrust-close-btn-ui{top:10px;right:10px}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:95%}#onetrust-banner-sdk.ot-iab-2 #onetrust-group-container{width:100%}#onetrust-banner-sdk.ot-bnr-w-logo #onetrust-button-group-parent{padding-left:50px}#onetrust-banner-sdk #onetrust-button-group-parent{width:100%;position:relative;margin-left:0}#onetrust-banner-sdk #onetrust-button-group button{display:inline-block}#onetrust-banner-sdk #onetrust-button-group{margin-right:0;text-align:center}#onetrust-banner-sdk #onetrust-button-group.ot-button-order-container #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-button-group.ot-button-order-container #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-button-group.ot-button-order-container #onetrust-pc-btn-handler{width:auto}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group.ot-button-order-container{display:inline-flex;flex-wrap:wrap}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group.ot-button-order-container #onetrust-pc-btn-handler,#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group.ot-button-order-container #onetrust-reject-all-handler,#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group.ot-button-order-container #onetrust-accept-btn-handler{float:none}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group.ot-button-order-container *[class*=ot-button-order-]:nth-of-type(1){margin-right:auto !important}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler{float:left}#onetrust-banner-sdk .has-reject-all-button #onetrust-reject-all-handler,#onetrust-banner-sdk .has-reject-all-button #onetrust-accept-btn-handler{float:right}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group{width:calc(100% - 2em);margin-right:0}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler.cookie-setting-link{padding-left:0px;text-align:left}#onetrust-banner-sdk.ot-buttons-fw .ot-sdk-three button{width:100%;text-align:center}#onetrust-banner-sdk.ot-buttons-fw #onetrust-button-group-parent button{float:none}#onetrust-banner-sdk.ot-buttons-fw #onetrust-pc-btn-handler.cookie-setting-link{text-align:center}}@media only screen and (min-width: 550px){#onetrust-banner-sdk .banner-option:not(:first-child){border-left:1px solid #d8d8d8;padding-left:25px}}@media only screen and (min-width: 425px)and (max-width: 550px){#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group,#onetrust-banner-sdk.ot-iab-2 #onetrust-policy,#onetrust-banner-sdk.ot-iab-2 .banner-option{width:100%}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-accept-btn-handler,#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-reject-all-handler,#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-pc-btn-handler{width:100%}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-accept-btn-handler,#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-reject-all-handler{float:left}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group.ot-button-order-container{width:auto}}@media only screen and (min-width: 769px){#onetrust-banner-sdk #onetrust-button-group{margin-right:30%}#onetrust-banner-sdk #banner-options{margin-left:2em;margin-right:5em;margin-bottom:1.25em;width:calc(100% - 7em)}}@media only screen and (min-width: 897px)and (max-width: 1023px){#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:80%;transform:translateY(-50%)}#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;padding:0;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{position:relative;margin:0;right:-22px;top:2px}}@media only screen and (min-width: 1024px){#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{right:-12px}#onetrust-banner-sdk #onetrust-policy{margin-left:2em}#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:60%;transform:translateY(-50%)}#onetrust-banner-sdk .ot-optout-signal{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-title{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text,#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:1em;width:50%;border-right:1px solid #d8d8d8;padding-right:1rem}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-container{width:45%;padding-left:1rem;display:inline-block;float:none}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-title{line-height:1.7}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent{left:auto;right:4%;margin-left:0}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{margin:auto;width:30%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:60%}#onetrust-banner-sdk #onetrust-button-group{margin-right:auto}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{margin-top:1em}}@media only screen and (min-width: 890px){#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group-parent{padding-left:3%;padding-right:4%;margin-left:0}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group{margin-right:0;margin-top:1.25em;width:100%}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button{width:100%;margin-bottom:5px;margin-top:5px}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button:last-of-type{margin-bottom:20px}}@media only screen and (min-width: 1280px){#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:55%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{width:44%;padding-left:2%;padding-right:2%}#onetrust-banner-sdk:not(.ot-iab-2).vertical-align-content #onetrust-button-group-parent{position:absolute;left:55%}}
+        #onetrust-consent-sdk #onetrust-banner-sdk {background-color: #FFFFFF;}
+        #onetrust-consent-sdk #onetrust-policy-title,
+        #onetrust-consent-sdk #onetrust-policy-text,
+        #onetrust-consent-sdk .ot-b-addl-desc,
+        #onetrust-consent-sdk .ot-dpd-desc,
+        #onetrust-consent-sdk .ot-dpd-title,
+        #onetrust-consent-sdk #onetrust-policy-text *:not(.onetrust-vendors-list-handler),
+        #onetrust-consent-sdk .ot-dpd-desc *:not(.onetrust-vendors-list-handler),
+        #onetrust-consent-sdk #onetrust-banner-sdk #banner-options *,
+        #onetrust-banner-sdk .ot-cat-header {
+        color: #000000;
+        }
+        #onetrust-consent-sdk #onetrust-banner-sdk .banner-option-details {
+        background-color: #E9E9E9;}
+        #onetrust-consent-sdk #onetrust-banner-sdk a[href],
+        #onetrust-consent-sdk #onetrust-banner-sdk a[href] font,
+        #onetrust-consent-sdk #onetrust-banner-sdk .ot-link-btn
+        {
+        color: #000000;
+        }#onetrust-consent-sdk #onetrust-accept-btn-handler,
+        #onetrust-banner-sdk #onetrust-reject-all-handler {
+        background-color: #D54215;border-color: #D54215;
+        color: #FFFFFF;
+        }
+        #onetrust-consent-sdk #onetrust-banner-sdk *:focus,
+        #onetrust-consent-sdk #onetrust-banner-sdk:focus {
+        outline-color: #000000;
+        outline-width: 1px;
+        }
+        #onetrust-consent-sdk #onetrust-pc-btn-handler,
+        #onetrust-consent-sdk #onetrust-pc-btn-handler.cookie-setting-link {
+        color: #FFFFFF; border-color: #FFFFFF;
+        background-color:
+        #FFFFFF;
+        } /* ALLRECIPES BANNER OVERRIDES */
+        /* EU Banner Accept/Reject */
+        #onetrust-consent-sdk #onetrust-accept-btn-handler:hover, #onetrust-banner-sdk #onetrust-reject-all-handler:hover {
+        opacity: 1;
+        background-color: #B53811;
+        }
+        /* EU Banner Show Purposes button */
+        #onetrust-consent-sdk #onetrust-pc-btn-handler:hover, #onetrust-consent-sdk #onetrust-pc-btn-handler.cookie-setting-link:hover {
+        opacity: 1;
+        background-color: #B53811;
+        }
+        /***********************************
+        * TCF BANNER
+        * APPLY TO EU TEMPLATE
+        ***********************************/
+        /* Base Selectors - Close Button Container */
+        #onetrust-consent-sdk #onetrust-banner-sdk #onetrust-close-btn-container {
+        top: 25px;
+        right: 25px;
+        }
+        #onetrust-consent-sdk #onetrust-banner-sdk .onetrust-close-btn-ui {
+        width: 12px;
+        height: 12px;
+        }
+        /* Base Selectors - Button Group */
+        #onetrust-consent-sdk #onetrust-button-group {
+        text-align: center;
+        }
+        /* Base Selectors - Policy Text */
+        #onetrust-banner-sdk #onetrust-policy-text a.ot-sdk-show-settings {
+        margin-left: 0;
+        }
+        /* Base Selectors - Toggle Label */
+        #onetrust-pc-sdk .ot-tgl .ot-label-status {
+        display: block!important;
+        }
+        /* HTML Overflow Handling */
+        html:has(>body>div#onetrust-consent-sdk.show-banner) {
+        overflow-y: hidden;
+        }
+        html:has(>body>div#onetrust-consent-sdk.show-banner>div.onetrust-pc-dark-filter[style*="none"]) {
+        overflow-y: auto;
+        }
+        /* Media Queries - Small Screens */
+        @media only screen and (min-width: 425px) and (max-width: 550px) {
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent #onetrust-button-group {
+        width: auto;
+        }
+        }
+        /* Media Queries - Medium Screens */
+        @media only screen and (min-width: 426px) and (max-width: 896px) {
+        #onetrust-consent-sdk #onetrust-banner-sdk .onetrust-close-btn-ui {
+        top: 0;
+        right: 0;
+        }
+        }
+        /* Media Queries - Larger Screens */
+        @media (min-width: 896px) {
+        #onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns {
+        left: auto;
+        right: 4%;
+        margin-left: 0;
+        margin-top: 5%;
+        }
+        }
+        @media only screen and (min-width: 769px) {
+        #onetrust-banner-sdk #onetrust-button-group {
+        margin-right: 0;
+        }
+        }
+        /* Media Queries - Desktop */
+        @media only screen and (min-width: 1024px){
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent {
+        margin-top: .25em;
+        }
+        }
+        /* hides banner after it has already been interacted with */
+        #onetrust-consent-sdk:not(.show-banner) #onetrust-banner-sdk {
+        display: none;
+        }
+        /*]]>*/
+        </style>
+        <script type="text/javascript" data-glb-js="top" src="/static/4.110.0/cache/eNqNVFFOwzAMvRChZxgI8YU0wS7gpm7rNU0qxynaTk9SAeuGO_GRKvF7dtxnO1UUELLVCF4cVsdYCYPFh-rabsM4BY9eYuXgFJIU5jEa26MdbsnHQjqfIp0xM4JvqbulOKrjNY-8IEe0QsFrAQM02CiADWEgjAqShByJjrXe3IObMN7Fi0YD-e4uaUbfBK6k5yDZtBEGDTRxE7Ofs4KNeWNqRhimkHW7uGcMnGO0NGVJN5NbVdNGbpePdg2cai3tCTo0M-HnnbidjEt1HNnB_MilxUp1TLUCPL_tL9bQJIdLw7wfnsragpab8uZlxrUuK9ZuhHPw1T7VjmKPvEsNobcZ_GvS_KH5bmkDE12fNLpSg3WsNxQmGw8lbWSVk5aRMK0LgW-PmsOHC_qfv-4PZWmQAHcopaEjtJhVEI0V7XWvXhDGrHfCw22dVw2RPQuzm0QP0DLGHmqHu7_j8PtaxMfkZyTX56HfSKS0vtlWfZURU9eLYSC3eP6e_u9DufKeBM3FbHLKeTz4C-_eAzQ.min.js"></script>
+        <script type="text/javascript">
+        //<![CDATA[
+        window.Mntl = window.Mntl || {};
+        window.Mntl.csrf = window.Mntl.csrf || window.Mntl.csrfInit('0a1ddf201e14758a4a4d4599a8fe9543', true);window.dataLayer = window.dataLayer || [];
+        // Configure gtag function globally for consent management
+        function gtag(){dataLayer.push(arguments);}
+        // Reusable GTM loading function
+        function loadGTMScript() {
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;defer=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;j.type="text/javascript";f.parentNode.insertBefore(j,f)})(window,document,'script','dataLayer','GTM-P3X3VT7');
+        }
+        // Reusable dataLayer events function
+        function pushDataLayerEvents() {
+        window.dataLayer.push({
+        event: 'ab-proctor',
+        'abTests-proctor': {
+        "99-0"
+        : "useOxygen | useOxygen | use the Oxygenated ad unit format and slot names | 1"
+        ,
+        "99-1"
+        : "vanillaJSLazyAdRecipeSC | active | vanillaLazyAd.js enabled | 1"
+        ,
+        "99-2"
+        : "alternativeIdPartnersTest | all | All identity partners enabled | 1"
+        ,
+        "99-3"
+        : "useFloorSearch | active | Use Floor Search | 1"
+        ,
+        "99-4"
+        : "enableUserIdGating | all | blocks All UserID submodules | 2"
+        ,
+        "50"
+        : "lazyloadOffsetTimeoutDesktop | control | Default payload (inactive) | 0"
+        ,
+        "99-6"
+        : "enablePublisherAudiences | active | active | 1"
+        ,
+        "99-7"
+        : "iasRtdAuctionDelay | previousControl | previousControl | 6"
+        ,
+        "99-8"
+        : "recipescDesktopAdRefresh | active | active, right rail ads timed refresh active | 1"
+        ,
+        "77"
+        : "enableReviewChips | chipsOptional | chipsOptional - review chips are enabled and NOT required to submit reviews | 2"
+        ,
+        "99-10"
+        : "prebidConfigApi | active | Ad Config API is enabled | 1"
+        ,
+        "99-11"
+        : "prebidTotalTimeoutBudget | previousControl | previousControl | 7"
+        ,
+        "99-12"
+        : "useDynamicVideoSizes | active | active | 1"
+        ,
+        "99-13"
+        : "orion | active | Active | 1"
+        ,
+        "99-14"
+        : "rtbLibraryLoadTimeout | default | default | 1"
+        ,
+        "99-15"
+        : "enableTidForAllBidders | active | active | 1"
+        ,
+        "99-16"
+        : "removeAdTiers | active | active | 1"
+        ,
+        "99-17"
+        : "amazonTamBidResponseTimeout | previousControl | previousControl | 6"
+        ,
+        "58"
+        : "holdPrimaryVideo | control | Enable immediate sticky | 0"
+        ,
+        "78"
+        : "recipeCard | control | control: Only show decision block | 0"
+        ,
+        "99-20"
+        : "prebidMetricTracker | active | Active | 1"
+        ,
+        "64"
+        : "categorySearchBlock | control | Control: Do not show category search block | 0"
+        ,
+        "62"
+        : "jumpToRecipe | control | Control: Show Jump to Recipe button | 0"
+        }
+        });
+        window.dataLayer.push({
+        envData: {
+        environment: {
+        environment: "k8s-prod",
+        application: "allrecipes",
+        dataCenter: "us-east-1"
+        },
+        server: {
+        version: "4.110.0",
+        title: "allrecipes-launcher"
+        },
+        client : {
+        browserUA: navigator.userAgent,
+        serverUA: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:80.0) Gecko/20100101 Firefox/80.0",
+        deviceType: "pc",
+        usStateCode: "OH"
+        },
+        mantle: "4.2.231"
+        }
+        });
+        }
+        // Non-consent-required country: Load GTM normally
+        // moved from gtm.ftl so we can initialize GTM only onLoad. From https://support.google.com/tagmanager/answer/6103696?hl=en
+        Mntl.utilities.onLoad(function() {
+        loadGTMScript();
+        });
+        // Push dataLayer events immediately for non-consent countries
+        pushDataLayerEvents();
+        (function(fnUtils, CMP) {
+        const deferLoadTime = 5000;
+        const readyForThirdPartyTrackingEvent = new CustomEvent('readyForThirdPartyTracking', { bubbles: true });
+        const readyForThirdPartyTracking = fnUtils.once(function() {
+        window.dataLayer.push({event: 'readyForThirdPartyTracking'});
+        window.dispatchEvent(readyForThirdPartyTrackingEvent);
+        });
+        const readyForDeferredScriptsEvent = new CustomEvent('readyForDeferredScripts', { bubbles: true });
+        const readyForDeferredScripts = fnUtils.once(function() {
+        window.dataLayer.push({event: 'readyForDeferredScripts'});
+        window.dispatchEvent(readyForDeferredScriptsEvent);
+        });
+        const hasTargetingConsentHandler = function() {
+        const hasConsent = CMP.hasTargetingConsent();
+        // Load GTM for consent-required countries when consent is granted
+        if (hasConsent && typeof window.loadGTMAfterConsent === 'function') {
+        window.loadGTMAfterConsent();
+        }
+        if (hasConsent) {
+        readyForThirdPartyTracking();
+        }
+        // Trigger the readyForDeferredScripts if consent is given
+        // or if the user has closed the banner(AlertBox) which exists for EU
+        // or if the user optin consent is not required, which applies for non gdpr locations
+        if (hasConsent || CMP.isAlertBoxClosed() || !CMP.isOptInConsent()) {
+        readyForDeferredScripts();
+        }
+        return hasConsent;
+        };
+        const purposeOneConsentHandler = async function() {
+        const hasPurposeOneConsent = await CMP.hasPurposeOneConsent();
+        // Load GTM for consent-required countries when consent is granted
+        if (hasPurposeOneConsent && typeof window.loadGTMAfterConsent === 'function') {
+        window.loadGTMAfterConsent();
+        }
+        if (hasPurposeOneConsent) {
+        readyForThirdPartyTracking();
+        }
+        if (hasPurposeOneConsent || CMP.isAlertBoxClosed()) {
+        readyForDeferredScripts();
+        }
+        return hasPurposeOneConsent;
+        };
+        const onRequiredDomEvent = fnUtils.once(function() {
+        if (!CMP) {
+        readyForThirdPartyTracking();
+        readyForDeferredScripts();
+        return;
+        }
+        const handler = CMP.supportsTCData() ? purposeOneConsentHandler : hasTargetingConsentHandler;
+        if (!CMP.isLoading()) {
+        handler();
+        }
+        CMP.onConsentChange(handler);
+        });
+        [
+        ['adRendered', onRequiredDomEvent],
+        ['beforeunload', onRequiredDomEvent],
+        ['load', function() { setTimeout(onRequiredDomEvent, deferLoadTime); }]
+        ].forEach(function(event) {
+        window.addEventListener(event[0], event[1], { once: true });
+        });
+        })(Mntl.fnUtilities || {}, Mntl.CMP);window.dataLayer = window.dataLayer || [];
+        (function() {
+        var isContinuousScroll = document.querySelector('.mntl-continuous-scroll');
+        var pageViewDataAsJSON = {"country":"US","title":"Hot Honey Brussels Sprouts Recipe" || document.title || '',"authorId":"156569","revenueGroup":"","contentGroup":"Other","viewType":"BROADVIDEO","documentId":11832010,"templateName":"RECIPESC","authorNames":"Nicole Russell","templateId":"120","muid":"4a995dca-46e4-4959-b4c5-08b4b9326ada","lastEditingAuthorId":"156569","lastEditingUserId":"166187521201801","primaryTaxonomyIds":"6502448|6651953|6652082|6652862|6652752","fullUrl":"https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"internalSessionId":"n4c7ebd895c384815bf10357e457ed95b19","internalRequestId":"n4c7ebd895c384815bf10357e457ed95b19","hid":"","experienceTypeName":"","recircDocIdsFooter":"","euTrafficFlag":false,"isGoogleBot":false,"mantleVersion":"4.2.231","primaryTaxonomyNames":"Allrecipes|Recipes|Side Dish|Vegetables|Brussels Sprouts","description":"These hot honey Brussels sprouts are a simple side dish with all the elements you&#39;ll ever need in a side. They&#39;re sweet, spicy, crispy, and melt in your mouth."};
+        var scrolledPageData = {};
+        var scrolledDocOrdinal;
+        var scrolledPage;
+        pageViewDataAsJSON.breakpointName = Mntl.utilities.getW();
+        pageViewDataAsJSON.bounceExchangeId = 2548;
+        pageViewDataAsJSON.descriptiveTaxonomy = '12291,12273,12373,16752,11184,16751,12550,25281,10439,11904,11807,12213,11664,18910,12118,12897,16460,12384,11098,11252,11053,10505,11978,32452,25033,33045,11572,11374,11750,12722,11213,12008';
+        if (isContinuousScroll) {
+        pageViewDataAsJSON.experienceTypeName = 'continuous';
+        if (window.dataLayer && window.dataLayer.length) {
+        //loop through events and collect previous scrolledDocOrdinal and scrolledPage values
+        scrolledPageData = window.dataLayer.reduce( (acc, curr) => {
+        if (curr.event == 'unifiedPageview') {
+        acc.scrolledDocOrdinal = acc.scrolledDocOrdinal ?
+        acc.scrolledDocOrdinal + 1
+        : 1;
+        acc.scrolledPage = acc.scrolledPage ?
+        acc.scrolledPage + " | " + (curr.documentId).toString()
+        : (curr.documentId).toString();
+        }
+        return acc;
+        }, {});
+        }
+        scrolledPage = scrolledPageData.scrolledPage ? scrolledPageData.scrolledPage + ' | ' + (pageViewDataAsJSON.documentId).toString() : (pageViewDataAsJSON.documentId).toString();
+        scrolledDocOrdinal = scrolledPageData.scrolledDocOrdinal ? scrolledPageData.scrolledDocOrdinal + 1 : 1;
+        pageViewDataAsJSON.scrolledPage = scrolledPage;
+        pageViewDataAsJSON.scrolledDocOrdinal = scrolledDocOrdinal;
+        }
+        Mntl.utilities.onLoad(function() {
+        var recirc = true && document.querySelector('.mntl-recirc-section, .related-article-list, .masonry-list-section, .recirc');
+        if (true && recirc) {
+        const docIds = [...recirc.querySelectorAll('.mntl-card, .card')].map(card => 'S-' + card.getAttribute('data-doc-id')).join('|');
+        pageViewDataAsJSON.recircDocIdsFooter = docIds;
+        }
+        Mntl.PageView.init(pageViewDataAsJSON);
+        });
+        })();(function() {
+        Mntl.utilities.onLoad(function() {
+        const geolocationResponse = {};
+        const externalJS = {
+        src: '\//cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+        'data-domain-script': '63a0b6bc-e912-4c8d-adfd-3b8a4b698c6c',
+        'data-ignore-ga': true,
+        'data-language': 'en',
+        async: true,
+        charset: 'UTF-8',
+        onerror: 'Mntl.CMP.onError()',
+        id: 'onetrust-script'
+        };
+        geolocationResponse.stateCode = 'OH';
+        geolocationResponse.countryCode = 'US';
+        geolocationResponse.regionCode = 'US';
+        if (Object.keys(geolocationResponse).length) {
+        window.OneTrust = window.OneTrust || {};
+        window.OneTrust.geolocationResponse = geolocationResponse;
+        }
+        const preferenceCenterTrigger = document.querySelector('.ot-pref-trigger');
+        preferenceCenterTrigger.addEventListener('click', (e) => {
+        e.preventDefault();
+        Mntl.utilities.loadExternalJS(
+        externalJS
+        , () => {
+        Mntl.CMP.onSdkLoaded(() => {
+        OneTrust.ToggleInfoDisplay();
+        })
+        });
+        },
+        { once: true });
+        });
+        Mntl.CMP.init({
+        isConsentRequired: true,
+        oneTrustTemplateName: 'ccpa',
+        showConsentBanner: false,
+        isGpcApplicableRequest: false,
+        isTcfEnabled: true,
+        scriptTimeout: 3000
+        });
+        })();
+        window.Mntl = window.Mntl || {};
+        Mntl.RTB = Mntl.RTB || {};
+        Mntl.RTB.setUseConsentManagement(false);
+        Mntl.RTB.setIpAddress('34.162.221.158')
+        Mntl.RTB.setUseGDPREnforcement(false);
+        Mntl.RTB.setBlockAllUserIds(true);
+        Mntl.RTB.setUseAmazonNcaHookTest(false);
+        Mntl.RTB.setUseAmazonNativeAdsTest(false);
+        Mntl.RTB.setEnableTidForAllBidders(true);
+        Mntl.RTB.setTaxonomyStampValues({"tax1":"alr_Recipes","tax2":"alr_SideDishes","tax0":"alr_homepage","tax3":"alr_VegetableSideDishes","tax4":"alr_BrusselsSproutsSideDishes"});
+        Mntl.RTB.setPrebidBidResponseTimeout(950);
+        Mntl.RTB.setPrebidUserIdAuctionDelay(500);
+        Mntl.RTB.setRtbLibraryLoadTimeout(750);
+        Mntl.RTB.setAmazonTamBidResponseTimeout(1000);
+        Mntl.RTB.setIasRtdAuctionDelay(200);
+        Mntl.RTB.Plugins.amazon.amazonConfigs = {"mapTaxValues":{"tax1":"alr_Recipes","tax2":"alr_SideDishes","si_section":"alr_SideDishes","tax0":"alr_homepage","tax3":"alr_VegetableSideDishes"},"amazonSlotName":false,"mapFBValues":{"adunitid":"mapFBID"},"amazonSection":"Vegetable Side Dishes"};
+        Mntl.RTB.Plugins.prebid.setPriceGranularity({"allBuckets":[{"max":"20","increment":"0.05"},{"max":"70","increment":"1"}],"bannerBuckets":[{"max":"20","increment":"0.05"},{"max":"80","increment":"1"}]});
+        Mntl.RTB.Plugins.openAds.setPriceGranularity({"allBuckets":[{"max":"1","increment":"0.25"},{"max":"3","increment":"0.50"},{"max":"4","increment":"1"}]});
+        Mntl.RTB.initVideoBidders([{ type: 'amazon', id: '3446' }, { type: 'prebid', id: 'true' } ]);
+        Mntl.RTB.initDisplayAndOutstreamBidders([{ type: "amazon", id: '3446'},{ type: "msg", id: 'true'},{ type: "rmni", id: 'true'},{ type: "prebid", id: 'true'},{ type: "liveConnect", id: 'a-01b5'},{ type: "optable", id: 'true'}]);
+        Mntl.RTB.Plugins.prebid.setConfig({"square-fixed-replies":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3599194,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34330331,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8361,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6389484","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-replies_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561381928","type":"display"}},{"bidder":"ix","params":{"siteId":"1146726","type":"display"}}],"square-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440850,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060092,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8362,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478956","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-flex_300x600_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323505","type":"display"}},{"bidder":"ix","params":{"siteId":"1005791","type":"display"}}],"square-fixed-comments":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8360,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}],"leaderboardfooter-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8358,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405217","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardfooter-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323495","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}],"leaderboardfooter-flex-1":[],"preroll":[{"bidder":"ttd","params":{"type":"instream","supplySourceId":"dotdash","publisherId":"1"}},{"bidder":"rubicon","params":{"type":"instream","accountId":7499,"siteId":426712,"zoneId":2440854}},{"bidder":"appnexus","params":{"type":"instream","placementId":24425890}},{"bidder":"pubmatic","params":{"type":"instream","publisherId":"158139","adSlot":"4297343"}},{"bidder":"triplelift","params":{"type":"instream","inventoryCode":"AllRecipes_preroll_pbc2s"}},{"bidder":"openx","params":{"type":"instream","delDomain":"meredith-d.openx.net","unit":"561365534"}},{"bidder":"ix","params":{"type":"instream","siteId":"1005792"}}],"leaderboardac":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8357,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405218","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardac_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323498","type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}}],"leaderboard-fixed-0":[],"leaderboard-fixed":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440832,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060079,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8355,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478943","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-fixed_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323487","type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}}],"leaderboard-flex-1":[],"native":[{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3699928,"type":"display"}}],"square-fixed":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440842,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060088,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8359,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478952","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-fixed_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323500","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}}],"square-flex-2":[],"leaderboard-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8356,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323491","type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}}],"square-flex-1":[],"square-fixed-featured-comments":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8363,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}]});
+        Mntl.RTB.Plugins.prebid.setSrc('/cache/eNqll1GP0zAMx78Q08Sk-wADBjqJ6Y7b4D1N3J5vaRw5Trfy6fHGgXhBqnNPTSP_YtdO_E_XRZygX48UaoSy7moK1-dLWWeGDoMOAhZ5fVt5Yni3Xgq5GOm89YITCkIxgFK2ycVZjcs2uCzAy2FPKYGX-3CYi8BoAgsk2bvkBhh1dPS9gWYUILvXAF0dBkyDAenzNhyAJ-AfGICWkwMkYPTtyUVXniQ8Mk3q2MKFuzc4DXf2vGp8SVDmr5hOdjriBPdJdAk7mx1yA6V1gc-RiA0HJdfutRbB7pEl7G82y5GyKUcoYtqt5dlxS3ji-4-UhCkuZyqGjd1TTdhjS4i1gFba0NdyTnCp5QMG-yG4tFC6QcarZQvLtUPtiS2oSGjCGHOEiL200JQhNSUpulKoBfTPNZ2MojghnDOxGJo2A4TZokSghhOsGJI2aeCVTufoDEu4dvUd8xsU15CULN8FYzGpppG4jNFIFPwJRkRb1vsdBhuxsRH_qpmhOpV1B_nZ-EGCI1CVbxWq4VhQ96KXti_VsSHCQKPD9KD3IFYJPNITkXy6zbVJxuEmVcbzv9z8BPOZ2FK4P4JhLIF3AgPxfGSXSlSG0l6XMsm2XNmeeHx07EZrBNrgOlVvrYxNrrqyu-g-LRpxsenwYU7emqbffwrq6z71hlt05f_0hb-Wuwv4el34FwDYH_s.js');
+        Mntl.RTB.Plugins.prebid.setUserIdConfig({"liveIntentPublisherId":"443"});
+        Mntl.RTB.setDomain('allrecipes.com');
+        Mntl.RTB.setUseOptableMockIp(false);
+        Mntl.RTB.setOptableSrc('//dotdash-meredith.solutions.cdn.optable.co/public-assets/ddm-sdk.js');
+        Mntl.RTB.setUseAy(false);
+        Mntl.RTB.setIsOptableWitnessEnabled(true);
+        Mntl.RTB.initWitnessAPI();
+        window.MMads = window.MMads || {};
+        MMads.adConfigAPI = MMads.adConfigAPI || {};
+        window.MMads.adConfigAPI = { ...MMads.adConfigAPI, ...{"modulesUrl":"\/cache\/eNqll1GP0zAMx78Q08Sk-wADBjqJ6Y7b4D1N3J5vaRw5Trfy6fHGgXhBqnNPTSP_YtdO_E_XRZygX48UaoSy7moK1-dLWWeGDoMOAhZ5fVt5Yni3Xgq5GOm89YITCkIxgFK2ycVZjcs2uCzAy2FPKYGX-3CYi8BoAgsk2bvkBhh1dPS9gWYUILvXAF0dBkyDAenzNhyAJ-AfGICWkwMkYPTtyUVXniQ8Mk3q2MKFuzc4DXf2vGp8SVDmr5hOdjriBPdJdAk7mx1yA6V1gc-RiA0HJdfutRbB7pEl7G82y5GyKUcoYtqt5dlxS3ji-4-UhCkuZyqGjd1TTdhjS4i1gFba0NdyTnCp5QMG-yG4tFC6QcarZQvLtUPtiS2oSGjCGHOEiL200JQhNSUpulKoBfTPNZ2MojghnDOxGJo2A4TZokSghhOsGJI2aeCVTufoDEu4dvUd8xsU15CULN8FYzGpppG4jNFIFPwJRkRb1vsdBhuxsRH_qpmhOpV1B_nZ-EGCI1CVbxWq4VhQ96KXti_VsSHCQKPD9KD3IFYJPNITkXy6zbVJxuEmVcbzv9z8BPOZ2FK4P4JhLIF3AgPxfGSXSlSG0l6XMsm2XNmeeHx07EZrBNrgOlVvrYxNrrqyu-g-LRpxsenwYU7emqbffwrq6z71hlt05f_0hb-Wuwv4el34FwDYH_s.js","configs":{"default":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"slots":{"square-flex":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-fixed-replies":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-fixed-comments":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboardfooter-flex":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"preroll":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboardfooter-flex-1":{"lazyOffset":50,"lazy":{"lazyOffset":50,"isLazy":true},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboardac":{"lazyOffset":400,"lazy":{"lazyOffset":400,"isLazy":true},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboard-fixed-0":{"lazyOffset":200,"lazy":{"lazyOffset":200,"isLazy":false},"refresh":{"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true,"timedRefresh":30000}},"leaderboard-fixed":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboard-flex-1":{"lazyOffset":200,"lazy":{"lazyOffset":200,"isLazy":false},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"native":{"lazyOffset":200,"lazy":{"lazyOffset":200,"isLazy":false},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-fixed":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true,"timedRefresh":30000}},"leaderboard-flex":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-flex-2":{"lazyOffset":100,"lazy":{"lazyOffset":100,"isLazy":true},"refresh":{"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true,"timedRefresh":30000}},"square-flex-1":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true,"timedRefresh":30000}},"square-fixed-featured-comments":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}}},"contentAds":{"loadImmediate":4}},"prebidModules":["prebid-core.js","allowActivities.js","atsAnalyticsAdapter.js","connectIdSystem.js","consentManagementTcf.js","criteoIdSystem.js","debugging.js","dfpAdServerVideo.js","genericAnalyticsAdapter.js","iasRtdProvider.js","id5AnalyticsAdapter.js","id5IdSystem.js","identityLinkIdSystem.js","liveIntentIdSystem.js","pairIdSystem.js","priceFloors.js","pubProvidedIdSystem.js","rtdModule.js","s2sTesting.js","sharedIdSystem.js","tcfControl.js","uid2IdSystem.js","unifiedIdSystem.js","userId.js","appnexusBidAdapter.js","ixBidAdapter.js","pubmaticBidAdapter.js","rubiconBidAdapter.js","ttdBidAdapter.js","tripleliftBidAdapter.js","openxBidAdapter.js","lassoBidAdapter.js","chunk-core.js","viewport.js","greedy.js","creative-renderer-display.js","analyticsAdapter.js","cmp.js","consentManagement.js","gptUtils.js","dfpUtils.js","xmlUtils.js","sizeUtils.js","uid1Eids.js","uid2Eids.js","liveIntentId.js","currencyUtils.js","timeoutQueue.js","objectGuard.js","domainOverrideToRootDomain.js","uid2IdSystemShared.js","chunk.js","keywords.js","appnexusUtils.js","categoryTranslationMapping.js","transformParamsUtils.js","ortbConverter.js","pbsExtensions.js","userSyncUtils.js","connectionInfo.js","urlUtils.js"],"prebid":{"square-fixed-replies":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3599194,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34330331,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8361,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6389484","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-replies_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561381928","type":"display"}},{"bidder":"ix","params":{"siteId":"1146726","type":"display"}}],"square-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440850,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060092,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8362,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478956","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-flex_300x600_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323505","type":"display"}},{"bidder":"ix","params":{"siteId":"1005791","type":"display"}}],"square-fixed-comments":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8360,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}],"leaderboardfooter-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8358,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405217","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardfooter-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323495","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}],"leaderboardfooter-flex-1":[],"preroll":[{"bidder":"ttd","params":{"type":"instream","supplySourceId":"dotdash","publisherId":"1"}},{"bidder":"rubicon","params":{"type":"instream","accountId":7499,"siteId":426712,"zoneId":2440854}},{"bidder":"appnexus","params":{"type":"instream","placementId":24425890}},{"bidder":"pubmatic","params":{"type":"instream","publisherId":"158139","adSlot":"4297343"}},{"bidder":"triplelift","params":{"type":"instream","inventoryCode":"AllRecipes_preroll_pbc2s"}},{"bidder":"openx","params":{"type":"instream","delDomain":"meredith-d.openx.net","unit":"561365534"}},{"bidder":"ix","params":{"type":"instream","siteId":"1005792"}}],"leaderboardac":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8357,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405218","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardac_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323498","type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}}],"leaderboard-fixed-0":[],"leaderboard-fixed":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440832,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060079,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8355,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478943","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-fixed_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323487","type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}}],"leaderboard-flex-1":[],"native":[{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3699928,"type":"display"}}],"square-fixed":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440842,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060088,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8359,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478952","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-fixed_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323500","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}}],"square-flex-2":[],"leaderboard-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8356,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323491","type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}}],"square-flex-1":[],"square-fixed-featured-comments":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8363,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}]},"rawConfig":{"slots":{"leaderboardac":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8357,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405218","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardac_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323498","type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}}],"lazyOffset":400,"lazy":{"isLazy":true,"lazyOffset":400}},"leaderboardfooter-flex-1":{"prebid":[],"lazyOffset":50,"lazy":{"lazyOffset":50}},"leaderboard-fixed-0":{"prebid":[],"lazy":{"isLazy":false},"refresh":{"timedRefresh":30000}},"native":{"prebid":[{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3699928,"type":"display"}}],"lazy":{"isLazy":false}},"square-flex-1":{"prebid":[],"refresh":{"timedRefresh":30000,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-fixed":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440842,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060088,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8359,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478952","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-fixed_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323500","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}}],"refresh":{"timedRefresh":30000}},"square-flex-2":{"prebid":[],"lazyOffset":100,"lazy":{"lazyOffset":100},"refresh":{"timedRefresh":30000,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboard-fixed":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440832,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060079,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8355,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478943","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-fixed_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323487","type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}}]},"leaderboard-flex":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8356,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323491","type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}}]},"leaderboardfooter-flex":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8358,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405217","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardfooter-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323495","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}]},"square-fixed-replies":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3599194,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34330331,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8361,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6389484","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-replies_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561381928","type":"display"}},{"bidder":"ix","params":{"siteId":"1146726","type":"display"}}]},"square-flex":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440850,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060092,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8362,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478956","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-flex_300x600_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323505","type":"display"}},{"bidder":"ix","params":{"siteId":"1005791","type":"display"}}]},"square-fixed-comments":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8360,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}]},"square-fixed-featured-comments":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8363,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}]},"preroll":{"prebid":[{"bidder":"ttd","params":{"type":"instream","supplySourceId":"dotdash","publisherId":"1"}},{"bidder":"rubicon","params":{"type":"instream","accountId":7499,"siteId":426712,"zoneId":2440854}},{"bidder":"appnexus","params":{"type":"instream","placementId":24425890}},{"bidder":"pubmatic","params":{"type":"instream","publisherId":"158139","adSlot":"4297343"}},{"bidder":"triplelift","params":{"type":"instream","inventoryCode":"AllRecipes_preroll_pbc2s"}},{"bidder":"openx","params":{"type":"instream","delDomain":"meredith-d.openx.net","unit":"561365534"}},{"bidder":"ix","params":{"type":"instream","siteId":"1005792"}}]},"leaderboard-flex-1":{"prebid":[],"lazy":{"isLazy":false}}},"default":{"prebid":[],"prebidModules":["prebid-core.js","allowActivities.js","atsAnalyticsAdapter.js","connectIdSystem.js","consentManagementTcf.js","criteoIdSystem.js","debugging.js","dfpAdServerVideo.js","genericAnalyticsAdapter.js","iasRtdProvider.js","id5AnalyticsAdapter.js","id5IdSystem.js","identityLinkIdSystem.js","liveIntentIdSystem.js","pairIdSystem.js","priceFloors.js","pubProvidedIdSystem.js","rtdModule.js","s2sTesting.js","sharedIdSystem.js","tcfControl.js","uid2IdSystem.js","unifiedIdSystem.js","userId.js","appnexusBidAdapter.js","ixBidAdapter.js","pubmaticBidAdapter.js","rubiconBidAdapter.js","ttdBidAdapter.js","tripleliftBidAdapter.js","openxBidAdapter.js","lassoBidAdapter.js"],"lazyOffset":200,"contentAds":{"loadImmediate":4},"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"ab":[]}} };window.MMads = window.MMads || {};
+        MMads.adConfigAPI = MMads.adConfigAPI || {};
+        window.MMads.adConfigAPI = { ...MMads.adConfigAPI, ...{"modulesUrl":"\/cache\/eNqll1GP0zAMx78Q08Sk-wADBjqJ6Y7b4D1N3J5vaRw5Trfy6fHGgXhBqnNPTSP_YtdO_E_XRZygX48UaoSy7moK1-dLWWeGDoMOAhZ5fVt5Yni3Xgq5GOm89YITCkIxgFK2ycVZjcs2uCzAy2FPKYGX-3CYi8BoAgsk2bvkBhh1dPS9gWYUILvXAF0dBkyDAenzNhyAJ-AfGICWkwMkYPTtyUVXniQ8Mk3q2MKFuzc4DXf2vGp8SVDmr5hOdjriBPdJdAk7mx1yA6V1gc-RiA0HJdfutRbB7pEl7G82y5GyKUcoYtqt5dlxS3ji-4-UhCkuZyqGjd1TTdhjS4i1gFba0NdyTnCp5QMG-yG4tFC6QcarZQvLtUPtiS2oSGjCGHOEiL200JQhNSUpulKoBfTPNZ2MojghnDOxGJo2A4TZokSghhOsGJI2aeCVTufoDEu4dvUd8xsU15CULN8FYzGpppG4jNFIFPwJRkRb1vsdBhuxsRH_qpmhOpV1B_nZ-EGCI1CVbxWq4VhQ96KXti_VsSHCQKPD9KD3IFYJPNITkXy6zbVJxuEmVcbzv9z8BPOZ2FK4P4JhLIF3AgPxfGSXSlSG0l6XMsm2XNmeeHx07EZrBNrgOlVvrYxNrrqyu-g-LRpxsenwYU7emqbffwrq6z71hlt05f_0hb-Wuwv4el34FwDYH_s.js","configs":{"default":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"slots":{"square-flex":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-fixed-replies":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-fixed-comments":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboardfooter-flex":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"preroll":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboardfooter-flex-1":{"lazyOffset":50,"lazy":{"lazyOffset":50,"isLazy":true},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboardac":{"lazyOffset":400,"lazy":{"lazyOffset":400,"isLazy":true},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboard-fixed-0":{"lazyOffset":200,"lazy":{"lazyOffset":200,"isLazy":false},"refresh":{"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true,"timedRefresh":30000}},"leaderboard-fixed":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboard-flex-1":{"lazyOffset":200,"lazy":{"lazyOffset":200,"isLazy":false},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"native":{"lazyOffset":200,"lazy":{"lazyOffset":200,"isLazy":false},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-fixed":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true,"timedRefresh":30000}},"leaderboard-flex":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-flex-2":{"lazyOffset":100,"lazy":{"lazyOffset":100,"isLazy":true},"refresh":{"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true,"timedRefresh":30000}},"square-flex-1":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true,"timedRefresh":30000}},"square-fixed-featured-comments":{"lazyOffset":200,"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}}},"contentAds":{"loadImmediate":4}},"prebidModules":["prebid-core.js","allowActivities.js","atsAnalyticsAdapter.js","connectIdSystem.js","consentManagementTcf.js","criteoIdSystem.js","debugging.js","dfpAdServerVideo.js","genericAnalyticsAdapter.js","iasRtdProvider.js","id5AnalyticsAdapter.js","id5IdSystem.js","identityLinkIdSystem.js","liveIntentIdSystem.js","pairIdSystem.js","priceFloors.js","pubProvidedIdSystem.js","rtdModule.js","s2sTesting.js","sharedIdSystem.js","tcfControl.js","uid2IdSystem.js","unifiedIdSystem.js","userId.js","appnexusBidAdapter.js","ixBidAdapter.js","pubmaticBidAdapter.js","rubiconBidAdapter.js","ttdBidAdapter.js","tripleliftBidAdapter.js","openxBidAdapter.js","lassoBidAdapter.js","chunk-core.js","viewport.js","greedy.js","creative-renderer-display.js","analyticsAdapter.js","cmp.js","consentManagement.js","gptUtils.js","dfpUtils.js","xmlUtils.js","sizeUtils.js","uid1Eids.js","uid2Eids.js","liveIntentId.js","currencyUtils.js","timeoutQueue.js","objectGuard.js","domainOverrideToRootDomain.js","uid2IdSystemShared.js","chunk.js","keywords.js","appnexusUtils.js","categoryTranslationMapping.js","transformParamsUtils.js","ortbConverter.js","pbsExtensions.js","userSyncUtils.js","connectionInfo.js","urlUtils.js"],"prebid":{"square-fixed-replies":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3599194,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34330331,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8361,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6389484","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-replies_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561381928","type":"display"}},{"bidder":"ix","params":{"siteId":"1146726","type":"display"}}],"square-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440850,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060092,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8362,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478956","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-flex_300x600_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323505","type":"display"}},{"bidder":"ix","params":{"siteId":"1005791","type":"display"}}],"square-fixed-comments":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8360,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}],"leaderboardfooter-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8358,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405217","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardfooter-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323495","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}],"leaderboardfooter-flex-1":[],"preroll":[{"bidder":"ttd","params":{"type":"instream","supplySourceId":"dotdash","publisherId":"1"}},{"bidder":"rubicon","params":{"type":"instream","accountId":7499,"siteId":426712,"zoneId":2440854}},{"bidder":"appnexus","params":{"type":"instream","placementId":24425890}},{"bidder":"pubmatic","params":{"type":"instream","publisherId":"158139","adSlot":"4297343"}},{"bidder":"triplelift","params":{"type":"instream","inventoryCode":"AllRecipes_preroll_pbc2s"}},{"bidder":"openx","params":{"type":"instream","delDomain":"meredith-d.openx.net","unit":"561365534"}},{"bidder":"ix","params":{"type":"instream","siteId":"1005792"}}],"leaderboardac":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8357,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405218","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardac_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323498","type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}}],"leaderboard-fixed-0":[],"leaderboard-fixed":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440832,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060079,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8355,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478943","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-fixed_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323487","type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}}],"leaderboard-flex-1":[],"native":[{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3699928,"type":"display"}}],"square-fixed":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440842,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060088,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8359,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478952","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-fixed_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323500","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}}],"square-flex-2":[],"leaderboard-flex":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8356,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323491","type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}}],"square-flex-1":[],"square-fixed-featured-comments":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8363,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}]},"rawConfig":{"slots":{"leaderboardac":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8357,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405218","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardac_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323498","type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}}],"lazyOffset":400,"lazy":{"isLazy":true,"lazyOffset":400}},"leaderboardfooter-flex-1":{"prebid":[],"lazyOffset":50,"lazy":{"lazyOffset":50}},"leaderboard-fixed-0":{"prebid":[],"lazy":{"isLazy":false},"refresh":{"timedRefresh":30000}},"native":{"prebid":[{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3699928,"type":"display"}}],"lazy":{"isLazy":false}},"square-flex-1":{"prebid":[],"refresh":{"timedRefresh":30000,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"square-fixed":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440842,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060088,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8359,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478952","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-fixed_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323500","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}}],"refresh":{"timedRefresh":30000}},"square-flex-2":{"prebid":[],"lazyOffset":100,"lazy":{"lazyOffset":100},"refresh":{"timedRefresh":30000,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"leaderboard-fixed":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440832,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060079,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8355,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478943","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-fixed_728x90_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323487","type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}}]},"leaderboard-flex":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8356,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboard-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323491","type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}}]},"leaderboardfooter-flex":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440838,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060082,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8358,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6405217","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_leaderboardfooter-flex_970x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323495","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}]},"square-fixed-replies":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3599194,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34330331,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8361,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6389484","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-replies_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561381928","type":"display"}},{"bidder":"ix","params":{"siteId":"1146726","type":"display"}}]},"square-flex":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":2440850,"type":"display"}},{"bidder":"appnexus","params":{"placementId":21060092,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8362,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478956","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"AllRecipes_square-flex_300x600_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323505","type":"display"}},{"bidder":"ix","params":{"siteId":"1005791","type":"display"}}]},"square-fixed-comments":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8360,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}]},"square-fixed-featured-comments":{"prebid":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":7499,"siteId":426712,"zoneId":3546358,"type":"display"}},{"bidder":"appnexus","params":{"placementId":34080783,"type":"display"}},{"bidder":"lasso","params":{"adUnitId":8363,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"6236519","type":"display"}},{"bidder":"triplelift","params":{"inventoryCode":"allrecipes_square-fixed-comments_300x250_pbc2s","type":"display"}},{"bidder":"openx","params":{"delDomain":"meredith-d.openx.net","unit":"561323502","type":"display"}},{"bidder":"ix","params":{"siteId":"1137090","type":"display"}}]},"preroll":{"prebid":[{"bidder":"ttd","params":{"type":"instream","supplySourceId":"dotdash","publisherId":"1"}},{"bidder":"rubicon","params":{"type":"instream","accountId":7499,"siteId":426712,"zoneId":2440854}},{"bidder":"appnexus","params":{"type":"instream","placementId":24425890}},{"bidder":"pubmatic","params":{"type":"instream","publisherId":"158139","adSlot":"4297343"}},{"bidder":"triplelift","params":{"type":"instream","inventoryCode":"AllRecipes_preroll_pbc2s"}},{"bidder":"openx","params":{"type":"instream","delDomain":"meredith-d.openx.net","unit":"561365534"}},{"bidder":"ix","params":{"type":"instream","siteId":"1005792"}}]},"leaderboard-flex-1":{"prebid":[],"lazy":{"isLazy":false}}},"default":{"prebid":[],"prebidModules":["prebid-core.js","allowActivities.js","atsAnalyticsAdapter.js","connectIdSystem.js","consentManagementTcf.js","criteoIdSystem.js","debugging.js","dfpAdServerVideo.js","genericAnalyticsAdapter.js","iasRtdProvider.js","id5AnalyticsAdapter.js","id5IdSystem.js","identityLinkIdSystem.js","liveIntentIdSystem.js","pairIdSystem.js","priceFloors.js","pubProvidedIdSystem.js","rtdModule.js","s2sTesting.js","sharedIdSystem.js","tcfControl.js","uid2IdSystem.js","unifiedIdSystem.js","userId.js","appnexusBidAdapter.js","ixBidAdapter.js","pubmaticBidAdapter.js","rubiconBidAdapter.js","ttdBidAdapter.js","tripleliftBidAdapter.js","openxBidAdapter.js","lassoBidAdapter.js"],"lazyOffset":200,"contentAds":{"loadImmediate":4},"lazy":{"isLazy":true,"lazyOffset":200},"refresh":{"timedRefresh":0,"timeoutRefreshOnceOnly":false,"fiftyPercentAdRefresh":true}},"ab":[]}} };window.MMads = window.MMads || {};
+        window.MMads.isLazyEnabled = false;
+        window.MMads.isLoadImmediateEnabled = false;
+        window.MMads = window.MMads || {};
+        MMads.auctionFloors = MMads.auctionFloors || {};
+        window.MMads.auctionFloors.setFloorConfig({"mob-square-fixed-ing-jtr":{"id":"a9a80dfb40d94d0282a5a9195db9047a","floor":"220"},"square-flex-2":{"id":"5824173ec3bf486cb1dbbb2b929b3a12","floor":"300"},"square-flex-1":{"id":"31e4fdc4b7d04c999ccd885f841e2309","floor":"210"},"square-fixed-4":{"id":"3494215537994a179ab6f5e7f95fd284","floor":"275"},"mob-square-fixed-4":{"id":"63aeebb3d7f741709cb514c21d64489b","floor":"205"},"mob-square-fixed-step-3":{"id":"741da6e234404eefa15f160a30920464","floor":"235"},"square-fixed-3":{"id":"c030decf8cc946e785789390e919336a","floor":"265"},"mob-square-fixed-5":{"id":"2b5cc585823e4dc8bd1a4e31d735e550","floor":"190"},"mob-square-fixed-step-4":{"id":"ad1591fe2a584cf6abcafbe7148fd136","floor":"195"},"square-fixed-2":{"id":"ae54df9f5df0477c9b0759c6e9d278bb","floor":"285"},"mob-square-fixed-step-1":{"id":"11bec2d1e08e45e9bcf43c1a4a297c72","floor":"305"},"mob-square-fixed-6":{"id":"f194f4428d5341cf8f0c24c4b96d94a2","floor":"145"},"square-fixed-1":{"id":"1ce84241562942a5b457aad8799a7253","floor":"265"},"mob-square-fixed-step-2":{"id":"b2b0a5824fa6414484b1f8059a526e04","floor":"240"},"mob-square-fixed-7":{"id":"5339259beec84f9abd08755778a6a424","floor":"170"},"square-fixed-8":{"id":"2715e1ccefff4421b148764cb65a43d0","floor":"135"},"square-fixed-7":{"id":"1b830ad6575a4649a417cdbbb4a0167d","floor":"110"},"mob-square-flex-1":{"id":"a302817c38734eb18f5a7cd70ba6dbf2","floor":"185"},"square-fixed-6":{"id":"49c2637d0c844e97a3b2fbc8b6f6a06b","floor":"265"},"square-fixed-5":{"id":"1ace91c4f7c44e779529141e9a25a2ee","floor":"265"},"mob-square-fixed-1":{"id":"6114c8c5e2f849be8aaf81e40d422728","floor":"300"},"mob-square-fixed-2":{"id":"4d835989a9154c199d99f099e0b9cf0c","floor":"230"},"mob-square-fixed-3":{"id":"049b14754f0d426e9b03817fc5881839","floor":"225"},"mob-square-fixed-rvw-1":{"id":"5b0b5736afd848b386723611bfa48510","floor":"5"},"square-fixed":{"id":"514d3fde28564ffe8b7c084e614b0f55","floor":"5"},"mob-square-fixed-rvw-2":{"id":"2496cc5fa2fe41bc9749b1f7c03b90fc","floor":"95"},"mob-squarefooter-fixed-1":{"id":"0404cbd0456447b18de145a480298b4b","floor":"240"},"mob-squarefooter-fixed-2":{"id":"bc9e7379b814417ea57508f3a27e7814","floor":"220"},"square-fixed-9":{"id":"54d42a6392ad421fa82203f79cd21d97","floor":"215"},"mob-square-fixed-step-5":{"id":"e739981a00074df092486a2c9d39c452","floor":"170"},"primary":{"id":"0a6ac91b37e54e81ae4e909eb454efff","floor":"550"},"mob-square-fixed-step-6":{"id":"2dc3f2c8917a4126b9e095aed9e99021","floor":"120"},"other":{"id":"4af69bd7220f4e5c8bd36929604fa4d1","floor":"50"},"mob-square-fixed-intro-1":{"id":"0e0df9a0908a4db7841b470f3c708523","floor":"220"},"broadmatch":{"id":"7bea761a03a141cd8bb73f4d7ec1eb2b","floor":"455"},"mob-square-fixed-intro-2":{"id":"869ee3f592bc48fc93212fca46940f9b","floor":"100"},"leaderboardac":{"id":"e76f93dc4f7d4853b6631f17a8d0d7d1","floor":"340"},"leaderboard-flex-1":{"id":"73f3cb380bf54f138ef8f67e8b216e6f","floor":"240"},"leaderboard-flex-2":{"id":"2f95e803246f4ee59037ffae85178044","floor":"330"},"mob-square-fixed-ac":{"id":"9fe88394ca4d43998ae12e5373f3d113","floor":"265"},"leaderboard-fixed-3":{"id":"00444850e0d44e68978ec594611a5097","floor":"5"},"leaderboard-fixed-4":{"id":"78fb56fa801f44dd88debed4406112bc","floor":"5"},"leaderboard-fixed-1":{"id":"4f428b79424a4048a04f282aff27f5af","floor":"5"},"leaderboard-fixed-2":{"id":"a6baba84f8de4a15af1b3b162b95b797","floor":"305"},"leaderboard-fixed-7":{"id":"8b72bdfbd83149cea6eec6118c03b283","floor":"5"},"leaderboard-fixed-8":{"id":"00e396ca56d04144b64d79acebf1738e","floor":"5"},"leaderboardfooter-flex-2":{"id":"3117c081e6694a31a00bcbf15f856734","floor":"470"},"leaderboard-fixed-5":{"id":"ab33db7dff224c188a1ea5591bc0ff1a","floor":"5"},"leaderboardfooter-flex-1":{"id":"ebe198f79ac4404d85bad393470134f2","floor":"415"},"leaderboard-fixed-6":{"id":"8b2fe6cdea244aadba7cc2a7c58f3e3b","floor":"5"},"leaderboard-fixed-0":{"id":"67953f038a0846898d36e09ec7c92775","floor":"255"},"mob-square-fixed-ing-nolrs":{"id":"a0742d5c9d0545bf8a4cdcf304e82a84","floor":"175"},"inline":{"id":"11e79babdf4244d69675650e54558b1b","floor":"525"},"leaderboard-fixed-9":{"id":"81862757c281414992819c31ad096a2f","floor":"5"},"mob-adhesive-banner-fixed":{"id":"a6a4ee83064144b9b205cc8107db1d90","floor":"195"}});
+        (function(){
+        const mantleDependencies = {
+        csAutoRefreshMobileAdhesive: 'true'
+        }
+        ;
+        const pageTargeting = {
+        customSeries: ''
+        ,abtest: 'all_ids'
+        ,tax0: 'Allrecipes'
+        ,custom: ''
+        ,sweepId: ''
+        ,rid: 'n4c7ebd895c384815bf10357e457ed95b19'
+        ,sid: 'n4c7ebd895c384815bf10357e457ed95b19'
+        }
+        ;
+        const baseSlotTargeting = {
+        gtemplate: 'recipe'
+        ,leaid: '156569'
+        ,revenueGroup: ''
+        ,docId: '11832010'
+        ,viewtype: 'broadvideo'
+        ,type: 'recipe'
+        ,tax1: 'alr_Recipes'
+        ,tax2: 'alr_SideDishes'
+        ,t: '120'
+        ,au: '156569'
+        ,tier: 'L'
+        ,jny: '0'
+        ,leuid: '166187521201801'
+        ,sbj: ''
+        ,id: '11832010'
+        ,aid: ''
+        ,tax3: 'alr_VegetableSideDishes'
+        ,jnyroot: ''
+        ,tax4: 'alr_BrusselsSproutsSideDishes'
+        }
+        ;
+        pageTargeting.mtax = ['12291','12373','16752','11184','16751','12550','25281','10439','11904','11807','12213','11664','18910','12118','12897','16460','12384','11098','11252','11053','10505','11978','32452','25033','11572','11374','11750','11213','12008'];
+        pageTargeting.sentiment = 'positive';
+        pageTargeting.concepts = ['sprouts','Brussels','Hot Honey Brussels Sprouts','mouth','honey','side dish','side','elements','pork chops','chicken'];
+        pageTargeting.taxons = '\/Food & Drink/Food'.split(/\/|\|/).filter((n) => n),
+        pageTargeting.w = Mntl.utilities.getW();
+        // initialSlots array is no longer used - ads are now populated via window.MMads.initialAds
+        const initialSlots = [];
+        initialSlots.push({
+        config: {
+        id: 'square-flex-1',
+        sizes: [[300, 250],[300, 600],[300, 1050],[160, 600]],
+        type: 'square',
+        rtb: true,
+        timedRefresh: 30000,
+        waitForThirdParty: false
+        },
+        targeting: Mntl.fnUtilities.deepExtend({}, {
+        pos: 'atf',
+        priority: 2
+        })
+        });
+        initialSlots.push({
+        config: {
+        id: 'leaderboard-fixed-0',
+        sizes: [[728, 90]],
+        type: 'leaderboard',
+        rtb: true,
+        timedRefresh: 30000,
+        waitForThirdParty: false
+        },
+        targeting: Mntl.fnUtilities.deepExtend({}, {
+        pos: 'atf',
+        priority: 99
+        })
+        });
+        const testIds = Mntl.GPT.getTestIds();
+        pageTargeting.ab = testIds;
+        pageTargeting.bts = testIds;
+        Mntl.utilities.onLoad(function() {
+        Mntl.utilities.loadExternalJS({
+        src: '//securepubads.g.doubleclick.net/tag/js/gpt.js',
+        });
+        });
+        const options = {
+        domain: 'www.allrecipes.com',
+        templateName: 'recipesc',
+        isMobile: false,
+        isTablet: false,
+        isDesktop: true,
+        dfpId: '3865',
+        publisherProvidedId: '4a995dca-46e4-4959-b4c5-08b4b9326ada',
+        singleRequest: false,
+        useLmdFormat: true,
+        useOxygen: true,
+        useInfiniteRightRail: true,
+        useUpdatedSlots: false,
+        loadAdsAboveViewport: false,
+        waitForNextFramePaint: false,
+        revenueGroupAllowList: '',
+        lmdSiteCode: 'hlt',
+        pageTargeting,
+        baseSlotTargeting,
+        geo: {
+        isInEurope: false,
+        isInUsa: true
+        },
+        initialSlots,
+        auctionFloors: {"mob-square-fixed-ing-jtr":{"id":"a9a80dfb40d94d0282a5a9195db9047a","floor":"220"},"square-flex-2":{"id":"5824173ec3bf486cb1dbbb2b929b3a12","floor":"300"},"square-flex-1":{"id":"31e4fdc4b7d04c999ccd885f841e2309","floor":"210"},"square-fixed-4":{"id":"3494215537994a179ab6f5e7f95fd284","floor":"275"},"mob-square-fixed-4":{"id":"63aeebb3d7f741709cb514c21d64489b","floor":"205"},"mob-square-fixed-step-3":{"id":"741da6e234404eefa15f160a30920464","floor":"235"},"square-fixed-3":{"id":"c030decf8cc946e785789390e919336a","floor":"265"},"mob-square-fixed-5":{"id":"2b5cc585823e4dc8bd1a4e31d735e550","floor":"190"},"mob-square-fixed-step-4":{"id":"ad1591fe2a584cf6abcafbe7148fd136","floor":"195"},"square-fixed-2":{"id":"ae54df9f5df0477c9b0759c6e9d278bb","floor":"285"},"mob-square-fixed-step-1":{"id":"11bec2d1e08e45e9bcf43c1a4a297c72","floor":"305"},"mob-square-fixed-6":{"id":"f194f4428d5341cf8f0c24c4b96d94a2","floor":"145"},"square-fixed-1":{"id":"1ce84241562942a5b457aad8799a7253","floor":"265"},"mob-square-fixed-step-2":{"id":"b2b0a5824fa6414484b1f8059a526e04","floor":"240"},"mob-square-fixed-7":{"id":"5339259beec84f9abd08755778a6a424","floor":"170"},"square-fixed-8":{"id":"2715e1ccefff4421b148764cb65a43d0","floor":"135"},"square-fixed-7":{"id":"1b830ad6575a4649a417cdbbb4a0167d","floor":"110"},"mob-square-flex-1":{"id":"a302817c38734eb18f5a7cd70ba6dbf2","floor":"185"},"square-fixed-6":{"id":"49c2637d0c844e97a3b2fbc8b6f6a06b","floor":"265"},"square-fixed-5":{"id":"1ace91c4f7c44e779529141e9a25a2ee","floor":"265"},"mob-square-fixed-1":{"id":"6114c8c5e2f849be8aaf81e40d422728","floor":"300"},"mob-square-fixed-2":{"id":"4d835989a9154c199d99f099e0b9cf0c","floor":"230"},"mob-square-fixed-3":{"id":"049b14754f0d426e9b03817fc5881839","floor":"225"},"mob-square-fixed-rvw-1":{"id":"5b0b5736afd848b386723611bfa48510","floor":"5"},"square-fixed":{"id":"514d3fde28564ffe8b7c084e614b0f55","floor":"5"},"mob-square-fixed-rvw-2":{"id":"2496cc5fa2fe41bc9749b1f7c03b90fc","floor":"95"},"mob-squarefooter-fixed-1":{"id":"0404cbd0456447b18de145a480298b4b","floor":"240"},"mob-squarefooter-fixed-2":{"id":"bc9e7379b814417ea57508f3a27e7814","floor":"220"},"square-fixed-9":{"id":"54d42a6392ad421fa82203f79cd21d97","floor":"215"},"mob-square-fixed-step-5":{"id":"e739981a00074df092486a2c9d39c452","floor":"170"},"primary":{"id":"0a6ac91b37e54e81ae4e909eb454efff","floor":"550"},"mob-square-fixed-step-6":{"id":"2dc3f2c8917a4126b9e095aed9e99021","floor":"120"},"other":{"id":"4af69bd7220f4e5c8bd36929604fa4d1","floor":"50"},"mob-square-fixed-intro-1":{"id":"0e0df9a0908a4db7841b470f3c708523","floor":"220"},"broadmatch":{"id":"7bea761a03a141cd8bb73f4d7ec1eb2b","floor":"455"},"mob-square-fixed-intro-2":{"id":"869ee3f592bc48fc93212fca46940f9b","floor":"100"},"leaderboardac":{"id":"e76f93dc4f7d4853b6631f17a8d0d7d1","floor":"340"},"leaderboard-flex-1":{"id":"73f3cb380bf54f138ef8f67e8b216e6f","floor":"240"},"leaderboard-flex-2":{"id":"2f95e803246f4ee59037ffae85178044","floor":"330"},"mob-square-fixed-ac":{"id":"9fe88394ca4d43998ae12e5373f3d113","floor":"265"},"leaderboard-fixed-3":{"id":"00444850e0d44e68978ec594611a5097","floor":"5"},"leaderboard-fixed-4":{"id":"78fb56fa801f44dd88debed4406112bc","floor":"5"},"leaderboard-fixed-1":{"id":"4f428b79424a4048a04f282aff27f5af","floor":"5"},"leaderboard-fixed-2":{"id":"a6baba84f8de4a15af1b3b162b95b797","floor":"305"},"leaderboard-fixed-7":{"id":"8b72bdfbd83149cea6eec6118c03b283","floor":"5"},"leaderboard-fixed-8":{"id":"00e396ca56d04144b64d79acebf1738e","floor":"5"},"leaderboardfooter-flex-2":{"id":"3117c081e6694a31a00bcbf15f856734","floor":"470"},"leaderboard-fixed-5":{"id":"ab33db7dff224c188a1ea5591bc0ff1a","floor":"5"},"leaderboardfooter-flex-1":{"id":"ebe198f79ac4404d85bad393470134f2","floor":"415"},"leaderboard-fixed-6":{"id":"8b2fe6cdea244aadba7cc2a7c58f3e3b","floor":"5"},"leaderboard-fixed-0":{"id":"67953f038a0846898d36e09ec7c92775","floor":"255"},"mob-square-fixed-ing-nolrs":{"id":"a0742d5c9d0545bf8a4cdcf304e82a84","floor":"175"},"inline":{"id":"11e79babdf4244d69675650e54558b1b","floor":"525"},"leaderboard-fixed-9":{"id":"81862757c281414992819c31ad096a2f","floor":"5"},"mob-adhesive-banner-fixed":{"id":"a6a4ee83064144b9b205cc8107db1d90","floor":"195"}},
+        utils: {
+        generateSlotId: Allrecipes.GPT.generateSlotId
+        },
+        displayOnScroll: false,
+        displayOnScrollExclusions: [],
+        displayOnConsent: true,
+        adsToCollapse: ['leaderboard*','square*'],
+        refreshConfig: {
+        'square-flex': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'square-fixed-replies': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'square-fixed-comments': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'leaderboardfooter-flex': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'preroll': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'leaderboardfooter-flex-1': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'leaderboardac': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'leaderboard-fixed-0': {
+        timedRefresh: 30000,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'leaderboard-fixed': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'leaderboard-flex-1': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'native': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'square-fixed': {
+        timedRefresh: 30000,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'leaderboard-flex': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'square-flex-2': {
+        timedRefresh: 30000,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'square-flex-1': {
+        timedRefresh: 30000,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        },
+        'square-fixed-featured-comments': {
+        timedRefresh: 0,
+        userClickRefreshSelector: "",
+        timeoutRefreshOnceOnly: false,
+        fiftyPercentAdRefresh: true,
+        sizeOverrides: null
+        }
+        }
+        };
+        if (Mntl.AdMetrics) {
+        Mntl.AdMetrics.init("11832010", "n4c7ebd895c384815bf10357e457ed95b19", initialSlots.map(slot => slot.config.id), Date.now(), "0.1");
+        } else {
+        Mntl.AdMetrics = {
+        pushMetrics: () => { },
+        pushPageMetricsStart: () => { },
+        pushPageMetricsFinish: () => { }
+        };
+        }
+        Mntl.GPT.setMantleDependencies(mantleDependencies);
+        Mntl.GPT.init(options);
+        }());window.addEventListener('readyForThirdPartyTracking', () => {
+        // Set a delay for loading the script
+        // Specify the delay duration in pushly.xml
+        const delay = '8';
+        window.setTimeout(() => {
+        Mntl.utilities.loadExternalJS({
+        src: 'https://cdn.p-n.io/pushly-sdk.min.js?domain_key=1s505zJTcPgEUiiSrtvjQaixszhrrYRtqwpR',
+        async: true
+        });
+        window.PushlySDK = window.PushlySDK || [];
+        // eslint-disable-next-line prefer-rest-params
+        function pushly() { window.PushlySDK.push(arguments); }
+        pushly('load', {
+        domainKey: '1s505zJTcPgEUiiSrtvjQaixszhrrYRtqwpR',
+        sw: '/pushly-sdk-worker.js'
+        });
+        }, parseFloat(delay) * 1000);
+        });
+        //]]>
+        </script>
+        <link rel="shortcut icon" href="/favicon.ico" />
+        <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+        <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/apple-touch-icon-57x57.png" />
+        <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/apple-touch-icon-60x60.png" />
+        <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/apple-touch-icon-76x76.png" />
+        <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/apple-touch-icon-120x120.png" />
+        <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/apple-touch-icon-152x152.png" />
+        <link rel="apple-touch-icon-precomposed" sizes="180x180" href="/apple-touch-icon-180x180.png" />
+        <meta name="msapplication-TileColor" content="#F4F4F4" />
+        <meta name="msapplication-TileImage" content="/static/4.110.0/icons/favicons/mstile-144x144.png" />
+        <meta name="msapplication-square70x70logo" content="/static/4.110.0/icons/favicons/mstile-70x70.png" />
+        <meta name="msapplication-square150x150logo" content="/static/4.110.0/icons/favicons/mstile-150x150.png" />
+        <meta name="msapplication-square310x310logo" content="/static/4.110.0/icons/favicons/mstile-310x310.png" />
+        <meta name="msapplication-wide310x150logo" content="/static/4.110.0/icons/favicons/mstile-310x150.png" />
+        <script id="allrecipes-schema_1-0" class="comp allrecipes-schema mntl-schema-unified" type="application/ld+json">
+        <![CDATA[
+        [
+        {
+        "@context": "http://schema.org",
+        "@type": ["Recipe","NewsArticle"]
+        ,"headline": "Hot Honey Brussels Sprouts"
+        ,"datePublished": "2025-11-03T13:00:00.000-05:00"
+        ,"dateModified": "2025-11-03T13:00:00.000-05:00"
+        ,"author": [
+        {"@type": "Person"
+        ,"name": "Nicole Russell"
+        ,"url": "https://www.allrecipes.com/nicole-russell-7113592"
+        }
+        ]
+        ,"description": "These hot honey Brussels sprouts are a simple side dish with all the elements you&#39;ll ever need in a side. They&#39;re sweet, spicy, crispy, and melt in your mouth."
+        ,"image": {
+        "@type": "ImageObject",
+        "url": "https://www.allrecipes.com/thmb/RDigrCswgpVoo9dPZxanUuRIudI=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg",
+        "height": 1125,
+        "width": 1500
+        }
+        ,"publisher": {
+        "@type": "Organization",
+        "name": "Allrecipes",
+        "url": "https://www.allrecipes.com",
+        "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.allrecipes.com/thmb/Z9lwz1y0B5aX-cemPiTgpn5YB0k=/112x112/filters:no_upscale():max_bytes(150000):strip_icc()/allrecipes_logo_schema-867c69d2999b439a9eba923a445ccfe3.png",
+        "width": 112,
+        "height": 112
+        },
+        "brand": "Allrecipes"
+        , "publishingPrinciples": "https://www.allrecipes.com/about-us-6648102#toc-editorial-guidelines"
+        , "sameAs" : [
+        "https://www.facebook.com/allrecipes",
+        "https://www.instagram.com/allrecipes/",
+        "https://www.pinterest.com/allrecipes/",
+        "https://www.tiktok.com/@allrecipes",
+        "https://www.youtube.com/user/allrecipes/videos",
+        "https://flipboard.com/@Allrecipes",
+        "https://en.wikipedia.org/wiki/Allrecipes.com",
+        "http://linkedin.com/company/allrecipes.com"
+        ]
+        }
+        ,"name": "Hot Honey Brussels Sprouts"
+        ,"cookTime": "PT20M"
+        ,"nutrition": {
+        "@type": "NutritionInformation"
+        ,"calories": "132 kcal"
+        ,"carbohydrateContent": "18 g"
+        ,"cholesterolContent": "8 mg"
+        ,"fiberContent": "3 g"
+        ,"proteinContent": "5 g"
+        ,"saturatedFatContent": "2 g"
+        ,"sodiumContent": "185 mg"
+        ,"sugarContent": "12 g"
+        ,"fatContent": "6 g"
+        ,"unsaturatedFatContent": "0 g"
+        }
+        ,"prepTime": "PT10M"
+        , "recipeCategory": ["Dinner","Side Dish"]
+        ,"recipeCuisine": ["American"]
+        ,"recipeIngredient": [
+        "1 pound Brussels sprouts, trimmed and halved lengthwise",
+        "1 tablespoon olive oil",
+        "2 tablespoon hot honey, such as Mikes Hot honey",
+        "salt and pepper to taste",
+        "1/4 cup crumbled feta cheese",
+        "1 tablespoon chopped scallions" ]
+        ,"recipeInstructions": [
+        {
+        "@type": "HowToStep"
+        ,"image": [
+        {
+        "@type": "ImageObject",
+        "url": "https://www.allrecipes.com/thmb/aqdax3V1v0dM1iYGEdk80SuiUW4=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg"
+        }
+        ]
+        ,"text": "Gather all ingredients. Preheat the oven to 400 degrees F (200 degrees C). Line a large baking sheet with aluminum foil."
+        } ,{
+        "@type": "HowToStep"
+        ,"image": [
+        {
+        "@type": "ImageObject",
+        "url": "https://www.allrecipes.com/thmb/eUPioUqRphcDxRjTsAyjPzwxZJc=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg"
+        }
+        ]
+        ,"text": "Place Brussels sprouts in a bowl. Add oil, hot honey, salt, and pepper. Stir to combine and transfer to the baking sheet."
+        } ,{
+        "@type": "HowToStep"
+        ,"image": [
+        {
+        "@type": "ImageObject",
+        "url": "https://www.allrecipes.com/thmb/UB3Jz-pfoXewTAcjSJz4RBjrigY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg"
+        }
+        ]
+        ,"text": "Roast in the preheated oven for 20 minutes."
+        } ,{
+        "@type": "HowToStep"
+        ,"image": [
+        {
+        "@type": "ImageObject",
+        "url": "https://www.allrecipes.com/thmb/TKyvsRHU4FOU6HJ50w5StS_jOqk=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg"
+        }
+        ]
+        ,"text": "Transfer sprouts to a bowl. Top with feta and scallions. Toss to combine. Serve immediately."
+        } ]
+        ,"recipeYield": "4"
+        ,"totalTime": "PT30M"
+        ,"mainEntityOfPage": {
+        "@type": ["WebPage"]
+        ,"@id": "https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010"
+        ,"breadcrumb": {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+        {
+        "@type": "ListItem",
+        "position": 1,
+        "item": {
+        "@id": "https://www.allrecipes.com/recipes/",
+        "name": "Recipes"
+        }
+        }
+        ,
+        {
+        "@type": "ListItem",
+        "position": 2,
+        "item": {
+        "@id": "https://www.allrecipes.com/recipes/81/side-dish/",
+        "name": "Side Dish"
+        }
+        }
+        ,
+        {
+        "@type": "ListItem",
+        "position": 3,
+        "item": {
+        "@id": "https://www.allrecipes.com/recipes/225/side-dish/vegetables/",
+        "name": "Vegetables"
+        }
+        }
+        ,
+        {
+        "@type": "ListItem",
+        "position": 4,
+        "item": {
+        "@id": "https://www.allrecipes.com/recipes/920/side-dish/vegetables/brussels-sprouts/",
+        "name": "Brussels Sprouts"
+        }
+        }
+        ]
+        }} }
+        ]
+        ]]>
+        </script>
+        <meta property="fb:pages" content="71158748377" />
+        <style>
+        <![CDATA[
+        .people-inc-logo-st1,.people-inc-logo-st2{fill:#131920}.people-inc-logo-st2{fill-rule:evenodd}
+        ]]>
+        </style>
+    </head>
+    <body>
+        <!-- resourcesvgftl -->
+        <svg class="mntl-svg-resource is-hidden">
+        <defs>
+            <symbol id="icon-menu">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M3 18h18v-2H3v2Zm0-5h18v-2H3v2Zm0-7v2h18V6H3Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-close">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M20 5.61143L18.3886 4L12 10.3886L5.61143 4L4 5.61143L10.3886 12L4 18.3886L5.61143 20L12 13.6114L18.3886 20L20 18.3886L13.6114 12L20 5.61143Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-logo">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewbox="0 0 127 32">
+                <path fill="#F7AF31" d="M126.7 6.91231C126.7 3.0266 124.524 0.0315247 122.026 0.0315247C119.535 0.0315247 117.352 3.03448 117.352 6.91231C117.352 10.2699 118.983 12.3429 121.033 12.8473C121.017 13.6591 120.875 21.3202 120.103 29.7379C120.103 29.7379 120.78 30.0217 122.073 30.0217C123.366 30.0217 124.272 29.7379 124.272 29.7379C123.523 22.2975 123.2 15.1172 123.121 13.1704C123.121 13.1547 122.885 13.2414 122.554 13.1468C122.278 13.0759 122.128 12.9655 122.144 12.9655C122.16 12.9655 122.175 12.9655 122.191 12.9655C122.459 12.9655 122.743 12.9103 122.924 12.8709C122.932 12.8709 122.94 12.8709 122.948 12.8631C123.05 12.8394 123.113 12.8236 123.113 12.8236C125.123 12.2719 126.7 10.2148 126.7 6.91231Z"></path>
+                <path fill="#F15025" fill-rule="evenodd" d="M0.0393066 23.7635C0.0393066 20.8236 2.08857 19.7123 4.6265 19.0581L8.81172 18.0256V17.868C8.81172 16.3783 7.85014 15.8502 5.95852 15.8502C4.38216 15.8502 2.87674 16.2207 1.19793 16.7094L1.49743 12.9497C3.22354 12.4138 5.10729 12.0039 7.21172 12.0039C11.1447 12.0039 13.1309 13.3911 13.1309 17.2296V27.3025H8.81172V25.4818C7.51911 27.0424 5.72995 27.6493 4.09054 27.6493C1.97034 27.6493 0.0393066 26.6089 0.0393066 23.7635ZM4.51615 23.1488C4.51615 24.1655 5.20187 24.5754 6.04522 24.5754C6.90433 24.5754 7.95261 24.1182 8.80384 23.3773V20.2798L7.67674 20.6108C5.52502 21.2098 4.51615 21.9192 4.51615 23.1488Z" clip-rule="evenodd"></path>
+                <path fill="#F15025" d="M15.3931 7.21181V27.3025H19.7202V6.72314L15.3931 7.21181ZM22.1399 7.21181V27.3025H26.4749V6.72314L22.1399 7.21181ZM28.8945 12.6424V27.2946H33.2295V18.3882C34.798 17.3872 36.6896 17.1113 38.3133 17.1901L38.5418 12.0434C35.7201 12.0434 34.2857 13.1941 33.2295 17.0246V12.1379L28.8945 12.6424Z"></path>
+                <path fill="#F15025" fill-rule="evenodd" d="M52.8394 15.8187L53.1153 16.4965C53.4778 17.3635 53.0916 18.1438 52.2325 18.53L44.1301 22.3054C44.8315 23.0699 45.935 23.535 47.5035 23.535C49.0956 23.535 51.4207 23.0699 53.1547 21.7537L52.8709 26.0493C51.7517 26.7901 49.7655 27.6414 46.999 27.6414C41.9468 27.6414 39.0542 24.5202 39.0542 19.7675C39.0542 14.3054 42.9478 11.996 46.7468 11.996C50.002 11.9803 51.9803 13.6827 52.8394 15.8187ZM46.8177 15.4089C44.8709 15.4089 43.1448 16.6069 43.1448 19.3892C43.1448 19.4532 43.1469 19.5173 43.1489 19.5803C43.1508 19.6414 43.1527 19.7014 43.1527 19.7596L49.3242 16.8827C48.8907 16.0552 48.2049 15.4089 46.8177 15.4089Z" clip-rule="evenodd"></path>
+                <path fill="#F15025" d="M62.3448 15.8502C63.5113 15.8502 64.6699 16.2364 65.5054 16.6699V12.5635C64.2364 12.1695 62.7389 12.0039 61.5645 12.0039 56.6463 12.0039 54.0847 15.0778 54.0847 19.8227 54.0847 24.5596 56.6463 27.6414 61.5724 27.6414 62.7862 27.6414 64.3704 27.4128 65.8601 26.8532V22.7941C64.7803 23.2906 63.5428 23.6926 62.3527 23.6926 60.0827 23.6926 58.4276 22.463 58.4276 19.8069 58.4276 17.1665 60.0827 15.8502 62.3448 15.8502ZM67.6492 27.3025H71.9841V12.1537L67.6492 12.6424V27.3025ZM69.8008 5.85616C68.0668 5.85616 66.9949 6.90443 66.9949 8.36256 66.9949 9.84433 68.0589 10.8926 69.8008 10.8926 71.5348 10.8926 72.5515 9.84433 72.5515 8.36256 72.5594 6.90443 71.5348 5.85616 69.8008 5.85616Z"></path>
+                <path fill="#F15025" fill-rule="evenodd" d="M74.4038 31.9842V12.6424L78.7388 12.1458V13.9744C79.7792 12.934 81.2137 12.0039 83.2629 12.0039 86.392 12.0039 88.6777 14.203 88.6777 19.1921 88.6777 24.7566 85.3989 27.6493 81.0797 27.6493 80.1811 27.6493 79.4009 27.5074 78.7388 27.3025V31.9842H74.4038ZM84.1378 19.6414C84.1536 17.4975 83.4284 15.5586 80.9851 15.5586 80.0866 15.5586 79.3614 15.8424 78.7388 16.2364V24.0709C79.1802 24.1655 79.6688 24.2207 80.1969 24.2207 82.8846 24.2207 84.1457 22.534 84.1378 19.6414ZM103.558 15.8187 103.834 16.4965C104.197 17.3635 103.811 18.1438 102.952 18.53L94.8491 22.3054C95.5505 23.0699 96.654 23.535 98.2225 23.535 99.8146 23.535 102.14 23.0699 103.874 21.7537L103.59 26.0493C102.471 26.7901 100.485 27.6414 97.718 27.6414 92.6658 27.6414 89.7732 24.5202 89.7732 19.7675 89.7732 14.3054 93.6668 11.996 97.4658 11.996 100.721 11.9803 102.699 13.6827 103.558 15.8187ZM97.5367 15.4089C95.5899 15.4089 93.8638 16.6069 93.8638 19.3892 93.8638 19.4532 93.8659 19.5173 93.8679 19.5803 93.8698 19.6414 93.8717 19.7014 93.8717 19.7596L100.043 16.8827C99.6096 16.0552 98.9239 15.4089 97.5367 15.4089Z" clip-rule="evenodd"></path>
+                <path fill="#F15025" d="M109.226 16.6542C109.226 15.7163 110.51 15.4798 111.748 15.4798C112.961 15.4798 114.427 15.6768 116.185 16.4571L116.067 12.8473C114.971 12.3586 113.505 12.0039 111.629 12.0039C106.829 12.0039 105.261 14.3133 105.261 16.7803C105.261 22.7862 112.686 20.3586 112.686 22.7941C112.686 23.7872 111.606 24.0158 110.55 24.0158C108.429 24.0158 106.656 23.4089 105.237 22.597L104.985 26.4118C106.475 27.1685 108.445 27.6414 110.542 27.6414C115.153 27.6414 116.918 25.3793 116.918 22.4552C116.934 16.6463 109.226 18.9163 109.226 16.6542Z"></path></svg>
+            </symbol>
+            <symbol id="icon-caret_down">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M8 10L12 14L16 10H8Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-account">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2C6.48 2 2 6.48 2 12ZM12 5C13.66 5 15 6.34 15 8C15 9.66 13.66 11 12 11C10.34 11 9 9.66 9 8C9 6.34 10.34 5 12 5ZM12 19.2C9.5 19.2 7.29 17.92 6 15.98C6.03 13.99 10 12.9 12 12.9C13.99 12.9 17.97 13.99 18 15.98C16.71 17.92 14.5 19.2 12 19.2Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="save-icon-favorite">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 28 28">
+                <path fill="currentColor" d="M27.4166 7.44526C27.4166 7.44526 27.4166 7.44071 27.4166 7.43798C27.4138 6.44286 27.2232 5.47684 26.8504 4.56267C26.4766 3.64486 25.938 2.8262 25.2493 2.12943C24.5569 1.42811 23.7486 0.886882 22.8463 0.519394C22.0002 0.174648 21.1099 0 20.2003 0C20.1423 0 20.0843 0 20.0253 0.00181924C18.8763 0.0109155 17.7632 0.2647 16.7173 0.756806C15.6742 1.248 14.7599 1.94568 14.0004 2.83256C13.2399 1.94568 12.3266 1.24709 11.2834 0.756806C10.2366 0.2647 9.12352 0.0109155 7.9745 0.00181924C7.9165 0 7.85757 0 7.79957 0C6.88994 0 5.99964 0.174648 5.15353 0.519394C4.25126 0.886882 3.4429 1.42811 2.75054 2.12943C2.06187 2.8262 1.52327 3.64486 1.14947 4.56267C0.776596 5.47593 0.586014 6.44286 0.583252 7.43434C0.583252 7.43798 0.583252 7.44162 0.583252 7.44526V10.5116C0.583252 10.5116 0.583252 10.5116 0.583252 10.5125C0.583252 10.5125 0.583252 10.5143 0.583252 10.5152V10.5662C0.597983 12.9348 1.56378 15.1816 3.71082 17.8441L3.72463 17.8613L3.73936 17.8786C6.31267 20.8131 9.1051 23.5892 12.0393 26.1289L13.227 27.2741L13.9792 28L14.7498 27.2932L15.9476 26.1953C18.8809 23.6484 21.677 20.8704 24.2568 17.9378L24.2771 17.915L24.2964 17.8905C26.4379 15.1598 27.4019 12.8984 27.4147 10.5662V7.44526H27.4166Z"></path>
+                <path stroke="currentColor" d="M20.0437 1.09341C19.0604 1.09978 18.0881 1.32082 17.1914 1.74197C16.2946 2.16404 15.4936 2.77712 14.839 3.54212L13.9994 4.54543L13.1597 3.54212C12.5051 2.77712 11.7032 2.16404 10.8064 1.74197C9.90969 1.31991 8.93837 1.09887 7.95508 1.09341C7.1412 1.07158 6.33192 1.21985 5.57327 1.52821C4.81555 1.83657 4.12412 2.30048 3.5404 2.89174C2.95669 3.48299 2.49175 4.18886 2.17411 4.97022C1.85555 5.75068 1.69075 6.59026 1.68799 7.43803C1.68799 9.56018 2.57184 11.6014 4.57525 14.0855C7.13015 17 9.87563 19.7279 12.7905 22.2494L13.9994 23.4155L15.2082 22.3076C18.1194 19.7816 20.864 17.0536 23.4235 14.1438C25.4269 11.5895 26.3117 9.54835 26.3117 7.43803C26.3089 6.59026 26.1432 5.75068 25.8256 4.97022C25.5079 4.18977 25.043 3.48299 24.4583 2.89174C23.8746 2.30048 23.1832 1.83748 22.4255 1.52821C21.6677 1.21985 20.8575 1.07158 20.0437 1.09341Z"></path></svg>
+            </symbol>
+            <symbol id="icon-myr-logo">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewbox="0 0 159 32">
+                <path fill="var(--myr-my-color, #FF3FA4)" d="M20.896 25.227H31.05c-2.156-2.44-1.718-5.974-1.755-8.662-.022-1.54.214-5.918-.34-7.338-.265-.679-1.394-2.503-4.024-2.371-3.17.162-5.83 3.019-5.83 3.019s-.278-3.175-3.83-3.022c-3.322.143-6.19 3.293-6.19 3.293v-3.03L.448 7.68v17.537h8.62v-9.275c0-.515 0-1.63.016-1.667.054-.641.264-1.3 1.038-1.203.818.1.803 1.247.803 2.214v9.94h8.138V15.109c0-.659-.117-2.177 1.034-2.036.818.1.802 1.247.802 2.214l-.004 9.94Z"></path>
+                <path fill="currentColor" d="M64.16 6.87v7.946c-2.01-.243-4.158-.207-6.064.621v9.778h-6.722V7.594l6.722-.688v6.806c1.212-5.634 2.252-6.913 6.064-6.843ZM75.529 19.929c2.217 0 4.504-.933 6.513-2.35l-.52 6.254c-1.35.864-3.673 1.797-7.132 1.797-5.821 0-9.875-3.49-9.875-9.398 0-6.53 4.816-9.433 9.529-9.433 3.95-.034 6.583 1.867 7.692 4.562l.416 1c.519 1.28.034 2.455-1.213 3.008l-8.39 3.8c.762.483 1.731.76 2.98.76Zm-4.888-4.492v.345l5.751-2.59c-.449-.726-1.108-1.318-2.39-1.318-1.696.004-3.36 1.007-3.36 3.563ZM82.685 16.197c0-5.596 2.876-9.398 9.598-9.398 2.08 0 3.86.581 4.799 1.054l-.013 5.853c-.867-.415-2.36-1.003-3.955-1.003-2.246 0-3.707 1.07-3.707 3.489 0 2.418 1.453 3.352 3.707 3.352 1.594 0 2.617-.413 3.963-.897l-.014 6.128c-1.144.483-2.499.85-4.785.85-7.099.005-9.593-3.796-9.593-9.428ZM97.751 3.766c0-2.212 1.593-3.766 4.123-3.766 2.529 0 4.017 1.554 4.017 3.766 0 2.177-1.49 3.766-4.02 3.766-2.53 0-4.12-1.589-4.12-3.766Zm.692 4.684 6.723-.725v17.49h-6.722V8.45ZM124.647 15.467c0 6.808-3.81 10.158-8.904 10.158a9.196 9.196 0 0 1-2.356-.275v5.532h-6.729V7.593l6.515-.69v2.004c1.074-1.037 2.529-2.108 4.92-2.108 3.707 0 6.554 2.591 6.554 8.668Zm-7 .79c0-1.52-.209-4.007-3.153-4.007a5.304 5.304 0 0 0-1.11.102v8.155h.521c3.213.01 3.702-1.926 3.742-4.24v-.01ZM136.139 19.929c2.218 0 4.505-.726 6.514-2.098l.008 5.965c-1.352.82-4.201 1.834-7.662 1.834-5.821 0-9.875-3.49-9.875-9.398 0-6.53 4.816-9.433 9.529-9.433 3.95-.034 6.584 1.867 7.692 4.562l.416 1c.52 1.28.034 2.455-1.213 3.008l-8.385 3.8c.755.483 1.724.76 2.976.76Zm-4.887-4.492v.345l5.753-2.59c-.451-.726-1.11-1.318-2.393-1.318-1.7.004-3.36 1.007-3.36 3.563ZM158.149 12.95a21.57 21.57 0 0 0-6.167-.9c-.66 0-1.87.036-1.87.66 0 .76 1.801.658 3.846.966 2.806.415 4.989 1.382 4.989 5.321 0 3.524-1.94 6.634-8.524 6.634a17.02 17.02 0 0 1-6.504-1.338l-.01-5.84c2.01 1.098 4.124 1.685 6.376 1.685 1.524 0 2.356-.276 2.356-.83 0-.691-1.321-.76-3.084-.968-2.46-.275-5.648-.898-5.648-5.32 0-3.178 1.663-6.22 8.177-6.22 2.391 0 4.297.381 5.68 1.037l.383 5.112Z"></path>
+                <path fill="var(--myr-my-color, #FF3FA4)" d="M49.72 7.331h-8.572v9.86c0 .658 0 2.239-1.146 2.092-.818-.1-.802-1.247-.802-2.214V7.331h-9.466c.84.988 1.097 2.778 1.097 3.889 0 0-.05 8.256.107 9.84.157 1.585 1.232 4.084 5.17 4.375 3.017.224 4.422-1.306 5.035-1.996.174.415-.17 2.558-2.95 3.293-2.655.697-5.02-.337-5.64-.659-.175 1.696-.518 4.19-.518 4.19s3.46 2.396 9.146 1.56c7.329-1.078 8.536-7.059 8.537-9.203.003-3.24.003-14.04.003-15.289Z"></path></svg>
+            </symbol>
+            <symbol id="icon-search">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M15.5 14H14.71L14.43 13.73C15.41 12.59 16 11.11 16 9.5C16 5.91 13.09 3 9.5 3C5.91 3 3 5.91 3 9.5C3 13.09 5.91 16 9.5 16C11.11 16 12.59 15.41 13.73 14.43L14 14.71V15.5L19 20.49L20.49 19L15.5 14ZM9.5 14C7.01 14 5 11.99 5 9.5C5 7.01 7.01 5 9.5 5C11.99 5 14 7.01 14 9.5C14 11.99 11.99 14 9.5 14Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-error">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill="#C00" fill-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2V2ZM13 17H11V15H13V17V17ZM13 13H11V7H13V13V13Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-chevron">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M10 6L8.59003 7.41L13.17 12L8.59003 16.59L10 18L16 12L10 6Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-arrow-left">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 16 16">
+                <path d="M16 8L14.59 6.59L9 12.17V0H7V12.17L1.42 6.58L0 8L8 16L16 8Z"></path></svg>
+            </symbol>
+            <symbol id="icon-facebook">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M16.282 8.46782H13.12V6.39482C13.12 5.61682 13.637 5.43482 14 5.43482H16.23V2.01182L13.157 1.99982C9.748 1.99982 8.972 4.55382 8.972 6.18682V8.46782H7V11.9938H8.972V21.9728H13.12V11.9938H15.919L16.282 8.46782Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-instagram">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M8.27326 3.05416C9.23411 3.01036 9.54091 3 11.9876 3C14.4343 3 14.7411 3.01036 15.7019 3.05416C16.6608 3.09785 17.3157 3.25001 17.8888 3.47247C18.4812 3.70247 18.9836 4.01021 19.4844 4.51055C19.9852 5.01092 20.2933 5.51283 20.5235 6.10466C20.7462 6.67712 20.8985 7.33137 20.9423 8.28931C20.9861 9.24926 20.9965 9.55575 20.9965 12C20.9965 14.4443 20.9861 14.7507 20.9423 15.7107C20.8985 16.6686 20.7462 17.3229 20.5235 17.8953C20.2933 18.4872 19.9852 18.9891 19.4844 19.4895C18.9836 19.9898 18.4812 20.2975 17.8888 20.5275C17.3157 20.75 16.6608 20.9021 15.7019 20.9458C14.7411 20.9896 14.4343 21 11.9876 21C9.54091 21 9.23411 20.9896 8.27326 20.9458C7.31433 20.9021 6.65948 20.75 6.08642 20.5275C5.494 20.2975 4.9916 19.9898 4.49077 19.4895C3.98994 18.9891 3.6819 18.4872 3.45167 17.8953C3.22895 17.3229 3.07668 16.6686 3.03291 15.7107C2.98907 14.7507 2.9787 14.4443 2.9787 12C2.9787 9.55575 2.98907 9.24926 3.03291 8.28931C3.07668 7.33137 3.22895 6.67712 3.45167 6.10466C3.6819 5.51283 3.98994 5.01092 4.49077 4.51055C4.9916 4.01021 5.494 3.70247 6.08642 3.47247C6.65948 3.25001 7.31433 3.09785 8.27326 3.05416ZM15.6279 4.6741C14.678 4.6308 14.3931 4.62162 11.9876 4.62162C9.5821 4.62162 9.2972 4.6308 8.34721 4.6741C7.46889 4.71411 6.99184 4.86073 6.6744 4.98398C6.25392 5.14725 5.95382 5.34227 5.63855 5.65723C5.32332 5.97215 5.12806 6.27196 4.96464 6.69206C4.8413 7.00919 4.69454 7.48574 4.65445 8.36323C4.61111 9.31224 4.60195 9.5969 4.60195 12C4.60195 14.4031 4.61111 14.6878 4.65445 15.6368C4.69454 16.5143 4.8413 16.9908 4.96464 17.3079C5.12806 17.728 5.32332 18.0278 5.63855 18.3428C5.95382 18.6577 6.25392 18.8528 6.6744 19.016C6.99184 19.1393 7.46889 19.2859 8.34725 19.3259C9.29705 19.3692 9.58196 19.3784 11.9876 19.3784C14.3932 19.3784 14.6781 19.3692 15.6279 19.3259C16.5063 19.2859 16.9833 19.1393 17.3008 19.016C17.7213 18.8528 18.0214 18.6577 18.3366 18.3428C18.6519 18.0278 18.8471 17.728 19.0105 17.3079C19.1339 16.9908 19.2806 16.5143 19.3207 15.6368C19.3641 14.6878 19.3732 14.4031 19.3732 12C19.3732 9.5969 19.3641 9.31224 19.3207 8.36323C19.2806 7.48574 19.1339 7.00919 19.0105 6.69206C18.8471 6.27196 18.6519 5.97215 18.3366 5.65723C18.0214 5.34227 17.7213 5.14725 17.3008 4.98398C16.9833 4.86073 16.5063 4.71411 15.6279 4.6741ZM8.99787 12.009C8.99787 13.6324 10.3424 14.9485 12.0008 14.9485C13.6593 14.9485 15.0038 13.6324 15.0038 12.009C15.0038 10.3855 13.6593 9.06948 12.0008 9.06948C10.3424 9.06948 8.99787 10.3855 8.99787 12.009ZM7.37466 12.009C7.37466 9.50799 9.44588 7.48056 12.0008 7.48056C14.5558 7.48056 16.627 9.50799 16.627 12.009C16.627 14.51 14.5558 16.5374 12.0008 16.5374C9.44588 16.5374 7.37466 14.51 7.37466 12.009ZM16.1487 8.49799C16.7457 8.49799 17.2297 8.02423 17.2297 7.43978C17.2297 6.85533 16.7457 6.38157 16.1487 6.38157C15.5516 6.38157 15.0676 6.85533 15.0676 7.43978C15.0676 8.02423 15.5516 8.49799 16.1487 8.49799Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-pinterest">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M4.00043 9.157C4.00043 11.129 4.74543 12.882 6.34643 13.535C6.60843 13.642 6.84443 13.539 6.91943 13.249C6.97343 13.048 7.09743 12.54 7.15343 12.329C7.23043 12.041 7.20143 11.941 6.98943 11.69C6.52743 11.146 6.23343 10.441 6.23343 9.443C6.23343 6.548 8.39943 3.955 11.8744 3.955C14.9504 3.955 16.6424 5.835 16.6424 8.347C16.6424 11.651 15.1794 14.439 13.0084 14.439C11.8094 14.439 10.9134 13.447 11.2004 12.231C11.5454 10.78 12.2114 9.214 12.2114 8.166C12.2114 7.228 11.7094 6.445 10.6674 6.445C9.44143 6.445 8.45643 7.713 8.45643 9.411C8.45643 10.493 8.82243 11.224 8.82243 11.224C8.82243 11.224 7.56843 16.538 7.34843 17.468C6.91043 19.321 7.28243 21.593 7.31443 21.823C7.33243 21.958 7.50743 21.991 7.58743 21.888C7.69943 21.74 9.15843 19.938 9.65543 18.138C9.79543 17.629 10.4614 14.988 10.4614 14.988C10.8604 15.748 12.0234 16.417 13.2604 16.417C16.9444 16.417 19.4434 13.059 19.4434 8.564C19.4434 5.165 16.5644 2 12.1894 2C6.74443 2 4.00043 5.903 4.00043 9.157Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-x">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path d="M13.6468 10.4686L20.9321 2H19.2057L12.8799 9.3532L7.82741 2H2L9.6403 13.1193L2 22H3.72649L10.4068 14.2348L15.7425 22H21.57L13.6468 10.4686ZM11.2821 13.2173L10.508 12.1101L4.34857 3.29968H7.00037L11.9711 10.4099L12.7452 11.5172L19.2066 20.7594H16.5548L11.2821 13.2173Z"></path></svg>
+            </symbol>
+            <symbol id="icon-tiktok">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path d="M20.4761 9.49649C20.3086 9.5129 20.1411 9.52165 19.9736 9.52293C18.1346 9.52293 16.4192 8.5702 15.4105 6.98779V15.6201C15.4105 19.1431 12.6324 22 9.20399 22C5.77554 22 3 19.1431 3 15.6201C3 12.097 5.77798 9.24008 9.20644 9.24008C9.33604 9.24008 9.4632 9.25266 9.59036 9.26023V12.4037C9.4632 12.3886 9.33727 12.3635 9.20644 12.3635C7.45675 12.3635 6.03964 13.8215 6.03964 15.6188C6.03964 17.4174 7.45798 18.8741 9.20644 18.8741C10.9561 18.8741 12.5016 17.4576 12.5016 15.659L12.5322 1H15.4581C15.7344 3.69727 17.8497 5.8038 20.481 6.00113V9.4953"></path></svg>
+            </symbol>
+            <symbol id="icon-youtube">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M19.8139 5.42068C20.6744 5.65216 21.352 6.3342 21.582 7.20034C22 8.77011 22 12.0455 22 12.0455C22 12.0455 22 15.3207 21.582 16.8907C21.352 17.7567 20.6744 18.4387 19.8139 18.6703C18.2542 19.0909 12 19.0909 12 19.0909C12 19.0909 5.7458 19.0909 4.18614 18.6703C3.32568 18.4387 2.64795 17.7567 2.41795 16.8907C2 15.3207 2 12.0455 2 12.0455C2 12.0455 2 8.77011 2.41795 7.20034C2.64795 6.3342 3.32568 5.65216 4.18614 5.42068C5.7458 5 12 5 12 5C12 5 18.2542 5 19.8139 5.42068ZM15.1818 12.0456L9.95455 15.0192V9.0717L15.1818 12.0456Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-linkedin">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M5.90187 7.78789C4.8515 7.78789 4 6.98834 4 5.8944C4 4.8003 4.8515 4 5.90187 4C6.95223 4 7.80373 4.8003 7.80373 5.8944C7.80373 6.98834 6.95223 7.78789 5.90187 7.78789ZM4.25243 19.7198H7.55133V9.24009H4.25243V19.7198ZM16.4144 19.7279H19.7132V13.2463C19.7132 10.0453 17.724 8.95331 15.8832 8.95331C14.1812 8.95331 13.0668 10.0549 12.7477 10.6999H12.7056V9.24802H9.53307V19.7279H12.8318V14.046C12.8318 12.5311 13.7917 11.7943 14.7704 11.7943C15.6964 11.7943 16.4144 12.3151 16.4144 14.004V19.7279Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-website">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2V2ZM11 19.93C7.05 19.44 4 16.08 4 12C4 11.38 4.08 10.79 4.21 10.21L9 15V16C9 17.1 9.9 18 11 18V19.93V19.93ZM17.9 17.39C17.64 16.58 16.9 16 16 16H15V13C15 12.45 14.55 12 14 12H8V10H10C10.55 10 11 9.55 11 9V7H13C14.1 7 15 6.1 15 5V4.59C17.93 5.78 20 8.65 20 12C20 14.08 19.2 15.97 17.9 17.39V17.39Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-flipboard">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path d="M8 0H0V24H8V0Z"></path>
+                <path d="M16.0533 0H7.97858V8.01068H16.0533 23.9999V0H16.0533ZM15.9893 8.01074H7.97858V16.0214H15.9893V8.01074Z"></path></svg>
+            </symbol>
+            <symbol id="icon-favorite">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill="#000" d="M23.5 6.38165C23.5 6.38165 23.5 6.37775 23.5 6.37541C23.4976 5.52245 23.3343 4.69443 23.0147 3.91086C22.6943 3.12416 22.2326 2.42245 21.6423 1.82522C21.0489 1.22409 20.356 0.760185 19.5826 0.445195C18.8574 0.149698 18.0943 0 17.3146 0C17.2649 0 17.2151 0 17.1646 0.00155935C16.1798 0.00935612 15.2257 0.226886 14.3292 0.648691C13.4351 1.06972 12.6514 1.66773 12.0004 2.42791C11.3485 1.66773 10.5657 1.06894 9.67159 0.648691C8.77432 0.226886 7.82023 0.00935612 6.83536 0.00155935C6.78564 0 6.73513 0 6.68542 0C5.90573 0 5.14261 0.149698 4.41738 0.445195C3.644 0.760185 2.95112 1.22409 2.35768 1.82522C1.76739 2.42245 1.30573 3.12416 0.985332 3.91086C0.665723 4.69365 0.502367 5.52245 0.5 6.3723C0.5 6.37541 0.5 6.37853 0.5 6.38165V9.00994C0.5 9.00994 0.5 9.00994 0.5 9.01072C0.5 9.01072 0.5 9.01228 0.5 9.01306V9.05672C0.512627 11.087 1.34045 13.0128 3.18077 15.2949L3.19261 15.3097L3.20523 15.3245C5.41093 17.8398 7.80444 20.2193 10.3195 22.3962L11.3375 23.3778L11.9822 24L12.6428 23.3942L13.6695 22.4531C16.1837 20.27 18.5804 17.8889 20.7916 15.3752L20.809 15.3557L20.8255 15.3347C22.6611 12.9941 23.4874 11.0558 23.4984 9.05672V6.38165H23.5Z"></path>
+                <path d="M17.1805 0.937167C16.3376 0.942625 15.5043 1.13209 14.7356 1.49308C13.967 1.85485 13.2804 2.38035 12.7193 3.03606L11.9996 3.89604L11.2799 3.03606C10.7188 2.38035 10.0315 1.85485 9.26284 1.49308C8.4942 1.13131 7.66164 0.941845 6.81882 0.937167C6.1212 0.918455 5.42753 1.04554 4.77727 1.30985C4.12779 1.57416 3.53513 1.9718 3.03481 2.47859C2.53448 2.98538 2.13596 3.59041 1.8637 4.26015C1.59065 4.92911 1.44939 5.64875 1.44702 6.37541C1.44702 8.19439 2.20461 9.94399 3.92182 12.0733C6.11173 14.5714 8.465 16.9096 10.9635 19.0709L11.9996 20.0704L13.0358 19.1208C15.5311 16.9556 17.8836 14.6174 20.0774 12.1232C21.7947 9.93385 22.553 8.18426 22.553 6.37541C22.5507 5.64875 22.4086 4.92911 22.1364 4.26015C21.8641 3.59119 21.4656 2.98538 20.9645 2.47859C20.4641 1.9718 19.8715 1.57494 19.222 1.30985C18.5725 1.04554 17.8781 0.918455 17.1805 0.937167Z"></path></svg>
+            </symbol>
+            <symbol id="icon-star-empty">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
+                <path fill="#000" fill-opacity=".95" fill-rule="evenodd" d="M16 6.19199L10.248 5.69599L8 0.399994L5.752 5.70399L0 6.19199L4.368 9.97599L3.056 15.6L8 12.616L12.944 15.6L11.64 9.97599L16 6.19199V6.19199ZM8 11.12L4.992 12.936L5.792 9.51199L3.136 7.20799L6.64 6.90399L8 3.67999L9.368 6.91199L12.872 7.21599L10.216 9.51999L11.016 12.944L8 11.12V11.12Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="close-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24.81 24.61">
+                <path d="M.234 2.826L3.062-.002l21.75 21.75-2.828 2.829z"></path>
+                <path d="M-.003 21.796L21.726.067l2.828 2.828-21.729 21.73z"></path></svg>
+            </symbol>
+            <symbol id="icon-privacy-options">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 30 14">
+                <path fill="#FFF" d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z"></path>
+                <path fill="#06f" d="M22.6 0H7.4c-3.9 0-7 3.1-7 7s3.1 7 7 7h15.2c3.9 0 7-3.1 7-7s-3.2-7-7-7zm-21 7c0-3.2 2.6-5.8 5.8-5.8h9.9l-3.1 11.6H7.4c-3.2 0-5.8-2.6-5.8-5.8z"></path>
+                <path fill="#FFF" d="M24.6 4c.2.2.2.6 0 .8L22.5 7l2.2 2.2c.2.2.2.6 0 .8-.2.2-.6.2-.8 0l-2.2-2.2-2.2 2.2c-.2.2-.6.2-.8 0-.2-.2-.2-.6 0-.8L20.8 7l-2.2-2.2c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0l2.2 2.2L23.8 4c.2-.2.6-.2.8 0z"></path>
+                <path fill="#06f" d="M12.7 4.1c.2.2.3.6.1.8L8.6 9.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4 7.7c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0L8 8.6l3.8-4.5c.2-.2.6-.2.9 0z"></path>​</svg>
+            </symbol>
+            <symbol id="mntl-dotdash-universal-nav__logo">
+                <svg xmlns="http://www.w3.org/2000/svg" id="people-inc-logo-Layer_1" version="1.1" viewbox="0 0 720 160.56">
+                <defs></defs>
+                <path d="M453.23,82.67c1.66-.01,1.54-.98,1.54-.98-1.62-20.71-18.29-36.76-38.66-36.69-21.4.08-38.68,18.13-38.61,40.32.07,22.2,17.68,39.63,39.06,40.13,16.75.39,29.17-5.15,36.76-23.4.95-3.02-2-4.84-3.95-1.02-12.2,23.88-35.11,15.33-41.51,8.51-5.66-6.04-8.83-14.83-9.24-26.7l54.6-.17ZM398.87,77.2c.09-16.01,7.57-26.55,18.07-26.58,10.41-.04,18.24,8.38,18.13,26.48l-36.2.1Z" class="people-inc-logo-st1"></path>
+                <path d="M46.14 72.2c28.35 0 45.96-12.92 45.96-33.71s-15.52-30.05-46.12-30.05H0v3.17l.99.2c7.73 2.05 8.33 2.94 8.33 36.14v37.58c0 33.43-.65 34.56-7.62 36.45l-.99.2v3.37h39.85v-3.4l-.79-.18c-7.7-1.79-8.07-3.49-8.07-36.44v-13.34h14.45ZM31.7 12.85h14.12c17.12 0 24.76 8.26 24.76 27.32s-7.68 27.39-24.92 27.39h-13.96V12.85ZM234 55.98c-8.73-7.06-19.13-9.57-25.95-9.57s-17.25 2.51-26.03 9.57c-6.61 5.31-14.48 15.03-14.48 31.17 0 28.97 24.85 39.76 40.51 39.76s40.34-10.8 40.34-39.76c0-16.15-7.83-25.86-14.39-31.17ZM208.06 122.1c-12.39 0-18.67-10.56-18.67-34.95s6.63-35.93 18.67-35.93c8.44 0 18.5 4.74 18.5 35.93 0 24.39-6.22 34.95-18.5 34.95ZM367.49.98c0-.96-1.16-1.32-1.81-.62-2.89 3.12-6 5.88-13.33 9.94-9.09 5.04-12.86 5.03-12.86 5.03v3.4l.96.05c5.28 1.44 6.51 3.09 6.51 18.57v61.49c0 19.57-.18 21.43-6.48 23.07l-1.26.15v3.42h37.04v-3.45l-.85-.13c-6.83-1.47-7.3-4.94-7.3-25.02l-.63-95.9Z" class="people-inc-logo-st2"></path>
+                <path d="M247.49,58.72c7.89.64,10.29,4.95,10.64,11.68v42.02h.03s0,12.87,0,12.87c0,23.42.75,30.98-7.76,31.94h-.47v3.33h37.19v-3.33l-1-.14c-8.76-1.64-6.98-12.23-6.98-31.8v-5.08c5.02,3.19,10.78,4.87,16.78,4.87,24.75,0,41.37-16.83,41.37-41.89s-17.08-38.23-32.94-38.23c-11.36,0-19.14,6.63-24.66,12.68l-.63.72v-8.17c0-1.01.03-2.76.06-4.35.01-.9-1.06-1.37-1.71-.75-1.15,1.09-2.66,2.43-3.84,3.18-3.96,2.58-6.29,4.04-10.98,5.45-3.53.96-5.25,1.11-8.19,1.39-3.17.3-4.77.23-6.89.22v3.39ZM295.57,120.49c-5.74,0-11.12-1.8-16.43-5.5v-49.96l1.69-1.89c4.78-5.28,11-11.17,18.01-11.17,14.73,0,16.43,18.51,16.43,34.01,0,31.41-12.34,34.52-19.7,34.52Z" class="people-inc-logo-st2"></path>
+                <path d="M607.86 67.05c-.03-21.19-37.6-31.15-50.48-6.61 0 0-.02-8.54-.03-13.56 0-.97-1.24-1.38-1.82-.61l-.94 1.24c-10.03 11.97-22.83 10.02-26.08 10.22v3.32c8.42.67 9.71 7.15 9.72 9.97l.1 31.94c0 18.41-3.61 18.43-9.05 19.03l.03 3.38 37.4-.11v-3.38c-4.54-.73-9.19-1.05-9.19-18.97l-.09-29.5c-.03-7.18 7.47-13.96 11.4-16.36 3.94-2.41 9.14-3.13 13.51-.46 4.37 2.66 5.99 6.87 6 12.79.02 4.51.11 33.68.11 33.68 0 18.69-3.05 17.85-8.95 18.79l.05 3.48 37.34-.12.02-3.49c-4.13-.69-8.99-1.09-8.99-18.97l-.07-35.69ZM522.65 125.54l.02-3.39c-5.43-.51-12.29.53-11.95-19.18l.23-72.07-.05-.51c-.08-19.07 6.88-18.33 11.89-18.97l-.02-3.33h-44.91l-.02 3.33c5.02.63 11.97-.1 11.89 18.97l-.05.51.23 72.07c.34 19.71-6.53 18.67-11.95 19.18l.02 3.39h44.68ZM160.36 82.56c1.66-.01 1.54-.98 1.54-.98-1.62-20.71-18.29-36.76-38.66-36.69-21.4.08-38.68 18.13-38.61 40.32.07 22.2 17.68 39.63 39.06 40.13 16.75.39 29.17-5.15 36.76-23.4.95-3.02-2-4.84-3.95-1.02-12.2 23.88-35.11 15.33-41.51 8.51-5.66-6.04-8.83-14.83-9.24-26.7l54.6-.17ZM106 77.09c.09-16.01 7.57-26.55 18.07-26.58 10.41-.04 18.24 8.38 18.13 26.48l-36.2.1Z" class="people-inc-logo-st1"></path>
+                <path d="M696.28,115.52c.01,6.55,5.34,11.83,11.9,11.82,6.53-.02,11.83-5.35,11.82-11.9-.02-6.53-5.36-11.82-11.89-11.8-6.56.01-11.85,5.34-11.82,11.88Z" style="fill:#ffd400"></path>
+                <path d="M689.77,66.18c-.19-1.8-.84-3.52-1.86-5.01-6.7-9.74-17.12-15.74-30.11-15.77-19.84-.03-38.39,17.82-38.32,39.99.07,22.16,14.82,39.67,36.58,40.2,15.94.4,29.88-6.54,36.73-23.43,1.15-3.41-1.6-4.68-3.48-.81-10.89,22.36-32.97,13.69-39.48,6.88-5.61-5.86-9.59-13.33-10.18-24.66-.14-4.28.17-6.29.24-7.76,1.08-14.07,9.33-24.77,19.74-24.8,6.42-.02,11.57.72,15.08,6.74l.08.22c1.05,1.94.34,3.94-.25,5.29-.58,1.31-.71,2.51-.7,3.81.01,4.81,3.52,8.5,8.05,8.48,4.54,0,7.84-3.72,7.96-8.53,0,0,0-.32-.05-.84Z" class="people-inc-logo-st1"></path></svg>
+            </symbol>
+            <symbol id="icon-check-circle">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill="green" fill-rule="evenodd" d="M2 12C2 6.48 6.48 2 12 2C17.52 2 22 6.48 22 12C22 17.52 17.52 22 12 22C6.48 22 2 17.52 2 12ZM5 12L10 17L19 8L17.59 6.58L10 14.17L6.41 10.59L5 12Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="trending-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="2 6 24 24">
+                <path d="M16 6L18.29 8.29L13.41 13.17L9.41 9.17L2 16.59L3.41 18L9.41 12L13.41 16L19.71 9.71L22 12V6L16 6Z"></path></svg>
+            </symbol>
+            <symbol id="jw-player-cc">
+                <svg xmlns="http://www.w3.org/2000/svg" focusable="false" viewbox="0 0 240 240">
+                <path d="M215,40H25c-2.7,0-5,2.2-5,5v150c0,2.7,2.2,5,5,5h190c2.7,0,5-2.2,5-5V45C220,42.2,217.8,40,215,40z M108.1,137.7c0.7-0.7,1.5-1.5,2.4-2.3l6.6,7.8c-2.2,2.4-5,4.4-8,5.8c-8,3.5-17.3,2.4-24.3-2.9c-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7,0.5-5.3,1.5-7.8c0.9-2.2,2.4-4.3,4.2-5.9c5.7-4.5,13.2-6.2,20.3-4.6c3.3,0.5,6.3,2,8.7,4.3c1.3,1.3,2.5,2.6,3.5,4.2l-7.1,6.9c-2.4-3.7-6.5-5.9-10.9-5.9c-2.4-0.2-4.8,0.7-6.6,2.3c-1.7,1.7-2.5,4.1-2.4,6.5v25.6C90.4,141.7,102,143.5,108.1,137.7z M152.9,137.7c0.7-0.7,1.5-1.5,2.4-2.3l6.6,7.8c-2.2,2.4-5,4.4-8,5.8c-8,3.5-17.3,2.4-24.3-2.9c-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7,0.5-5.3,1.5-7.8c0.9-2.2,2.4-4.3,4.2-5.9c5.7-4.5,13.2-6.2,20.3-4.6c3.3,0.5,6.3,2,8.7,4.3c1.3,1.3,2.5,2.6,3.5,4.2l-7.1,6.9c-2.4-3.7-6.5-5.9-10.9-5.9c-2.4-0.2-4.8,0.7-6.6,2.3c-1.7,1.7-2.5,4.1-2.4,6.5v25.6C135.2,141.7,146.8,143.5,152.9,137.7z"></path></svg>
+            </symbol>
+            <symbol id="reviewer-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="m15.73975,0.45073l-3.73975,1.6059l-3.73866,-1.6059l-2.07997,3.50878l-3.97075,0.89094l0.37398,4.06865l-2.68383,3.07975l2.68383,3.06885l-0.37398,4.07091l3.97075,0.90079l2.07997,3.50987l3.73866,-1.61694l3.73975,1.60593l2.07889,-3.50987l3.97182,-0.90079l-0.37508,-4.0599l2.68385,-3.06885l-2.68385,-3.06875l0.37508,-4.05874l-3.97182,-0.90195l-2.07889,-3.51868zm0.59395,7.02856l1.62795,1.6279l-8.06252,8.08344l-4.17974,-4.18972l1.6279,-1.62787l2.55184,2.5629l6.43457,-6.45665z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-share">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M14 9V5L21 12L14 19V14.9C9 14.9 5.5 16.5 3 20C4 15 7 10 14 9Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-recipe-social-share-star-empty">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M22 9.24L14.81 8.62L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27L18.18 21L16.55 13.97L22 9.24ZM12 15.4L8.24 17.67L9.24 13.39L5.92 10.51L10.3 10.13L12 6.1L13.71 10.14L18.09 10.52L14.77 13.4L15.77 17.68L12 15.4Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-print">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20">
+                <path fill-rule="evenodd" d="M15.834 6.667H4.167c-1.383 0-2.5 1.117-2.5 2.5v5H5V17.5h10v-3.333h3.333v-5c0-1.383-1.117-2.5-2.5-2.5zm-2.5 9.167H6.667v-4.167h6.667v4.167zm2.5-5.833c-.458 0-.833-.375-.833-.833s.375-.833.833-.833.833.375.833.833-.375.833-.833.833zM15 2.5H5v3.333h10V2.5z"></path></svg>
+            </symbol>
+            <symbol id="icon-twitter">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M13.647 10.469 20.932 2h-1.726L12.88 9.353 7.827 2H2l7.64 11.12L2 22h1.726l6.68-7.765L15.743 22h5.828l-7.923-11.531Zm-2.365 2.748-.774-1.107-6.16-8.81H7l4.971 7.11.774 1.107 6.462 9.242h-2.652l-5.273-7.542Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-email">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20">
+                <path fill-rule="evenodd" d="M16.667 3.33334H3.33366C2.41699 3.33334 1.67533 4.08334 1.67533 5.00001L1.66699 15C1.66699 15.9167 2.41699 16.6667 3.33366 16.6667H16.667C17.5837 16.6667 18.3337 15.9167 18.3337 15V5.00001C18.3337 4.08334 17.5837 3.33334 16.667 3.33334ZM16.667 6.66668L10.0003 10.8333L3.33366 6.66668V5.00001L10.0003 9.16668L16.667 5.00001V6.66668Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-add-photo">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M3 1V4H0V6H3V9H5V6H8V4H5V1H3ZM6 7V10H3V20C3 21.1 3.9 22 5 22H21C22.1 22 23 21.1 23 20V8C23 6.9 22.1 6 21 6H17.83L16 4H9V7H6ZM13 19C15.76 19 18 16.76 18 14C18 11.24 15.76 9 13 9C10.24 9 8 11.24 8 14C8 16.76 10.24 19 13 19ZM13 17.2C11.23 17.2 9.8 15.77 9.8 14C9.8 12.23 11.23 10.8 13 10.8C14.77 10.8 16.2 12.23 16.2 14C16.2 15.77 14.77 17.2 13 17.2Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-check">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="inherit" viewbox="0 0 10 10">
+                <path fill="inherit" fill-opacity=".95" d="M3.33333 9.08333L0 5.75L1.16667 4.58333L3.33333 6.75L8.83333 1.25L10 2.41667L3.33333 9.08333Z"></path></svg>
+            </symbol>
+            <symbol id="icon-help">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none">
+                <path fill="#000" fill-opacity=".65" fill-rule="evenodd" d="M1.66797 9.99984C1.66797 5.39984 5.4013 1.6665 10.0013 1.6665C14.6013 1.6665 18.3346 5.39984 18.3346 9.99984C18.3346 14.5998 14.6013 18.3332 10.0013 18.3332C5.4013 18.3332 1.66797 14.5998 1.66797 9.99984ZM10.8346 13.3332V14.9998H9.16797V13.3332H10.8346ZM10.0013 16.6665C6.3263 16.6665 3.33464 13.6748 3.33464 9.99984C3.33464 6.32484 6.3263 3.33317 10.0013 3.33317C13.6763 3.33317 16.668 6.32484 16.668 9.99984C16.668 13.6748 13.6763 16.6665 10.0013 16.6665ZM6.66797 8.33317C6.66797 6.4915 8.15964 4.99984 10.0013 4.99984C11.843 4.99984 13.3346 6.4915 13.3346 8.33317C13.3346 9.40227 12.6763 9.9776 12.0353 10.5378C11.4272 11.0692 10.8346 11.587 10.8346 12.4998H9.16797C9.16797 10.9821 9.95307 10.3803 10.6433 9.85123C11.1848 9.43618 11.668 9.06585 11.668 8.33317C11.668 7.4165 10.918 6.6665 10.0013 6.6665C9.08464 6.6665 8.33464 7.4165 8.33464 8.33317H6.66797Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="light-box-arrow">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="2575 18840 48 48">
+                <g transform="translate(1355 18464)">
+                    <circle cx="24" cy="24" r="24" fill="#fff" transform="translate(1220 376)"></circle>
+                    <path fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" d="M1248.675 390l9.38 9.38M1258.055 399.38l-9.38 9.553M1232 399.38h25.186"></path>
+                </g></svg>
+            </symbol>
+            <symbol id="icon-made-it">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 21 21">
+                <path d="m 10.7567,1.748 c 2.0332,0.01666 3.8392,0.66823 5.3873,1.99041 1.5879,1.35677 2.5553,3.08458 2.8477,5.15396 0.3431,2.44853 -0.2624,4.65733 -1.8398,6.56753 -1.3587,1.6418 -2.6446,2.6072 -4.7527,2.9322 -0.2513,0.0436 -0.2649,0.0228 -0.2838,-0.2461 -0.0592,-0.7672 -0.1302,-1.5336 -0.1882,-2.3014 -0.0397,-0.5048 -0.0778,-0.9985 -0.1145,-1.5007 -0.0326,-0.4842 -0.0678,-0.9632 -0.088,-1.4507 -0.0162,-0.4096 0.0652,-0.7955 0.3341,-1.1239 0.3241,-0.3781 0.6438,-0.7696 0.9264,-1.1788 0.4499,-0.66803 0.668,-1.41719 0.7487,-2.2023 C 13.8088,7.65404 13.743,6.94664 13.4911,6.25091 13.3523,5.84372 13.1479,5.45539 12.8843,5.10893 12.5735,4.70758 11.9286,4.47331 11.4318,4.38456 10.7625,4.26633 9.89399,4.35675 9.34003,4.78258 8.9917,5.04362 8.53409,5.41956 8.35493,5.81102 7.6968,7.24716 7.75993,8.68258 8.3992,10.1108 c 0.24166,0.5299 0.62312,0.9753 0.99812,1.4132 0.25323,0.2914 0.23635,0.5919 0.28521,0.9907 0.02333,0.2238 0.01885,0.4466 0.00646,0.6715 -0.07167,1.018 -0.14584,2.0359 -0.22688,3.0502 -0.04198,0.6142 -0.09729,1.2244 -0.14,1.8365 C 9.2918,18.423 9.53013,18.424 9.19222,18.3725 7.63888,18.1124 6.49888,17.4735 5.31014,16.4335 3.96076,15.2576 3.04409,13.8068 2.65191,12.0595 2.04712,9.33518 2.60962,6.86049 4.40191,4.71081 5.79909,3.03456 7.61482,2.08216 9.77493,1.79695 10.1037,1.75779 10.4298,1.73195 10.7567,1.748 Z"></path></svg>
+            </symbol>
+            <symbol id="icon-arrow_left">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-avatar-1">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 80 80">
+                <image width="80" height="80" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAA/a3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjapb1ZluS4smT7z1HcIRAk2uGg41o1gxp+7Q2LzDpdfZz3IjIjPNzNjSSgKiqiDfza//t/fdf//M//hBhyvmIqNbecb37FFtvT+aDev1/9/BnueP48v9KfL/Hvf/r89fcXHj718vf7+2fNf17/1+fD32/w+6vzUfqHN6rzzxfGP3+hxT/vX//ljZ7fX6935Mfrzxu1P2/0Pr8vhD9v0H+PdedWyz8+wti/v9dfT1J//1/+Ees/3/a//buweitxnfd59hvemz/f9/ndwOv/z/V2v8Cf9xt5YXjz+fj3Z/jzZizIf1qnv3817ujzVuN/fNE/7crfH4X//PnrX3crPn9e8v7LIue///6Pn79C+pcvvH9f5/nHK8f656Pnnz9/lzf/7uhfVt//v2/V7zwzT9FjZqnzn4f661HOR7xucAkvXS9uLd+F/xNvUc7vxu+KVU9MYd3zHvyeoYWHXfnwhxV6+MI+f88wucX47OspfPA883nPJ+tbnvZMd+yN/g7fU972rreyyfNse3yfv+8lnMu2e17napUrr8BLn8CbBe3iv/19/bff8H26Qgh3/XutuK/ncbG5DXfOP3kZOxK+P4uazgL/9ftff7mvLzuYXGVdpLGw4/cWI4X/iwTv2eiXFyb+/vlgKOvPG7BEXDpxM+FlB9i18KaQw12ep4TAQlY2qHPrDz4z2IGQ0rO4ySe+b2Zv6uOl+ZYSzkuf9PDpi88DZuxEwr8Ke9PezmbFmLCfEis21NObYkopp5JqaqnnN8eccs4lC4q9vCVeJZVcSqmllV7fGmuquZZaa6u9Pe0FNFPLrbTaWuuda3beufPdnRf0Pp7xjjjSNfIoo442+sR8Zpxp5llmnW329ax3gR8rr7LqaqvvsDGlHXfaeZddd9v9w9S+9/ril778la9+7et/79qfbf233//FroU/u/acnfKF5e9d47Ol/PUWQThJ7hkb9lwxsOPFLcCgH/fsriHGx51zz+724BXp4SaTe7aCO8YOxh2e9IW/9u56fjvqzv3/2rerxH/at+f/685dbt1/uXP/vm//adeWYWieHft5oYt6v3gfX9+1P7Ub7P7t7+v3wYhf5MVf7m0/cawy3vU8q+z1AnSh8WjvnClOHSS8LT93STmk0TKBroxRr2en33fm9qzJYvXnHTl+YbKV6wtrj76/u6cRAcWx0pPGHCF+T4+lxhlTDXxjuHJ663xL+Obz8P6pzh7bau/g2dcz2wjv2ciUgcrx7R7XDuFjV7x4nWs/JY49rqexuBPTWHsDuXfPQuW8Wcm38Q2pxO8Tn3oo88FuY7hXLt/mo4QVZ+44rPu7Juaweg0h7DnqYsPqnRqwv+9cRujsShgsUSMwy1A+dny3Gvf7cA2MPk92tb+uUesjZN5lpjc0VhQ7/PpK7/jGl8Zb6zsqqzvy+uAoX+zjxR3yWi3M/tWlczUC5IgthzCw1J3qCpPNXI332GO9IxVsabyzlXu9wuK491pPnxuLrHH1nly2973YSYhDgaiVwmqWlRtxJd5133C5r/b+zbn6u3mWPUPnQXimNYlP+uvqoxHG8r4wRzwpp9Bqze/KPRdMZqxn53duIteOZeF2iXtpmwfmQccDRSy751ETW7tLSd+V3rZxj/KEUdpdatgjgdA1jPTgOM9KHYCfFS/Pe3Jj7WVNehm4bJrzbbxs5lihNUPHXth2i3MFnWm+WCcXeDuu0/HpHDqLwSO97QuNWwS3WPc9WnFzK9/OG2ENqXysLjeixQRMuXwzpY+9jTh1xBhZtsIKjrfxBtyq+MVLueJsO+q0cEisamBjMa8UCneac2tvIZJOF/q+Ny/JGEQePGIJac9dCyvcH4Bgzq/dX2Kx75372KGOHVmRrKfOVaAdd0tJTy3Y/QPoshpgV3q/BsAtt5cnJ/rhYLjJ5fevlUHOb8Q1n5gf1uIDceIhLDXUlOGYA2/cuOvgGb875g97SCxSK1gj332xR28Y+WvvjW3MzrU2IZ/FSBm3HfVLGAXkqNSdQkzS5//09/X/+gIu3cOumE8aTwZc6/PEpeWOpxMlBsFlEh4a4FEIEtf+1gaF44o8LTac8RJupmH/sX5xAEVrTVx1JuBpPl9Ivc39Qb1DeTBPbnl/dV8rbSA26hgbZH8n3pgx13fyqXFn3h9DD+/GoluHB+ahZd1Jowfp+644KwgJddp7TcJRiEBF2FyAEPVgpr1v3nDP715QSqJLXASC9GFQHwDmEpa5auuxjueaMPy7zbq9nohNsEEzvK2vec/MG8UXAIBagiCY64u/pb073lG/Iw06uNyeK4NaG0AFXPBpAkyESpb8vbWP1cseeGRnZXhzHivEDjZi0SvyXNCpBUKESWy7cPXEHueZ88jdYBpKiXP0RkxOIMB4RcJOAIOJVKyFTxIeWLxvzF7vgUBjAa+XMNGIFmN33C9+bC4rEx4QGEd4v3IeqGrrQDK2u+uE3NzNkAZ01ruyCG1ffNxHfVMtK40Pv3zmxkdY/YR7N4JSx6c3ILkinoc1YB1AQcVjqqEH0/sIExeAPW41F1smqYkFG8PLcFRwewODiTUAA7Hv4RMTp771QS/zSN8YQ6tjRy7IUWkf3pcgggE3ybMS+kHmjIFhDOA4BnEv0IqYgaO9YnSEJARMvEJ8zsMj/GAVixvySi8oieUS4TCSyN5hNBjFaHXFwVVi3UIjnwaBalhvrt+G6ayCrxFAN6D2sMqsJuvdIR/tQ0T2iWVjVZgjqApME6Ce7ga8q/SzeKH2dM9+s2vgTa3sDzfPGjVAsBVWGvfYm2uwpHw7yzMeHvQhdi7XGtYBpdooqxkg4z2ES4ckioOPfZZFwAfxEoACgSdSPR8evwska7H0PQPZuN73HkbJrQVRpm5i+VWxzNtYGSXw+NJeW4p3C5K85sXId9PYgvsfU8duuf/4FhhcxSIhY6HXa26dmL1OuXQCYexbxUh0Zc8bm4hhBwIUKwuJaQtkfzrYmwkyRPVXPkRo7RdXak8FktnyX/B5eQ4sF9+EF0yX5I0YjWyQJcPPJovNxxNaBj1b7wNfGKhs9CaMax/qkGQ82CUEMoaK0+LsbHCD8vcC8Vxu3OZdtnwZ430WhHhBdi9i28B1CF5w2/1C+nGLDvH9HjYEYggkVW4ez4ABVniL+o9AKWDCMTBsPMpHCwSInSv78VW4G95kCGlaK5BzYDx1xOp/BPbSpG+4WL54mjfwsNAxtguiAGRnAB0j5nkI9qAT4h67BZkw+UFkwrYgWtzHW3hB2Fhiv3jwefcPk64RevGik2f6JiDAs+IRMHwc/OkpVjgbT2J48plka/39vlzORa94ouBzgzLlAdhDIwpHPORVj9d5705QxRogF0u+gfSoL06V4OmBRQVh8ah8wS1ujKepNkDAnaElXC+LKoQybLg+iNeNFSRulqCU5phPdw0RH0AZIA7ZIxzhqlBimBQQwJ096iFc/IHjAOtrvnGGhSyqAUOocnqiD46N70IbYRJ75HdcBHZQsafG92MXu0U4dBIsAGJUUJNjZAyoD6IKFxvDwIr6T3JOzDLgR6VcUIxV3jd+UD1C3UqsUUpDAor9tfZoq9C/LvFRUHU8YOeH1RwECoysPjkQIMehB40A7lMTjrOshH0gABDjsB94CE+kL07We06CEquIpWEKgFuM3Oo9ru7eYKWgW0SUjfdlWzKkLOQUiV+48wcZ4qsFwMi/vALhhbcQgFjmJqEbF2sHwcAnkFM73gQW3JgNjfA2UBEcYAEB4P7lDbevQgsEpXW8EvNHER+wzRdLB2ky36WsAI1VZsi8LSfCqYAegc1XEzJBcm66yBZyBhcxtleqPwB/TG9/hFZulq1fW4wGixqwv7CqG6wm5EZCLSvuZ2ENK2RlBUZwsxASbsJR+tqDR/CP9rWB/szwc+6iqrwgjCvDQuD4GPESvPuNZnuxSEIdwsPwNHnXC3MsH8oAzon7DvYKlohc/R49tdSTOSvcSEbPooJRDEQFQsMg5r1CyEAc1XnBPs6WpSxf4v0DSvEtGT65y5GPBaBEwbBk4AygB+FrBjgxCbTCWF6+fhEqCRD8uatWR0AiAoDEFW4jAVNro6wWN4ZxhFrNHxHPcYPHKE4YwUxnQkF++BlSD3yPU8FWiT8YgY6Fks0ImnbzRE8AC9gqDA13YVci2w26YUe+7lLEgynwJ0KbAJIBMBTV13cyXoJ+G3W/WBGYOc+GgY0FmcBZ5W5xVLYYX+PfoPgjcYBM9JtvWAjNOwQMN6Hs8GNEyWcwmwAc0RvZiiaFr00toriT5b6GaREgfgyVD6uB+7MCCa1p7DQ6QyD2QdUEXy7sSUljhfWwtkgepHYy518NxEF+zB8L9yDKE0sgu0XxjHwDyWGf3NZcqf7JPcQTAZLYFjay+wZGEmSps/bJLEl4Uo/PXgHLzMKq1iNKqvZebI+dQSQjWtczP6jCToSsL9/zwpdgaEQhYjN7zH1B+xuShGDRoPCwVFSE6/+i/DNqnPVhcdCi/Q4qJV203xfxV4KBcUKdN2A7YeX557qA4iFBbB+GyqUqPA1ZRSxnlSGmTfAE/zqa9smT9biJU2w3VzWuQ/dg7yJeROcmUyYQa4LW+w33HrmBvCI4Ya/YF7i111Xd75zrOFsQukaFR8WG8yqU5/dU9gceiHbpgjXrBrUYpiK4PL4P2Xv2ha7MrfKsoWcYWfXSEAceDXq3+fUgORsqdS1oJwuGljhpjfKw/oVgk4wN8wJnCRooerhoaqjfQjgh6N39wAxrDJSxRphGjRW4WhBivp3VvtkMbB7bY1OudDegmaUZCokjW4CU8N54KH/tbnaQWFU/7gWCii7qfjNkLEn5IC/fhMBDtLbZFA2dDeAxE+QFkKnPztmkXQPOCT/oYyJL3+g5OCTONmNk97Eo9PEq30WQSFBdFFBeG9JVUzF7/+otqw6JHs8D8j7sHdxTi8CNYFufOFAXVBS9Fa/B06yFYGH7CSKItM0mGIPAXtwMgc+Gzo/XwkzQt/P9cJrHHYFHQDwIwtBBmD8014wVq1q+DPIC/xlwQevKguKj7qo8LiHPDBn8R5qMh30BUyPuCe8vzP9jcwP//AZ7HFCy8CsTCYvvJJAlEL6eKFxrYWW5U7BVz0Fa3ofZiRJXwfVgu+9NHP06kaawMs3UDmIHuootIL86a7Njx2HBcYJ+27dZ0SoRHfhpfq5784a409k1WX5FsOhphADCUCf4mfRjmb+xAewdAHRsQio/pbvEBTTsvHzBQCUfofPoFPh13IPd4DrrRmtWOP2GHJnCkNMnbvnj4gRs7OZDhsEorkkoyEQe1h+L/NAcgzdS2c5ZgOmXXQFLCHCoEnOfhdt8gGyJZyXeAXkRuLxSO7sibQ3ekokJYP2bmDv2CFRC32Jgu0Gf92QeO0scYT940ROQtC+8IlwQ7ELsZ+uUVRKuBRd7sRh3CI6V4XH35D2h3SIvEIEZQUsK/Hh2U8oQMGkNRAfrt456BJCpO4wBVvfBj+WULJ6C1HSRgEYMUVeHp915GfkrdDJet0IBqsENPs1yWHmnYQx90XOEmpgfrLOKebCL/CRuQAJAyJ7nEu3dM39XADgKGnerJ6sONiDZ8D0gHsyBmn0YZjnEMPMITa39Qfsw9RLvAo2Hhs9NONoPDJk42QhzC4aEhogCXURO/lFeeQe9BrA2GCCbiJQ4brorTwmQQRThRx0OhJHcXy2FoJQ/bubkV5HbBALgJNb81HyYyt6ZjcIYzUJgiKhx87C9XNxn0Lq5JgxpYQbQt/WaCWxyaKgADkFsuR9VKvIEr8UD7tgtcD5YDcD61QvBADj3PZTLS2UMTclPjnCabqryp7PaRsOUjLLj3rRKbZO4jGkQVoZ6LVtiRKOPAnRyGx16BFcZie2Bl58qWeaiFiExETRXMzHJyqEGkToEdnZmXKVBgbhZtAvqHArUfPg0C5GXpYGbg7BEQyD6SWD+04i1acBLlXeJEPOt+dzfRTwMCn9uFOfAaK0Ff+yrCAlSpIgkZSuiTkKwQskQqyH7nUgAJZrgCW4Xrhy7zoZRgXY8OB6Ok0BLIZhor6ehQg/jP2kPbgcWuM1bbZQd2PSg5yxiXQMn1mQt/KwuFE5UFAxy3IF4F+GZyLj7EOSPEF1wSLOLLZu25XnrcK331YiIyUS8wAsjZflA5jIe6A5RX7NnaW/Db+2D58R600RwKrOGS/qZto94P/FWVg3kWHNZ6XvMXn4CIMQN3QIVidGE+wucQ61YeOtMqfW3mZmHBj7PxRrgXQeuCZ/rLUhDQtl6HrhbtizpVhJ5TJOaFo4ogFG57ji0GTF5R5z7uo/eReht4ieRrgRiT9PPANOgIxZkE9EYLCdMYUPoD7CBe66sAaJjhQJ/vfBvouowY80yg6JmeyxwTMzLDAZuuXwt1BRQwih5MgzzxsBcHd4VFr+hfgDOUJ50H6J1JVrBFDqMzPIKeEEAzgmfT7ep7ApFRFmzgqjyUS18TmzwMoxHpNarVNOfQPZKTASToLqmunc01xPB5udrh2fDHhAh8HtUa7ZKAAO8cHBCIXIQE4ZJIasR7xL1ZsacaAFqvfXeTwMFXt6OJ8kRPhE/CK3ipeEIYaggI1SRm4WoYzFEPjSoJX8t6nvgF/h35RfgysPxbHj5Vv+wismyQILP2oGwDoyOxwLSPXmsCRvFghLXTFg4OpoQC1kfFq3LunmiDtFAVteKz7x6EdvPor2H9hE7UJNQtzeCDUktBEfDoePbn93wkgQaYr1EauJOycPiu1qUaFYuTE6mgHRN3ToW5Kzxj7CMGio/oDwC7kgPTBKZUofKMhEVuUb/zFXdYNGll7HVDdw6Qdac6E4f1HJZsuxW+qe1LRAYJIOTgcmwjcniAQ1T2YJvfldTKEGrUNIoh7iI0pH3TmIITMYcQW5cleXRJ0IEtuDmxBesiStUbNh6xAVNLIDprhJNMKPlZtMK3IkbZFWmUSpA2muIhfuFE8It4WLN9TSfmcxg7YuQYfIaAzgkXQ2N7tNwASlLEeZZiWKDT94/4LoXIWlaCJ5CZgWU076AnhfjRyxH0/32wkjzNnqaIBY7FNZtSsVa42u5BA3y8bSgyZvTPa24cEtXZMtlTsHdPqoMTcuaE5tQ7OjiDxqf4R48NkH14b0KSiSa1qrz1RUe3rpfVjk/gzBf4+s4lXmMk6+AH+FpkmzlixroJRwZKdhiK3f3NreNj7eNr1VW9yQFs0niXQ6JgGASo8F3NjFDwJZ7B/Sgsip4FY13mEPLb/89yXth1Ch3VL5OH3CjZ6nyjtsgUpBZX0UDziZ0QrgWCIl23dBJ5BG7gOFA/b7LPBIKFznSLXjDP59tymBaKQ4nMN3QLoAeO+rbrqLEGieTr9CWAdpms19XV4F2aOGLLw1CF2GULQq1oNWAtHetuAQNC4e3MhyABDCIZ0g+86NBcfxen1Kp3DVa/CoPsKnyByp5YyAS6mf0R6qxwL4najJDYKLye6PAQdyVdsnX6oYeYjUYCf0YeZrUOpHy5r6/ZhNFQa/AQ16v+kAJWCnM67UgNIgM6I5+YTgmr8EL9qKYuLNCi0PBiyAHkagLNPHkgN1J2WOYN6H2ZY/z0Qh5NyLGlT6kxAzRbOaIBOr9GeHSMo3Ak4JLieDvhQhum+1e53ZOJUa6LJrjFDitlemAjma/xpvhYJjGN1JGbWKBywaGYWYfmH/mxKEzwRifZD24v69Iw1gj7sqeid2jlINQdSxIRC6AGmyjbvgGWz/YKpQ5yEhkg8lnrMTGP5N4OaRrJatTpwbWplVNQO8FUjdGDNMPuv+8rRnbJICloTRZL8ivJQNIkooJUolBupVEInxHYo0Vs9jHJmZIVp4xGzt4YES6DJebCo532DyBWdvHQRy9jBW35RjwCtzi1RaSk9EU2jlnXlAB+BLfPZX4IFKz/8qiLW4OjnJbeAnCLxIOb5gQezeQhGwyiolNQvMQNkVZmEqQWILteP6Y9gdBFeCQAeHzNAhCveDSbMBuAAzMAbh6ThT4kKlgc4ZYY3P4F4vH4nyWazYyqCohLZRYGNSNr20rQz7pHOxqGyRPwiaOu7rtxOfXsuQ92kkGWJ7hdvn6xIT2tOai4LmqfQBNKzwtAbmPGVFdL44EBNUJOSM+YzRJSCP6Tct5XNlnBeciSLNhahdiwFQXgjVg9Pgn+A3uKGSfkzA3wZC5xTef0i8MIEImIDthmXZHtj0Q6XZBPkDZjUbDJXkzKMrsqDT8CsgFJIgkkKZ8ujMKnAhFiPkT3e8OsX0j4G8q96rAkAVGHxTXbhZLy4kE8GNztXyA9H/Q7ay7BbdNyDtpYvMdKfSy4Tr5Qrpxz1ggBkgUhzg2U56doNaer1hmQNmrsmq1wANTqESBFzHPMvBW0Ck8IV/QFvBvwQXN0T221BKv8Fs9tMdPPOtSbp6RdYLfT8zJsjnmUK1sQ9txiMuWHtN4HeRDmj5yGvic1wPCFEEBss36vvhxyIQw+XOEdrbP8jBOSryr7BoAH3qHQfVOeIEEIsW5YCI+Q3AN2I1Qz9raxnsaXSwoamumUKCHy4LxdxGesccNw4dJEFyrOXtuzryHKS5DGUt0Q0yxXdXCsMonjyJmEIqTdfsv2Tb05WW9HNQhONhItexWI/qXgTeBjywnoSyAMWYblKMQE2KxsjMDirhxu9DK4juxcHxvuwEtAGmYlCdiE58aVP3j+9MEYNnRaAbtnYQDC1rYJOFnsTNXAWD2LQMwIYOGJNQMdC/41GfAWLDc+EnzEeAhxwVJZeUxKUHQhr3ZUYDr4uoTCV2xnUa8Z5n5R7dkq+fgE/k1AQHTNTo2LvnMDyOyzmyJYhN7IPvvxY0Pncc0KJweLn0CF5yWsGVHiaIRn+BNAVDzqQPnJHqikPr4WM2a0E33hSKVKJgVRJbgVPDG0U3Cf4PYFWe3uGEuGeDV/9GCyTJPB5EgHVAky4HrukVwtGR4MRlbC3xD0MHUm4/PYtnv82rxpz6VMBIey9gCm+Xtb7PD9YKEE7LuEB4UGzZVTdwEQlxJ+b0bgYr3zFiDxdP5wLbMxZp/0Fh50RdPqwlvFCwVAKp4Ujb2Aco8Pmp1WejnKVvtE7sVE55T1gIvZrWKAcyz9bfJ6YtXQtlMetzwdbbLb+YzliGLOb3I+3EFtB1v9KEZX3PraGQCMVrf4t+All/oBTzc1inW8vd5nGcXjB+6cvzB3MxakB1Y5a3IP5nU04YDNwPcQFcb4hCJ2dQRSIe3Q36Q9sHSY9Xmt6LJ/Bhhk+0HgjZSGR6CgOP6od2G5rtc4TAhfJWoRpBWzb6niBlVtSZn0a8rf+YRn9v+EUAo2WTzst4ENmTWwH6Ja7a6wt9XjZi9BYVxuN1WT0fYECbOi+w1Qs12VaA9H1zxyUgva/wmV6+T0Mq23qi/5iFWCwNDtb82ZdoLYdPcRtAjZIrJutc8JztcrFRvYK4lYASqSFwAvgnrnfCLGcBOnmxKJdsu8M1h89iyzBXjr5prFYll/pq4j6hJz7XQq3b8sIaYvnUfwlnCcmOzHw5R19uvQ/ML5YYkbejaMItIRH2+2j4CDnt+2ZuNNBG412kWs2OlWBxf9YUU4WfGhxtc+uA+n+0yJzk+sc6ZEWwL5fatC7qMChqJSMELM3sR0ZpQ/4ewoXcHWTcsvPJ+D3trs6/MBRZqECcs2ve7IOwsXVPeZSlct6EgQUBkDnNEAWEe1Q5hMg+0K8QpsYEo4Lc0qK5FSdjIY3OAhoq+FCq2QhVgem1Um2iYJ+bjN8Dmd+PzMLJs3RqVQZRnF8uGPqOyIVWsNQiM7MFpFtbIbmabLtYiBrLZ0VKOBVCD9F3Y9+/kD4gHc9j189QEHhH0sVh7bsawmRPwSuV+bL4pxMDk3sNfC4TMFjM77GBeE+652dQ47Ol9wgXC5PmjhxZqng9C6DoSgIzRLHkzmk1CiA0TD8AAME8tzVQYyEkYFWqNOg7oqJRn2EeTWw59bwzmg8BvAIkgZu/jzI+EL+3PnkxW0BT1x+bCwy4YD7LOOud3Zzuns8nvG6RukR2DfkMu0BIBw29qf5Qu+GB57YTeekooa12NuzclQowd1osye9xeTBiExOq3efuyTDRbu9cEbmhif2HFvGdNmgkS4r4QGBidivk5jVuEsI0Y/6C/tfeYgXwtg/8i4WCDK+9HhCBYfXZrwBz5C1y8us0thP51t/CYFG+mRbofjVMEgm7en22A95wojx5k5mACtCl121BBLbbkMnUNVwKC2VS7wuxdJVgGdhnVBrgTcMzf7K1Mi/YFoGaGrPKTEVdAY3V7/QqAKnG6vcD3oP468CqLlK/AFhsrDVZgBcqjHicvtMUyItiJWmLDHhfGip8jSKcgkW2RBWys4xR7N5A6o7zm9lF57GFDoN3Zhb4hENty6UMYSM3YP8e0RJ/ynewtDA7cBB0QdvL+aUVmUQmbDZmJZAdOTt202+eIrGyp7gsaHfu9zYcuteONeiCkvy/830G4qG+wDBAzjPnkAtnkUZQLN7uUFui/OvxoglDigY8Am8pnauIkK6MxJaVmu7aZ4Pid4i4XffR47uy1M7GfPNq1A6tnPz4oBlXE9n4ZcMhqTIGYOddhXCCt02f29aIgQa7T+At9f6B8oOuV+RYE7xMT0ElcsSHIFtl4ulkCsQIeeuMwePRIwNttlysY253/KKawshLv8srQliWMmWHFEJHVzzZNH++J4aOqAyIDLx4IodwJske92LmQLFEVsGdftcGDozgGefhCbbbsoSumFVYe0ZEUpyOI6mgXbfhdw9rGtHEKvdAyaL8GrPaUoufadgNsWN4idKjbkAT4HyacFfsRqLjNkxYIH2aFJz+n4bPiN9z+hdvDKyFkwNJeCPJkHJ7YEW704aSF7edpCC9P6AK6HRx2UMpGMCMiJ7QiXu2z5bfbFbe1sFveiREAcLxqttr6UXYZ3frqKQGeZlEy2j1o0mn+vN92K/jqsjq4zkwguFhYGOG+LVB7wW2ssmH8ewOHUf/LFgoa5F3VizPmi60lRkD+Sj83u4Ea97+iWbacpKXTAGzvV5sQtmXTJhaoQGZf2Foz1qhs9Qak40HM8yjcdR1m9iV2FrlUxQuga2gYwu24eW5COpEbGIqHqphTTtcLnX/sy8svZCjALILpG3sL/kq3oCiJdTAoKBtGzJrz6qm4jkhAoAGIHZeJuNeiaX+mefmXsIqvzK8dt2FREakFPQWrQLut+kCIobHpl0G1RlDqDavF5A1cYGCMp393f0NIkxF2c/rrwZrg+likxT+Ekok9jMKKKEE6qitvENJOKVY0wV1lR7w2VALva2IzqCM7PAFcsZn6hXsSExAV3W7aU6xD+kZc9LIcXWoqxlSiHxYcibnE49NJB/2Y+s503Ii7M/ln+uE0Q80KVbRWtNvoV8ea+NaKesK5tih/OlNOn4LM8ysTsZTtyTVc2YpBlIgoaFRhNm4Q/594WdTDCUFeACluVpO7Yzt4FvPPSN2ypPJEx7ukhptilynbAQpPQ5fzu0/4EZj+hLoAklFsYfws3yqOAInHjCVbe7N58CtnNlx+W5es/R0F3MzEI5Mux3EeqInFJhjMV152HXfqzg/hbWMsUACvr+0R/8oxCcK/bSIrPFvHyatdaIWpcWEkuIPTMSYEt2TlJvKWYou/vWkLNdZsAfv4oLgrUjF4i/sYP8tiSJ0SMZfITm1tbsGsUyKWQAARCCOv5PQBxARFAmScmjmUFXUEcpbguMR1e98/K0VXy+9ljncz780+4mv9ZgUJoH98a1p1Wwk5bVEUavNYRuiXHUPFTOZpz7EMm4CvvhDwr30VycwIK9dhhsRWnPFBSUQD+bNrsKP+fne9L3QIxh0sAuGpCbhsiMMM+LRTqLrNIHVosl3H2NH9zKqM3WDItCo8LN5Fy2Kx1Qc7Kxb3sIoBoPEoOA7M2CmCvYY98vWglWM9jT8cyhV/bJxCap8ky7BXSNtfrbkTm7WG/kHvQDJT2S+aErFqk9h67CYwq9FfB3gctLHqPokiSc6JDS4Hy4LzOXjzSR4hNG5dBQXMXYMQw7akVItsFQ79SkUgCwjYd163pJ61ZyvmgilAr5otG3J+83hLbskdbZtqWXQ++dpNGCFGj2LC2Tc0/aVGAJsty5taU/D1bmd1+LIJ15gPe8M0FibptBmBkIhmTsy7tZEFahuvbI2wnG4jPo2zJCQ7OEHMt6cNQyWQJJUi9BM+lo/0WxaQjoqb0X6f2K4DK14Khh2IyYHtJlITTJGcbAEkBw+Oy2ZW01PFXorv9Bjz2ChPCJEDE5e5YWweUcvufpFwm9p+TPU/JkRw3u2+z8dWDQIdlMso/jgVBbK8vRxq12yGh6zx7GD7UxxXvWt6f31O8H92MAOctjNzU2baUOuRZT4teng2jOPUNa5uA+GE4CngIhCB8QPY8dc2ePTXE7RHluB1PmPKxlx6CMpjmQIPKPe8rFKaEySooSuh4wgbKTMMGhGyHF4eBrSE8Mv9NleNvh8pB8I1fNc2uQ0hvT7bn0zz2MQC+8KcAQig237/SDxQ83MFdrO+NsDY3Q6u4ahwmmdhjMn+0QuwyY6OwM7uAKZ/pwcfnVhhnznvh+AQFtc1QVmcILXWB33IkNjoTIDDQ/Bs0MVGd4dCjSpQZaADhuHoXnlAEJMZ9j6ZD4TAF8uzd0/TMgWk/HsIl2M5eZCL98SSnCY/C1osE7cFFGzAfp8idvywq6nqk9xhM8FWaYfhapn2h19EfKKnfTth1lPU7nYPEBGJmAs2ydKW8HYIKE6En4fpq9S+Y4PrbAsYakeUr8w2PQJCcaN3ZbhJUAmCHMSjW+/T3dBH0Vmoym2bHutEDrsXiO7t4nK237KrLwSJiJ6Mt9uahjzcDjQ8F9g2+sJkIJZOHH75NBMHIcPekX3hQJhBXfbS32YmA4EmozlxPaDTB2ddcsRJrXE9D6yL95EFgbSzdt+cxbjYAIdph13yxKjWYeXLPDpgSOTZsIn4ZvP11QJyhhLaF4J/JJNedvx1hFq/JJpofNQ3VIznDFCp2R0+RAREG/CQlkthhhk2CDhq5deamm5iqaWsChdaV8TjHSpI0a4Km0cqt8Eb2Mdmh+6Y4iYrsMwVdFuWMRSIT9lYDYwx/0aqbNm7NRje18L/g1e0M8MBBPYT+49O4ZkCLlujJzSEoSDcSP7ngXIhK+s1pxkRGzCAonyUMyqZnXvu0/6jxaCpI4+OfxPZsln079WpAVabSjCFzh2BXkBFd5Uh9YDc+52BUFkrugr+noFAHqITf7pJ1JsYP2oixhbbEmcw23YFQ6HnUvBwHf/HAmEuMN5hHzug+p2ch7MEtZf8oYyz8zeQfOsKr7/gHfn6HY1SuvUkArbzUyxTsdBsLhxCY8Y2sFAYNbCXYMFxnEZbWD+eYLY0VzAbau7U35ZBNfuXgw05AS0f21rNEl7bsHKBVszbBLYMVRsDUOimgG57CK9iQR+FYZlKPh9RB8mIi07OZw7UcoBGOmt18ufDtzsO3teTDM62U3Cb1xzdsZhp8bYni5RgpB1TkCDWkSuGFC3IosbhPphReoE1/Pxb2MFz2/kKkbkkc8uTb2BD5kHC6SAp5vUDOqWaFkJ22thsO8OyNylDjh3rhv3DwIrNL4jj+RsA3ARg1BPPcFr3zB8FWy1A8xUcC/2QiB8IbJzO7P9dq25sv7ZtcJeNHGVGrARtC57bsW5Ty8Qo4dZj88n02QbUx7BRyXZ64NWsY7KJ194CyOe1iHXDvllE5hljBNVzIz50k4HEGAMGYPbZZcQKQGQkHVmuW0oGux3kwLL3iWeOVahYYfev+vx5RgQmItc9lfQjjerpQwAPcQ7rbVNctk0trXthR8ky0fjTNgC5VtPytFBeeBsWPtQxEDBWIifzgXmZzrE3AzNDNcBM67pgdx5PYvatumiObKHQzLlBQuA6wA10HvEMPomO8CvzZGZarFx1eAnIUC9rKkR2O/ZGeypci0geHdO3/jFARvv8xxmqBkaSQYzo4cjbkZyhmpJP6wpEAESZXZng2Vgsi6Xc1p1O7J45AJ7tig+i3JKtIQ/fbZr0HeYlkJQV/MrmRlJ3nB4b9BHF9TNGK8pCBV7pfTbd4VT8uA/mOVfpURbQtSL67vRe8hbQBcjHDE+6NjvqzsKhE4ZNvE3HgLCDqDzqJ4Ae0odQgbuEwbIQYC8u+1ocAHsJZ9CoAFWshnWHoke+U7aP0cYmYBV4yxZycH2nyxBkjZBnleByFERTxvAsVcV2WgHsj4uPreLfYQyWh5/P4qL14Zx2AG/gT7BMczvYwQUPQo1gLIM/twdPAPiqYQL+iJYnc7a1oCtL9k0859ueHBd03V4e2y729pAgHunNpWzboaDpi0iMjRFEg1PgM58meGjSvu2AwN8d6kIR9O/M+XmiRn4+8Gi9lvOHhW4MAY6RuDdHDh3whRTI47VzRABvYeHD4RW0nFUve8TrxzunKzyKEOJruM/6ZctewDFIwk1hKuwvcL2s+NoPyfZD3dCHRYEfo2lLW2agNclZV7O0GLz+dBQ2jIYr7GKRNw5HZLGbpLY3K2SnY5FpWvXOws9zZZvRJKPTofvVPeaoexgG9vRKdRxRm042mLTZwwSGmYoJbprFWCY6rYpi4vb/nbnckM+AIVh+13kK632AYJ+JaAs8EAc4mMwvmEvrUJwDAqbcL4zR9MR2wLPb4+1kzMkSt2qlrC3dG3sBAgjd0zKGM+ADSw7Npq/kuNm+Tn0DcX2bz3VABy2NhkST4vMOs6bGnb7t8Duoql2E9XQXs4FoPigY4vRJF+4QDV0IGwTqsMYRYRiockJcmubTSpOtoGCGwtQt/swVZIzJEyVwBrjKpbg4QxCOoQ3Hxj3RCKoFc5iOjZ7UcnhYoqoy74fa2ZHq0AX8T6sBo6512vODh2Cw5LXDG5uxGkrL/nbl6CO+W1qUgZRiadk5GhVEGBbi2p3DZb2rnX4wZ9tYjjHmO19j8ilU9DMBiRXC4XYMD57oqFX1DJ+bsPzYwU2QvCzFg0nAfXfqKGZesQwM70MI3vLo7PQQK0GUq5pqtRb4q7ch5tj6tHK/AlorsqGh3nY9ONB+Jn6L7QCnxOmABVGmOUILCYxO7Nz28cBpEYrgCi4fdFqzip0A+948UMzh1He+mc54ImR0O9RiN8wHuG+nwzAETGE5brinp9Q8L2wExtTPlBGhViaENoLDmSBDdgzb2bpng92i2m9GgpAQPfdBCEV2dhhKudCOeJVKBnJomxdILdxO/M3DJrby4STCMwQaLgYP7RkzDk55AGU2iDkpHvvJkzhqiTZluV/nKjy2jC0IpvUtPbcP91oW7DxO6Zn3YUeO2dgedrPkl32Wjq0GUxuPowA2DxHb7/y+HisGeYVZPtArluZxGQ4aQJMLGpbH4g2wpevnjzblHrnmRC1L+NjDz7ttC6jmJifMZTlhhEy3v9r2+HPYhvNFCfZ7YT4w8WrZJJx288IiEtKtgTwE9S+am7UKeBI9o9g5V/12PgPRCvcZDC/XIwVqDnLDQ+o8kr97PMCMmGWFx0yPo3hkENxmzM5DRRZyeAgdMP0+TrpNB+HATvw9NygxzmQf94cKRsF1FfI8vYb22iaooGdNRUfQ5WqOjtgUO0H8a0RHYOVqQPRKjtCDy+iRzQK9ODBh0ioD/CzC2p+0HhtAIQDoUs/JIU7ZRu9AJaoh/vpuC/grr122ry5L6Z4W8aE1bg/y4POeA5GhC/n4Ri2OahBT33WljpSLDcUh1YRjZeBBrIBB82bYHD5Szojn4mkR6BCKxwcyy/HZpQm4z3Tx7VYH3vwRuq3Bjs+RsnKmwb+J+IpmxNqvQEgcnuhez4KCLQwPfQOe0ATv9Xk4lb1C+Etjm5ocnN3LRQHs7KkZDnDJc4E+BDSoj0CqBh/Q6LS2Suuu6EgS20wkwsJtBYWoq1mzotfS8LRf1Vu9tZvhOQ8NiW4Vw/4n2/nfFa7HwhtapOUzSU80Sj8x1IXyu5yeoJhr2M4vbuc2QDpJP+8LG3o8+pDVu77dT19iTrkBpZ5CqHlLMeArnnH3NAJSW56Lx3WsLXU7rSyY3p862DOc6jWUkjzvQpIX56gyDrqQfWZUbieNPe8FGq7uZac8daHfgKuT/a454fQMnkCh8qm7gqxQKvQppAGPKv2pJ4du+Igi3ujcM9iZidKRNQvxg50R/zrPHK8q9f/Fgtd1IzwJT0/qJ7HGd0fPAJTDdBFFzcrDv9JMxbDnrIHz89qnecX8IjEN/3Ve2PTQPKEyQsqnLGH115xCl7qWTzf65UvKOFNsb7pOv0EBlbENEM0TFKTOWrWeDFGOyeYtXntvIonnrSGBHrCbR4voeQL2K6t90ZPFcrw90xZ9HMvG+dQ2xVYhSwAKLaglPnzK7ejvzzlGKGpzCoCdvjwFB+/18Au7SlmYbD+b1m0nDuFkdTw0m0By7H13oA5O7ygjaH2GJLnDftUn3EC1/bCW1K3Tw/7AtHL/DgLz5C40PLj6oUl8JmOAMxhoFc+geT4M8HREEcudFAPm67R9NJ4Rp2xqkh3LOUKf4ERTlLUAQ2Cfw/Hj8C7ZPWqmvBd0y8y2HXf3yVB7cph9xQMMDyVx3YLK3c2xT4QqAYgICtA/jrNw70XQJNL+xpw92wei78kzHslyiEmxxtntfEtxqiKDE2YecrZytvuSeGEfn9PMIVzNZh3bw1RJvzJLNTUMcSme4WNJgaAKmN4Bh3drW6/y3+mgVRNKbcRC02aVA0ZGALEBGaxaT/LEw2qS6ddfbzENUWnOo372uVoKd/oYdVlRkQ3hB9neSCPPp5E74lIOz6DQbDTGxh2iikAf66Oi9UgoDwxj0TAWItFy21q4IOb5KRsC8HTTboTA18ydh1c5lQt5MyxjbIu9L3ZU2oEa7NOOJ0LxxrmNCzkBqPBieDnfcDtX+thk5MIjh2xaZPn5N8GpmukjYiZ7A17rLegzfFDC7rlS9fSZOt92EjFCpJUYIojnWHXz0B6vctvNhmQjlsPOsG7rKSDClNFdNqo+mYi12y6niUMua6cJ1qC1NsJcribzzKJNUWWNBzk192kI9SSTfUMigs1njqclUWZaZK0w4eFwiBU0C6MRl7IA6Ak7BbDidp9gRj84LuKpIsP2/ENmtbsa7aOATZzSQU1Wrst9CtyADl7xwM2DmT8IkNN8L7zXugA2fREZPdTm4z6HRzsRpPptIiwn6wbDeQTCpV7vSLx9XgN2WzwtpqsMfECkHsB2o37OIXwDi+6eNdXscca+kiN4rEmHHGTn78sZt7dfCk2OL7buQZswBe4I5QNRQX9NwsWbm3MBiHpHELJ9Jiy2DTzT4TdL5VvDhy+eo+tA0lrD58kwV7j9Gsg82dD5nSI+tAgiAcqgOHM+fWgsqEPXr33kov9zTw8bRSLZnPR94UqiAXb2OIDzttNN5MyeEtNjEaBfOIAdWzthrPeZ+Nk7e/SFLYyrmeN4o8cWQY5eSxndqiv8r8GNje3diSg+PcKwpcTzgOBIt3U8Uy3wuvkrrwNKOG1M8wxyLWEpTh27F22/2g9VF89HCPPwmWnNpVngIWx8vwNz2BjEdNys0ZIaoF/hNI6KL0RfPeOUdi7gJY1AYSh+HXu2W31CE4F7tjnysB/uIzm8nmGGvVq18TgRJ2qR7yPgZuedPtHbBisM6Z6OvpnW24pJx9hdkkpkC+e8Wgt3zlxP+50wH0yGawvA1c4G2+h/4xJE2mkPG+7UPcTD9rdImIM3XTyqFvjGx1MFpX81PFasi6d6Jg9HW/ZW4WXoeni4DQdlBrc8W9Jiy7ihcdnOkx5CvP0KLLXHcG080WMeYL5FHy5n/scjfNI72S7oznuIIWoQdI8VoUTIvh3qg908Z2g4nyPf8hdBjZlNAhAylwcULI9y4/ppeXTk7ZmWtqT17bGw4/LEleRsYNZ9CY8eKtlB0eWxV57R4fkf1dNerbHDHoFo2AY+LTFQvb+2Y15gHdhphrYGbeJXvoKFLvhKAWht/y8exHDDsCvhEIicv3oWimt7HKVZkyviC6VmtggWlz3/Bxu574LvOYLouT8oZA9wwUleK9fhNJdhYJY1T4bD9uoLNfueQ17fPgeUlVgzneYLzsawRXZlzTtaRsL3kBPbI1+wA+dtH6tQ4BwR7MLW7+ooKYYHV3GQeHo60g7OBpxT5mIdHvdk1wB4f7t+NvkQnG0F/Zxd/fLluSIoQxvxDp44VWo3OQ6IiRIA0APAlAO23dNvYDvAMVZhZTSpawBiXnax/MOa49t9kWeI8nrESfE4yd/ZZywWl/3ryBv+bRSHiBYH4FITbFCQrC0uaT/VC3EylewBwCaF+L08KsDjOYZHxBCjiL3BkUL8A6hdSDJisewrXo+SA46F3pd4srGr+k0fDJ9wzAMWNEZsMPRkF7szN2bteR77dAKhAv2FOvLAr+25POfcmEH4xgfa2cWmxYwX53D25BF6H0vTuMDRBXB1O5c8Tw7wb93TpfB+Xd+UwyLww3CI42ip5QGx3irrXR8lVPcQCd4ZbrFuODuoFIiDOC34Zz9NgSHuWZ6TNCImjfscdGFz1LRxoBTPpXRsHHAd6LnbI2cfuAXwE3q5PPUGmdQ8AfS0BK0XlZhDG8UsUTHiQTLRlFBFRBJPZ+9t8ODNL/7RlanXC9pt+jgQXp2ctEppgjaXbIaHWGDZHZrcZMIpvJZppxFg2I8RP9guEaezayyCRe3b4x8B5197K8AKjRjJx9Kx/pxQ5pkjntJbfzVCQHb09222Pl6oM+hbJrx4+ozVXYlPtLyK6IFjN4+O+Ez7NHO8xLYx7fA5cjn9Hg4jvfABpW5o09Oltymx7RkRHqQzHFNN3zkYgEfG6j1J1B7j5kypLUAEp+wcQkFmCfjhJd57pqAz/J+pfPYjQC234zeWcYiQX3j/ojvJrI1teNnjvqdn1W/PKmKJfpU/iDE60dEwbOIcg9XOcXxmYOPw1CMuzn83wGuLaIn32o/1ucvOrO7YolM9kC3WWvd/KzZUPR7KagoQAEU8o+QTxrQ+j4BIt2XFaJ0UOL6kywn3hVlYb8dt5KovAREqPm78xgnLai43eeQZ0kCK7iF+ASRzEn17giDgb+dUhhSBWG3cZ2j7E7dTBd08dxq78aC3cxYynyzOdLGvqxFVzrCo5zFfy/MrADCoC0Hm8+Blgv/G4TfSbANoxfPP5FesPQAJ0BTR8S6ndoQGIgCBkGF8Hr1nWx3UXFVa/I50BgpDirfdw78DZkGXwWeWBMMTsxpEJtkr04Gwi+97z1Q5Wjg5Hb49Ss7KnD0wcNblhM3ho/M0US9HMqZjDedcZ6sf8L37Ytn5HfgH+hDt1up0lmfqFTwYi8rKwE7YJXOL31oeLN9M3apm6zmkmmh5fWfQ7LFV0i7RXxOfp7J7XgqffxwAG7V56Bdm4zhNqY7FEmT2+qXLCLkvLsLK1vx5XqXN2f7EDkgI8YAPoqedWr0MaOsNuUsOAW7PZLA3zzLwZn9MxrNG1dqgyaWd31JPP64nPVoYRyV8Hi+cbLI68cSjEYIduHYYP9v2vFel1S5bdX9RJyOb/wo5/xB6WH3bffGcBsd1XgqaQdCFIwUslZCFo77tKpALz/bmwS2lStH3OcTHPqHp4Byx5W4YfA8OAFTEZREs/nTonaysQ6fnCEvc17Slx4PeHkag6Lu5ic+cMnvf4DJ9pjm1vvh6mgxRxFakosPNO6zrO6P/BEwbARzRgPudMypvpwzj96IBqydaTVwLFD5HX58cGG437fmB4qLbL5uqAScRAst4WGmleTkpd7OAnl3tPE841QjY0hoKenvIt4mIPnAx+2rT8AjQauOF/MofEcA3FTvhrGdKbNTuuVrVctbvz9GPtnV93UPUyof5tus2O/CtvxqWCey3ZYVuZ3L1AM1yzoJgjz6w3V4ZhHc/HdfW+dc5DIJFuJ7k2VC20YIZ5T5T656jjB4rwTMYPEbdQ8I9gMV++McuotI+3s8ZUDt3rfZcp0a7PYgKrWc1d55+BIJv8/hUiyrpQQnb4TA8wA648KfsvJ7E5nGKnrKMnLwsPyQIAN9VPQ9gQaMwJKdATUXgYPPzzM9U7PxEfr9x2ELiEbR4ehgn5fEoRcPyZ01MgRa7Y7FQ0Z72nzyg4Zz6ku1/32f8Z52xK4+97/blm6KM/siEDox0i73wGkexPeSieZx/MUnMI8RsRwV0enid7XkckAdo8GlG96dZpHPC03udEsfuHhTBPYei0LYP6fH0UacLPhiJB95Mj/n0KNWPQOcPkmEr3s+kHFBWxuXYoyeI2B+fnzM05aiexBXe7PMKCGbEEWY3oa4q/dLphSu2CA/buDFIO66N1eXPyAQ3MjzkAeqrbLYD4mXpHw860Oks6a6HyIZxamgmM7vh6EYD+zMhbFLNDhu/RYKLdVjN1ervcQpgjydqZTvl7PD21GRIpAPm/jyIz+Ec1LtftmPADumnebjpwBdyc8T5zIk41ugAl2HspPOcJlZ7vmpLj9u+IE/5PT9jaThFYGk8eWRG8qfsbFMOyMcsf2OFOrcGkpidskvJ8YAytuHtuWydTNGKuymn79woKgje6k/TgDCM5Ek8CxRf29BV6jLli2Lx3L5R5W+5hMvmaY/UsmTlADYo+HbCiv+xr+9t7XT+Trxkz/4NjP/6+/qXT1gxIbA4rWM5BZU9T1fY73h6jy4WEz2/w2PM98kIVk+B8LApoG4sYonMwVrVaqCWlTpng+G8p2XTgeMNsDkjbkc3RmEHGasCxblHvjyQIdu0h4448288wGvlpx7tQshfzgujhHo7vYyo9hd6MD6HjOxYeYMn4V/yQSxw2tLrmDDycXgCHFKFK3munafFWacqHpO2gz/g4fWHPKBMgoPwhCTA9LptPDy9QKc3qNo8ivjtdbUTB6b5i88jW8Y09QGUT1PC0dQ2Lu6REITlhqaFdgqQBBz7XkY+J6yfk0hV16h5zCllbpCwNT4DkEUej84zJQ0sHynmGVHnpLxz3NnwpFHPNHkfU7knIWavD/yVJSjWO+rnj6d4Pjj4fg01IB/O+F7FH1nS8klY2zvqaTuO6Cw22HSxWInnfsBxtV8ZGjkAaVfaQu0zLP6DeNdpWn/s72NXHIOcIddTNhjTZNzT+WCfLr4zg2Xlee0ZPSPBASM9+4UgXIBHciphO42wNQoDwznntj2egvkOjx4iUJpFes+PcQl3O7PtKflDA2xla93Dpgi+I6CPBib1oVmelGT80YPhnC+Lv0ExxHYFvD2gi8CTZdOP86W/ItoFyBJdoeg29Xo+0vZHkfRvORLogXLN4Te2xVOqnynXOz+dpAcr7gbkZI9QujykyWJINHPPgvP7JBRZp3Nwc07np4GZ2rPThXBePWDi8bgy+4h7PV0X8QrhNJMQFs38AkWgh6dbeNeP542j+kz4Ovls6t/zKwVx8dqzEb1BaPK6iGool9/ZpNZVbI21v8yDvD0TL4BnBBJgGfbpYWOOagxkEutXPs+i96QTAqRty3JWb5ln9mS/4sjZ9GcflOjUPNoje2KlzZDNjldZ8X7wgE68huC9vXoOu2dWgHbOIuFvpznQWtHtj1bxLECPZLFy3u0zbEVRcIOdWE05x7S0+vtpHpCPPwfA//vP9Qjft/z5c/8HEg43AJXWwg8AAAGEaUNDUElDQyBwcm9maWxlAAB4nH2RPUjDQBzFX9NKpVQc2kHEIUN1siAq0lGrUIQKoVZo1cHk0i9o0pKkuDgKrgUHPxarDi7Oujq4CoLgB4ijk5Oii5T4v6TQIsaD4368u/e4ewcIrSrTzMAEoOmWkUklxVx+VQy+IoQAIkhAlJlZn5OkNDzH1z18fL2L8yzvc3+OAbVgMsAnEs+yumERbxDPbFp1zvvEUVaWVeJz4nGDLkj8yHXF5TfOJYcFnhk1spl54iixWOphpYdZ2dCIp4ljqqZTvpBzWeW8xVmrNljnnvyF4YK+ssx1miNIYRFLkCBCQQMVVGEhTqtOiokM7Sc9/MOOXyKXQq4KGDkWUIMG2fGD/8Hvbs3i1KSbFE4CfS+2/TEKBHeBdtO2v49tu30C+J+BK73rr7WAxCfpza4WOwIGt4GL666m7AGXO8DQU102ZEfy0xSKReD9jL4pD0RugdCa21tnH6cPQJa6St8AB4fAWImy1z3e3d/b279nOv39AJ1mcriUxFCtAAANemlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNC40LjAtRXhpdjIiPgogPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICB4bWxuczpzdEV2dD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlRXZlbnQjIgogICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICAgeG1sbnM6R0lNUD0iaHR0cDovL3d3dy5naW1wLm9yZy94bXAvIgogICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iCiAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iCiAgIHhtcE1NOkRvY3VtZW50SUQ9ImdpbXA6ZG9jaWQ6Z2ltcDpmMTY0ZjEzNy02MjQyLTRlYjYtOWI1ZS1kNDA0ZmQyNGUxY2MiCiAgIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MWMxYzMwZjMtMTFkMi00N2FmLTg5MjItZGNjNWFhNDZiZjMwIgogICB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6ZjNkNzc1NDgtYTk4OS00MTAzLTk0M2UtNDRmZTJmYWUxNDg5IgogICBkYzpGb3JtYXQ9ImltYWdlL3BuZyIKICAgR0lNUDpBUEk9IjIuMCIKICAgR0lNUDpQbGF0Zm9ybT0iTWFjIE9TIgogICBHSU1QOlRpbWVTdGFtcD0iMTY2NDkxMzk2MjQ2NzEyNSIKICAgR0lNUDpWZXJzaW9uPSIyLjEwLjMyIgogICB0aWZmOk9yaWVudGF0aW9uPSIxIgogICB4bXA6Q3JlYXRvclRvb2w9IkdJTVAgMi4xMCIKICAgeG1wOk1ldGFkYXRhRGF0ZT0iMjAyMjoxMDowNFQxNjowNjowMS0wNDowMCIKICAgeG1wOk1vZGlmeURhdGU9IjIwMjI6MTA6MDRUMTY6MDY6MDEtMDQ6MDAiPgogICA8eG1wTU06SGlzdG9yeT4KICAgIDxyZGY6U2VxPgogICAgIDxyZGY6bGkKICAgICAgc3RFdnQ6YWN0aW9uPSJzYXZlZCIKICAgICAgc3RFdnQ6Y2hhbmdlZD0iLyIKICAgICAgc3RFdnQ6aW5zdGFuY2VJRD0ieG1wLmlpZDpmNDgwMmViNC1iNjIwLTQyMDgtYWE2YS02MDRiYTczZDU1MWEiCiAgICAgIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkdpbXAgMi4xMCAoTWFjIE9TKSIKICAgICAgc3RFdnQ6d2hlbj0iMjAyMi0xMC0wNFQxNjowNjowMi0wNDowMCIvPgogICAgPC9yZGY6U2VxPgogICA8L3htcE1NOkhpc3Rvcnk+CiAgPC9yZGY6RGVzY3JpcHRpb24+CiA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz5aLnNOAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5goEFAYCamAQzwAAIABJREFUeNrUu2mwpuld3ve7l2d/3vWc9+yn+3T36e7pWTUzWgkSEhL2gFjCEltsBsohIUUwCTblclJlG28kBXYsHFFQTkwBBgscsQkYKSAJzWgbzSapZ6b36T69nf28+/us933nwxFUUSHEFbM475fn0/s8dV/1X67//7puwV/S7/rWPQFu0Vn7hHPuEWvdWVubDTeeLL/2kz8x3/z0J9O1ngqsyOicWC5Elk+s5x/MRtPt/Z3Jrf6euOYF3sXh2QdeOvmT/2z3rW99k/vLOIf+i/zY6zdup87xHid5ylnzLufcprNI4RwYiy0rbv/+R4hfuETqOUqT0+pEaKXiGhkrYRck1YNaQ6ulqYyjzEtrRpPrL77wxU8orT+ilfr9hx95YPIXdSbx5/2BS5/9rLJ+9DU6Tr5HSPVeIUTD4vjDcHEWnLWYumZ84wZ7f/8fspTdw/MkOrR0Fruky+uM7t4niBT5dIfJRFKWAf39CbtDjfze72DzO78d7WmUVmOlxO8Iyc8rpX7v/Pnz5s/zfPLP68WfPt1rfGpt+YeHv/LjV8dffOHpejJ5n6nrhqlqbG3AWFxlcHVNXVbUkykHv/xLNMf7RL5HnIDnO5ydIj2P8WSAHyV4foLWFt/LCHzL0oLA/P6nGd29T1VXVHXZqOvqfdaYp+u6vnrp0uUfvvTapcb/byLw1l9ZTqzhB4f71d8RwuvpuXkOru+i3v4e4m/4zwlPnUKECfaPQhCq0rL/iY9jf/FXaRdbBFFFFEiiWOPFHt78ea596Uusr88ReI7ZbMBsUGKqmHGec+cIivd8HQ/8V38TGXpoJZBSglbHT+S+NfykNOUHHn7iDdM/y/OqP6sX7X/jpvjRR9e+3U+iX6vLybchZKIDQTWe4AuLf+918o/8NuP9I7z5FUgaWGuxlaE+OmL3Az/NXNYn0iVxCEoq4jRBJQllXXH73gHdVBF1lqHIKPISayx1abG5pbi9jzx3jmBxDiFACAEOsA5rTUKZf83wysXvfOqVZ3Z/oOm/+guD4j+dFL7z3hOn1NzK74oy++WgtXwybKR4gUR7DikdUUOAtjQaguQzT3P49/42g498GDOaYPOS7c99lng0Q/sKHUZIAdqTlGZG2JxHVhk3pxlGaKSvMOR4gQNZoaWj19YscsTR009jcoOpHaY2mLrC5AXZzl1u//qHuPx3/8eTQb/8Zd/ndz/36Pyp/yQi8LMPdb8bwW8mc92HUQHV+Ijk1BuxxRhXT3AGpAQhHZ4nscbiZlPKTz3HWAb4vVXylz5Msjeg4cYEPhDERKHFj5qIMGY2nHDbKM60UqI0xpMFGIupHXUBVWYYjSyju4c03vMuvCgGV+NGffae/yxb/9u/ZvKhp2lUGY0mNFt6s9WOvvcffNUj937ii3e+9JdCYz7y1HyY3LQ/5az5/myWc3jnKr2zj+H2J+R3LtNYXCG3Q6zJMRX4KJwTSGUJI0FdGWYf/Fkuvvgcy+kR7c4CsZdCfUgUKIS2BI0OLkqopEc6N0+cBJhqiow62P4AKQWe7yhzh5WGTuIx3rpLGCdkt57nzm/8CpNPXKLlCxotRRQLklSRNAWtjdMt47xfuP3Uibf7SeNvLX3o1fwvLAJ/5n1ftXjvc9tPu4P6m7S2SAVSSMLuMn6jQzm4g3MQza+jKbB1jkRQ1yC1BCmpnaEoBfs37tGqAxKXI21JEEVoZYhSD6MqZDLHpD9lGEWkxZTQV2hXU+cFGLClA6fREeBy9o4m7Dz9m2z//K+wMCxphYZu1yNtSsJIkaSCzuoqOmlS3L+BDMInxdziu7+/O/3t//XmbPrnXgP/eWNlU2fJp+Xc2tsGXpfh1FHVIcY6JtuvUNoCJxTlcJdiPCA5/QRRI8JPNMKvUSE4XROkPqrh0Xiiw6m3XCBeWkEIQT07ojYV1jqizjKuKvF8TS59tNQ4QPgJSvkYaxHaw0rLLKsYH5VMn3kRXvsCq23HXBsWFyPC2JE2IU4FzaU2wdwK5e4tHAZ//iR1XrzNVv6nv/jWtc0/1wj81Ns3L6jx9GPLFRvtZIG9wQFlmtJ8sIk5GOF5ELU7eGGb0nio4pCqyEm7c9higNLgsGhf4YDRJOPu9QF2b4Qb7SNFgecLPE/ihRqvM4etC0xecT+bcTLxiEOJ9H3KyT5lWVObGmGhzKAuJKUMidKSxYUEX9fEsY/UNc1OQHN+nmRxg+LwLhgf6QnU4ilm+32K0bSbz8pv+eue95FfHOUHf+YA3v/Wd23Ww+xjCdna4skV/Nk94vGItbMnyceOyzcrUj/HkyVhMyENQ6zzEdk+ImoTtTo4N0JJgad9ijKntHBQWHTfkqYefijxPIMf1OjA4nUWEIAoc2x3jUU1xQ810oux2QhpFcgA4Wm056hRTAtNmIzopIIgAN9XRKmkub6JN79KsX+b2dSQ+A5aC5TDHaYHr1NMK7JZ1cxL+03vPXH6wx/aPzj6M0vhw689tajq0UeWV1prC0s+sZeRqozV9QYrnRB//zZpPeG1PYGtDPhNqmJC0mig4wbl4B4m6NI8+y4aGw+jYklj3mN+rcPiWpuh7+i96VEa5x7HxT0qG6CCFjJp4nU6RN0W51cXCRoJJA1EnFLbGuOgBooCZoWlpmZsZjSagjAOiJsefmKZ3ziD11ul7u8xm0zw/BhT1xAGFJMjqEOk8ohiDxGzFn/H937k2d/52OKfCYDVj/9IGJ48++uBPznT7Ho02h5JUBK3BO2VBmZyh25TsrkhWYoUrxcwOdrB+DF1NSNafoi0vUKxf40s7sCZJ5CdBhVQZAN0ecioV3Lgdjn40kWm93coswnj8T5FNsE2FhCtNsnSMk4KVNLB+SFeI4WgxJqcujRMR4Jh3yOIDIEvaPY84m6TzrnHcb0Nqt1blJUlXXyUWFbYOMHkJa5WCKcRQmAtWC3w53tngsj/9YvPvRD+RwNY3Ln6U1538W3puTfirZyi0esRz7WIG5I0htgvaXc1KwsBbc9w60uGWe4QrR6VyaEa4/XW8aOAcv8mlR9gu5tYXxNEkoX5iF5kePb3LzHYnaCdxhlJ4QIyayiShLzRYlxNsUkD1+lSVRlFXlCVFidCwqUTxO0EIRRRY0rcShBzZ0gfeQ+utUx+7wqhH2KiJZIIrHL4cytQDaEaUdcTijwjn1mqgSJI2uggeBtK/tR/FIC/dL753Z955rPff+f5zzPd2SavQD74HvSJC8S9BXRsiBJN0vCoq5rYh3PLiq17O9i6Qi2fo5jtYrVGL26CUuTZFHPiUfyTT6LnlxlHIVm3SdESbLkZe5XjyERMypopAVnSYdRaZRjGjObWKJtz1KFPKQ1GKKbTERUW29SMkx26PUm4fAJ96gkq7VHcfhmvmuF1TrK4sogZ7WJljfBCbGZwVqKUwvc1ngciiki6c3hhhFT6+199+Yvf/f9pmVD/kx861b9+9eWPvnixlfWHnG0knDkzR2P9BOHJ82hfYXcuYYuc7Og+g8MJeuEJxl6Lw+xl1kRC86E3oY7uIuoxYnGTTEWUrRR/fR1Jjq2OyGeHeEkLMz1ANFYItEIlbaTXos4McnwdZw11UeGMh5AB9WhEPRtgDBT5jMnYcuvKbdTdG6ydfZTGibM0ewuI159HHlyh2XsI11jGTY/Idy7hGgsUxYzp9l2qWUVdO6yxlAXsxSdY/ccfIFnuIQVYWw2FqR4///jjN/+DJxH3T39YmKOtn+5unG19TW14+splXh1l7F68y8ODisWjA+KH3ox/+m1QZGj3OZqJ4nA44/5Lr7B1uEPvzasU4xH+0hlcPYKTDZK1edLGGi5ZwM3uI7x1QhnghMRJhRMSaRzWS7CAlh6iXgczwzcWYabgt3AqxliDMDlu/wsI4NzXPkhhmmS7GeVIUO7t4OUD4qVHoLcJeUbRv4f1AoQXYnZvoaxHbirKomY6sQwngsNGxex3P8ypNz4OSlJks5by1E//74+d/7q/+cUr7j+Ixvzoyc63EwR/V/qauN1jqS4ZGdgRloPhgJYICN0EWvOwtIEwBbP+DofXL3F4c8xUOpqJBwrCxx4meXiRYHUN0ejh0gWcF0EwjxESpwOc9ED4CBmBVuDc8QCNAaVBeuAluKCDlQFWKJAOgg4q7iCSHq65itdcJOo1SdIJxni44QRv/hROaIqtl6jzXXRvE6Ek2eFdZuOSsvYY5nBzFw4GlnA2Rr/0Alz7AvXnPsvRr/wu6fa1zXh7cOUXh4NX/l8BPPq6Nya2mP2ar1VbiQJac6SLJ1mnIPACdnDczMa0qox25MAPcJ1lzGRAPhgwGuTUwrL0dU+x9vVfQdAaIOdOY5Jl0A2c8rHVlBtffJnO4kkQGimOJwycxZkJymRYBOJ47gDk8WbKVscZ4gxSapwrQPg4qUDFYKdov400h/iNGr3xANlgSnV/CzO+i272UAunyO/foBqNOJjUvHzTMtuTPLQpaUeWTkMyPydpeAa/npF6Je2Gj2ezN35PM/rX/+ZoUv2pAP63p8799zpqfputK8hzZNlHNNp4SysspwlrnSb3ZzO2DvdYbySEcYxt96j8GJRm52jMg9//btbfEBOkCtt7I66xArqNVT7Gllgj+MwHf43uqZNEaYx1DiE0uAlycgsxvILSEQ6HkzFCHk8uQoY4oUAqwCGEwtoKKXyQAoE+BttLkcpSTS6TtVahKFE6xjv5GHVlKPeucG9vxsuvWuYRNMOSpZUmzVZKENR05wOUdKSJJE4kWk2IItdudprD9988/PT/I4C/nq42A099UNWjxGeCEiVSgcAgtIdcPEGcBDy42KM5t4QtJVEaUHoBedKl8EKWvmqNxTWDmjuHnX8U1zxBmWX0794iaISApq4tzz37Mu2TD9FePYsKWzjp4WyNjFch6OKkAAFCBwgV4qRGSoVQ3vGyVEqc8JBC4Jw9PopQWCxOghMxn/n0NhR3WDy3iklPUB6NKbYuk2eSP3j2LktCc/KEZWHZRzpJs9UgCGtay+v4ckZzsY0fWtpzTYJEk65svOEfvPOJn/0nn3mt+BObyF7a/r5zS81e3AzJDu5D2EPaALu/jxoPkWWOW9hAzK1yZr3GTMZkoz6Z8tg9OmRlTRK6LVS8ieicwoRdcJa6nPH0P/+XvO0H/hbLZx4EG1F5CxTTMcpkeF4CXorTIVWdIesJ0tSYcBEhFLUtj9NcSKSQWBxCBThjMDL98kLBBxlgyoxyfMjLn/wMuzsT3vI3/ipqeIMk1YxmDcwr29zeOqBjYXVFkySC5ZUueZ7hhxlB3MSLY8LOg6jGAmE2RDaXkLMMJ+iZfPp9wPv/bxH4we9/n9ra2f63s+1BJyoVUWuJuhhhhrtIoaith5ke4Ua7iGKMi5rY7jKlkky8kLgjaHiXUXGKPPGVmMYGCIetDVJ77B72+f1//3E2H3+QOPa4+PTPc/LsBktnLyCFRVDhTIZUPk76xzVQOMTkBsJrHtdIITmWQGdgcgQNVNhASIWSBmyOqzJuXrzI8x/+KO963zcTLZzE+W0ufu7zzOyI9snzvPzRF+kgmF9tsbQUEnSXiBNJONdDxTFifh3ZXaOua6rpjPH9uwzubjG9f4/i8M65f/TOxz7w4y/dcn8MwO9877v+qg3kD926MyCYOJSZkPgWiWU6chQ1aDs55mDTAQgwSjGL2hxNj1hs38LWI/xT78AGKU75OCuwCGxd0e3Oc+/iJ1k8fYr59Q2aUcbpN76dMG0jkAjUcalwFUJF1MLHYo6J6r1nIe/jpIcoD0A3sX4XFaTgKpTky02oJBsf8omf+Qne9s1fz8K5C2TjCR/78DPcunqfr/qGryRZDIlWVrCXrtNtQdDpEnYX0O0WYvkhVHsdm8+Y3brK/qVL3Lx8nZu3dlj0NEkQkJ5/pGM7C5/9n575wvU/BuD3fPNf+ccmnzy819/l7tYRQS1Y6PocTX3Gw4rWnIcSJYfbNcXEUs6OcFIxyTPCXkazXaDnlpG9x3FeSjncIc8dxgqEbhM1mmw+dp751SV8D+aX2nhyCtSgQ4RU4Mo/FIoxxmGv/gZqtofzImQ6j6tzCLrUKkXH8whKEBLpxQhb4OoJQsKpzTl6D72DcjrmIx/4l9z8wpf4xv/mu2iungHPJ412aJ7ZIDjYI5ibR65sIBfP4sYHVLcvM70/5PVrW0wmNWnSZikNaM2FRBsnIGmR7dzTP/ny6x/6IwA/9as/l1JmP3t0/36wu3Wb29v3uDkbs9sXjEaQZYbS9TmYaG5tOe5Na26MAm7e3SVYdUTqBbzmMnr1bRgdQjXi9Ree41f/2ft59doB4yJjfqFDe2ENrQ2y2sdMr+NchhA1QmkoD8Ecd9SiEgjPoxgcQtZH6AiX9TFo8tkUGS+jfB8EOOEQKGy2DVIhVUAwdxpZ7mNG1+mtbvDIO99BZ+NxJALpRci0R7TcYzICL+wiu0vIwR529zaz/QGzwQRVKbpS0k4hXm4QbT5C7acU9y5D4U7+d2dX/tW/uHS3VADvXFz7uv5zV/7G7JlrzPUHuDyjpOZWOeF6dsCdfMjF3TGf3z3gtekhF0dHvHC0w+XBEV/99SdYOLlGuPooprUCugGupjOXsvHAItcuXuEzv/lR5k50WN88g1QOz2+A12F6OMKUU6yr0SrG2pKqGFFbjfIa1FmOPXgRqgF1f5v+rUuYYJlobg0hHQgF1lJPb2Ly+0hvAeeK43TOd9Cd8zSWT5HOn8TZmroqmU4mlGVJmKaE85Jy7CP796i3XqYeTCgmFZ7UxE1JenIZ/+x5ws3HseEcZu82dtKnJA1Ec/n5f/HSq5c1QOsPnnuq3M7p6RFBOyFyMCr6DMuaoYEhMMMROUEpJE0fbOX41u99jOUTHXQzxjQ3ccSIcow5egXCVZqrj/HX/+vzbF17jVOPPgRmhjM1hYG6HKHaZ6gm91DGJxsfYYUEJEYpUBorFNWkj9ecx+udIY0myMWzIPVxaXAezpXY8RbGhtRejqbGkkO5jw46EK4y2dvmDz76DDdfuUZ5b5e3f8PjvO2bvgnVSgk2RpS7GSqMQdUk8w10q4fsriCTFtZWVAf3MDt3sJMjROkoj7aZlHtPAb+hP7P5sFBV/10mUQgdoP0S3fEpWWVcDJlmJcZZjAjI85zeoiQzKXv+Go+e6ZBPhnhn3v1lvubjhMDMhtTjPt7Su0lWFnnk1GOARUpBPblNMZsyHuZc2x/z2c+8wOFwysbGCm99cpMzmxs4NM5YrKgZTwOkGyH7+xTxBnHUoq5raqvIZ2Pu3b7BuF/gacfS0h7ddgNpRnhVDrakLqZUkyNe/D9+iZWNZZ76gW9h84k3g9TY1gVUdANx8jRuYRMtJcqPcH6M1T7kI9i5hx7vUZdTlG4xHd+mkh3oNt71W38NoT3XXww8sRk1usxmI+JUEhtJbqBbJZhmg3FV4AWa/kiQRiljI5g7KWi2POLHvg0WLuDM6HiiqDOkFLisxsz2YekESkiklFhX42RIMbnDv/u1l/no8/uE8ydIu6vcvOr45Bdf5tueynnHW96AKYdUec5kPCS0ASifMmkRKI9axNx8/Sa/9Asf4uaBQbc7uLIk1D5PntK896sfYGVlEz9YRiJo9Nb4oZ/4Mbx0CR2CsyUYi/AS6G5S718me31AamZI6eE1mgTCR5oc+vcpD+7h8oq8npDlFQe797m1lG4enjy1qP7eufl3BFHwXUFUoWSNH2iiAOLQojzwFKS+JPAsaRwjpUNKxfrbu8w98iBy+XGsFuBqlAzATBC2gvQMnt9EJnNIpUEe05miGPLRT7zIz/3Ga8yKHFNXzIYDmkvrVNrn889dpBFUrJ48Sz7uYw+uEiQxzljonUc0Frm7tcP/8hMf4M5YYoVjOhqxf/8mdZVzaOa59cqXeOwNZwk7GwjhoZUiSJooP8SaDCXtMREXIKN5dLPL5JmPExYZcrSLV9WoYoybjjBlRXl0RFmmmM4pJlnNlesHbJ99WLTPPPwJvbDWesQah2y3Ec5hywlOKFw1JalysIo8N9RUIGA8Lamnlu7pJtgZghpsjTP5sWlNhrjGJnb7Cq7dOk5rJ6mrgjLPGR2NefrZPaJGh7S9QDk9xAnJeP8+TnuM+0f8ygd/g80H3kCYF4i6wuUZw/ERvogZHw35wPv/Fbf2ZsytzTPNK1qdBRqdJapiRmUqbhUJz798i3csPkSoFIHUePEcNutjncU5i7MFUoc4DToOiB9/mOzjnyUUNb6YUrkSlc4z292jNBFl6VEe3KMKA/oXTrPw2CO0Nx54RI+y/KwhJKp8RBCi0/YxeXWOQFlkNSEQNSLuUNUONdrD1jOkrBDJCgaNcl92/Alw1QA5uYsZXUF2H0TqCGsLjCmpqpLh4JDtuzvkskGv3UUlTcb9XZQzZOMJZTXj7v4RVy6/zoNLAZ6BygrKIqMeD3nl8l1euXKPqLNA1FkkP9jD931MVdLv77DUvED/8B4vvfgab37TI8g0RDeXwJY4U2OrCqv940VENUMqjZsdEKwnbN0d0GtH1JMxOojw8yFl1SAPUlyzxbXnv8i11NJ++1fS3bhA0ls+qwOvs1HkNdu39ymLjKIuiRWEvkQpQxDF+GEbEw0RUZO6vUlj1WDsAar3RmyQIOoZVgVIY6HOcE7jgjZCezgpEChwElfW2KomDRSldYz27lDUjmy4x8F2DlIxODokNDOqbEgxciiXUWdj+kcDgt3bTAaQlTN0XVFO+jSaLVQ5xBCzdPphpke7zEZH7GzPMNN9RLqOwGGlosgnWJPhrE9VTSGfIIIO2m/iByX+f/Zmqt0Jg9tXEJkjSBvMRpLaL3H+Hq9NRjS/4k20N87TXFwmbLc3dHz6geVIStL9A8rRBFtlbB322R6XtMOYOHNEUQlHM0pzlyoImNvcIFrcxOnj1LVSgrWUW88g6l2IN9CtE5hqhHAC4xzOSRyS0HcsL7dIwpMMBwNG+/cZjieUVUkxGyOV4tR6l7lgxmjrIs2mRfuQxAF3Ln2SsPsGZgd3MFXFdLBH0Jyj2VtDBRXl7h12bl8m8D3iMxtk1qMbdI55YVVS52Ok1mAtCLD1FKXi4224F9N8KOWFT71Ec2ef1QcepIy6bPUtO1evs3Vwl6IoqS+POPNVCwTdHsqTy3p2/YX5uNPGS9r4K2dwZc35Wc6p/R0q4VFMc6rJEXVhqI1gMuvTNQvHg74XAQphHS4fIMImcnyI8FrUSPKjKzRPfgVKBUht8L2AQAc8eCrlYt9n441PcOf2PM9/9lPMDnYoi4JeJ+Vd73g7Vf82XbmL9+UxT+uQbLhFsvAwa4strtw/ZHGji0Vy6cVnabY6SKnIZhNSL2ZjZQFUQFXXKK0oxwOqsiAJmiBBqBDVWkOqBIVALjxCM3uZL+zsEd6f4A8/h9fwOeonmPE27VBybmEVr3/A4Bd+kdlTX8fJd7x9Xv3IqRM/ZgvrVZMDpAGpK3SnhbewhL9ygmiug2o1UGmACXxMKGk/1EQEEr14AYfA2Bw3vI4gQFYZlEOs8KiyPtlwRLR09rgLlzNsMSB1I1555Sr9ScG9G9fpb11GuopzZ9b4L77tvZw/sYA8eAEdNbmxW3L11oRJJvCYMckFftrghUv3mFtYY319g507tyjLElNlNALBhc01vvqdb2F5/QRhnIIxHG1fJUjn0GGIVD5SC5T0UcpHej42P0Tl2yjrk197BZvX6LJgTo1ZSiPOriwx32rS8x2tvKJ6+VUGd14TenI0CoR0dJbalP3buFFCOB3jfA/P9zE2J20uEsyfQRYlxf41DOC3z0KVg+ch6jFEC9idF6mKISLogp9APmb/+i8iWht0Tl5AxS2C5iIrZ87zHV8fsrVbcbe3yuB8l1a7yWOPv4mqnHF05fMc7tf83IfukMuE2IsoqpJ1T/L44mXm1i/wTe98hM9fvM6tyR7dpib0A6JIcmKxw7ve+QZOnt0kijsgNDuvfRodarT2UMJHKQXCgaiRwoGzSD+F9jKrD8yoNlapc4d2NZHXou0HJHFCKEFLyeRwRJA0GL9wMdD7/ZxGr0t9WKFNTpgKqumIMJLUToEHxt3ABi1q4TM73GJBP4ae28T5HVw9xRGBH0PjBLgbqKiNw2KqDFeMufZb/5Dz3/D3SRdX8NsnaXpznGmf4aRRzKYTxpOcwdEhRTaiHBywfftLvP939+idfpSO7yGVJPITXrs25fW7A95T3OTChfO8+U2PUVU1w9EITUVvLmXtzAOsX3gLnYUTeNowu/cqxeg+jfk3oLTEUSCIUF9WdJ2zKC9ARB3spKa73EM++U7s0Q6hs4hZjpaKSEa4bERVTkgSRV0P0bJCv9JXxXrRj6PIZ6FdE1QTat1hdDTAmhovDNBxi+nogGleMK4yvEYPDl4EHkaEc1hTobwY19pEtc7g8j7l1d/CEyleFNNKutz42E8ho1V6m4+j0zmMUNQcL/Im+ztsXXyJg0tPs746z3NXPZY3HyOMEmbZADMcU5Y5nSRgKla4u7eHtK/yxuWTvOkt7yBOFa4q0VEDnS4QtHp4VFSTIwb7e4jpDlo4oELr6Fjwkw4pJIIKjIIqx47HeFLR7HbQvS6RA9G/h2dK3GgKPpgqpCwybCVIokahrzbrydHAxsnE8PbVs/TH22ixh3LeMUfKYFwcUZeGfq7JohBnM0wVIXSMVMcrJGGmx6kx3ceO7hyLRFKhnEF5FVV2yPTwLrcOv4h1Cbu37lMYS5hoiskBLh9yem0BnXa4n5dMpvfx5xYRQYP1pWUORxnFpE9YFZQqYine4+bnfg+JYuOBhzixeR4vjammU64/89sc3fgSbvBFlpZTFtYfQrkJwia4cgJeCELhnAOVUmVDfDNBmhlMJlRXX0AKKKSPp31EnBKunEIC5nAPPT7AFBOsqye6/fYnD6588sWFN6/3eP7iVc41K5YWQsqZhxMF2jO4OKE2Pvv7u0wXQ6rdraL5AAAaZUlEQVRiAGIJ7TVAHEu0ppqgih3wl7HzT+LVFjvZobG8iUtWCPKMNJtSFTnZ5IDZnS1a6QJ+2sBGKabwSZoL7I1rfCGIfZ+o1UbUhv3+mNHuXVQYUVtHJGf0Opqq3Gbv8/+Ge5/T3H38W0k6TbZf/Tj16HWaiaA716QZ9Uji4FgeVT5CHgtSwlmkDLEYlN/AmRCRNDHJHFn/BeL5JvtHAyZ712i35vHk66Rpkyj28cMGutlFUh/oR972pu2l5e6Drz7zEp12k8ZsRlQk5JMDtJbMdbpsHxiGuWI4yplkU7I8wg+6CGOxfoozGcpPQCzgJrfR0TqVLwlXnsSamlrGeNkApbawSQtPS6ZND4sjiAOIu2hTY2yAKA9omBlD0ePw/m2QgslkxKjfJ240iRUspAW+B0kgMZE9Bufg/8QVCwRmiyQSpAG0Gm2a3UUcBqoM6TyE9hHC4KjBlCgRUk3uo5RAlFPKfoZIW0xHQ2Lfw7S6jIqMUTkhGh3BdEoaJCRRQjMOt/XiuSdvtVrzqKzg47/8MaYV3HnliEeXE0z3LFM02wdHzD15mtK1KccvcTQVNPs3EKtPIkz2R0tMJzxcnWPKHJrnYXoLpSJk4OEKgxU1Ml0kCJtUK5vYyiJ0TdA+Szna5nB3iLElb1oZcf+ax7Q0qCCkriua3R62mDAfVTywBFEgaQYedVkyLgxpWJAEI0xDoF1AHEdEcYNo4TQqTBB+jPJjtB9AdYRAYJVESA/dPonAUWUTquFzBO2UZrqIrmd0ygVkkaP/sCnWDnA4B8rTt3Tr5CPXGt0T2OmUB7/yDlefvciRgIUyYnlmyJ3l/NeucfTxS/TMlLV3r1CPHWrhQagHCD8CFWOlxNYZIjmB6lzAmhLheTC4jrMFQhT4vUep9l7GS1aYe/AplI6odi9TmRrdXKJ/0EeYKUstx4XWIbfGLTIvIk47jMd9VoOM92xOWenN00yOXaa+Vsxj0UkHpXwWTz+Jpz0m21cJopg6G+D1TiODGKkctp4eC1h+ihAWTIVwFltMKY3P0cUbtOqYylgUoKRD+D61hWJygHIKGcSYOqMajq7pyA8u0uwwv/4YZx96nWSa0X5thzPOEU630NLRuK7xkhzdjCgOWhzmW4j3vBVXlwipEIGHcArhdXB4MLuPCObAlAjpjotv8yRSpQT6Lbh6Qjy3gLMOKT3qG3+Asz6QE+uKVuh4Q69kJTlgd3iEMY5uz7LWdawsLbIw3yEMwAN8r0J5EbUMaD/89ahGD3f4Ktrl2OKIenyP6k5FdOIJXNRFeAHOSawVSFtinEHlO9SVpRqNGbx0marWVKHD6RaBgsZcGzPpo6UlL0qELBDSgBMXtYCXhPZssHRGLqy+geb4RTpaEQcGJwQyqHHGEYSO2vdg8jrZvZzi7iX8xQq39iSKLxuBvBApBLacoM0UM7mJ8+exOkGE8whTQBBAcUh59zlmu69h6hIvWCA72sbaiiAKmItaSDWkMc5ZalYIJVAOOs2AbuyTJg2arZRysofvSfAT2uffS3DyLWCmyNhD1jPKfkk5G+KHMQ4fITU4h5AeztUc3wmLqfeuQjRHOSrRowFx5EiUTzEaU9k59gaGMLEoHNZx/F+JddQvaTy1aytz3e7vnws+8zF61QCROrRvUdqn9lLqakStmsh6gFKWZstxuLXPYismKNZBzSNlAM6A8JDSpx69jrAGO7yK6r0BV4+hrnDWYUZblINbhO05ysmIcnyLuq5pdlrMZM1sltNqx1R5hgqOyW4QCdK0QdLs4uqc2STHFTl+GJLGAY31hxChh6slxjVQyTx+tgthTFVMqe48iyjH6N4DOKmPpVOhUPjMJlNcrSgPBiRti3ISrId1Gc7sYceSwaxL2I2pshxnS8JAXq+zbFefWO64m89+4RPjX/3gufSFF4jmPETkoaSHY4YWGc4TpMGUUkpcuogphkxu3mf54TPY6V2UmyGSVYQIcNRYIXGqAbKA9hpudBvRuYAbXcZkfVzQwD/9FA5NWI/xhjvUt54nXXqYRpZzcOMPGI2nhAH4nmA4BF/6pKFH4FnGxsczMdJfpsoGaG9KOr6NFwY4pZCBxHY3UHGbuhgj64JKh2gk1c2PotNlrL+EdVDPdjDDG2R7PfovvkZzbg43HlCWJVo7nHY4WeP7h+zsF3jSY1h5yCmf+Obbd5wC+GuXr+vk6mvvi8OaODYIlaN9jRc6hIQgFniRIOguIeZPIJoLTCcTosUGmH3oPvxlA5DEmhk4AcI79vZ5CQTz4CqcKdHJIq6coBbfDPEcVZnzmY8/j+8JGounEbZCVFNcVVAWBQhoz/c4eeFtNObXMdEyM9ug0nN8+GLItVeu8MByjVeMENPrWJdjwxWk30KELUQ0h4jmwUvQHDvTTC0pbn+O4bXPMbzzPLVNuP7JKwRbt4mVIVCGwBP4vkYohxI+DsN4e8rYaO7ZkiNp/ulHR4PLCuCHqe/GofghL7SBF4MfgFYVThl0qAiaPl53A7l0nvHhiOG9K0wGu8yMo7XgoaIGOmyACnDWHTN8e6zmCd1Ehim4GgkIU4HLENJDzrYpjm5x/eYhv/PsCGenNHUf4Xfw5s/S6ixhyzGBHxAnCQJLPpvxqdeG/NandyjvvcxbHxVsnD6JVhnlaBe/9xgqWQTtH38raKKlxG8sYgZblPs3kKoiH9yimu1RVgoZn2Zw9ZDeqcdppi0iM0U58FTINC+oc8hmNVpLnMwZnlgcjzcXf/DjV28fC+s/MxqW/8MjFx5VgXlYmClI8GJJ3AmJNh5DzZ+nyAzTW9cY37tJNh1hXcFwcETrzAWiThuhfMgPscki0lVgDEiNQGOdwbkZ6CbOT5HBPK7oY63B5iMWTpzENpf5yNOv8PqdnHjpFMniOcLGHFKn1NUYYxyHR2M++MlDnnvtgEe6N3jPYx6PPfkOehfeivIiXHGIJicIYpRWx1qN8pE6wOZ7SC/AVTluuo2oZ0yG9wh7b6SiSxAt0149gxelaO2jzYzZpI8xDmGPvYhRFJNNS9zW5Nd/8LUr/+6PeWN+ZE1PlS6+S4UKHVqC3hp65SFMrcm3LlEdbGNmBbVzGCzGV9ikwaiwdOYqsBWq2UOG8zhX41DHhbqeImx+7KyS0fE2pDhESI0LF7DVFFtmzKeahSXN5VsHPPfyNhcvvsKzz91geywZ1R1ujVP+/bN7pInla5/0eGjJsLTQIZRTdD3ED2JQHqp1AjO8hqtKCBOUTnFCoJWP9iMCT+EmW8fNrvsQ40HF4OJV4vEIf7SHZyp0q4ffXiWQDk9UVGWGxVGVFdKCxv7ov82K63/MH6g89Xt+LF4PT5w/rRIPV0J15yYuLxCVxZMRdVCRdufAVuhY43mGo8Mh27dLFtQhzl5E6S7CSxBK4Mo+wlTHIPptBBkOha0NohrihA+O44vW+ZiNBc23vKPFTl9w8/6AwWDIbDDioAiI6gO+8bGY1c2HaMQKv7hPu3ca7fqoMMa4Gu35yHoCQRerA2w+w7k+KmwhghaquIub3UVqH/ApRj67L75MMhxANaOwCuVF2DBFLJzBX71A2GhjeYVqMmUmLAL3ulHx73E4/OP+wJ+8eeT+ybufEE74T5V7u5i9HYTwkfPL6PkVVG8Bf/UUqtVBNVrUw5tkR/eZHO5x55XbJCfWEPV9KAaI1gbS5cc10dVQ1xjkseQpPPBSrJ8iTIme3gGl8Oc28bVHEkLaDFlv16x3Lec2upxZUCzPCTbOPsL8yjkaaYgwJe3VDawriOY3EV6KUw4hfawQmGQN3TiBDlI8pZCUiOktyv3XGd19icLOc+lT12g21mgqhZePsdMaM3O43CImfVw+xZ8/Qdhdh+k2Co3W6seeeGX7s3+ixffvrKeXXF7+l7q9mHinL6CWVhBhjKOE8evY/m2KvSvk+7cYHBwwGc+oSsuwX3Hl9Sntk0tobXD1FDHbQ0ZdlPLBa+BciamPnbHWHRvHER5EXbR0SC/A8wP8uk8cBPi+Im00CH1BEEb0Vs4RJRHp/CoeBVGoUM0VZGMDR4Fqn8V5TVTcRSY9hN9CeiFKWJQwxw1r/wbDu58nyyKufWnI6OLrLF54M63V00QOPDuBEiQ+tpJ4RsDkABlEeK0eouzv29p+3/u3RuWfCOCPX94tfuw73idsWXyN6W9THO5S3HqJ2f2bFIMhs3FONjVMRiWjSU1pBLuHhkntGOxPeW1/QmNxDltPKXeeRzmJiuZR8Txap8fypuDYhqZDkD5OKZzXxqkU4adoz0OELaK5NeLeWSJVkjQ7BIGHbK3jUYIZo4IYvfAwqrUBOIzyEF7jWHsREj9q4Ycpypa47IB85xX6Vz9GrRa49sqMg0+9wEKkSON5orkVwsV1wsYcQeAhXAZVjSREighXVZjZkGR98x8t/spzn/hTbyodve/NSX6496pw8qQ1Fikd02mB72tmeY3yJQejGcOyol9UjKua7MIyda9kVB5wOBYsLp/hrY9sMNcKiANDmK6RnHkXTmoMgCmP74LoAOoCKwPc8ToHISxOhuAKhLMwvkstfaTNENEK9egmtsqPFxTNDUTQQQqQfoipagQG5SfHaSsF9d4lZjefYTa4x3Bccee6YO9Tr7LQPkWqB3Tml0h764TNLtHqOj4CUcyotq7CYA9mBbaSGFNuSV89tPG7r07/1GsO//Mr96q/fX5xdzwqv3WWCWbjiumsZpYbivL/6u7cfzSv7jr+Oud8r8/zfa5z35nZGfbKcgcJhWKagluKaKrYpAU0q7aEWJvwU02aaPyhxh80GhMTownRxsSkFNKmVmrWUgUWy3Wh7MICCzO7O5edmWeemef+fJ/v9Rx/mP3VBCjV6vkTPic5+Zxz3q/XJ2eQpPRGGb2+ZlQuMvnFW6ndtojwNWHaojXIWV5vcX51wMzcfsrlWaLt95FhE6s8jvTGUUohLBtMjCQH6SCFuRIDuRK7UC7CjLCEwJTmUKTkOkL64yi3hLEL2N4klhtguUWESVFCYvkVpAARbpM23yDafpMwSmmNirz2/DbdV89TdwU1L8czCU5u4SVtVHuLbLtB0tzCCBt7dg+RVUEZSYbriN+f+94br38g1Cs3zuNbzcYJcnVv0Rd0+zm1cZdwANrOsFwXXSsy9+VPQFkTxiNMySPzfDInw7jQT0a8/k6LaGRYnJiF5iZKPY8/ezNy/BgGjbDcvTuyNkih0CZFKhutc8hTEDa55SGNAauMrSx0ngApXmEOQ4q0FFIpEAF5tgfokEbk/Qa91ddIpc+FnZRXXjlH8uImcwEUC4rAs7BTg512kaGNsRQ67GKkTbr5Hlllitzx8CrTOLV9J0tu5XF49YMR63+1tM3Dt9//QnN1+Xf0pOs1LseMf/oAa5eHtLcTxCcOUf/Nm1B1yERIZGIGSUZnOGQYDokTg5IWC/uO0W2HNJtdFJU99EsNUFIhkQi7gFQuluUgnDJSWQgEtldB2TZYRYQAKQRYBWSWIGwXZRIsp4ZyAoS00HmK0SnEO5j+CnlzlZ3lZ+lkDs+9cYnz66+ycP0cs588jN8a4cURJla4KGwlUQh0plF2BTMaYJKcPB9iBj2S3bVuHoafm/7mU+0Phfz/w9JbnVsP7L/8bmtw/65SLO20GEQpwYN3MP/5G7GqLqluE+qIVCjCRBPGhlHUYRRpLOFzZO4go+6Ad069w9LJNxnmCsux8eNlCFeuHMASom2EkMi0j8hTpFVA2AEyT1DCgBVgmRHCDfZ4OrsMJttr0MMVRNiFNCVqniMZ7NBqLHF5J+O7p86z1liiXLeoT1WpzFap3Xo9Oi1S7En0IERJC6VtpNF7G5FDnGq0Ueg8weT2I9f++9JzH8mZ8PT27tmHHvzUbOma2V9wZieYOn6Mw8ePoWWLxPQIsz65NiTaMEwykgSiSBP2hhTdSbywwMYTLzDTHlIWGtHcYuX0e5jSGLXxOkoa8s4yWa7RrfP03vwexLuYJNx7Le6cw3RXMOkIk4WYzdfQnXcRsoCJ++jeGslwl6izQXflFXr9kJ3tDmfO73Dq9AW2dtdxCxBUBKWxCo4LbqAoXXuIvFygf2YFpRO8wCWOMrIsxxiFkYYskcSj+LHbXtv5059KvDN5ZPHR8vj+65zy6I7ipCROlkmyAXEaYYzac8CkKVJYWI4PMkAqiVprE7/1AguuhSXBcjSuD04g6Z45z+nGLqXFRcozY/jlBiVPo0UFkRrYfAOz+x4KSTpYR7jjuPVF8lEPjQ39l8nDNhiNzmCUeKxtwU9ePs1qs0dpso5lC8CQaQEK4jgki22iuIfttCjcOoc182ukj59i1OkwHGQUPAtcCPspuUleTHP96Mdib3v9hb+dMs7uj9Ph+wdHaYdRPCQzNlkmiOKEMMwYxdDaCdltDsnObXNguUIl7CKTFsWyxAsk0ha4M5NYnkdnMKTV2KDbFTQTyI/McuSGQxw8sB+voNDpEMfzsJTGRqCkJMeju7nBsNPEaGhvd9k8v0VnpUM2Aqtg6AxgXdsE19cYyG2cEiwcCKiOFajWJcVymXJlnIJfxXf3IROX1R+cpfPkS9R9RdFThD297Cpx56+vDRsfm/7upRe+fCiKOs+EUX8u04IsVyRJRpxkjCJNNNL0Owmb59pMPLvFPhlQU1BxO0hbYHk5wcQMTtUhTkPCzGJn4xLRwGAyQXsIb8ewZBmMrxgfKzE1XqVeKRHEKYV2AyWHJFlOHOX4RYdybYqk1yZrDchjQZ7AMHLJC/N09h9gOX0ay9eMTStm58YolHKCqk+hWKRUquD7dVy7jqDK5rltLr20SnEYrXtnl+96+OJg6WN1Z93+yb9f+tcfHr8nM+KHuVZzcZ6R6RwjFFprkiQmGeWoM33GuhGTkzbVSg0nD7Fdg1efoLJvlrB1Ed+vYQuBcQLiYk6eQCCh4jpM9AQvpm06nTa9nQ7ROnw6kEwdEFSmiki/TL+5SZ5p6pbAnV8k8VYxeQnbGcOWE0TWPL25awmWipzPvgtaEYYRtusQxwZlxQjVwhiN9lJsN2H6hnFq+8bXW2d37nngn88sfdC6fCj52H33/Oid73z/s3dluTmptTmY5aCzK3SWgdbGZarrMfWggG8JylYX27EpVV0qB6+mvf4+IlEUZhZQu5vYbomIDCxIZEIhVURGMqUKdKyQwUBwo1Ph1skZKqUBxWodOblIOz7DsDOgkMTUFxYwpTlc7eDaJXJtE8kqsdUkWLiW5bf/E6USUp2TxBliZEDkCOEj6F35403BSZbdqcl7H/jGk0sfpiYfWj72xLeWW5//4sFvZ2l2p87lfBwnRKOQxtplChsWR4NxnO6Qmmso+RrftyjvO4S0FZ2VFkopagevge4GdhZia42OM/JE7DW41XEuGc2wEFLoKG7Q4xwNJNOTDlNz+6gduZOi9JAjiQTqMwepXXUTQZagshiSFBV2Ga2eY3urQSuCqLKD7QuESvbAbKmvANsSISVC5C86lnXP3Xc/ufY/ImB88Df+rZFl6d1JEj+WRhHtRoPdzZgwqRIubTNegmpg49g+ruNh2TbdlVVMbuFXKijlIKLhXj4FjasEJW8vqiGMi3EsEB71qEQ9KCFNiC81RU9RcCW1mWn8osvaVh+7sYUrNP7MAYoFn4LIsHoN3OIiYncNvXsBLWNAoY1DksTozCFN97R5SZo+NorDu49/9unGR6nFRzZYfum3no9+70vPP9LdGZzodUrdG687wVx5AWuU42YO0hhsx+D4FkoKdAI2KaWp/ZiwA0m0dxvJFTqDwSBnmJXISoqdGviVBYZxl4wuTiBRjkKmCpGPcCZnqU9UWG3u0NlootoNpC2wkXiBR7HsYzdexO1uoYSNY5cQQiCFhcAnjg1pIrraWCdOnHj3kQcfeCf6qHX4qQ2WzzzbPHviC1/59oFjtx0N3373UH17h7EAymUH37cp1MaJo5ROo08wVqS47yritXPEvQFkkjTN0drQ6+a005zTTkh/dhrPU7iXBtw8VuXqq2yKk9MoC4Tpo+wAhWKzPUD2eswUBM6+RRj20J0mST8mynzS+iKyPIaZq5C7EVKC6xXRJjyZJdHnvvb1zed+LhyqX/2Db1x0ney+bHX1oZIdrfi+BUJg2QblB6T9EYGnqC4eIt+5QJ6OsCxDlickcUY3NFzeTTi93uNC1SKouhRrLlGQ0AldNld6dFYukLfWobuNSWOsQpk75udojEYMt3uYsI8pTaAKRYTvIR0bkYSYTshNdzzMZOVGXG98BdRDtlu+74//pH/x58pk/plf/oIBvvXMgf3fH/XjrxYt9TWrODtBatBJSv2qeaTUpN1NrMwQpoJ4pBmGOf1Esp7DpYMSd8qmVC+hww7OdIHWekZvIJmkBKqG6bVhZwlZ20+9VqJWGWNzu011ZxPhBKT9LmYwhFFI1kuI6/NMHf3FZsHL/+L0uSf+5ut/9MzHqkH+2FXwd11YHQJ/vnV84e/cyvTvDrYvP+r79gFvdp7h0sukUYjJJdrk7PZSNncTLo5yNhdq+Df7lCdLFAKNthz8hYDmUhcOz2EqJbqtFtVqgtXdQJcmcKanODq9ydvL73M0SnEqHjJu0+saWoXrSTznQrC//NfCDr55/P6v9P5PquB3fvU65U8vfkZ66reHF8/+Shzmpd4goj9KaXQcOhMuL0cZ8shhakdHFMdq2MUx9KBN+9IF1v5phWNWjdvKLnMTNhPTNl7ZxZqfQpRmyfoxPzl1iiNHryNYmCPfWOq3GuYHTbnwj53cfvqupx77margf+bDCMafeiuHt04CJxu/NB8Y6R0fhMN7L20md70XDw95N14jS7X9WL6kVHexChLXG5HLApXZGp3jG2z+x4j1fgHfE3g1F5mXEc01RJZi77tFH7z6yFLY6TxTdg+dNMngR3P/8sr/n2EE/936s0JFbMwXpmq333mLW3Kul54+XNw/XJRuPuN49ngy6gVZZNywuc3l15dj78fO4LZgbOdTd92yGTXWLhX95vulieqb9uzh17W3v2H94V/+r4zD+C8QFRRjpvMnsgAAAABJRU5ErkJggg=="></image></svg>
+            </symbol>
+            <symbol id="icon-avatar-2">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 80 80">
+                <image width="80" height="80" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAA6jnpUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjapZ1Xku44El7fuYpZAglLLAeOEdqBlq9zUHV7rBQaqXv6mqq/aIDMzyATmGv/z//xXX/729+e+NR0pVzf0kq5+Se11ELnD+/9808/vz53Or+ef/Lvt/j7P339+usbgS9Ffo8/f33L7+f/fP356wI/v3X+lP/hQu/8/cb452+09Hv9918uFH5+iz6Rf16/F2q/F4rh5xvP7wX6z2vdpb31H19h7J/f1583eX/+u/wlvf/82P/298rorcx9Ygg7PvHm1xjDzwNE/wtX7H6DX++Y+OATy8+f+TXH8nsxBuQ/jdNf/zSe6PNR03/80D/Nyl9/ev7z169/na0Ufj8S/2WQy1+//8evX0/+l2/Ev+4T/vHO6f39U/jnr4f6M1bX/S+j73/ft97vvDNv0VNhqMvvS/15lfMnPje4hbd+Lx6t3JX/Mpeo59/Gvy9RPQmFdc978O982hOYle9Jz3r68z37/D6fySOmsK9Q+UMIM8TzxTfW0MKMzl/y3+fj4Vtc8WWS55n2FMNfz/Kc27Z7XuduL3deDx8NDxd7jIv/9t/rv/2B7zMVnud+/xornisEB5vHcOb8lY8xI8/3O6j5DPCff//1H+c1MoPZUTZFGgM7fi4x8vN3JIhnoiMfzPz+k4NPXb8XYIi4deZhwKP0MGtPzE957hpCfR4G8mWCOo8eyJnBDDw5h8VDhhRjYW7e4K35kfqcj4Yc+PLF1wEzZoLMipW5abEzWSll4qemlxjqOeaUcy655je33EssqeRSSi2CYq8RhKy5llrrW1vtb3zTm9/y1vd929tbaBHQzK202t7WWu/cs3Plzk93PtD7CCOONPI1yqjjHW30SfjMNPMss853ttlXWHGBH6usut7VVt/PJpR22nmXXfe72+4fofbF60tf/spXv/drX/9r1n6n9d/+/S9m7fmdtXBmyg/Wv2aNr9b65xKPcJKdMyYsXOlhxqtTQEAH5+x+n5SCM+ec3S2QFTnwkNk5W48zxgym/YT8PX/m7go/M+rM/X/N21XTP81b+H+ducup+y9n7t/n7T/N2pKG5pmxnyx0UO9I9vH9/fbwdsnu336/fv4w0pf48Ld72yGOVUdcgWfY6+E1CsORvvjkyPy+N0/zvs9itCrfewmWUr6rry+Pwfjk2WL6Rl8xM2INaATC+tPGznFUgo7Hfcr95WeFwf+8cWFkvxkZ3O+qrafdPh698NMA4BPj11aIO6cG5HO5h7ujNRrDP1doiSxnPBgMhiiHt+3S9nPx9/h+tZY+1w7p3V+Yu3wR1hh3Ik6eEcs7n30TGm2+fcsLT2JWy/h2/UYuPsY1vvH4h+8Z/UuwQKsx78SQ3DMxyTWHUfu9J/cvLWUxe4w+3r3z/c31tF727sQRI/DOup601ko3sVHJtdZJIIMmz8X3H67B3XqsM57bRmaXrFqfz8ff33UtHniHxguGzxjtaz+dFyxfqbwgExoXj3aXuXoNtd1j7spX1xiR6RwjPC9pmq68uD0xlhMR+PXNEA7G8l5592ywMRJ8niGZqRMcJQyngbSeRH3kS9/sAxYZm1GucT4RxvuesL5AzPavV56+kJhMWhjOYyhAc0j3DGgyomgx4Uxk3Hdb37rmHgxv2LxaaasM85GLFQaxtsQEzH7HUjdzs8PkEWtf/A/8DqQySZjA832nK74jTpOPEP/SCzaduL//r37fZOTDoC6TdhAKpfR19zUzeQ7Bp3c9q2UCrKDGAJxN6o3x1T5396WIPAONAXjOLJm0pE24V+oA2DNSXWsXnjA4PIRtQr999Y4jAw/fWwrhudBz9ygLOdPy6sqFvaIiYlZCoGyVY+WmZeSF8HvzBJhS+UhSSK6u0J3gzGy9cfI09wBUOxg1gKx1xfGQMXHGRAjPUSNAukogOHmy+RD4N7NHDvv2ZFAiPoGWhTolrGKe5OAD6iEi+DN6j2TrCUCaGUy7AdX5gcqJVFyFrMugGgFVUwbOeohr8VCdjAPkANuXMbp5igmTlLpiMTYDeRfv8QYu0wZIBfc/5HQCXOLkPerbvtLbM+GSHCvQDBRd8Rl8kHgfWJNFsKQRGzB9M5m8UiMsn6f43IQXY1sIuzRma1DOLoPUnZ86/8pPJ7bfAArWmxm7o0Jyj0R4FBIFTPKtCMQMz4RR1J7wUKsD/C49EzyZcb7qnH7x+bnXu8FAPjn4+Q+wFLMyKUsuEyVfv/nUXZ/dC6iPqFdHLlDwnVc/t0T4PWv2OUAbmOyp+SEjiX3eljvDIhEkfnm7wYxrVRpZCZI/tXxE2zMZI94+gTi8hdPFvdNc5E/kfi1AkMwPc1QidMBNJ5wHCRCgjAnotSr6CYa5AIan7pkCz5ozmIB3ed6X6eArDPgrlHL93XinEd5lqNU3fG9yDHpOYMvn9HdUAbjK2KQJK8B2gZeezCt8AmQxzVsJwEQWCH+AG9DlWC/42tscgAxT2jF+b1yZma88Uc8I7lkauZWi9ALrpMJ0MBLP/a1F+n3vvpWDO68cMlmUWyvxQUTg68q95SC1ZGWaiPhQUJO1GPEHAQF4EBM1wAPwR8TF7ZgNLNlqz4o4SKQkicq0VnJs7FA/b81TVeZt8kVmoNaBJojv6sxsfJzofCCBGH9f2KnuazyFmZrHxxTkKy+GbkFDfSRkSk979yLyUU5cf68ZoaYGnsebJ+SXO7Y12k5XWQ/jjYp4w9ZBrLk3SExE6JR3ZWjJW5L1IXRQNOuWKMIjFe8Om+S6Q67EEUCY3sGr5LFQ3wicLPT0h7QvLyoIOZbOL9wZnIwTPI+8UU1i9EfQgOGMEUqJISPKEHEVCOTeiDPw8vxB2/3337lXhyc6osLU8I6pSbQpXP0tBCAy8mlCSx0ENhF7A+wZQZj4nZ8G/NBeqK0vbIa9ciHTc0DCmYuRyReCJce1B0AYblXbALdnKDNgNdAw+X2gWulN04acUccUYAmguPeniGOi1776FxmxzYuJ27kgU+MqCY33+uwZSEbv9IAQaAANwATSzW95cxI3f7k9gEW8bvzq117SrgEcGdFQQgGoUQ3aymiUD7OO0e0fT/QiMwSEAAa+C+Z17WLeF+qlwl7jhrUqsxPq/iKJJIHV5pj2lOGPMqAM0CpjTYNpge1kLBjZbXLti/vcxhDSCVxHiKNqJEdGE4T46kC2rlyIbMRBRwNHZDP6gAAjwyDZV1mDy2ZWNtJ3EwBBUY4/nvsuBx8RVOdjA4RgBga8ubgwuM+7hE/t0fADDFUd1z0/pAoKJgCNEBOhlu9W9RERXnWsEEJtYaR5rogY2uGbM+c0oG4x8gXBO5j9Bu6jjODhQT5eX2ZKNxpWGgUXgIBdE1kYJsgFSBAAKzBbX+ym/uz88EWWwZAoBbE2c9tNmhUkHFLthkIBHgSegAcDAmOvzAfsILgno+kQ8N4bu76i8jhEYgZlkALz1dpk9h5C82NCXhTGjoNIRxKAat8kGgL5D9KAwmMC+DjIhoKoCAkULM8kXO4W0LyT98mowwnhq7NJTGgOhn2gvzTQXK9iuvcT7b1eqQ2Q4yXC0mAQAvKQiCYOMmQ2Eji2ebumVCMelObzu7HbvNrAIXTRoIDHl/TIS0fU0WPqZFGZ6MHzdYxaqx/fjmJi5EcYdWwnMejbfsAAJJxQR4wRCQB3dUId+QfgEZRchrtHkgxiZ1bQMowJ+D0kVjw1JAWkw5iQH+RDZhUCcqnHla2qGBIH9ELMQzQluqJIGgICvGWNyBui9UHYq4KJRLwbqIZs6S1fDIYLhPD65yrC3fBNSKwxZh6bZwjrnagzJDDgogidsCfTyWPU+JT6TJNx9Gu1yfzxkxNcQv+0iegnNsabJfEMhDU5I2EBeVjA48US41wzBhOv0Urg+h19FHg+bjcUlqiRb0tvpmve5F1qkwRFHIIgROoCYDt8N9FtoTImqPdDSeP6boQiHohoL5htnHJFR0wighQjIw7ug/dgbyqSDwlRcV+Ew/uRN8g8HivUyyeMBnJn/DujLr1/ESjgTTdKIQFUeOEK2fEYyAm+ukAJVe33fLDZ1ltewkybroOO1LBGkHIeig8m5UYqx4TNTiBQFA/LmiAwNHFPhItKa8dVJ/x2rZdrdEjyRKwEMn8IqPTwxy7w9BhXdAGIjWuoANIWwjTNFfJ9Mb3XUto/5GOe+hyiO/eAN1Jc1/J+j1O3XZTApMbq65F7PE+CYIh6Bug+VlQgBTnw0FrtSNgwHGBjQKEu3lVZqADDmL7gnHH8dqKCoRj9Jj8ZP2Z3XeB5IlMBHTKDfFkFnTpcQVa9JeYYMocFmDswIEHIuNbmCso3CMuFIcg80L7Ia+gOkijgMAYd6rn1uAyYwRueCr5ihqHaaCChTpj3jCUj3kEL9B0QGkFIgpo4Ry0S2WROgFwZMoIZF7GQmSm+km748iY0CDQoAzvCyzFOMTfsEmanXspg1BrxVolKpnIN9TFy7U73fvAgcmJG1WBG8V3pUYs92JywTS+8Jo5XOiIJeez0TEQ9IcbwNsww2he8I+QRXGQrkzE3lwc0oQLd0UTEoO8cOBztFy7UAsyM6EYVN54BoREN242NIgsSzh87wW/MQCA/NiIct4klIysD7ojUBXfjtYH8Ph5X6BqJwFgz6Z9LYWR4h6TXQN7IbEm5QmYCtGQebknoRjwzhHA9TAstgDo3k09WT1/zNftdX9iOzOcj3iviapDvCBroMU4w+UHU7kzUkjH1CuAgiY/CzuIFSj4vF11gLmicWWEscmeeXt9bjT+fr0Tmhfck3HEW80R2QPpt/QLZOzLyBUMSWkcibDR6xudoPd63gySgyQu1o7ySSRQMf8QsGLafS9GZBkoeKOX1EVCVC0rLsDr/1QlXQNW6Iu9MrLqMgVefmOvBUI2BlP2uL5UiHkEuQGoBPzowT1KhyhLOV2+PTUSDtu/ZmOT2LnAHIQSmwyyf4oqnu8g81BJsha8MjSlkijIihiEKE3gJVYU4wRyQD4rEqqT+jIYz1teTA2BOyeuyCHArl4hE4EMAxbkDYcwGvoJ4a2gwsF8qwwHBDTg8vCbXrsIKozXXs66OBoNFXVVl5ILGffJaxGTBcaFvUPRDzbYBs+Eiz9TrgDSkT1c38sJg6kUGMjMNu7oz773QkkhW5m503A50rsKqLmzGJ9xBc8EQIc9EQ4Bqfk/CVkxMjcxckHvAB/AI7gPuIHoe89Arc5ykf4IfVJr1QbCQucA5QcB07oDrbf0C4Jqjzo9x7UBqdmA6Y22Y/cefejojB5Nzj2DuLnik9RelGFEXgA4PdZcLlDGuB7oNb3Qg56kEAz/OpJSeECEzGEEJFJ5A1puNLnB5/Mw/4mvljqdl7oZFm8BL8dZELtOxKuyOHwduH6YP4TN6tqZFjMMqCUaLoMM+OYS82NcjvAUX9HiIL27VVUa7RKSHOUkYgMFgKSMOsD9aEWJ7je8dKrvd8JhlY9dhjsTsC5O6A/IqkVT6P/gftPbBP60yQFTOVXSghWQgSDDzH3A1erpQydmV4aatZGagMAcYOc2ondWoCjwAYxAvRBWIlCCRAOzoXGKBJK1wqBoSJ8fMuYCj4EE6AHoTaQnm6ggQfMQVOs5MRAvA3GelgzsCxHgnqbxdmmsEJIYR80jcoKJ4AvJgKSogCljrUwvIqo9K+ykucGAJm0spGEay9ukXPIyPwwYSKng48wIbk9exKlyaH2HKCw4eFKmpovaVRhGm1jJ3lAjK9tvX/hkNYW4Pq3UE9SbQPnRhw7zN8mIL+zcJUNgfpnoY21WYnNTB8VtlgV65MFuaZggdyQ/lgtsblYb7R/MJ+1w4PFprJp60iHU+aNnCQKG6HozmRyisgV2HKACXQH7NgCl0SQXhDIQMa2GYjhvkIVYhmPmSpCAKtOyrL60QqU789wu/hwnoMY4FIpJ1DS0FPp3BgD+yKfYVVCApD/KblgRCIdc+V+HA58nPlktv9KaFec8uDr4qXDCHIEYlIHMRKZZtKn6rwwPA1cfVU8MjAgdTPQGQPuN6GM4oJXZC7c4qUHQsQScIvtj071jie+84b76L2EfNoQEx3ne5MUAhbvzg5bqt8gMoPMoHRcQNQi/O9Y18aLikqezdz3OYvLsOhQ9eaEgXG2El7BfK3yXi8ZHHMBQSHAeL7SV74HZGGceIMtHXkA48vFBC0Pe7uNzTjRjs1J31IjAUilOUJzgh9/hrwQciOGEk84P0wrJPppIZYzagQAB2zIIT4jYAwXfB0bAxMrDiDuB3sNr19Tsdfn6wm/sFSwH0/Lzvwp4Bpgw4IwOSIqVxUZiEdfEC3Hl9rrXwDC7JeQ2A10jpqAhs7cyvOW4J7nV5w/aFAkYqI5sCs+wL+OazQyXkEhTRcei7odtcQRtST9KwoQKrUPy1zQt9wN43ZsuuPHZm4spH1cG8ON01sGr4YGRLHJbskGbAMln4CrXTlEV+EDvTlewPMxNBDHmhXamrYEEsBTXfLuQjLzR5smmFcX+MMKGNZ8F9YmXMuNuKWHBAkKxIXrD2Ksc6QP5Q2pHDKuEWLSEhnwpYT3j0G16DzgqKTnGJIA2NP75BOxHfMdY1eZCI1MtvwfjfE4oBmSV7TQJ67cWJIE2HEgcJNAg5yK9Zqkf64OsxYrlYhOqvsvU5q8B9Ivxung3l6ho8oUeyYlIGWC8UxNp20izBdcDPo8+YSLL3Qv/dIh06BmJI64EtSQ5IKbl0dpaV4sP78TNwiZYHB6FbLUU/B95W4vG74A1eASFJRpFht08wedTqq/asx3sLOWW1hLABIibCeYcEYZJkgJYifjzXC4KiDLcFzCw1BtUmdHCLgjCubOIS+OAaGZlvmLRlw9ImMtFLCl8o+7M+Q/xA8QkGLqcslkfj3lwFYU50wuojIwzJr0OjSBRgeDDy5J0BwrxcZNhkRFB6XBI3Td4ARwTKhysuVRZe85RR4JwjxNYIdiYwb4xR57Z1zrYvaPN2cvGjug+kCENu9QKtiZJEfJIc1hunxam7utorhz9yPt6ctFwu2KKPuC1X4BGJltcSQAx7lMmbt1E+EiYxXM+od+Hhkjw0VdCEbW0oyR1F0HYxKBjNz/UxYkaRXUkt61RJ+Z4f18V3tS7XAvYahk0fEoULJZcZCeYsSlyCxS+BQgC3lXwYU381EGpYaGT9L4eapp0vwDBYYJhdujorCl8eECRCCjrOCNWbxA7JS3M7BpS8w3GDnXjmJZmjukAF3CcwswsU3k4OE0w80Qyu2TNLCHTGS+mzWk7WaoDYwfwS3CNUXoSHxUl8BMQoL0MGVpK2AxnUx6VQjOcpQEyuTXC89+1SY/pZcSHVCZx32VwQeJwO99gY9HFDFIzOJH0LWaMWWfJgc/WAzBpWg0oWcEuANSwSpIi1ICNcZ7IQlOEhMhlvq3LbPP2FwhiN2HtBsU6+rOOBHJFsB9OXwOhc9JfE0FkonHgRkKQWkJqI4DkJQCxEbbgd3CAZlsitAlrhImFbcAOvy7DAG7lh3pkpi8XYb/7gOj25z7DXSjKFC01OlGSNyMPr9fLWafFrWjesXReA7UMylcc6RHKJk/DY0Wpd2RN7CXsjRhu/4HRhN+iuIFrnZnqsNL7EBLIffQISEcQPMMNgBEtEwzWyRkijMrhUitaOTtm9Jz5NaL4F7fJu/1vcGQrBDljsxrJI/fwVcNIoHDfwKpi31XwbUHC0AlCFjF+m5Dnr7aWbLTDWQDpj0cBD27neMJl+kI+nijezoJguLcBrZJWLDLMwLpb8Jb4s+dVBJiDG0KikKLiwGVck6OqPr13xtxh+QBLsK+M6dT9EKsSI3qhg9gaSH0TDi+FcB1UYpH1exNGHgzFYvFlABJOw24rHLBeSEmxFAC2wAsiHSODZ7dJfVIyON71H4SGUrDsCkExiK93FFBhWA4gcTNeNiG9z8uZ5VWAPBTk0gy50KO1cGf0sRWVM0k0cNmY4AdYmQWtwF26xaPwQkPNpw+aHQXIvyBzHhye6XXbsEGxHTbyWildHFyJ6P/sBmWKMuGspWa91gUsDvC8DnWUz2I1WBS2Iqmg/ACnRcu4M1q3iG5ZcgvVJLGTFRgsCN2IkX64J/DRs1ORKHzodpmyu6X/WaHEqgA6RFwicVspMLjZYo7KBBoudXAkucP+jZbaYAoLPcUe4gPG7EVTAU0S3IKwg7NpICiwzMYDMZl7zPis6DwY+YOSu8rOaweMrfvinYI1bGmHjG6Ftl6+Q+8T7+F1UJluA/8jzIX5PXiAcwwVqdJyDjHQjMqvNNBX7L4/hunCDsCrJgjWvLqWPNLvlfEgI3WYtFdvHAF+P/RQz7/7CV/+A9ITBt3h6wL7Bmkwdcwvc8tQiJ6JtrA35lUQEr1QvCQGnCZYTIEBgKTbc2dNjX1Ejnj4Xk7kSwtDSVGoWfVxff5fPAF0Q4+kqri2IMVyWPLX6DBoR4PGFAJCLb7wbwPNYHgE9lMrfc++WCGeG6C24RJT2BUnVYmdVWOQNE/YRztkFy9A+mwi+hDmtYi+vm5rrPsxZI+8fsxCj6+r3usyo5sgwtUYvBsJemKlHXAi48aL18cdCCbDi2u3+XN/Z2Vow89UJltyuzDdcNkQjEyHYQkSq3SaiDgGtG/aJbNZIgglqIsU5+QvQatcD3oqvAv4WWQmA3E6xlle2+4iXR5RhrfX8GSpAeyHtQ0k6Webqs7cJZ4QAh/aA52uk40rs5QrQJ/kGBGA6kmjL1ZvrstWgerA9p6Z7xDYWrqZ9A6jA9h77SgA34p/v6k1id12fcAQ8ATXXS4lcsBjutLZQQHrzgOhhMiHfx8Yyifey3fZ2aZMXnYTgBgZfO1AwRC4jcV9UeTnfJpWHDU7N5hCc9L7TjbCG/kvh1TBaG/PGkKAuGUJuaLlXe5BsPGAuiYun+kPMKgb3Tl6GRInrOw4YPX7dNh6hypC5TUvMo4N+N3I7ftYi+4P3GkgtcO2053zmK9LKJq6P9PiK8fFd6bT2oS3qbUsQfspFLV4QGiCwIDU8u449czfMyw56HpzXjcjtD/D2IBywWTZ3NmDD5TTMdvwS8rfX3CLyZGzcNhOFjSOyAMeMNrfyab6BSLw5VqvbQHNZzEBbbVf2+QzmEtCzrsXUYdH5edQiinfe5bgZXhSNtJ+Ku0DhlVP8Ip9IEUbVfh+GFGG9LcNVOU8VjzTB+5ARfBf+jlZ/eb+IJj6PZG2FlH3u/l3MrSEJZHWV/7LNi+jBghbk7Xgnb4FkhmrQBS4bwOfYI4yyoAlMIQ9I7HLht20RVPptpKALkrYa46YBfrXI05YLxyTUnEgNdJVlE0sRrjB1xPPiu8ga0B3v995vgHiSS27MAjTwAr7wPW4kQDDlBdsDdt8q41dfkHJ+CX+KMOVjHVlTITnGGYlwVnBKJHHrZ9vVsvdwTkQJ+g6cKk/CMEEwPGHTuXFtpph74wixoq/t62Q0pPWBsuiwbDntnjehlxnRELT2s6sveIxulx+xhhTX9SYX09t9vbZrROb7I7006IILgwr/vpItCvG2I9u2Ov3PMh6Si8qupk5kN9obWXyRPTb1YE/R3wnNjqaw8kzy8Rr286ElCS9bcnmRhDDxMsR/t6yN/uPdU5CyczoT7cJzZM5dpn3u0Kt2zk81aKHc5pMtNYecal0IrW/dPx6G7IgXz/9rgUDoAepuFwwhIh3wJlRdLwZy7QLq3SJe5vNMc8IjfNhf5i0TAQAbHG2JmvkBAQnU8bOUgE7vaTPwDD5yPiJNRtMStbP8YgVtWJuA2kjjdH04ENQDXAc8T34CYZJxOa7/4jHMeqbNvr5RlJtTh4oC4TMVSfGBl30zBxdCpMX6gBvoPjhOcMD0QQkJqQMmWNomOsuIGPWnWNmxdSwglqbF/OAa/MgXUh5PMlzSQZJscXTbnxOLhcRvQKwO/zztbM3nrLYYWbTHM21XF0+0XgkAsdPUKcEnkKJIdt0Kb5Eh1U5mfW3DWC/Rha9DaIK0j3QmL9t3sazT3hZOMXCkjI2VRNHX+tmEA0Qu0ZLxhjBOc1CFgTps/lTpsKGBblQuMTL35TahLXrqT0ij8trCw5jmaBe8JXrw/aB0Vwii7BiV2COwit1Z4fR17vc6XFd6AFkgGSzGOsKmh2kvaQaaXePmWeLPwjQJQuZbwMxK9zdpdHAYl+0lDPt386L7tqOQLHItuq8tRtluG++EzXwHD2DrIDGC2mH0vwjNQXqdSD12HfDQD/OmsPLXP5JS/MIXojdQ+mP2YE9stDsLvWr/PVH6BEAbs/eSq/vinWPlrV0LseVeva4rWwgufAMR3mwntq2hdVvzt3UAJA3jNdq8CRRSrj5XNnes/pI9A3NCCm+h9AODYWwERGfy5lkxajzbtp6Z3/oeVQAhDm0MVvRNmdsvdSITavmlgYgBv29p3wWqh7E8DWVEZUNYNe4cWkp9jOICwLLfJlwWb1wSQa6DZyswGNnSk01uQy3silYFVvbHm+P3Jp53Ak+3vXXkMYhH1sxr4pqJd6MWozmQYmRPL6hriBG7bBNAJaP5EkpxqpFR0qju8dPCsq2Coiuvearnbnrgy3AyBOtyHY8M9cCXD77puZHTSEfoKkr+t2v3q50lWzSqzbXoI4wB5M18oriBs5FsF3ytxus0jj4BflUP6FamD4nDzRHPX0vlNHHwBMEyfcpfGE+NLn/xCsiYbosiT1MBnabkBL24hehe9zGlruz3s0SiPH7yd5P9tp+Ez65tCAldApEA4jcqSVu1nDy7K0d1xfV23QHBBehaNK7PCCAfkQNC2ruRoNc04Fk8A9RVbijksTywbhfm0NuEQ77bQnF/4FiMhEpo2kJbqoCsC7KwLKh8X7WcMayuWLkMGn/LIzxyakwh0xL3h/mxVohAwbItxtXQLtdZf/H5mUcMSrUwd5b1cNWuDjkNyE3ugZYxi9DOiIDaVYzWYePjuhbTD9yjLHkTodXWLNsTESyo7oHiIUbPtDN/6ZQYGfB+lEjetjyGtgpsmi9kuGmsRYnIkFDtT7S9BXefP1d0bltOC7CMQStExkeAgTkzumIybaVmjO9rImBvDLqvpCSHEF2OgtEmMdrOvblVPn29CXULv3V+fgXrhqcXA1vW3+uBgHWAqszfH0of4GBG8hF4ttvwNTBm1VYotLm1xMe2vnZsDADrpor+Y9Zdo4r21WWc9YOrcqMbMbjOotrRZiDDcgNLGS7qfhbWEWFTecbYXp/azBVBRF2z0qbOs5nAybY3QGYIdpSga77HrrIg2GMWMbFx2n/PiOerp8cQmz97dHiFR1N+h5BxjDcfZPwRAwLywAy+C+gkQO32c29ld8knRAYb1YsKwNWQmY8r6vDiR8rb/MVs51cVBikkRcYXXNPaPyFsTd4aQEzS+pVJUt0pRgu15Zqwlt5WfLT4jTyCSMrZn4qMQgwSU2iSBaNAMwviHLidFzG6pqbnp7c2Z35bCK6nqT54htp4QbiVWIjvT5UNjjI8+whJb4L1r0W/hnEXciY64o1l2Fxkyegz/JPtQ99gULNNSvY+NGHotmX3zwuCThkjdZGXsKIN2x0DAKKHZrmY2813IgEGgm7F6GJje238/RDO/QN5uVexq5xr5XFfFe9qP0rCPCIALEDYbbLhVlJBc0k85NPjgIfoRYFsi/LDvWxGSDMeMXStTlypE9Csp80NRwIMFhAZCMDW1ZztLTmcAzOJrF+BioL9o9hsprI2+yEjsh1td5TbDXbZUvo5fUjEBfFsgKe7uoV0RmRh1W87X4ieUhRSyYXP+FyJ6AF2GOciljOOSmVUOi9b4FPwvm4Q/rb5qePjueKD9uW1+QDvGdXhWQtBjtl7dOfOB60bvVLtjljcbMMwucTrvcFNSel7l/uF4JrWNuanmzoQQMAdMe/QOzcm4TajwsgJZSUQ5m9+XfA80rOd3g0btxAc+Ul4pnikKd9HsSGMiGMFcwyAq50mEe0KNWDRbf+ZN4QOn6CjS0PQ2ctSdFT3Y4WYnCFK+3NBRVN5TyRtpaytvHfN8w97PcFdi0w61nmhTBG39XRB8dOK9sRM1de+kXi7+2rYZLizLc7fMjQWQzBwSFhCS2jkanNBy81uv615hxe/IKSTuxfiYrswiq+5nfRlb47V9uVWhjJv8P/n2RDfxa45QNyuD2uAjPVLUPH88cq8mrS539MMgrJh5Jxqpp7YDXDQY91liCxdYiR/QuLNRsM6B7ukbMi69tDQ4/qI0LH04jZnlo+8xkhLdPfm/kjPKRLDn7/sZ2t12/e4dat7XsRL4geGo/i53up2ht5VlJWXjO4OncWNGX/awaB/yIPnigybG7Alh30N+wWsqyEJFMIkJ3bGLUDuBb1BpGe8LqYQU3h3FGnP6bSv4pACc+62sNzL1dyialkCJ+7uDBzE6wCKxRaULcZXN3vZphfcBPqSP0ETYSdFdW9eLpga8PU1Qe1r+XKpqCNextbQ9pCZhRgVDtynq10lJoGq+K1RAV7g89R17pRRI0XOTqOcspPy52dfwAMr2UOuWrtd3obl3VVio+pbrIcy7vEFNB6UpR0ICBVcAE9tpx8M1vJtHZw4uV3dyeK9K/5PcjVCDm33BvC44gcoNtwYXu3qyCRevjBThDs8uJWbLq6aTEIu9puJHa8by6dbbb6fBLJhJmJP+2GFq9iOATTip85DnPkdB48hOKQND+iuTYOK2YxN643A5sqYXDRbaMGuJFe0rHHbCe+WLPfKuZD4POBDVBanF6AIWMJ4urZgwGo7JWx7k+MWcGSMfTEsPDUYB3ph3Wy0+9l0OjB233hVVfW1DOZGYOvaw4Uz+z1fUnt+p+Tb82WbQCFF3NTydHtctj4F9b/dG4mn764A7xJgZueBIG+6B3cYuEdAlQK6w2sE3L3thcYwhbNpSgt1uspmv6tNAkTf7e5JiFAXHj+0mFVAfISd3uO738uy+oMzyjc5QKJia+zXsPci8PH7dYPg2diLWF2bv3ItzBgQEEQZKGecVk8yKFQYJaKQkZltPfbdAh54NqQEUQkMhxmQqgQ5dFlNVigRGR91BsXqx7QfcnUDC9dN9lVXSAOuDDXjcj4iy1uCh/H0Ay/9G5LEho653DnDn7jRh11HiPI0yHEX3mF9XKwGg/kK8ewFD0ribf22M2bQTWIoIFycC0q3WeYvpAi4UfoTiWl0ptvn1MpuDOmu86N+bYpfto6cVqbg0nQ5PdoNksKdM5gu5F8usCx3HojIaJR4WmOSS2JbHJrO93zd6g452nH0vAOenJ6QsBUXduXWdTW76nuzI+T1oYm77FYexgiHPn/qK6ZofxeT64KSCz3pwFjHiXwfU8sYoRKHdXxF6LvcISLEPGdRDE1pe4ZWAJ4OirfIw0ECnzX5N1r+t3RfTrvHgti6WzFbjnAAimHYZMNHz94Sy3/1rDXjjbzWbm47MK9JAlvEz67jC8LC25Daubj14yagz26O3Ulh+MTSN+AWxnTZQWVgOdnNcgi94A5mNff8Lps93OTdpfcWUaHrI6TPjzAkBIR94V/BuuD73uRW09gO6gLarYhKoWPXMRRQjlsmCgLM/qOb1/ywfzNY9ao9pkmouEvrA87zcMFckq0ZYkUfjY80jhdO1g5Y9+dEyy6/XkyDiJdKroiBYwGenWngPnlseUxL557jF7DBcOx0zX22E1hxwKMl+9Bbz2ed3A0vzX70m6k75sk2hoxO71ZxQJKAQLD6jX69bPR7ljvbiZrwBOuBHX2QuUxw2XGpfgEqpifoSVWQt2VV+0orXx72ZO7LJUCrbuElMCA7GB6+INjLA1fceTIUdXJRC7JT40327sfzJLpT8NnFjbS9gs3fESDucG5x99ZMpycg2pPgLRRg2L1qGuG17zSCvQrfGHgN1/8F53EF+8nLbXf883PywLKOTXo+1gsOhYFtQ5vKFLhoOlyc+l57Lixn2uwVhgiJy11mObgyPAwD0iVp2pEduL3s+u/Q1nJPIdpTBCAXe0uhYKQKPBQuAapiCR/0+NBlAsCJ0CKHqu20NkzxCbjsAUhtyypgBKSFx8AhnELCgVqeiCx6Y71JOJsJo08xbRnKuLpvWyeQnTFbH9f88USQHUID3iJa2+mtxtPu0xiSp/0ccAW293RJMH1ecFuXQDXYMU8mV8kdtMa4L7u/7WtWF46r8OzZFrRCCN2qJu4EDj+Mhwu7qA3rmOgUJBRP+3IPjAXq1K0j3wKpmJcSsOs2qGR3om/3+WGNXfgLExpknuwXTO563zffdxTu7rk9D7M4O2g3iBzb4xAR5Jg70bWE2z2ExYEGI3md2+K2i9CwUpPygMGfXk04vg3e3s2r3GrW67NN2L7BxG3BmelqjquMNiq7Lx4TarkQS4BSe05b1XFsExjgE8xOETguAC3Dwtl9lNtDb6on79ihwP8QUIucSGXd7UY5QFJx4osmsqNZ0HDHZmOw5otdj9NTBD7Ps8g2jOkcU3ZhlSDQLLtI2Z8boxRQEy+CjWQked34ykDx1C0Ed0IlRHPGPzqg/cmn3XMEd+h98RQ6sh3aoXV7UojIrbC3Kt/cUIoTB9HiFe1ZtlIf7fclWm63x7af0sq21ogve4yo2y39n7vR/Ra4Z2afnUPAw31Bi63jD4anWdjQp5RifJB1023W9+sZE241QVu5f+Ori8dGEdZT8yVcPbGrXfN0AwPmlhA05B5TYY3+aa8NerpBPoc6wWspjfkawR3hgeo5FLEsz265r+S2SCTUUkLINF2uD0MYd7+E6ygDuQTxp6gidTv/6Qq2xMzonxr08163Z8ZEt4QgdlEF6AgtBznCFL6H2g/1oVNsTYdLmGyPw6mrnhVvMB/rUN1NT9acQ1QYnemmAdTCT08IkcC3TgUC/WTrHgLa3duruRkO97zTLpoVBDs/1UnO0TT9y83nhBOeUCaDB8bAqupade+Ykmfpdt5zShZCIg23OesUr/ZARbxxJssgSmg+NDvW00D23Ch1pZ7NMVZLHhHK/U48n9vk0MERZsgk8eVqlhjfnuzg3naKntNJXN9rd3MDKD8HrKFjsM3w6uZ1GNPkWQvYQd4bRXydE0RsZ1aUpGr7PezghBN9ljKh9xhGRoHZp2qt7jnFptdJQPy6JWOuiRh98yfQYwebvf7ug3SPGnj4CCno4FjSjw4+PQ8oI9ScreQL21v4wguiX+gYt3omjJj7PjA+buckNxqXfk7XKL5zuGgZbafpFrUsiHd3GoM90T2UuCN40Vb3D4UycCc3xF0fraZWa0DJqfxZ5LWBEtXi0RBio10vmCz7qLnTNVxy5bG7y914c+Ts/snt6FwjGT74fKazyfF1M8OyAW+ir06rj3QJB7XrDybYw2ObUf2HDxA3f0qmY0DBy8X4SPzPHLOt1W7zcwtxSvOy7cBp9gCT4bkbTGvH0qGlrJxv2Dx17aIbYtyUZP+J5f8TfgENhlheCzri0e0nQjH/7EJHGWfXk9oKbpCM7ja3k+dxHxQXSe5TK25wJp/wtLBPJAsu3HoQiWuyZEWiAcrf8HwnWzjtoEaww5ATY2RvAfqh58/+3dsTQEjshKXb58w6OK5pBBeMv+BXnqkoEMyE0FwurXc4K4kAyAJ1tppC/FMjv9ZYWrtu1yaEOcDh9ZQaqVw8hFRBg+hCx3c6Q4m+5X7Llu13IPhdh2EO726rwJXriztFCPMchGmyja4FfvzNgOc6O2GzsAphevCMu8bOXPFUgA0gMorV7st2m4E2G1Ol/kPp3ylApNs6yAdunwPjgMFpT5BsZo0bo7rPpmstM2OkwQHwXbJwO4UtD/jkr+rZYOqC7OBZMF/EDmhiV9vNaO58Wr7WOdbpfasdmriryrC81isf0PeeGGwPbQiw8+FGXsF3BPinNbZXTbhcFeJ/QWMd13fZtgfPvW/q2KZydEpn9uJZGvf4FsToiHbg279uecS+XZcIsE/MrMejkV/gUSXWKw/HBCP8F0gZbWCAYBmBVofbDRBAsEqzVIW45+Y/7UqlN09LIvAs1LVT//NEi7/yDA0IzdbTimOmvfZGFPzCg97Cs2PwgcXxe87Fod6LkbVrxGql28XD2d8AvG4XXh4M70JTI1tQ96ilLzHQkNbZ1nvGCL1/PPLlviJLou5/eTWiZIVFW35s2CIRe8H+uzlaiba75w+FSsChRTyLpA1CG969FiSV4cXR/a8mD1CAHqBX9+43dxH/dt641BBsv3clFNsabIUhLF6PU0BoiVC+JfeyLQcz+WMDGh7HorRNaJqm7qabb3pO3HbZ1P54+OvG+iVs3oUqxw2U/XOamaclWIkUXJ6b17I09Lj+NVyg2AL33XhP7CQT4aY8fRxPiTvqliHnz74AcGaD2+GR3+6OFRTag9UlFF3Y3zlJzN49ph0G/eE2N01cb96gosQMJQvFE/eMX4HdYKqiP3e/5NJ0uiHWk/Bky3Q2XWvpojpsX00aa7gSRf4kODxR6AVBPTptux67nhSYosFFoi/lEQ/2pZ3Nq25DHh63cUX/OYSMaEUjoiMhMXcTknlDTQtoW9d5fdX+W4LK7nTMSaAU6Hi5y8XWEd3iiu8iiGSSBCuiNxCKNltE+7PtU8fQu8QSfrpz03tOPzl7yPnslcFdQ+vxmLYhsWoObjuHOySaQEw7GUzO70c1LSea9HGTxKeuJZxs0K1opgoSwFHLnj93BZ2GFAsR/P6e4z8+3noW+y3H2WdpaI40t2daAb7xu357jNY5LM99xoctCRUAu//4yLPREMJy08nvB7AcD7BioyqMeXveCMG2UC5kKqSQpgcYbvTVhOWsqiw30Z6Gweds6f/7LoDhUl62I4fI3M+FRUJrBUZf8/SeZWXcYsweLtM1oKNY1j64crtmLyI2gKW4ydEqiAqpXXAGnyOsIKLM96I2TK9m0RltROS7Aw9kzKQUxqdBmMhKqyDTc91IBqTQuuzgsoRyWtU8JrBZtMLjEFSPJwHU06AwQ7lPr57PqYR2Gyl5kMk5soE4GoNUd0eTlRj0KcE/Js6jAkV13YSzf2ruz/IktZl0BQwKxiFtwqTwCOQolI3OJ0VOBQ1E9MQweCZbRrS92R4HN1CdPSUqZ3WZ8wgHkGrpbe9p+P3wtB0Ej34Pfd3PeRDP6bMnAYqLR+7iaUwxEH+fTulum5U1cdv5z1k6qOIrHRh3996fvrXXjeUbNcgYEL5uCEBs3rYie8jLbd9bfDxq4vOAjuWERJc0PIAMCCTHn/I1z0k5LeX9rKo+coG7+j1E0V5Rq1BEsxVce2tQnmg+Bv5KhOHzWqtvCLZit363XHCje1DXru66fu3JQmcd//TaL7vyxK9nufT02aVBcjD+gjSf+bqqp7gtBGCe9+mgUlwP9wY1nQRzVNw5d7tjArRk6B6B/bK7HlNpg6KdYkwuctY16SCLdQ/u8fjL6oEz97ssIvFCKN84IR/mP7i+XdMVeAVlnvqce59TNfj5d7wruX4zRQzS9SGfRNJnuKf2gJsHhnyh2AY66lWZ+Y4wtb4I/74ev7HjixJOnoh6uxDulk/PGRzdY22xwF9yFzvsFdzQL4DXSzP1g+WYluyeq+fxQAdG3vPl8FSQ+mMV9OyXfSCn4aqnpqfgHT3JE70XL2gdP/0Y3u71cStit+iLDb4952q73I1dYX5eV8jswW4eRBxseruzm0UayHKVYsP/LBbOrFK9zSDr1gEQt9Uys/t7kFgdPeB291tgajyJW6S+e9tiNPBrK3w/jUy3B+rcZ7ONZ6J4csCezBy39ywK+4i3S0pdOkOxiMzpnF3MlPNEc+aHOK5AOT7IpkHP9iBWHly8m52Wx0MjEBCHaPkzXy4SE5QPT4tf2nbbXtMZTFjDL7mFGjZSB+Cu3ZhJjuG+b575dvfqbWXzmI2nErEup/h67uapl4veRf/i4S8iqdrQg02tB29PGLSLGMkIHCf74FsLRFKIuhxEH3mAAC/xskXUZoQvGZHbjnkisjQApNh0+ft3+9rauyK6xRnAfmEpUTbncCQ71q7mkTiSHmob9Ni+MphD5FVXDFyHtjHbnctv/iO5lvU5KNTzCJh8fO99iV+nJ4V7n1yzLGoTXNCp5ePBsfjxKfpJtwe6ozR5/geTCr97WASQeK2zK8NTVYoi1Z1d9op6Hpgr4+eMMG0w4YW9vK2P6TOP3V7RA01s7Q35+lad6AkSOBJbzfW+GPM+ZVGQCd7wbDgfvrl07Xlfy1Ykz+8guPCEMBDUce1zTBswAu7YKPp5gtAZi98OPDSOWwiIpLOL1oMNnMqzcdta0DPcGZmv5DFPsFAorsAHhtH2AJw1t3dbHZaNOL1/zkLq51y+mYkrnPJN1mC58FHRTV7oW9Td1g281q6h9Hl2dZx9Tl3ZvD3uJ58D+myYbGMFlwFd/fNQR0T791weeegeBfLYc9dmlXCahye55cmjl7M9MF2myQrxH6Yp7v2ZE061sw2wuDJva5Z4+Ount/RCyXNrhwcQMmvWZTV6sOq2enqagOyWt5xTiXFP7B3MWrehycMAZnQxzBucniz3Dr/FtVgBcQy3b9v5ReqCo8M+5seTc06QrnO6R6042NczFKROwmnd05Wf4tZRRqhNz9F3/RdWhr1u99MPURmMJ8TuAR3F5fEW1b4gRJ+tibjL7I6rZCW3nd2HwEcfu7lPdLoByWN3i4dhPsEyuT051xHTrnSq6RNZa3c4cja4L1yFTqZ4FlLwPK1zmN5608bIBLjmcbUNFR1fk/bnlOXissD7e/6tFiHfGdzEoRc32s6fY6BHSP92LjSRYcG3ohlisg49bSUB9Ca22qVgvHrB/KLJMXJum4byXIj23Gt34r/Iq24zbSF994UmsWG/SNDxcQXe4oqGH4izUGWbkpj1Mcaui1vfR2G4M7mfw0o8hHiMa5KybkRgUqziT4/L3ee86nDa+x7UrdLltkc/I8jd3OC+unM69qtd90TIfbk5nXhyiRd/pxd3ad2jDon34iGetoEud+ecA4nIhOLh3y4wFHdBI7KAFUwNxsMjlbFV9kGX4KkEtuoQEHfE89nhst3E22Ow8RCoqOeCjHQWBjxYu4crWLJC8zd/s6oZMUMfHA0xffWcZmi59v7zt+/1fMfswca44u6xpp4g9F6ocbL3PpLiNGehTW4nAwPvToEnIyS7Z56898x3wr3ZeXh7xoIHkQ3BjTy++ofafN0TmYEvTwTUa4AWmK67qfHPyZNrDQ9g6WeBAVvjFj9syN6nspxqv2YCrv9xMb+JEdNTdhtiCySF0lBewGJCGs5wugNuj56w9Jhcd9zg3fUu2A3havi/AAwxljwwpTwe/2o3wCChSTLP327WAlO0US+eHs7IcJ5+tez6kUcUudW0urGICOKJKrFtnyyKfCsJXndhWdMGCRBXpOT2GAjgF+L3zLhO0nrqwgj2/tmZgrFKGkkPkYIEPAjxtXzj6QpME+TGrWQ8Cwko3TdgAoNHzNvF+3887vQ//c4zltc9ct2dYIT3e33u5/QoyIhfd8Pj2138ggW7C9d4xjo9D3Z5AsH2PBYPxpKfGNZ8lCryqqSLv0Cp9T6HV03S9VnJRgsMLPBbLdg/ngi7th4WV8B7VEuYBMCTFZhCQ7wvj0Gxa754NG9Ha9qxXvX++lwsO/RH0kIBbrio1sft7rWyVF0zAy5tYMSLfO61ibXZWoJQeaFzrJOnVOLUlczVE3JvD5OHYeyb/DxN7jnaDeECkaHTq///Iq6pvfnz/B17PjEGA4MJ2BSsuCION0iOIFJj9qhE9xx5AFom5jwBumfg8nqSxbAVbv//Juy32Na//L/suD261OMoXVGw7GNx6Sy5NVgZd+j/lwBPmefQ93/ugvnzmHN5+h4iLyz35ZbX/ZX4j8//nw0QGXZhgss5HFjzhUrsx1PLtE+w0R0uEx7cL/QtzCpJtXOxgoNUso5yuzPa0gvZdVaFAV2e6W0ehpvyuGyj9p0PmaPjzAjbmnm/7qF8ZJcll4evLuugMK+NUGffuZtHth2FkVxz+W3cw70V3XKQ5/Q/8pp9lceulFb+twFuO+d9X/8LgDksqL4uyzgAAAGEaUNDUElDQyBwcm9maWxlAAB4nH2RPUjDQBzFX9NKpVQc2kHEIUN1siAq0lGrUIQKoVZo1cHk0i9o0pKkuDgKrgUHPxarDi7Oujq4CoLgB4ijk5Oii5T4v6TQIsaD4368u/e4ewcIrSrTzMAEoOmWkUklxVx+VQy+IoQAIkhAlJlZn5OkNDzH1z18fL2L8yzvc3+OAbVgMsAnEs+yumERbxDPbFp1zvvEUVaWVeJz4nGDLkj8yHXF5TfOJYcFnhk1spl54iixWOphpYdZ2dCIp4ljqqZTvpBzWeW8xVmrNljnnvyF4YK+ssx1miNIYRFLkCBCQQMVVGEhTqtOiokM7Sc9/MOOXyKXQq4KGDkWUIMG2fGD/8Hvbs3i1KSbFE4CfS+2/TEKBHeBdtO2v49tu30C+J+BK73rr7WAxCfpza4WOwIGt4GL666m7AGXO8DQU102ZEfy0xSKReD9jL4pD0RugdCa21tnH6cPQJa6St8AB4fAWImy1z3e3d/b279nOv39AJ1mcriUxFCtAAANemlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNC40LjAtRXhpdjIiPgogPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICB4bWxuczpzdEV2dD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlRXZlbnQjIgogICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICAgeG1sbnM6R0lNUD0iaHR0cDovL3d3dy5naW1wLm9yZy94bXAvIgogICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iCiAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iCiAgIHhtcE1NOkRvY3VtZW50SUQ9ImdpbXA6ZG9jaWQ6Z2ltcDoyMmI0MDQ1ZS0zZWJkLTQxZTItODQzOC0wZWE3ZmRhZmNmMzAiCiAgIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6ZmQ4ZmI0ZmQtYWE1MC00ZmM1LWFlMzItMWFlM2RiMDkxZmI0IgogICB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6ODRlOGIyMWQtMWI0OS00YjU3LTljYTMtZDdlZTBiYmIxN2YyIgogICBkYzpGb3JtYXQ9ImltYWdlL3BuZyIKICAgR0lNUDpBUEk9IjIuMCIKICAgR0lNUDpQbGF0Zm9ybT0iTWFjIE9TIgogICBHSU1QOlRpbWVTdGFtcD0iMTY2NDkxMzg5NzUxMzU3OSIKICAgR0lNUDpWZXJzaW9uPSIyLjEwLjMyIgogICB0aWZmOk9yaWVudGF0aW9uPSIxIgogICB4bXA6Q3JlYXRvclRvb2w9IkdJTVAgMi4xMCIKICAgeG1wOk1ldGFkYXRhRGF0ZT0iMjAyMjoxMDowNFQxNjowNDo1Ni0wNDowMCIKICAgeG1wOk1vZGlmeURhdGU9IjIwMjI6MTA6MDRUMTY6MDQ6NTYtMDQ6MDAiPgogICA8eG1wTU06SGlzdG9yeT4KICAgIDxyZGY6U2VxPgogICAgIDxyZGY6bGkKICAgICAgc3RFdnQ6YWN0aW9uPSJzYXZlZCIKICAgICAgc3RFdnQ6Y2hhbmdlZD0iLyIKICAgICAgc3RFdnQ6aW5zdGFuY2VJRD0ieG1wLmlpZDozNTY4MWRmOC0wMDQzLTQ3YmQtOGMzYy03NmY4NmEyOTc0MDAiCiAgICAgIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkdpbXAgMi4xMCAoTWFjIE9TKSIKICAgICAgc3RFdnQ6d2hlbj0iMjAyMi0xMC0wNFQxNjowNDo1Ny0wNDowMCIvPgogICAgPC9yZGY6U2VxPgogICA8L3htcE1NOkhpc3Rvcnk+CiAgPC9yZGY6RGVzY3JpcHRpb24+CiA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz50TmQzAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5goEFAQ56V2baQAAIABJREFUeNrcvHmw7ddV3/nZe//GM587D2+4b9R7mi1LsiV5ki1hYWEbM5vGmMlQscEFHUI1TVelughFQaDT2NiNQzqkGRKTJhiDjeUBW8ayZFuWNb1Bbx7ufO+Zp9+49+4/znlPEglgQhKSvrdO3Xvm3+/7W2vt71rru7bgH+jnmbPvFhbmlbF3WCluQYgjwIoQYlEaOSMQJcCfvDwBBkBDCLEphLgMnAOeF4hvCCm2bzj4W/Yf4jzEf8sve/rs95estQ8IIR4C7gdxWFikRSKFRE4OR0x+LWZ8T0wO04qX3weEEAY4D/ILwCNCiM8dO/R/Df5/A+DXz3yvwtgHheDdIB4WQpSvfe01IIQdg/cSWCbPWUC+9NHJfQvXQRSTx6+/uw98Ugj+HynEZ2849BH9PySAT5769rJF/ohAvB84OAbkxZOWQl4/AmkF4jom4q8cnkJK8Z885OufaeVfdxgXhRAfEFL+6+OHPtL/HwLAr558e9Fa+z4hxM8Cs0IIrLUIIREomNjQNWc1AqQFed1NJQgDf8Umr/1IqWDyOS8DEYm1GoFC4GBFfv39QshdKdWvCSE+dMPBDw//uwTwS8+9WUjL9wmhfhnYf926kGNHFB5gQNixBQLSShAvgnkNmHFYs1g7XhesBfOSI7UIhLj+KQgxBu+aywfqILkZAB1EXiRwZslEA018RQn5876/8NEjK79k/7sB8F/+3o0Hji4tf1iG6iFvFBGoeaLOVZQ1VBfvIQ0dBlzFiQzKDchzg1YpxfBu0s4VrLhCoBSOO0MvaVEpHSTLdxHeLP38FIYca0GT49tZAu84w/grFNQyQ71NZhNyMyKLc2aLr8MX84TFGxi1TuD0Lf3LX6O271YaG6epTM/i+HseUV743mNv+seX/sEB/Kc/uPCuu46ufLAWlKpCSDIt6XVG+J6DL1MKpZBgapk8KBK3NrHJCL+4RGo1xVKdfrtFsRiQDPvoPAFlkN4M1SK0dJXEucTU9DxDYdjcPMEdR99FOhgS9Z7HmhHF2RVS4XPuwicpTd1Iff4wXrhAWDxCtnoSu30B6xbJR326vS5ISX1uDzbtdWeWD/zU3jf8zO/9gwD4r37voaB1YvMDNwbl93hBlTjJkK5Ht5dQqxbpdHu4QQFtNJ4XILIhYanGle0mXlAlt4JyqUq95NBqttmzPE+aRGTWwYgCvhrSbrWYrlRQwlKbqdHqDimWZogGuxTLdXrdBr6TMBomfPGpM1zOJLffuQ8xPYOijtvvckNtmmFjE5WnSJsQJxk615TKVQqFCksrB3/bm9/z/v13vSv+bwbgW36uOn88m/vYG2f23uPIEIRLcxDhKA8tHPpRxtZun0ZrSGOUoP0cf8GlvFigVitSLRfJbYSrfBrtJqNuzlI6y0q5giMk09NzxFFCGncxJiHKfbIkRdqc8swC/VFEZ5AxHHTIhUunN+Srp67g7FXce98+jhzaR7VSQ6gUrGA01Oxs7WBWm5RHLoHv4Tou1VKZaslh39GbnwhK6h2zd//U9n91AB/8qdnDeSYeeYuePnTXDccYRjk97dJqNtC54PR6l36c0c8E/ZmEV79qkWMH9zM3tY8wKOG5ZQQejixgiNF5nyiL2W5d5anTJxFXPI5XSmTRgFwbfD9gvdGj6HtoY4i0pdmO2WjHFEsBZ3d6TB2DB950jOMHV1is34EjPRzHQQofY3O0zoiSNmvtczz1/AtceXyXrzzd4H1vvQ0Xy+GFInfcMnsha597aPF7/+z83wUP5+/y4tf+6MLxYZ/PeB1vz+EjRQqLx6HfprW+wU57xNfO97jY1siS4v5vrfPAvW9hpn6AwCviOi6O62DJUNKbAOmg8xitE2rFRebqe3hq9gm+/rVVXjV1gFpZsbbVI/ADdgcxSZTQGKbEqSVKDY32kAffucT9r7qfmcphfDfEc6sIKZFSIXCx1mKtIfBmCPwp5isHObHvG2zopzm70We5ZJCzgn5SPFRevO8L3TPv+5bqDQ+d/mYxUd/sC+/7oT2H00T8xbDj7jmKw5G6z1NndglcyzOnLnFxN2Ojm2OKmm/7nkVuPXqQoyuvoeDP4XslXNdBKYHr+AReBc8roqSPki5SOTgqxPeqVIo+1CNOXNpkb3EKRY6SAikdGoOYVEN7mLE10rzpe+Z56+vfxkz1GMVwDt+toRwXKR2UcpFColSIkA5SeriqhOuWqZfKVBZS1toxutFhaX4WqVyUkhVbGLz9h39u5c8+/BtPtf6LAfiqH1icT2P7hbivVtKh4N5Zl/lCESd00FnOs5eGPHp+QOpK3vJdc7zuzvtZWXolhWAGzwvxnCJSBhgyJApHBTjSHdNC6Yw5HxmeWyD0ppgqLxD5LU6f2CBAcqWRcGa9y+VmwqmNEZ2h5r63zvA9D7+VevkQoT+FIwtIJZESxCTLsVgsGmMNjgoQWITj4LlFFqeWmFoQPPL4CQ7VSpBrXEdSd20lL+cP/+RPv/IPf/MDTw7/3gDe/YPLQZ7wqXTg3JpGgiyVTJFx82KVsLLAySu7nFzt08vgxnskb7r3FhbqN1EqzKKUhxQuBkk8bDMcXEXIAt2eZW31BKNoFUdppPJRMkBIiSvLSKkohYpnWyc4+8yQyxtt4liT6xytLc48vO8938lC7SgFfwbXKaCUg8DB2ByjU7CGPGkQDS6TRpvkJsINqmNwhcF3qxT8IvV9LsOtPnG3S6k0ReAkBMXaVOr373v/z7zqDz74G0/mf68YmMd8IB/Je7JYkKcKkwvWIs3XL3Q4uNclqNZZGzSgJLjvziPMVQ/hKBdjYjItiZMevc45Br11htEC//cf/A4nTnVwhKQcCL7j24/z8ENvYH7xlvGSJgSeW6RaXOKWIyv8yeMnsFZyfjdDSUtkNN/9LfuoF4s4MkQpD6VCwJLnffKsj9EjHK+GtgqDQkiFFAKTxyinjHIccpNQLe3hjqP38qfrlyiccRhEAyJxiEKnAWVxjzHmA8CP/034yL/pyVf/wNK7dMZ78kSSZxJrFNaAyBX1aonddsyfPHqBTmI4dgssL8yjpIO1hihuMhxcpdV6lt3tZzh7/gL/5J/+Pk8/10brcZomcPncp7f4lV/99wwGl7Emx6KRwhL4NZZnDlA9LrjQSJFSM8gsU/sUb3zN6yj6iwhpJrcMYyO0ScnyAYPBDufOPsX58+v0em0wGY6qY40ArcFaXFXEdUuUwhnuu+M1BPNlAj/g8sUL5J2EQBwHeM8LF/7Ru/6zLPDhn6kfaDftB7P0GngCYwzGWhSQRn0aI49eYrESbjwyR+DUkdYljttoMyKPWyRJm2Z7hz/7zDpRrK9HjXqhRDEM+f53/xgf+fBv8LnPPMWDb07xgkWkLCCFZLq0xA2HZ1lfarC6HpMZyyvvmqZarGNsTpp3cbMiWmeYtEEad3nh3AV++3c+y6mzbRwB8zM+P/bDb+Xee6u4Tsgo2aZSvWEce61GSZfp8hLt6hP0Yo2bDDDGx+gmjKtAH3zh4nsfO3bww5e+aQv8wX9WFijz4SwVVZsKrBETOmCxWrJnaYrpUpHVZko3g/KUBMfFkS7aWJJkQLe1xdraWS5eOsNuc8CJ83ZyvQQG0Fhm52aZn53m7lffxx/90WNEoyZZ0sLYFCl8XFVlob5IV+WMMo0bOBxamUOJAtYKkrTPMOqzufkcG2t/wZNf+3N++hc+ylefb9CPc0LrIocuv//bn+PjH/8CIHBVZXIcOUIIHFkg9Oe47fitrDbb1GsVjF8gEzvX4Khi7YcvX32/+KYt0Njk+6wuPZSnEq0lxhisGVshaJ473ebQjSU2e5rcSPxAM1UukWcxI2vIsgGd7g4XL29xdbVLoykwxkVMqiuOErSGQ2ZHQ1rtNnE8ZDSCOLL4QUJB1chMinSLFAs1rLRYqyjWFAf27QHrYI0kzVN67ZOcPfN5hr0LPPqXIYPRuIrtCUW1EHDk4AGCQonPf+pJ7nrlYQ4cuRMjLEoFSGOQ0kNKl6nqPKerJ0isi0lylC2Qi+gaJA9FefZ9wL/7Wy3w/b9J0VH8sjGMLc5Y7LX/LVgrkMKSZznGAMIiBMRpH20sxlqSNKPb6bK1PaTdESSpGVOISW0wzw3aWq5srPOrv/4rfP2pr1EoWWanb8Vx6pOT8jA2oTtYG38PEBYNUrporTFGYTKf5s4VtlbXWVszPHtmNKlmj3MspRSeG+A7HkW3yPZugpTeuD5mwVqDUg6O9EjSDsNUo4UP1sVmg5fXIy2/fObie4t/K4DSivfpnP06lxgtGRuNwJpJT8JKjswJdJajJxW14QCMydE6xhiN1hlJkqDTjIW6YKZsKfjmJcmjBCuIkpQsz0lyzfd99/3kYkShuAgiAwzWWpQI0dn4RDxP4HkBEg9tcvI0YTjo0u0P6PUyygU1PlbAWEsviUmSiFPnTjEYjkgTg6N8pJBYa7CT78AaSsE0UXeHPBnglWcR/vS4CCzktabBfmvt+/5GAH/x96m4Dj879mNAA0ZMLpgYE19t2GwZskxQCyUSw2gIg1FMmmUIafE8D+VYHEeSGYPnw503JRSLGs+DSlUQhuMTlVLy8AP7eMVdK/jBDMZmGGnJbUKUNFnbaTBqj8GPBwZpHKywWJOT6gFIS54L+kNFraKx4sU6aSfKOHX+PKNhxHqnTamckmRNNGYclqzF2JzcZozSLrNekUDleGEBgx1bvpXXY7cV/OypS++t/LUxUAjxwwhm7V+pNFjs2PqEBQHbGTieQgmNIy1pbNnYSrnxUILFYmTM3n2HKQVlBv0R7cYVXEdwYG/K+k6Rr34jI07g3ttqvP1tb+TW224jjjcwOsdxQnLdI8sj+qMNTp3fYdTPWCkptlqWi+unqISLBCrEcTzCwKda9RlGQw4f1FhCzl0dL1JDnbE6yFFC8o5vvY1jx25E5xnW5kihsHmGzWPyrMu5q2dZrOyBLCLdeR6zOCmVCxeBwuBgrJnF8sPAb/xHAH7wj4XqJ7x/4rPXEMVacb2deA3WXiqpFBT7pyWn25o0hVNnRtx20zZTlWmsSqhX97A4f4iiP8Wof4k0g2b7PMu7Z3nnd72B2dnbSZMmxep+EBbPLwJDUBV0nhKnXVYb65x9PuEnbzP80Os13/u7PsIGdAdreJW9FIJZZmZv4Oabcxbmz1Eoutz1ioQvPxnz2BNj2rN/yeO73vYg3/rWN6Mcg3Q8pBUYm6J1Spy16I2ucOLMGe4P9lOtz2BVPnG/cZw0QoNQ49iJff/py+/7zeMrH9IvA9BI9aAU+uCLPVheEmwnLcbJ34JrKfiaPbWQ+WJON8vobCu2O032Lw0IvCradqlUjlAtzFMoTJElTXKzg1AH8Tyfam0Rxz04jiNOgKMOIYQlNyOMdml2V3ns6Re4aaT5ibelLCzV+RdvHfKJRpdj+yuAwHF8avUDVCrzHDjwaqzNyNIhh44M+fEfWkS5dWamp6hUl8nzPlI6OE4Za3K0TtBakyQDtlrnYV1Tf8U0wpG49QKG1qRPbTHWTPovAPagMeZB4JGXASgl775uY1IilUU5FiHGIF53amtJrEI5LqFrWJlyudTNiPuG0y90uelgi1rpMIEnkU6CVQYvrCKlZX7hTmpJB9et4Ac1XLeCFA5WKITQ5PkQk6fEaY/1xhnWTvf40Fst8wvz2NoKr7r5ImvfOM0wPU45LIHUuE6IG5YAF0f5aJNSzzXWaPygguf5uE6AENm4oGEMxmZok5FkPZrRJb767PPcvbCMznPC0izStBHCw5KNW1jixWA2weHd1wCUAB/5ZKGEMQ/bay8x1yjLS7DjWqNbMBVq6iXFwkyFqVBSdUFhOPWMZXV7hyzXFPy9KOrkuUAKHz9colq/mfmFNzA7dzeOU8FKBzBIDBiNMTlx0qHROcNTp87wizfmHDtYg7CKCGeRxTnefpPHub98lH7awdgEIRVC+riuj+OE+N4UpeI8YaGK5xXw3BLaRrhuCYtBmxxrLLlOGcVtTl/6BtU1xVTRZTgc4jAk7Ud4LGOtgxEOFou4bmsCrHz41MX3lq4DKFAPCGTZXkNNiL/S37ZIa8eLuYBWJOhEPlq4zFR9js6FuFKS9uETf7rJUy98nX7UJM1Tcp2Q5gMsGcYMMQwR0mJtCiYeW4NOSbOYJB3SHm3xhac+z/2bu9xzQxmkQDjB+LCMxStV+YF9Xb702GfpRxsk6QhjNNYKDOnYYzBYUqy0pDZGI0htggY0hiRPafUv8o0LX+LSVxrMeUXWtzosTldxiclnHVK9ikAjrUZag7XpRH5iQOiysfaBF11Y8JCd2Jqd2JqYyCvEi0TyeiahjeX22/dx8sQ6R1ZmMarDTjfj8kCwfsHy6U+vU698heP7jlMr7yPwapPrkoKRCFyU9MYporHkOiPJO0Rpl6+cfpTVz63yC29OkTobN8yTPkJsYpIIkScsVx3eMhrxyb/8HA+8RoHci6eL+F5x3JcX40UiTtcQMkDKMXfM85wo7bHbuchTpx6nc7LJQ8eOc/nKGtavIR0Xr1yiW1/Dikncs2JsfSKf/G8ZRzX7EPAn6nc+Oy+MSX8919l0lkMcw2CkGPQ9hj2HNJIYM16NrR0T1Pv2COoSZsoBG62ExZkS0ahPlFiGmaXbEDx/tkGm1qlUMpQYxydjLVkekeuEXOfEaYs46TLIWpxZe5wvP/0UH/u90/zzewcsLlWR1sJwgLDpuIEuFSgHqy17a5ozT+/yZ+fOMDOv8Rw5liNZjTYx2oIwDsaC1prBqEOnv8nJC4/yqb/8IgvtGRbtiGLg4psI5XhMlRQld0A2a7HSvkTZ4CLspIGPRY5pcuUnf/ruDzlS2HkhxOGXeqz9K1RGjPn0mAoiKBQ8tBLjpk+hhO8LDixWGOZDHBGzOsjpbwk+/tEBz558knvvuszh/ctoM2Juap4wqOG6LlZLOsOMtY02f/HFp3n6iR7/x2tjju0pIGONHfXBk1CYA+WMrdGA8H2wOfvKlg/8ccz5s1/igQevsLg4w9L0AuVSjdwIfMcl15ZOr8v69hZPP/08R6hydzjNylKZYd8gbU6cw/xcSKU2Rb7Pkot15EtqzRp7fUW2SLA5CA4b7Lwjjb1DIqRAgciREjwFzmQVHqcfL+Xbli9egd6gwTvvXmKqkBLW97OSpfQSyVzFo7jWJ7OSzlCz87zh/z21jXG2qM1JavUXmKr71Gpl1tZirp5NGLT1pD5oKHoWKQym30UYi5pawpbmx7lpNEIIB5RmMIr4sydc3rAo6DUsz/3hFZ5xVokCi1+FPHCYK3lMhQE17XHhQpeH7jzIyvIsBc9hc6uN47pEvQYqrNNvN/BfcTejwpMTVY66vupKm2OEixAu1sbXZCYSa+9wHOXfojFImeIrjedC4OcEgcYPwPMFOrtumoAgimO+vgY37Y3YXy3guw0qhSIryx67jQ4PzBTZbUVstwZo6eBLSLSmPdCkPcFg3cEtZewPfKpFQ8PCxU5ObhXPbijeMmqj8JC1aWyxCFaB1ggJ1saQ9NlpVbn7aE6pXOTizoil+SpD49HqDqkUfTxlKNbqFBwDNudwtUYlUGANqVFsd0ZoNHWZ4rlDphaWyasDrE0Qwn9Z4iCEmOh19PgCkl/z0lscEEdAoJRCSfBcS+BDGKYUihlRKMlSgc7FJFEfX5XcSP7tEzv8r289gFKK7Vab6UqVy5czjt60hE02mSsXefLCkOWFkJW5Ov3E0k0lxSDghpUF+p0dup0Bn39ul6IDw9zy52ddfuJOmN9Tw1bKCOlih1uIOMbEHfAVCEPGPLfeUiYIPaZnmoTTi1xd77E4HeJ4LkIqQr9EWAhodUcEymH/8jTPP/s0N9x0J8JRZIMBpuQR+gUqlRqOyslFEU0yXjAm/G+Mlb5eIngJuTsilVIrUjpI6UwKjALPnQBYygiKGtezKPlidizEuBAwyuEvTzcwCnzfpV4KOLh/ioLnUijXWJqv47iKI3tmUBKOLlcJbcKBKdjc2MJ1JLWiy2zZI5ACg2UjEzx2NsRkKcgCSIXQGTbtIcgRZCR2GlXfy8zCPJ1eHz8o4SpBnPSYnV0ip4LGIwhDgrDA/v17KRdCTp6+iCsEwkTMzcxS9hSOF6B1RKVWYpScJGc4gci8jDyPGYjhpamutWZFWsviNZ2nchTSEfgehIGhUMwISzlBUaN8/bLajZGgheAzp/t89fQ5FmZrtFptFutlHGlZXiizvGcvdR/SOGdmqo7jKF5x4348v8DBvbPMVIs8faHDTNFBSXs9TPcShY2HYOLxkWU5ojwDrgvKZ3c4jTXQGyRIt0xpeoHm9ibFYoDru5w4d5nlxRmKhZBGP8fBUg7h8pU1StUKg36XpZrC8V2kNRQCwaW1Xaby4+OyHeMMbAzi+KSNkFjhgtQIxgUGIViUQjCjECgUAoErxm92pMVxMzzf4PkW1xMoZa/3XMeWaHn9ikPVVVxYb1CplIiynFEUUw8lDgmlULHeGpBnmn5vRLVSY3l5L4P2LgpNoeBTCB32VRRFOQ7fj6/6ZMMIzESd67pYIbClKWxQZpQH5FnGZ758go9/7SrNxg65KLA0N4MwGW+68zDpaMjO7ja1okRIg/KLvO5VN1AulymVA0axJkAT+IKvXRzw5FefBTPOOqzVWJuP038MRqgxZb7+WDa+WTsjhRAlkFhhrxNnIUBKMRZHWgF23Mwy2l43YWEFSyXDw/fdQLMDH330KsMoQwlLGHoMei0MDisLFW48MEuxGEAwR7fbZRTHZLnmuQsNluo+vmvJNfhyfM0f3ZU0ehLiIUgHG1QRXglKi8RmjtjbTx7toFzL0yeuMOi1WFqYolCqYHARjku5VOTJ59f4wpefI08z8lEL1/c5faVJuz9uK5QrBa6anD/4ylkee+4Kpt2hmO+bFI7Hgk8BYNKJDFlOhKF2rKqFkrQW/3rDaJLGjUvvTAg05LnE5JPCqrUYKwiV5fCMYk8JUkfyfMvw9IUtCj7kKFqxx9Z2k5InqRR8+r0OpbJHvVYiS3LmFxdYWTnA5c02pWKRS92cii+oCEuC5emNEsSDsRpVSijMIoSkn5TIkz6l+iz33HkHD96xwLEbj+OHBYwWSLdIOhpg8pjRqM+BpSraKTAcDbi82eQ3Pv4c/VEKNiUOS/zBM8+SpJbmQNPc7cKJDWrZzVgEFo1FoYQDpAiySUl0YkjG+mM7E2NrA7CTvoa1YBAYDToX2Oz6EkQoBQEQdXP67V16mUIpwe8+scOl3Rg07FucxSNGqyJFX9EzVfSoj3JcaiWXQuAyFAWeODdkNBxw69K4VyGFILOWT170SYc9SFpjVxYOFs3GrqVWyOm2uxSrs3znt91PqznkykaLOI2QpKxuNFjd7HHvbfsYxQlfefY87VaTj372OUJh8H0XG1T4yFe+QqY1eSIYGWh123R2erj2CMLKMYjCwVw/efviojIxNGlsnmiTo22CMYYcgdaQG9CZIkslWWon/eixO7/2SM6hackN0w712jTKKyEEZCg+9IlzKFfSaLVwvYAk6tPp9Rj1Wvi+w6A/wC9Pgapz4vR5Oolhu5OxUg+o+w45goqCL2xJtuMiOHWsCsGkZInizKU250+fRxTmOPfYv6ezfZHMaBYWZ3FdhVuoc3mnR5xE7F3ZzyNfvcLW1QucWNvFlGLuvNUyHLY53x3SGIywkUJasEguXd6mPr+MGDVAegg06GhsidbwUk+d8MBEWmsHWI3RBq0NWWbJUkE8chn2XUZ9hzQe94axgrv2+7z6yDw/9yMP8rZveQWpNggdIdW4O9czhk8+9gLDOMdzPZ6+MmR6Zh7X9RmOMkaDEa4b4AWWN9w8y3zFZa4eoHUCwqKkJTMCJSRnRnVs7TiE06AC4uB2jhxc4sCxIxSKZY7cfhf9wYjt9auARzh3nLR1lntuWeHwoRW2drpIPeT4kuTYjcvceG9Ktr9H08v4wye+jBBgXYMQgqID/VHKRmNA3H4BN00nlSnzYlsDroOnx7KlgTRGN3KrMcaQ5YZhDL2BpN0N6XZ8ooEizyTGwkrdcqA8Yn/1AMnV06TDiE6vT6VWRYgxV9RS8Oi5PoN4hJCKVx+tcmWjxUxJoq3ACX0aqyfJ0gyHmH/05r3MVQukVhIGilBaCmrsxo+ft5B1sE4AToFHv/wssfWJjYfJEwYJpIlmanqKpLNG1lkjFxVm5pfxPZ+dxhZ5ZOi3Y0Inx4ZbqCDjEyceoxX1EAh0PK64LM5VGCWWS1c3aGxFuKcUHnMvFlTty2sEY1ZoGjLJos00T4jSjEFsGQ0lnZ5Pp+Mz6ivSVGByRcGBd947z7GpRTo7q+x0c7q9AVme4TrXZGUGKSw9Y/nE1zZ44uQVFCm+GKKEpVpQRKOEHAetiki3DKqMkjBXKzITGGYCiSctnrB8/OsRvcYaImky7Pe45chhtAjwK8v0hyNC3WNh7z7SJObkpTZra9sMIsuw10MpQa0yz0zBMre0iHY0vm/B5mTWTOjKpNEvwVpN7hTZ7uRcXt+l3cswna3rAk1ekhu/2HQTmzLOo8ujJGUYW3pDQbuvaHUChl2POJLozGK14aa6pNjJsHlOK3GpzcxQXVimUCpTLJWRgjHfEmPqea6p+eQzDZaWFmn1FYGjibOcxIZsb26R9Bu4rsf8dIXp6QozZY9uIpAIQmnxJByuCE5eGELrHP2ozOWzzzJVtnS2XmBzex135iijboupegHHdYijLst7FwgCie1vEJoW3/7AMXa2N0ltNCmSaJR4iTsa8KRgoepR8zVIQbsTY9xp+t8YFzSszUEkWHKs0Jjr7xeXnSjNzkWRptOHdtej1Qrpt7yx9SWQp3DTrOYdtyxSFC5enqJKNYapy1Ze4WA1RUU5jmsxk5ErKyAX0Irh1NUO81MBcTygEbVoDODVtx1l0N6iVJsi7XewKmB2psxcqYk0UHDGvPTO/R6BufW3AAAV/UlEQVRO6Qj58Ama/hS520HnGWFllrXLAx77D4/wlje8mpm5GW6vJQiraaclWhvPsrl2jltuvgXXK9HsdHFKEpVZrBizC+wkrpvxhS8XPaYqBZr9mFZ/xM7ONodXVqhHK+yWTmHJro/nSauvnec59YZ32Goc8z91Bop2K6TT9Bl0XeJIkSWCghV8/z0zhLGhUJ3FuAU8RyBdn6y3DemQgXF5Zm0LrSddgskXZVaQ9vvMTXl0egnz9QJ76x7NXg/PD1EmZXbvMa5cOM/s3Cy5zqm6GX7BY7Wt6Q419UqAs3Avu90RUzOzDKIIKyQ33niI+f2H+OC/+jgL+w+xMF3AxCkbV89SDgwFz8cLqvS6Q+rVAFGCLX2BTs+h3QlJIgdrIUvAjSWH5kKWZoo0B4aCL2jstliYnUUNdzCzPlZE41qAkNenqKyx/0LGMd/oDjHtnke37TPqOWSJJE+BTPCT33UfB6cWmJqbpR9rhlGKzXJG3RbScahOL1GpVQhCg+sZpDLjLEaClJbndzSXtwbMz02T5ppTqyO2uwmhN9bJpEmMH3gIqzm0Z4rbj+/hza+7GeUoGonk33zuHH/66HMsHL0TIxSu6RN6Ob3GBllnm5X9s6ytr2KyBMuQkydOcnm1SSJKuKFLYn3c6jz9sD/p1AqMnvBcYzHC0teQC0WWa1wlieOUoVbsdkeMEoW4Eo25MWYyUjYesxVCfEO94k1y2Bk4399qhtO99njVTSfWd7Ao+NZX3oFqrzHIPHKtafVTJIb1ZkTRd5muuMSuy3Pb59GZwGiJsdfmfS2ZFWw0Io6tzLG7scrBA0tM1aYYjmJ03CWNBnSGGfVSkemZOTItmK5WqIQ55VJArx+xvtnlzmOzzM0vsHrhBEFQwC3P4WY9VvbMsm/aw5EuXuhTKYfsWd6PRBMUCrg1D72YsMuXGCYJnY5Dux0Qj9REtCTIjUDZAodmHGoFxXY3ZbZepdvvMRpqDu85QFzqgXrZWO05JdWvqK98yrLvturNvU54Z7+vSCOHLJYs+JKfuH8P4bDPE6ealEp1HCkJpBlnE9UCipywEJIUylzoPE+uBcaM5XDavDg4nRiQcZ/VpkEZzdxUwJ75KaRyOXl+k0q1TuAXKZQD/EKJNI+YKRe58fASb3zNbbzh1TchyRn2mxTqS0id8eyJc0zPLVKaWaHdGTHoNyiXqhRKNUa5TxgISuUQMwu7ziNkekic5PSGgm43ZDRw0bnAGAuuZX0jxhOG4/sXeGG1x0LJ4ruCZrPNzMwC08FR0nKAtU1AonX2R7fc8LufkACdtvfIaCDJI0meWnRiefjuIyxPLaKTEbfcsBdERGY07VHO6u4Qo3PCICTptyDaoFrLKdVyShVNEIJy7NiVFRhpeWo95oVmRqnoUCoVOHNujTgecuvRJYoujOIu0bDH2uoqFJapLqxg3TIwFhO5UtHYHeC7ilGScefdryQ3Ap0O2beyh8APcJRgffU86xeeode6ip6p0Cl8GSEFUkqUA56r8bwcIfSEyowLKP6UoTSzn8S4vPLYIp7n0+mnFGtTNJoN0tWTeLk3qQfkCGFebKyPBs7nkpHsZwnkiWDKg0XbIBmk6NIyRiqajSE5Dq4DgQe9YYojcobDiFp9nmIxplzSFIoGP9S4rkXIa5UdSKzGkRqpR5g0ZqqmOL8+wg+K5GmM7yoaW20cabl84QzJoEfRc9jZ3AQNxoIyfdrNHjoXxN0mfuCzduUyW+vrVKfKNDavko1y9h9cZOTu0g0eBRGNNYyT0rx0LY5nkGqie0wFOlPgWP7DY8/i+y5palBBhVwV0VowHAxYbybQW8fYHGtNXwj5uetjDpun+ml9b/3WNBY31xV85+172TM7Q5wIhLD0eyOmZqZwXZ/BcMTi0hy7Ww0qRZcsT8mCjE1zDm0suZHoXJElCq0nVAHQBjIj8PyAisqphi4FmZFlOTacY9RYRTkS6flUC4Jhr8/Ozg6BGLK508fTQ4wKmK4G1Ob2cuH8OU6cW+emlXmsdBj1h5RLPpVqSFgJ8W7MyZwdcpOR6Zg4HTGMMto9SbtdoNf2SWOg63DX/nmqruQ77r2JQ7MBoevSbLbRKOozc2zvNDmwbxk/3iWbBeBjtx77t//uZXMi1eX68Nal4Afe85bXc8ABvDp+WGB3t8UgSiGLUMqy3exRcCWhMjx3fpOpcogMMnqFq2PRo1Xo3CFLx+HAXJOHWImxkp1WzOHFEp5JqdUqdLs9pkoCo+C3Pr3K5fUO++qCwcgSyhHWKfP0ap+ar6kWC2xs7RANhsxOlzi6r86ffuoJvvbMVWoFmJ6qIISgtHyQbvEZjInITUacjxglQzo9w+6Ox+52gUFHoRNJmCqOLXi87pbbuWnfDOvrm5y82uaWI4tEo5jllRV2Yh8R95irzaJKZXJv8E9+60Mnzr9MYHm4pD+7rywvVoZNMungFss888wpRqOYMHDIgK3mgOmyz2iY4Pnw/NUUKwQ6SSmGEje0FAsZYTEnLOb4gb1Oa4SwCKkZWcmffHWDqdkK0ilQ8iUHb3oFZBk/+dbj7JtzaQyhHCpKtWV21la5KWhwdAacrMczp9bwZYrBZRQZ9h9cZrffZ697CqlHFIoBuadBZxiTjZvseUSaaqIIuv2QwcDBGIk1EiMsVzd6ZIMddDRgfqbOZmOEFgFaWQa7G8wXEi5u7NCMoByvXHSdA5/9jyaVLpzv2XfcvCRmZ2ce6ugynWaDJE0YRjmFokc8ilGOJM815VJAs9nl9gMhjicplKt0iqukOkPnltw4ZKkiS8crnc4nOsNJHukpSbfZ5o3Hp0hGERubmzRaQwKRMFstkA0HfPHZHeL2Om95RcQ9N8TMzsN0KSNOSwTFOs2+YO3yKk7S4z237nDrnctEch4xtY9u5RwpV9E6IckjonRAb6jZaTlsbxXod92xhyTjEPm21x5iYarK9sCjXvKZm5vHmhTyHCUhFiUC32fY3qFe9P/346/55Sf+kxLfQWfwO71BvNsZxCTDATrLObM5wKoixWJIvV7iSiNjdb1NSoBfmCKPcopuiMRBTbYqseZFLeE18j62wjHv6mQgo4Qb7ae4a38fPxuwZ6ZCu5Ny4WKDJ062CETCj9w/YP+iIAuWEW6ZcG6Zb3njEqPeFudPnuSp51Y5bC6y77bDUJxHmz4puyTi1KQgLDHWorUmzSxJLEkShdFjzbcxUAqg6Ctk3KS7e5Urm23KtMiGbbI8ZxBlRJ0261cu0+z0dhvt1r/+azXSv/SJi72tdvRr9ZLg0tUtDuyfpxYKPJHQ7kdgAhw7YmEmRNicUZSyM8iRNsNxiighJqVwgZnoaLjWDuTFzSbA8ERDMohcZgubvO42ePzZi3zq6TY7jZhcp/wvb0+ZXphBlBbJcoX157FG4IYl3vDAbahCzn3zHe566E5sdQW8acLlAv3Zc9f3kcltRpYPyVJDEkOSOKSxROfjVd1qGMYgTUpQqDBT8XFESqM1ZGp6AdcpEKUZOu2QA0arX7vvx/5l/29U6W9utT7kGHvl6IFFzlzcYW66QrvbpV5y2N5exfcDdvuaqakSyitwaO8sjmOxpjMmpVzrm9jxdNNEzYAwY9WcHIPZQ3B14GKMSyno849/YIZXHfS43M34xe/WLM8FCGsReYQZphMa4kI6xBNDfvydr+Dt33EDsjY72S3FwZYFVg7HhVLysUDSGowQ45u5NvcytkBhIc0Fn//GJq3YYB3JRz59nuX9S6yvXaUXJyxNlwkrUyzP1a/88efPfOhvHXP49Y89Oxy0d37e9yRJbshyyK2HVAqDh+MqGr2YdmdAu7VDFicIdxYlKkjFpII7dl2LHQ/o2BcbUmMQLVJYTu94kCeQGmo+/Oi3T/PPvzvj4IwEvHE/2OSIqIPNB9hsAEkbMWoRMsRfuhErJDghOBWUHM9BjXPWax2M8a+Sk6hyre+joYJirqT4/LmIJ881KYoRD99aJ4okxekFDuzdi5AWkfbY6js//xcnrwy/qVEvGRQ+6hfrj1QKCr9cJk1Skjih1R1wfE8ZORFca+NgMKSjBp5aQsoXBZnXmi5CjPvHQoyzgZc+/o01F4vCahBaMOX2uWFRQqZhFEGaQZ5ghn1sOoL+BmL3HGw/A43TiNYZRNzDujVwQ6woYMkx5sVbrjVJBv2RYDDwSOLxRTUahNR82z2z/OjrFrnnpr188dkGi9NleoM2M/UQLTReWCJPR4988jNf/eg3PSv3Y7/6SfvlLz/+Xq3pGmNZmq2w3swIw4BEFFhYOUKvl9EaZczOLRFHBi/3UGP9B1LmKKUnjJ8JeGKcmUwWFCnh01suo8wBK7FxhNjegGgI8QjR34XuFqxfIdrYRe6ehf4mVgqs8sZald4lROM0on0aEfexKkTbHG2yyV4JOVpPNI89xaDnkmcKbcYyZgUoq3j9rUs0+5IH7z7Mqatd2t0EaQz5oMPmTreb5P57Hz+3av9O466/+dkrl6ST/tTp8xvEcUSpIJmpF7my0WLKbFCuFwlch9X1DZRy8bUzDt1qzP1czyB9g3LNpOFkkdIihJkAKegLwdpuhM0y6G9jScb7QLkS6+QgU7J0yE5LYpIOwpMIpcALJiQsBJ0gmy/AzlMEg3WsMRibk9l8Ii/OiVMYRB6jgYPOxgpbkY/366pWCkRJxq2H6wTFAuudIR97/DyDwYitrR0U0U+99//81KX/rIn1zz+98ZwbFpfPbSavvGVPyNpOj1LoklgXF6h4hhNX+uxfqmNLI5pilSQV5BqSTJGkDkkCOp+svVKMp4wmm2cJYXnTEiyzgSIDZcDEWGHJohiDJY4Fpy4V2H/QQaTJeOnME8iGYBJEmo7jbt6lG3TZCSzaZKQ6IkojhpGm1YXtnRKNhksWSXQmMYlk2hU8eM/NtLoZaxvbhJ7ljuN72VOGkxe2ueHIgd/+nv/to7/095pYf9drl9/fT8XNrTi/58DyFGiDqxIub0e8+pXHWYs22djYZG6pgqfA98D1Db6X4/k5rq/I03FTUJpxLBwPKY454YnLlttKOcLNkFYhHRdjcqzrk9mASxsJO7HLoNshLIKIBiA00itiij5RXTDyXHJH0w4yjB3TF2MydJ4S5TCIBaORIksF2YQZSA1SKaIoxroFpoolhBhx4tRFtM6pFsMnqkHn/X/vbU/+5498Kf6TX3r3O4Ki+vLmTu/QlavrLNSLLM6HdJubHCxHVEsBoRfgS4HrWfzAEgQJQeCNqxvxOCeWVmPM2EvHQz+SgRmT3cFAkGpNkhsSLcgzTZrmDGOXkSc436zhZAVWWw6ZdrHCUn+oiDevx2JRcjA5WqeTyfURaQZxClGsiCKHPJXkucXkgkBCvajY3lxjdmEvy/NTXDmzyuL8DMXQuxANmu94w/s/9rfuZvRN7drx0c8/O3z4tTf++cGV/d/huFSG/T6hzGn2h3ztbJ/De2v40wE9/8w4vozncdATbQ1CIpXE8cALLF5g8QsWPzSsWXj4QAJS00WwMXJYTwpcjV3O9UMuJS6DPXt4Lp0lLOxht2dJZZndimHvnWMpyLW9Gg0abTJykxKnEaPY0hvBbtOjuRsy7I/3fDBa4KSCB27fx9E9czxzbodKQSGEYn1zZ2225Dz43f/s06v/RTfeeecv/MH5U5/9N9/S7bc/88KF7T2hzPj/uju3ELuqM47/vrXWvpyZcyaTmUw0xsvQmCIBhdinUKhaVAJ98kGoL9UWKqWlFnp5aKGPpS9VaaR9aMGmKKJPLZVAaAsNpCYPWgn0oRUTjY2ZZJIzzO3MOfuyLn1Y6xwTUbBGUbvgwOE8HNh7f+vyfd///9s33zDPWhV4+dR/OLj3djplifVDtBZQgtYV5XRDb/uIusqj4zO6olJaF2tyhy7lFKHgza2M8+s5wybSQZTyTHcD11fnUYVntpmjO9tj7vrA4p0FWgyBeMh2qoksBvH44LEhisObNuBag23TCSEpzRa25Wxt9PG24Labepw58zatbd7+9bFL9y+dPfGB6UX/E7lo332P/Ovk4e/dc8dti0cHGyt7bFNxYN9u6maOTjZPpnLKfIQSUHgyBZ0pT92raV1N8BIPpsIkSr0ThgQGQehauNUprNMQICsDva5l5xwszAkLPUUnD2S6jWup7saHEpVSeB9wLu6+zrpY2GjANTr2WdNB2nghp2Fudo4b9u4njFa50B+e2XPL7oNLh09+fOgngAOP/PL04R996Yt50f2DMubA8oYwZYcM1lfI5rvkZj1lG1FQ2lqwDmxc9NLeIenCPZYxk3GyMIKyZEbo5FAWgW1TOVNllzLrRKSTEkRMXPfG2cZYeufj/wTid+uF1saDvxFACS4EdvZKnj22xPz8v9m3uPvkjh1TDzz00+c+fvjYeDz9/bvL6TI7JGbqmzPdkp2Lu3hz5gQD+zI+xBvnAGvHUrlk+EzSMJ8yvqCSWDGV/pHYR9FK6JiMMt+OMS1ZVkTAjiojLkrlE4SA9x7nalo3omkHjKo1NoYV/bXAuSXD2Te207/QoRoKtta4Nc/X7trF7PQsC93ObxvbPvbwz178UPg782Fv4DeeOFYBj/7mB/cfB/vU/ObWtnLbHCOj0ESVlRXITWzh+ytk2xOZnUjytqXsRAJ63LtGyHRJnmWRa6CLxNoyKBWb21cWL6Is18USfmhpXKBqhLpWtI1OVrO422gFmcnXb5qf+e4DP3nhmgCM6loJlo8+/udnynL7/v7KpaOdMEOmC4zJyDJNxyg6habIoTCQZ5AZyLJAXkCRB4pCKAtDmWVM5SVlXlJkJdNFlzIvyDLBmBKtCpQk631IehV8Ev4k30aaxs55WidULQwaQ2XBSsDiccFTKHV0c3Vl/7XevI8UQvvKM9+S5fnTXx2Vp34uwi2BFufr2MkPKjKtAil6kiFUVKL3xk1DiUmgB0GriHTSibymlE7o5HExwiTRY5TmWddQ2U2G9QqDqmJlDZaW4exbM1w6P8VwoHBOveUb82O2zPOv/eP1Tw+E9srxp+M3TofAd8D90Ll2wYU6LfA+XbiaoItl4uGOvyk0iEIrjdYmAslEJxagvsr4LIkKHIKLFWdfU7ebDKs+68OGy6vC0kXh3Lkea/3py02lfuGd/OrUkXOfTgzyu8eLx3fPOO+/DjwWQvhczH39RPkeBe1xX3bBoUSj0bEBrjKU1miVJ1vFO7TyGMHjj4+YFd8ysiPqZpNRtcLa0HJ5FZYvqzeWLvYObW10fnfs6YsbnymS+XgceWmP9qG9D3gY+ArQi1MvbilOxtEXZb1KMpRSyTmV6odcOXXVJGIh8Wp8TeUqmmbEqFnb3NwaHemv+9+vbvGXJ7/NZxMF/17jj3+/uSve34uSg0HkHlC3igRFsvkoZHI8uUoJn9yiIjHdugpT5a33vj1tffu32lZHWzf864N3Lf//vIzgfdfKE58XpdR1QZo7JejbVVB7lehFEdkF7ADpKqWLGIGmFpGBiO4LcgE4i4TXgX96718Fv/zlL7zyibwO478TBEBdpryXaAAAAABJRU5ErkJggg=="></image></svg>
+            </symbol>
+            <symbol id="icon-avatar-3">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 80 80">
+                <image width="80" height="80" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAAx2HpUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjapZxZll0pc4XfGUUNgb4ZDgSwlmfg4fvb3FT+6h5ctlQlpW6ePA1E7CYIjjv//V/X/fPPPyHE7F0urddRq+dXHnnEyRfdf37N92fw+f35fpWvb/HvXz5339+IfJT4O33+2evX8T8+D98n+Pw1+ar8dKJuX99Yv35j5K/z999OFD9/Jd2Rvt5fJxpfJ0rx843wdYL5eSxfR28/P8I6n7/3jyfpn/+d/sj919v+49+N0duF66QYTwrJ82dK8XMDSf9Hl6a+wZ8+ZQ4Mqb6v0/s8fp2MAfnbOH3/GtzR1a3mvx70y6x8fxX+/rn7fbZy/Dok/TbI9fvvv37uQvntG+n7OvHnK+f+9VX89fMxX+RxR7+Nvv6/d/f7npmnmLky1PXroX48yvuK4xaX0KW749aqb/xfOEV7vwe/O1FthML25he/LYwQmZUbcthhhhvO+9uCcYs5HhcbX8RoMb0Pe2pxREuav6zf4caWRtqpM8n2pj2n+H0v4V12eHPvap0r78ChMXCyoLj4t7/dv/2Be5UKIfj+PVbcV4wabG5DM6c/OYwZCfdrUMsb4B+/f/+leU3MYNEoK0UGA7s+p1gl/AcJ0pvoxIGFvz85GNr+OgFDxKULNxMSM8CshVRCDb7F2EJgIDsTNLn1SM4sZiCUEjc3GXNKlbnpUZfmR1p4h8YS+djxOWDGTBSyrDE3I00mK+dC/LTciaFZUsmllFpa6WWUWVPNtdRaWxUozpZadq202lrrbbTZU8+99Npb7330OeJIgGYZdbTRxxiTMOY6k3NNDp98sOJKK6/iVl1t9TXWNMLHshWr1qzbsLnjThv82HW33ffY84RDKJ18yqmnnX7GmZdQu8ndfMutt91+x53fs/Y1rX/8/hezFr5mLb6Z0oHte9b4tLUfpwiCk6I5Y8Kiy4EZb5oCAjpqznwPOUfNnObMj0hWlMhNFs3ZDpoxZjCfEMsNP+bOxc+Maub+X/PmWv5l3uL/deacpu5fztyf8/a3WdvCO3sz9slCDapPZB/fP33GPkV2f/ztPl+sfDPjeescJ5Z12ko7xt3OTgBdGDxaMivZlCAhjRp9KzXcsdvUqLTj/CiAVF2r7njWjpXv8fjxnJtm6LWNnFazmfVApdwTLRwGqXCG09Px9fpze3XnDn4kt53usd3AUg3ptTsI2Jl7zJVP+pkz8e8T5uqnM4OTr4Amm6WMCMS7eK6f10Ib3MQuY1leYZ898j0VOF2MX+DXSrVzL54AGdbnETuEJ2UysbyuqwwwA9nuBPxOauXMvvxpO3It6GD6a2f1cmJdNva5NYVWYr5zFAH92fnc2IfjLqrlmLZvp+VLlIe9GB4rhUi3wgOWtf3lm+vkcXNihIsuHtsZuTPihOutpEiNxKJvn4N5Qg1XmWufwm0NjXtbpEitOnJ069xE525bZby4P063EwiZ9pzFfKnJRnvPzRzwRburNF153R34Iqx56jWuTo4e4rSUZYAr43nsHlc75yBYI/lc6ybRjAEh5ULh2UlRYqvvCYHsuMi0Af60Vs8pk/QpO9/hU9nX+XPmOmEwAIurHILwEwV9MEoEITE0EJtpMMKNj+4gd0mXQh40gN3SUgw7ft52Tfk9RN5G3MTIM5GXL45zD71UBNQKmj4jB3l4JME9p5W9xmg5jJTdWYWhIlpG8rYTAcY9wWeL+FvtBsKkpE3kn4EEA4LqUAwRT32XfFsyQUDsbp6Tip8v/fz/6u9DxjBXRNM6fVSeEMQbjhQDwHzvYfcE+G6BRyWsbjsXNRLXiJpG84McFEpVIUrhb4GPH6ndsaLB/bMeYjQQpRtU8spHxVToO5D/DxTKPAM4jplZnxYW4W2WA9nSojHDPi2HYpnL1mHsSb7ZSEH4dEV/kMVesTRj66A22JZjyIsfNgMjOKzVilyLA6TaboEJHD02Cc4VythkQZo3b7BwMb5ku2ccmKJaufaFepjSMWLwJB8JwgyJjvKJHJp003YquQNU+7PGFO20PBGJmfgY+lZaCS7YMFAGu/PunuOymGIMR7gwboguUi/vCXuRORmEmnUgzgYaLMYBAqVD3gF1QAo0VzIJfrf4g6wpK2BqOJDQg6EYlbqPgGCSvn1ZGzw2E7DX2oSQT11Djd0ZXkEeNLqRACX9uluFkdgtnho3oX0HIyPSIGWIz2LMJ+mDRFoE61WAEskExenMqOcWWwbv4nIQVIecckOl9tVtW6sJyTnj2soiIihdLoW4FFSjfzwQPxZ/zjZWCIweSTycJ9lbTHAkSErCw10QIRHFQE+rU88XW7GyuU0EWi6hoJz/ICTHF2vCBHAWCk4xCM/NmLkqjOoh7lale6FzFF0nNvYFMZmMA4n2cpHMgF52kBEMs7iZXHBMuRtBUgDsRk53A5q5y7mWj3MftAWBDEnPyNfWYbjTxgFY4LXVu0aWeMNU2S4gIc52hUzmpHigGCY4k/qpSfzH5uE3a0zJWUxOVMTcbI6xmUzU5TiytRF6Ch67TC4zW5CHjG3q8QBKGcjGFhiQOVA8UA8DJjmwzVwTbhKxGYwChBAjMSnzNhfgmXjgS9JANGh17w/5wbOWbbdn5EY6da9YCG+HziH6N5eCBOCSA7txFg9O8mnjCqDz5mEvT7ZRdPitHQbkCf2iq8kJQ7ZVRybEikwjdWLl669voKeQAXwIboINpKA/jF6tk3QAO8Pmm/GlFoPB1y4KVcJLws/n2Xz+nAOJBU1G6Agc3+mEoPE5oDHIbF2qxEI6C44Fj5jYuRsHikFIqRyVs7HujNrK8FebzEFFXpFUDF7pOwPxW2DLA2bdBApgO0OH1lvshi1tUFepUNG+h2m1hIIAU/wCr8k08tbg5LR7uIr5THIMv5F4ObkMGDGvR3R0GrN5My6S4AP/4DUQogy4eqMv1uCsHI08sPCh3QIHhAQLgZDEmK3WILCJuRzgaS9EKQrySFk0TXZHTEweHDmWm210TYxzZjiqIU9xSf046LHNwsMgKxl/YD+Y0m/fwKMDUBOptG8dhDWCoxHxMxzhNVLFiFVk+DhpuPJSiQQFyHfpX9mcleW58BTSEUgzpn5UgPUQowioakDf6BWqiONIujtcABlMuntm7DBfthByZUqcBlQaUTYqkQXxJ98bXGoEQEY4o3YaswjvHpynrKjyS+IwNmQEiiUhI6rd+KVlW7M1/EfLIn6RXsgLRkAiGzEBy3J9mJafH7oEwLhThV8OkFIhZXw7EuhuOAC62xcdwuCgyb21wKQDrRBVmyAMsOOw/Z5shjy40BoAUOEhFgyJnEG1MhUKmcpcoHSRfiZJyKQiMi5QlzXd21Bs5OUFgD15ntAfESuQNO7MP/AhYizHr5W8tAAsk2siKNHPFaUHypCT0hTuHA/6yGwBzkwz8AxOZL6OaCVGdAeJBoIbSAnIA3AKLNcM4phLVsWPKWwO5Qw8SAajP1MlZwkSi3gp+GdEkS1WzUTEF44snpDlQafUMoIYHY6IWzwaSYuJRDJNdBsiS3KFYGMEIU282+FbGa3GbVbC/zBsOAmeWjeXMVmIHRxfdRF1swZsdg2sqlg66B4kJQTIqIL4A9HA00wyg+vSGat2bEFSdu6BW8R/FHR2GoM8QG0de2OA1NiVmcVtoqZjumGiPj0PzPAesYAUceOoAiy3SWB11Ju7CDAG3nfQPgVGpZGJCEt0C6OxwIPLYDVDAkDYwFrhsvhe2U7Cj3AAI8Py+H5GpCngITgcErhBvKFgIDnsAULOaoMn4XkkPPPKEfVsIIT8lkhEO6MbvUtwQWW6cTOQv1QLwDaRY9y3IepX6dwWeI1XRY7hKK7QG5GVgICJ3yDnOZ7sT9BJIJb8zrPpFlCCdV2ojJEAk9HTUFh+sQlNlvfXITD0/AWVxRDF7IYPIWsYiRk0kjGk2BYCSSpzSBVuDdnEcRJX3D2uCOnN/PZ6uyYfWiEA4TVUTYK8cIL8l8lDsze16OdTA0Jg255jAXsDjNL1RMkZVDyQExMCvu3lLjTIJzw6/NLOiWA4YWhxIvci/sCTOheDVQMonKTvSWtYGTMwku6HJ4OIHAMaBpdACDOskngSoWsXDUEGFxDUoJH8N5PBvwguVArPCYmJm1BCRUKLoMnc0VK8ocqRQEtCG5WocuLlVPIiOL3l0U9Nk8XdeTRvR3pIjqI0uDnUCPQaQQUEkp/Vk27IHfRlJFOxxfKyYQ1OF2TVDtHCxMIhC6jG5EqulmOVpEUMJGbxGVBcNrIkIxq8yA9oGQF/QCigdoEI6UuGmFzISkAEt7Qhj4diC4w/AY+tMujC70OqSfdyfQl1tORamDXoQg41Ba+4wjlYReED+w2CAbwJSNwST+Ejrg4aVFmiX12S5FS15TDEcKlHRcJIZAQ0sF/oIQu5OBlB6sAiKEqQLDGOG38xcLckkpHgfgX8NyFNXKkK3dCmCA+ON9kgYfOC8fjXtGlOWkBZjQHAbPkqRYiwmq9en6GQAak0jGMaMlc9SZOgOyDvSoQQxcggHsttaOIcRC5OYWAOQJUcBdC7qpgpnEe2LEA61B6L0pqZRzmvIRoFltrN/Kyr/PLibOM2M0iBx22MD8h2B9dEmmWi4KoMxtj4nsfey8Q58kMb4iPZ4nWA7IILVNlJDL40KNblwK4N5oTMUeekOwGDEZ5YlcjhJu3gGVmkPEIcaYYa2Qi7gsGYhkQNBatAIqhCoptHKEExuMA0bW8cBQmA/kNNYzTnK3bAP/DzcUHxB2LnibsC8kqeJEFaeJjMcRf/0eR+wvWoH5X1KjjIxKcEXpKdEBP6HnnMHBK/ZCmTHk2LTtdnLy9Wwqlv+eLJBmUU40D+4R6mZBWXB4RPE91d6AiyaBPFu7BSe4OVlUBA5vLAvYBtXD8++VfuIJsGY4CWR0JgmphG4FguwsUFwxyGEMnekBaELTYlDgQBdreQE5PIPCgt4kYWhnyzRMyHkPoAKVMC0gqKrTMcCzqaveBUL2IdOQSuJqgVKWaIM+KEn0bUJRhDepk8RhitFMlOSOEMv5xFLEj2zBzhwFEBYSUc2DKyCUo5IKhM87R+UTORYINUISSgapIPqPN8enDcC4p3chcBdRIZE5kWuM0f5VarZAvTwxhl7rXomQfPh8NomOCkGikQ2LKbrQ8gi2QC2+C+GZnMoQrBaDg3S+Q0woukPSqOwkoYTMxrg5Dw52cS65FQdyRckqIPtUoZ+YuDXoD2KfgA6HnjUAHgpRSDf++F23HIcpyVu4RikHndZ8d8krFzyg+ngsDkdLBZh0+jCr8EAXSUAbsYEOZ++gBW21kTeeE5rX2kFCLiIH2ZwOe1mX3VOZ+hILwSSDd6O6rk4YsFZROTHfTvHZI8AOOG2bvdLdSyceOE0wF70VrICBAFDMN1hZMfmkXUclaFjFzmLNzc6u/pAGisLLfroBcGwYMHDDaMUVV40soK8h4qQ951RppRwiEklWYQgXuMjsVEGqF5kD4Zq+o4LzEOTGCVOAaHAsfsO8h5bI2BjgG/q8I+w9GVL63wfEjCCNVh6Ei60TA1qAd0GNK6EB1g0ET83qDqWTu1EI48qQwRjzjl4/F2h7vFx0DQSC8eHO3Tp2MAAa4BD8EYa+sgqVvTV89EAc+QlwWVo0lRlbmqJI1kKwwvtcuTFzcZWSE0VpMoIi+4b/Q1jzo/BR5gDXgCI3uALRCT8M185IE0OHCHSAnFdj1hsDVhF8dOepP+DFJWDYPcALch0Ow1QUQc93l6I2Y3FI7Sno14R6SRa0DxRcQQ81oa6EA0EpaYqhHGJ7gI0aqa08mGzCtd4vpVx8DSgK4EgLmR3FEjU/XnAj1PFCKqe1yuh3nMr87LZBQNNLpnovLb0ZCCDoALZIgC0eoI8s8hgzty53BRLod4fvDMTAD02G8ACeDwmQsnFE4OyNpVODmUklTGW1j5G+X7tQiAJCf+0GU+W0yCRQYSAsdLNlXxlSzIyClg2KuXCabmheYiRrNx821BkP2owoFVWDwi0C8nq9I3T1RQt8T9ldcGn7yuyP0QG9C7Sbb5V1Pm7M4yog+05fY4SVLRAd5DGaUmUQiZE8IgYWf8CMJuKmZhu8bC7gLjzAVxUrJbHhfkBxnLM0KLQ0tjBBjSD2rF+jJJjEZIAB6YHnDIdmCogQrqMzfVLy8Kzk2N+8a5ijBld2zoBAz3BmUq6gNF4atKMlvpCZBUIADK5T9m23cO6T6JIEEr2Yy6MARn4Gw4BDpEdCVsQ20MH6ImyCB1wQZydpD5PDjwkcACECy5kTqQV4QhoYKPsNzijiA/DDUCOKO9eGKpf0C5qFqFQESp4+WvqvhaQFlzOJKsW5BlP1p5MGAHPIC+YM4gWybL17AOx+OFhAiEN6qR6AGb571EY/HIY5THjaIknO7szWTMGCvUAFg28Oiw/lMsqKalmlYn7UAm+NsDmDCQVPoOriM4x1XdMcXK6VB9YA7PBolI9C3oSpqCzJG3ubgTM0Q0Zi6ogMCMi6BQtSpPZchyF606gcvcCwLRI+KhMmm2KbefX3EmAsq4AEIW5q5yGqAJpL1ks7hwyApWPoBiQS1DZN35lvVFc2MLCCU75MM3A0BIEWpMD9gdJP96c/h9NOhSAY6IAjcVabidTLRpvQKhrdWUYrgHYA8KAQAhl9kU7VjeqPjP0UUtqpy1UP4llISGYvS9IJExCTNkrdRlPBMeJOH6mD5N8VCRzeM/8BYgSmzOTOs2egy7VXnOWcPFCKpmy1VLTxN/CR92DBwhFlPQoVDVUUGCUQfhh4myQ8Ga4y+kUatEY0bJm2p4aO1CpCMDM6oLEGobJZ5yRaY3CcJ6jnQKz+xilpWQq9c6l0jr4FPIq62FIRBsA2MD4CXGSe8NQxqzDZchrIzJE0wwQ445vgAr8CWky1doGQhs09KoSkNaKmwczmlMRUE8XYYH/eM1KHPptCs5xBingeoYHvL+uV4Ge492Nyr/2eRMBJX9lsuLAh2ZBQwDOFtrnpngKcHlS2LlqIUSgrmar8uTSfysVrBBAgwJtp7ExmqjTBmnqpLV0NIpkJI+C0BaOiR8QDqUPiPEMCImlBt4APB/qR6ktQdIoRcMFwDsiQiIpH5AVgSLD6uuhxvJuqlV6aRFxx5wGtUfcuvCbyuiu8DEy8lB3c7dFdxzF8ti7ToKI6gs65Ysc9paxgDNOul660Yt8e8ZVZVsOHhwkCBh7MjGF211tI3vCssyVrPlY04ev6k4fxg3zNrKZC7JiqOHK4lvWDomQNQShl22lZwjOGQB+JMAAO/ahbItALAI0CwMEJkt8htAANc5G0CEBLojdCaN5ybyCRE4S/UdbhH/agh32XUCGucPuET/ovsgKFonWCWRUJXMMxCstenGUCEyQaFApII7h5vz0uwF6dcsMjiEgurOSp0sWfNSinwE+kwjXrCrPAT/toeQhBU502VyeBhkV3NYUvwsGH7gPw7SukF4i2FJnKDa1akq/Wz0b/ZaN0Dg4gjn9RGKDzEcRL85HBNCiFOlhE2s54p/pxb7YXW0RdGaWsLVxJA9VIh00YpyQvgEQiO2GkFXxChSDshsWKXaMsGLuh1aIjzymqgqtcYMhR5WhbxbWaUHsKYjXHFOFe70eFj/WEQFASKasJw8DPSd4C41VRCHQzrCS4YhZseRzuSKZQ10eSTRuDUk1t1O6kw1GEjvXo6CIpDkxoOQfgPGSkjZhL/yjKw6x0hFrS+MiMOdYqsto4yFOESTR9FyOWZAwhhhp9TuuHLvi8q1DeOEUlZnhmmtAdOYuDmSFTDYBLp1B2wREBgrZNq1pNKiilIwNnMOfZGqyBO1bDDyhL9ighkDboFBHN/SonX007WB6YdQmfmkiZTtIxux5gQ2oQWBkvyMKj4wQLNlrACDkkToZo7bMBjZZQ4VCBnivxCQqhjCyyFwUeT+ITGXyh1JRYWkFbbUOJbQZqJIwjUqsIZkIWTQR+Rmux7SWIwFcIqW50AOh8ykFQTBsW3wXt1mRBAGmMG6Vwuz+hktmBDZCcPq1XiCb8V/R0O4MMgwjsZzXHIcW3LDBCMQI2pGGDdrFQ5sxsODUbpZV8SpQwOBh20b24kghSyvOlyWaj3YauTMU/1YRaBmEWEJZYqDRlqgKD9L0GjnO1TAF29Ech8TAkSGhdbR+sw5rz+D1N5q2DjqRkHnTvAGS/AaVypP71TXFlfDtnl7kZGKPMhGWF88K3E+LeOhfRwGSQg2EHWIE3RuIxV2RJ1wR6AKBC2HWB7daL2cm2BKgGlUH84D+Md4Q9HTulQYl+A4fLd6oPDV03g07q+DZ2LlKjpB/m3cClwztVSOkwcHtKB4eQDGDDDAiB51BuH8La+EsPGpq/9oAtjQJe4Zn/VWOgLCTa4acD6GdbZBPKi+AFXxk4yelvpwp9HUHMpdoI9KqlrUWzlu5kmLDPdNlMiGwW8o4tSwTqjYJrG/U1QBjPGUDC0mCdRRI6qFaEG5yM0N8/LQE7JCOu8+pqlgnZNkKLfKDaSWUC0jknUq4CJ4LtS7iiPCN9rwCp9VerCIuyBcufDr9dF6Gv4NF4mNP1hPoevxuk8xBdoChZ6WyocJk4eCwlDyWA1ExoGLtWtUGhaEMcCHvyUhcbpwtlYWIZ89YCvVGVT/Dw5ah/Iq2nAjF8j1IqvYK8QALz+3D+7NT1IQ+Iz1QgbMSCKq/dYY+YwUcLJ1GWVsSS0DhgNWwRc3pJVbJoYZYZIZYvV8YQZUUz3MJWfqcjTqrhkgnUuSOPhgCwIBQJ9B3FJqE/enWphaxpqH9bZW76Z6dYNKaKmrllxAsgt+v95jxUFEXhSc+wAABPGqMPHwqG/1P228HFpEdIH1ykOtQnIcYr0sF3ijk6ckr7w6h5GzAoeq1R+IEpie6iDgaWJRjZUr8MABeroVkpTfatympJcBbIs81kSHql6MObqsttqBcCBktBrgZAU7br3J7rVFVCJFVxgoUqg5qErnlJ4EAlNHwJ6aQScp3Ko2S65QNAvhJjVDRbQK8ICIHF7XR79F1ELEkrbonrHobz0D32VHzN919owqJTB212o3yAtwJjV35hHUPzPnEYX3x9GhTze0nFNRoGVuUEsWnlsNKBzVK0xW6vU4qdsDtQ8la0TRVmA6k8KEp0giY45xb4CjXBB+mntQ8w+CS6sgkShWrVR1o6QaK1YB5dwQ/SiJ7XNjXD04RfQ4Nc3Af1mrfdu0YEYCDLVrES7okqSFvc0kRZxEQMcxICr1kcd5dS2UxBp9ICBxHlA8oKn+FdKmL1wHKjlrJRboe00XPb6+C8+EAx9SpJNBOmHjRYEpAN9lmLprBVNPY1NVTCvSIigFgECVJRCcWALjcwLg4BwCvahjs6PsfUFTk5ZOblOrijHKe/ihYvqEx6IsPPYOpxYwcTwnSpxo05IE+CgdDhGhhBAGGLrg0IhqxA1ECPrEcD0oWWhmFNIJH0T63SUdWMH6rFY9/8wwIkmKx19SXXULxyNfEHBxlsq9rx7HQcBKQKKF9wQnGAiyAV93DZuM9lYdDne9JGwkUmcq03lcOVpwyRYtyQseEQIfA8c6p9qP1Lb91l0nkRMmlCFbPxUDG6/Crcl3u8vETB14VS3iztEjJTDkiBg7SnXVzR7h9k+t7JJOsONWszI/2MgLKMcVFby2aulkaenqNJbCl33L0uodP+WJ8uTbW+Qhh2zK7wALRB5QxyCi4hwRjuUQ9pHx4a14IBxLRJMy9vUIJvkUKaSlxfq6dLXCDk0BMMh87hkF4l3rz2boWBUU1LK8x3htnlo9bgD4wTJiQSEmqIGA1OqqFqbPFF9rme4AtTDhft+Q9VnT1G290bKKUKQtMkrVl1MZlMponDDEfOAUXhiUK/B4njyVS6+ehwtPtpEFrz3AvxTg3kTZVw0GmHhAbqjstpa6WkC0j2qboioG1AmjVMZRnw+ssjwpC0WpNzaeKDNM8uvHvFZCClIP5IL0f3L5HbbNDlpEjYS3lcPeXGEMK2zIpKgn8ms9DokqwthRnRVHTdzcJgiNe1eJs1UnWqs4qqqGQqToS5amDngea0hIq5ka8Q1kVUBuvqVrLF+zVUNU5cprBd6hMNMlmaFBBI7W4ZE5cr0bWkTjoQsjjgn9nUHghptHJaVqKCP1IavBGXHbi0NbatUqZO3eyff1O220ALpPy1I8nCoRKskhSk5hnrg9BhvtrnBN6lyNtQ3oKGi5vIDIBW9VSvCRJMhIPkQswANVhIncwC8HdRUq7V47tGrOyEMIgTs6zoTVgNIhMNsrhFT1XDIYg8e9wAm4xGA+5lOjIH4UZ1Zgo8Z4Xa18AjvZDahe/XrcKz8vZ+lleTdfaoEIPIYMqy2tUWhBjKHjU+vBVCEm9mcNkkradtZHfo0SyrTl1YTV1c2mSh9YisfXqsyKMiHaWGDnfMpWE6XGXOCe8LxOi6VohClNUYEorbABkGQXrp+4g+lgPXRa30tJebC6asGZqv1dOXE0QfE6EcPALQrJMfsENZirejdzfkUxuIgdHrSgzjHaJdw9UNB4JyKlo2II3piRftMDEWrKL0x/eC1EZC+xCB1Jeoo4DWCLB2um7SrxLXCicEGRGoYYgRSZ6m4kVSGJrJ40dahoFjHs4Awc/za8IS3Ue8qNke6qmmYtoWt8TjtadyuOgEJyVDIQ2hMwkyKIG6SCGm+raq1h6NHVkklKANVaglwAJz5ZXUSZuMqcCL1qkDJy76J8t3qR1eSilSZEgRqgAFG0tjCkCo+QhNqUtF5vVWE+DTjcLqs+o0V+BZziRj1VfNIImq0feVW0QGq8Et9Wj5X6TAf4Hppxc/mtjDsCQ705is9UBvQjIx6Weqpha6LSvxAgV7QzRXsUE/HNNBAOe0N5fDjAA7yINTEL3KQuMa/CoNK2pqnOufOdtx6rFtDQFh/PDD49DPLG0zFO1f0AA9QOVIW9B/jL64pVfUR9n9rziAlOeqB3l7NDo+DezgKsmDLe9jpszL2DHNb6yi+LURnPU7RKi7u+QanCI4TLnA71fcAzAMbYaF7GanGiTpRqsR0I3ON0sanETKvib6xHE+9wdFIHVlIPoZaemyQOyL3eGvA8rp7mse/Mv2W8qzrR4kWG1Nf0Jyw6Te0yhYlSvQLkRkEiatQzVhXfak9h+pExr3MW5Uma5fjk9UEirPxWJ5hK2KNVnBiooD5IpCIK4WhfBvB3MEIwZ0Nna8FiaRi07kUCcP9wXGqD3FDXgsicKZ6E1zYvVYGgRwiCccj3Yk+5DacOoshcMyATVEXJFUkjrQkkhhuLLSGuYlnscXHkYJhNKw0V9k7t9VM28w6BmHmSplWjo77xQqhIpjet6EBM0I0XQKn2h1/T8t3bhnWkFdXHArcjKhzGAT0w1SDZtUnXFqQw8b0ci1z02pYlRaI1eO3c6fdJZSBvvIINgKoSR3dqQp2zMlHKDq0daGnRE3daa9AKCbrwqPOzPTUh/YCMi9r5uZdENTMKVrgMYmW1YGkvmGyOHIo6dMszLzt2QBg0nGpw9Oo41CVUQwMVABRwHWJLTWvZEuhla6uatFy2Loo4oCpiHMG16jx8utSilLUMc7QTQlryKQiuz2MkJ9RYbyEA1LQE22o6Ea/qn2E0EMmA+kbuTq1X2OsEmBEVuVRPNJnziW10AFHLG6IaKpWntzRWrlYc3w6vzwLkvjFpxdyrRetteCoH+WtqzB5qDKrT3Vdb6lr1fCa/veAvWPpP46T6sbcaAhCj4a0MX1X31bwkbmLqiM8dt0MC+q4KsPobMaj7s+1laqC6Qly9Kwa83ouF+mlx4i1NnNH5YfWy447UVu8XshUton4rLvuWxeWkouTRkfGXTsHccudq555nqRtioek3qhC56dTjflCoYW3wcMExr3EMCaQKX5RV0r4GBmBo2RXcAz/8q7YTxJ/GsaFarVqg8JDa1rZS22pnUdfZ6ySqb1P0Xlq6BQCJ5S6B06y3wkxcr6caaJKtwY6tQx64mo2Sntrkox0YKvgn9B70K1MFG1xVxqeWGqZyWvUGRDMWUy1Ca7oFGaulPm0tci0GeJAniO3gZd68Sm6wmLXXp4C+lXG8Kgwz2YnzcOeRsXFqC4BAVCdiMiCBT1Pl1kAabEgAldfZhMQTQKukFrVQe1VuQdd7RAzu1nl+nBRTZa5o+T3fIUvC884bJJcYTwLDZDhxcbAo6A2I965uAkaWjNekO/UrCPX9fpJYpQPZc2T01N6lV6gQqKBQoDv5FIGiOuNJzdizdkdohVVqRG5mkKTa0gkmYzFQDwC0zgznkMBwB5ZjBHX1IQaVdPstJZFbqctpVxcItJukn8mNoBbExQOqNKIS50DeEqXozvl61hjsqlVktQKarDCmIKHFs7kSb1TjURNxYrfQj1sLceA7Tlsrl0XAgDbwhCbfY1KIUoxEVqfWK3IzsxsvshBPCS1zAW/r2sFnahPBI2q0teerI3HUAs2EI4t02aCNYFo4BiVCYOCG21N7WFpEJgER/eFNup/ZxRGoaxujJN2AE7B1YlRhMi606Pbqhe3ABHZXbYzYJG1zZcY5LmhxuQMrWv5K2snVGMx0kR0X4H8dwyQqAdIgp6L6UjVVj6t2F0SI9IjBGAOtKS8yCY+UmQK1RPFUWknYVWsqDTmWiXNGnIfVvmg0UcTTzo+pVyM+8s6SwqF6+FW46D994U2tKwN1I3OtPSgKtBAzCdfUD9gqJ3o9cm9JND3LekQEqpAzmFp4zFpGkj5RwYyTIFfXlZAmr7T+ixFXK7LT+g847iWgLakLmCm8AlVtQwE1mCNEaMF+jisxigbnPu2pZzXOWt2e+HOprYWzkL9SXc60Z22p+Uq70mpVjSRr/wuMDNEhB2qOR2+GUL8GoSQS1uO7Il1pqsGXq45iLVJ2LZ0yFgpfC1qvgaHg0WHhqHf2GWnkibYOkIQFBkpOK57EF/yf8E5b86Gluqq+J9V+eVQU8a1qxYU1DmG7RZthYDq0Xfcas3/GZ9ch2pg/Apq2q8v8vqqPitgbbjy48QH8AiOwHKAoiNpp6o7X66BnoosjBFE+c6LJgjaRPVhjiJi2gGaW0QCpPYKrZEm5jpCLaitb6oKWpWny6wTkN1ncAQWinvIkhFQGVS8gg2LCabOi7FB/giG+rmrRoa0fXFFhkbMgyODrLp7B9QPDGbUAddScsUR+cBdCYnNOoIAZ3wmQtqkSmHp4tDjTsVmo9SMJqp7NLX1zw2vG9epUBwnsNpS/Gn5f786HiN9C8116TYK2KwL2Di4VHuBGxeJMAkyNtmtg9E5qptTGbCSMHKTytZIwBo+QhthkRnm1viRrLL3WLkblSMjrP89JXju3V5vub7cLm3YZgtb7BG1VGsUzh+OKKvJSZjzwlAM3LNtqcuCJsfUKnaJuz6BSDfnOj6EvVNudEAfqfyhL8LSbYNfuvlcwVclF1ker8QvAwR8DskkeMWJYGVSyvaF7G3IjNzUVMxw4MFy2Cs3oGZjZK6o9Yj8WokWrDF09oMawDVI3qa0YctUaUce62sbPkoMDvW7BhfFRYNhar51BYLHeVDIXgdM1kkBuVv8YqlVrwCjYpNLDCWp0Vq04M4W5u8x4yWN6vWoET2bZx6n7Q4zs+qrZOg2eQBmPT2lqfwSpKvl20XpL7RynOrW3tPeSDY7K322nWmVAUGZ1GRNx6DL1verdDUMdEOqsR9ZjeoL2wpNNKP8K7HOUNkAyUxG7cfUijq06MfysVAhHqzScjogC+LbaK/V6ExV/cbxa6XMJ9w7zy3Z4KUYepGtBYhN1BDbGMRCHR/gA6IfxNsiDARAhqBDxFSLBbU5l5FdXbpgCQp0w12AWbfkBqiBrbQofrxEMxGlbjTEBQiuStf4gnC7qv7ikzg+wyNTGfqY6ZKzyoGgK39RjrFqJWrQrYUTcAAtRrAtYIwrwh8hh1QVc/ywy3KGNam+fq3YqTvXxR/GZNsKjVm8t50F+K1ntpE1rOQSJhl47CRNqxPAXvnW9JEJSHbonj/1rlFIN1fTGi+mVP8delbJpZ+d+myTTwS2cNnx2QJR6gjvZD/w1bThkElX87Elx/mqBthQX6nQi//WCAZ/QFwODzp3BFdqdcUi7hSDCCMuGGQ4DBaDNOCj1xLCqb9PW28ylTYd6S4Qqq4yAdt4I8rzKD+6tS08trIBYUEr40VKlV1AQmq/SOo66yIraLkHEgBXlvLgz2DlkEDvbcBVc1duWtoAqqHFGu2Sw/tqqg+PhhNo+WYR0WjSX567ouLdn5BRtpcWB3eEOGMFQd612dTKIR2FwNiwNNO8Js4rZOAtRV/GXabw9Du1cWERSVZ1xZBJilPDYz3uN3YGfDyYf9Or+z/sBkEcqilxVYrVTmrj2S0USvII2lVfMca69Iq2gVuZZwY1GYVL7q8Pdro3hWmdBuWqxhkQJ6oVDpmJQ1B8L7O0B02YGneHR9kqEcfFDZeb+9l8j4fUyk61KfdM7WlTiUkkbTVHVcJG0PqwqtUREz1qXuMybtgCoe3YnWSkiQRsfpGC3GqG19sO0a1Nn1R4ZHJMKE68qhWyGjsyrcTPm+CQEj5z0jg00UU4qCAGyU5sZ0I1qOxsSwxMlXBVhen+IqZXyTJdu72/xeKvDlZTGKguQJ55z9kX6DXUlTZDlMrMlyyffZ4+6yq8qMNuu1Yn1Tdta1aOvBnPF7oJFG2YUDifrUXPPcXDLFRTb+bUjdDXXv0plVvnTMREEvppdtfMSckb2pZC0ZKrWs4AFfZ0tGE/AnGxtTZsgh6pfWVHMUXir5MASvRhBZJrfAk+QIRzq1FatEHzS+tsCnGBG1WiR0GgTNNbRFlO4DPGBWnRwFldRQ2FRr4heN3JktRVdS2sjXm1t2iaqlbU9Xz+kSlQq+FQwLLzt8tMdrXdwrzeqvwJyxF5pZzk/9HqGyC5MhkCs620iBH2S1ZcFVG9YULcOcVkdjiZAZ/wMsxvOUWO5mgFllhASa2J4U5cM1OY+g0QhdcJLFVztxCQTGA6MH+l1StD2sAHuaAU/qrkLXUHarwulqSxf9GYM0JHQCeq3LnoBydtggunVKQbTf1XxRiAd5KZarpqaQfB7yMCvraOD4a+6Vy0ByZZpAQM1EZCkojY8M8ofruaYT501jpRQ0ZglFMxSM2V7/e3a2BpQrIALWGNqYIT8RtQ2NSi9IsCddg17NcVpv4A2UJdNDEbt+Miwy9ErQSo0fFLVTqGupg4lAXFVfYUjk4oqBzWCEENVL7QfxITbklnTFmjoSn2SIbWjXcWqBKBGonZqbxUx1KGv/Xkp2/bWHfdmnTRGGAAM2vCjrTGoFa0ymKohQrkoa75V4VKOov1wK+PHWyOC9pW7t7H8xwbzoEY0bTFX9zfaXutyk6F6NwFtJPiAlIQKFzeBeeYfuoewlxuBH3n2zqtzTs3W2lCmMk8Ge6Ka4QmYUJ5s2aJSbThA2WrfLAYBVxlIShykdkAg2KfecnJGXcTP6aQL+u/7zUdeJdGqlzxpV3Tjrg/jWvWuje11u8MtJrJ2bZJPWkUbXU4LX/LqTeh0vVIGDc/EhfeeIMI1Fu2Ts41uGnqjWVVEOrBOBleFb9ytOilDYDoEiapfiUTbgxmBXFWL/SGwg5oVil6sg1TsuI3plgrHggv10IMvL4HU8sj07wu6BfXvTym9ZUgSMkJuOKjr4Co+Te+j6sfpxViJYMOsYou10QmxBkyDCRPUPaSHtgso88fbEK/AuiIP5E7D8ibtEvHJMXwAsPoc+1Jl8WCc4JQ3j9AoGq1Lgm+99SAlfBfpQPprTxQiJE69DUMdG05NuQjulZBZ6vvRhk51Zs7XDzW1t2NFdbhq8fttikcqbQU1dBb1YqLGuMfmturIssdH9rMQuQrn3SFg7e6BvnbV/kQ1j3Lo0QalGBGUK/u3r7KMiqrVCydez9rVwaG1oTKJOhuyxKBezRC04QLZqRbarG3/kCKoGEdVt+DQG6P4zKNGlrZHKyel4fQihC+sae99Vq8VQ83BgqMB12xNsma8qoWO6L9othgc+B7DW05Qo8f67PZBCZOL2ompwilJAvItPJ0tbeHXPuqPbX1NG7KtjBHnv5g6HOlV70leiAqmWCnat0o+ej0R46V1ES0cNHUrARfCB9CkSH5nkA6btfvrSdfydQTdltANToV6vtCt6nVB6mYA1UA3kSyfal/e00BkP7LaFcEbySgAP+81EOXIEhWADhgHNjlKi1LxyxajNv7yFjW9t+bP16vBKXqlmdYNSf330h6e4HEkoKttE3o1WtUesKwNX+jI49KpStClbZJMxMZ65qthaOSjXu8k/0KuQUTqADebxFnW+2L0Yr0I5cz3ajanxTxDpk25696JyYs/vsjMA76jgaoUvBGnaNi5TtGWbbDQA38oC9W/5jx+Ou08758XWgmYs5pXF3OOrUMwyK8lbVYGCk1vOXiFvzpUvqlNe5G0JxVR7J1XS6veAajtOfm9uuAFojYPSyZH48bvXQjE51WCIQKxiklFt4F+UCe/IWtgjq23SZFXeg/e1BshgtbDgU4BDhro5qV+Ue2M1Vw/dm3a6AiNDPX5qmDltgpAu1W9O8ynrM1KW4JYOxDU0KFtm1lti1ov9cqm9N7ZkD77KrUPBkizyx1l2ZSpSGpqey3aY1fw3Wjm3FQquJxZbwGULQsqofMxaj9XvS+hE27qsneq0um9D0clL55VRV7tClLvSTzaFSx3U097u6F5dlk2Rk/2R6uNepOd+jgdH6gPYja9YcLDku0pEKR41rGAsjaREJSEOYFJiiF31couBI3aNqOXTWHX1YytHacYwat3PaUGI6EGhZV6d1AaEod609s8qAKvAvlrg0fNMhPkmWT1kmCHb3A0rY/XDM8oNySr18beU9KLQC3m6bUaj6+guIZ+U7WpMejchvp7kwM889Hbroq6wKQy0bMahqsN4TCmtoy/IBNxnan+Xr37b6mIqO6fhBNiQF0FRUYvPnO7QZuw0C4oKfUqvLZl7c967xREFHFv++t9VWrp+uUtbe6n17ZBQXu4/wEOzOteHAtZ/wAAAYRpQ0NQSUNDIHByb2ZpbGUAAHicfZE9SMNAHMVf00qlVBzaQcQhQ3WyICrSUatQhAqhVmjVweTSL2jSkqS4OAquBQc/FqsOLs66OrgKguAHiKOTk6KLlPi/pNAixoPjfry797h7BwitKtPMwASg6ZaRSSXFXH5VDL4ihAAiSECUmVmfk6Q0PMfXPXx8vYvzLO9zf44BtWAywCcSz7K6YRFvEM9sWnXO+8RRVpZV4nPicYMuSPzIdcXlN84lhwWeGTWymXniKLFY6mGlh1nZ0IiniWOqplO+kHNZ5bzFWas2WOee/IXhgr6yzHWaI0hhEUuQIEJBAxVUYSFOq06KiQztJz38w45fIpdCrgoYORZQgwbZ8YP/we9uzeLUpJsUTgJ9L7b9MQoEd4F207a/j227fQL4n4ErveuvtYDEJ+nNrhY7Aga3gYvrrqbsAZc7wNBTXTZkR/LTFIpF4P2MvikPRG6B0JrbW2cfpw9AlrpK3wAHh8BYibLXPd7d39vbv2c6/f0AnWZyuJTEUK0AAA16aVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA0LjQuMC1FeGl2MiI+CiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIKICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iCiAgICB4bWxuczpHSU1QPSJodHRwOi8vd3d3LmdpbXAub3JnL3htcC8iCiAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgeG1wTU06RG9jdW1lbnRJRD0iZ2ltcDpkb2NpZDpnaW1wOjA2NjBjNmMyLTgwYWMtNGY4My05Mzk1LTlhMzBhMmEzMGRlNCIKICAgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDoyYzk4NTVhOS04OTZmLTRlOGUtYjdiOS02OWI3ZjU0NzhkYzAiCiAgIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDpiOWQyNGI2NC00MTA3LTQ4MzEtYjkwMi1mOTQxZTc5M2NmYjIiCiAgIGRjOkZvcm1hdD0iaW1hZ2UvcG5nIgogICBHSU1QOkFQST0iMi4wIgogICBHSU1QOlBsYXRmb3JtPSJNYWMgT1MiCiAgIEdJTVA6VGltZVN0YW1wPSIxNjY0OTEzNzk0NTUwMTI4IgogICBHSU1QOlZlcnNpb249IjIuMTAuMzIiCiAgIHRpZmY6T3JpZW50YXRpb249IjEiCiAgIHhtcDpDcmVhdG9yVG9vbD0iR0lNUCAyLjEwIgogICB4bXA6TWV0YWRhdGFEYXRlPSIyMDIyOjEwOjA0VDE2OjAzOjEyLTA0OjAwIgogICB4bXA6TW9kaWZ5RGF0ZT0iMjAyMjoxMDowNFQxNjowMzoxMi0wNDowMCI+CiAgIDx4bXBNTTpIaXN0b3J5PgogICAgPHJkZjpTZXE+CiAgICAgPHJkZjpsaQogICAgICBzdEV2dDphY3Rpb249InNhdmVkIgogICAgICBzdEV2dDpjaGFuZ2VkPSIvIgogICAgICBzdEV2dDppbnN0YW5jZUlEPSJ4bXAuaWlkOjM3ZjViODlmLTkzMWYtNDFkOS1iZWNiLTg3ZWZmZGUzMDRjOSIKICAgICAgc3RFdnQ6c29mdHdhcmVBZ2VudD0iR2ltcCAyLjEwIChNYWMgT1MpIgogICAgICBzdEV2dDp3aGVuPSIyMDIyLTEwLTA0VDE2OjAzOjE0LTA0OjAwIi8+CiAgICA8L3JkZjpTZXE+CiAgIDwveG1wTU06SGlzdG9yeT4KICA8L3JkZjpEZXNjcmlwdGlvbj4KIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAKPD94cGFja2V0IGVuZD0idyI/PveL0N4AAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfmCgQUAw4eoaihAAAgAElEQVR42ty8ebSt91nf9/kN7/zueZ9z7jzLkizJQjbCGGoM2AYRN6E4LXVXMU6dmAZcnLYQVgyrxVmskK6EVRqwnQJtWBRCnIZAgAICG2Rbso2tWrY13Svd8dx77pnP2fPe7/T7/frH3neSZYyxE0jftc60h/e873c/8/N9HsFf0vHo3j8UQogVnHs18IBz7i7gBHAQ6AohUiCw1gEuF0KMgV1gA7jinDsvpHgGx1MIsfVI5yfdX8Z9iP+goO2+L3XOvQn0I1KobwN3RkonhVCLSxHz71IgxPzSnHM3f770d+ccDmudqy4AjwGPCiE+8kj3feP/3wD46PZPKod6sxDiHULYtwipalJ4SOmhpEQRcANAKSSIOYhucXFzyAw4uQAMnLVYciwGa0usK7HOYm2Fc2IE4vfA/IqW4sNv7rzP/EcJ4KO776s5594J4j1KeqeUClBCI6WPVj5CSKSQSBRycRlSSEAuruqWxIFaAGVv+w8VxjksFucMxlqsLTCuwpgCR4lz7hLwc0LwLx7pvm/0HwWAv7vzPyVCyHcrx48qGS5pFaB1iJY+Gg8hBFJohNBIKZH4eAsgQSGEmAMnDMYZKm6AZrDO4JzDWoujmAO6wNhaS0WJpcTaCmMsxhYYmwF2B/gZnP3Ady3/1OSvJIB/uPWTonLmbULqf6yVd9zTIYGsoZSHkh5SKLQI8ISPUj4CicMhEDhXYbDYm1fjbkrbHKzqpjLfsoM3njc4qtuANXMAhcC6CmtzKpMvJLhaBd7roT/05uX/2f2VAfB31/7Hkyjvg1pHjwS6RqAjlIpQBHjSx9chWkZo1NxuLW7eOYcQBje/bQxffE/OOawrvsiR3ALT3gTwJohufrYb57POYExOZTKMNVhbPepc9UN//eA/uvzV3rv8ak/wY3/3nW/ffDb/XOg1Hon9LpHfwlMpoY6J/TZJ0MWXCVgo7QxjzW1AWBx2Ll3u5QTC4Zy5w+veDt5LHwPmZkEqhLslHVIIlPLQKkarACnkI865z/329fe+/S9NAv/+3353KBw/58T0XYWY8ca//yArRw7gqYBQNwlkiHUS6yrAvswZbkkOgBXcVGFr7W2vMS8rfbe/BmFu+3uh1q7CCIe9TeXnElpQ2RJjCspqirXlLwkh3vPdh/9J9h9MAv/BD/zIilLBn1Sle9ewV1GOLB/950/DzKOhD+CJiMpWC9WzX6SOjrmXfLnjzljvzsduB+9mnIi7A7z5a+fPKXcjJDI4yvn1CJBCIaWPpxOU8t5VWfMnH/j1d678RbBQX+kbfuJvveeM5/uPFVX5Kokim+UIaRFTn/2LIxpHYnSkkVou7P7CyGPAWRAvb7udWCi0tSBuSJ79ksH0XH/m9u6l4M7/8Q2nMgf5xrnmNtIhhEBIxfqL+zzxi88dXft09T2ve/Wrfv/JZ57b//cG4E/+4I/dO82zP06S5MRslhOGEXmeY0yJVApfBIwuT1h9+iIrr1zBC9Tiwt2XNRjWWYxzC1DsS+LAG+DZmyH2LYAXobYxN+3m/L0LwG6eT9x8zDkwznDl6ev8wU9/Cq/fIIrDdruz9NY3fsMbHv3oZz65+zUH8Ee+/wfPaO39sVbySBgKpNMUWYGQc5VwrqIqHN1ul0mvZDoccPCe7iIuFi/jHm5XWzvPJITDueolz94O3lzibmYn3PK8t85qb9o7B1hRgXA4JGAppjnT0ZRP/srn+OQvPsNK5zhCBSwtd/G8sD4dzb77vlN3/+5nzz69/zUD8Ef+1n+7ooR4rMrtCS0EymmazZjKGsaTCb7nYW2JqSAKY8qyYvfKiNqhmNpyPFeXl+a2AioclTXMw2XzRc7mTpU1OOxNdXx5L3wLvLn0ufl73C1Vf/r3n+OJDzzD5jMjGq0WYVAniAI63S7TaUZ/b1y3iLf8129927/+o8f/ePJVA/iet70j3Fhf/4Mw8l7V6/cQymOaZZRAOw4YTTMm0wlCOGphSlmVRHHAZDqmd32P+tGYpJ3OiwSLLEMIgbMGQYV0FuFuqbi2IN3Cu5YVTDO88QiyfC5gUs9dn3s552LuDLjt3CRYazC55bO/+TSf+5eXqLKQWjOmUV+iKiRL3SVsVTIdFRRlRbfdbl9fv/rN3/zww//y0194qvqz8NFfDsADnZWfw8jXXVu9Tm3ZIFVnnntWhu3dHnaWU0xmlBK0jWjFAVVlmU0s2cUxT/6bz/JdP/JGhAqQUt4RgsyLAgJlDGpvjBv0EcUM349xvSHsbuFZjSkts8kUYwRZaVi55yiy3WJcD8nqEhd7zE95QyLnofncBRuuPrnGhcevsvqn+6RhByM0Bw50kSKkLEZIIfD8iCTVLLeWuHL9GlLK1w37w58DfuAvDODvXvnptz/7v++9q7xacvDgCr4fQl5hqBiXIzylcaUhDAKEUlRlhTGGcjolm84IA8XOs/tkowmy5qFveNXFNzHLic+uIS9fYryxisjGlE5QyRw52yBZbuN37uLKhR2mY0WeT6msRQx6KF+h68t4foZ36gCj0wex9RDhxFzNhQULw60J/+8vX8UaQa3eIvBqlNaQJHWy2TwcCsOY6SwjjhPWV68hURhTYQ3vevsj//njv/rob/zqV6zCHxv/7Mkojn5bN0Q4OpczHI/xpI+1FonC4SjKEqRAG4fRkiSKsZQoz2Ow2yOMfLLhiEOvb+AlIZ6ae2XhDGJ1E/8Tn8Scv8x0tE29HdE4HHPg9BLdu2oceOXdqLBOXjhO3pvQaEuCVszKwRU2NzcYj0omgz6rn/8c+eYujbVdVOphWnUQcy89Go049zubjDYF2hMo5WNdQFpLEUJSFpBlGcrzSfyIca/P3qDPZDJjNBwhBYRB8O2vvveuf/3UubP9PzeAj+cfEMLJX9e6fn9SD3jxifPkI4Pva6SvmOYF48kELSSB5+PLisrMzft0mtHr9ZmOJ0ipMfmM5W/QhI0AX0YEk5zw08+TXnueSPfpnFIcfoWmtWKoNUKCaAfpj9HmKkqFpJ2QMKyotVKWlySdjuTEqRb1VsV0UmCyjDgMkJXCrW6SjDPydsJ4UvHRf/Qsg+sV41GGlAJrFdmsQGpJGIRMJjNsZWg1mwx7+5y/8iKj4YQ8n9FoJASRJgi80Blx93e+/g2//vhTT/45Vbhyb/Nl8oiWGi+u8/Db7ufxD36BvMiQnkb5EjstmBWOvCqpxSGhrchmU4z2mE2zeXjjBEVp2Hhhn3a3jr64T6M/oBbmhMcNSpcI+mBKhPHAjLDWojwDzuEFQ5wYY1UbV42Q1oBfR2nFysGUpSOHMNkJ1q/s84XPXsJMLY2dEcvrO2z6DaaDKUo3GI+HaK+BVreiyL39PlVpWF5pk43HPHfuBYqqBAdRmuAFPjhDWZbIGo9cb3zmbcC/+rIS+MTk/YlC/6angqanfHwZokPJtS+sUo0k015GOSkJwgAlFc5a/DikyEv8qmRcGSSgpEQgEOWYrujx6iThrpag1RoQ+GsoswXVPqLMEZXGlZbpzOFHbQQTwJt7YmMQLkC4mHw6ppoIvEghgzpCWbRfJ+10OHFymZmoYcsMYQuee2aHa9sSpQMm0xlxVMPzNNlkBsBsmhGFEX5peOq551CBj3AQBAFJmqLUPHoNQg/b3WJXnfv6V76h+UvnnhiVf3YuLOS7fRUeV1LdrON5qc9DP3A3rYccAoOS4HJDEsYsdZeIwjqdpQNY6aPK2bzSLBST0QQtZ3zTvSn3npTE3iVE8Txmtks5k9iiha3qWNvAGEdUW5kXBpzCkeJEG+cdwMqUwfpTPP+Zp7m+M8XoFlZJJAFCR/g6JIwrXvMNp3nw9V9HZh3bwxBjIM9mIAR5PmM8nmKLkvFoQhTFqLziqbNnCaMQLSRaazzfIwoCamlKs9milkYM1TpOcNwPvHf/mRL4xPRn61L4H/JUlEipUDLCOEdp5qVydWiGSfYptxRmaMgmJViJKUqGozF+IybWljyvEJ7HgdqAH3znMV55fwevuoyYbmDzMVlxgsGuoRBdomQJV+yztyVIOgdwpgTvDEIqEE2sUEgX8zu/8zRHH/qvOHTYI0haCNEE2QA5zzakKZBaob2cg4cPEyjLM1fG4BRVLlDaJwwirCmIazVqeFzYWCNJU3zPR0qJtZYoikjShCgKUVqSqT7r/mcJw4j2UvfrvvMd9/7C479xJX9ZAP/Oj7/17/oy/ptKhvgyQjow894ClSkoy4qZ36fSI/Q0nqdvlUFIiclzyrKkqhzt2PKae33+5l/rcOxQji4vYLIxk2yJaXmG4X7A/l6N3kaFCBRJ2sJFHTzP4OT8kpyKkMkxHAU4QXD0uzl9VxdfXCcbz9Beg3JyBVSKmF3HZteRVmCdBDvmwEqTo62C672Qwf4UL4wQQpAGHodabXbyPrVGirVQFDOgot5IqdViGo06whomdsAF/6MobUnaTdrLraS51Nz641994dNfBOAnsg8oKfSvaem3fBEgpY9ZFDzn+WaFNYbK5AxNj117gdIWTGSPsdphXz3PrjvHkE1ed7rG977lAI1ayXSwzXh4iGH/Lgp3nPEwJp9YSuNR5RXjiWVa1vHMNp65hlQNRHoMES1jXR/hL0PYonP0DIyewpWGQV8Q1mqMhoIojqmsw1jJi099lLhWQ3sK4UnqacHJI3UuX58yLRXCVJw4fISnnnua/cGYfFYgBNTrMaEfkUY1HIIg8NjPd1iNHseoPtoPaC03aXfbdJY6r/i+H339B/7t+590d3hhYcSbpZKnbpR5LA4n5j0LIQSe5xGGEY1ah5WVGbPJmB23xmx/n3yUUSqLKeDNZ1b4vrccIEr6zAaOXv9+yn4Pp3J8VyMbjxBaYYsJXrOG8hqM+z2yQZdeklLrP8NS57WI8jqiGOCUQ4UtJi9+hEhfRvhn8BoncNrRPHKQaX+L0YZhvKcYVd/Azv4BGu0m9VpFFM3wRM47v+cI//ejAwJ9kE8++ST4AUkYEfoBUewtqtVqEVSHICr2k2epVA+pNDrUhElEWkuIoviU0tGbgUfvAFAr/x1KeEghcVIuqiLzzEEIgVIa3w9I0zadToEtSjw0Unr0q11KM+Vbj53ih976EHEwxgx77G3dQ//qdbwgAu2wo30cGlc68CKKbIacTMmmBlNUJA0PdfBBrBeiigrnd8BvQzlFZecQnZOgJGkqGW4V7G1eZ2ffsf3sMwymFuMsyzuObmtGY3mZqHmYlUMV1sz43jcrfu33Vmm2l9BKU1UVGDCFxAsl9UaM9H2EKnih/CR9cRWlFEEYkjQi4lpMnCYEQYjvR++4AaAA+OTsn6daROta+jUlb+WsNw5jDMYY8nxGlo8Zjwf0+zvsbm/S29mjv9cnzXP+h9e/im4KFOsM9k6ye6nk6oV1olqdZPkQ+WxAUZQUQOg7ZrMKpR1x2sXNcoY7qxR2wkNv+Do6SwFeGOOkQogYW26DqajykvFkhfWL+8zKHjYBzw+onGNvt8dsd0ZH+oTtI+TTPcJmyNGjFSjH5cv7/NbHDzGeZpSmwvgWP9U4VUEwY6B6CG/GkFUQljCKaLRbNFZiVg4vsbx8jEajRRzVR56nD31n98fHel769t4kpagJxB3gWWtv/i2kRXsS3wXEce1mkTKIYtqdNv9ly9FplbjsCq5KGAxTKjMgXVnGkz6z/hjZ8Ak6Oc0aGCtJHVhbMRleZrJjQUvysWb14jWa7ftRZlEMzc9jZmso7yjTzZBLV69hGoq4GVMYHy/sINAcOXmC8tA+WxcuIvq7oAyVqdHvVXjRVY4dUrz+ns/xiU9vISKPT5TbkFeoUKCNQguNKgVogQ4C4kZC2o5pdFKSJMb3FUoplFI1gX4T8O/0XEX1I1IohBS3gVfhAGPczWKllGIeK3k+cZyAsHiex0M1WElmiHILUQWMp8tku3ugQtJGxHBnl7DZwdU2aHY6TPKQcdmizIc02yENr4ezLzLarOPXQvLMsL8zoL0So6IUqRvoSFLOPPYnATJxVNU2lT7N+taYP/j0WZznc6zr+I7X303t8Ji1ZzboLB9mZ3PEoJezcuwAcXfEQw8uU+QJ03GByAIe719iUcCZf2mB9D2iWkStldDoJNQbdeIkxvMkWnmL+qZ8BPh38snZLwsp1LcJIe8sZGJvVn3B3SyKKqXwPI8gCIijiFckiruSEcJsQDnD2Qh0CycdEsdge4dZUbA/vELaqTMzHf70rI935q38vZ/+Hf7wiSuo+Di1Q6/FhDtIEZAmB+nvVRQTC2WBcCXWSPr7AaPhjEm2ig6XMNbng//qcWZ+woMPv5b/5ef/LR/71ItE6QHGcoDLxxw5tczKkUO4PGUyqQiiiPseULQaLb71zF200xpJrTaPDVsNaq0WraU2nZUOraUm9VZKmtQJwxjteUh50218258MflZo68yKlvrMy3W85jWn6mY743YQQeM5n3tGWzi3h6wsVqwggibFuI1zJeNRhlU+UviU3iao+9jeF/zCr/0uP3b6P2H1+ib/5P2/wde/6hSHVtok7ePsbPVYYYmqKOhtXsUXS+CNsOIAk0lFv9/DJY4gadMfGl68tsWzq49y/oVz5Kbi/3nsSd7w2lfglKM/mnAojZlsrDOZToiCDBdrmg1NFM+Y9AQPLK1wvQtR7C9UVCIjRZSkpI2UNI0IwxTfi1DKQ4ibOJwRiBUtUK8W3Ok1nHNfst0oxNxOOutxNNsiFEOkseAChPIxqkVRBVCUhKHElhAlMSMTUVUla5sD1q5d591/5x240lA66A8cxw4FhLVltnov0NxNoCjRh7eZpBlRukwVHsWqTaJai5kGEfg0u4qVVsSzFzd58dwMX2uOHz2ADiKqqmJoPFYvbOBMhedHOK9NPn2GqHmAu15Z8vQnNjge1xh2LK1OivIEqHlKFwQBcRwRRTFhEOJ5HigwqsIjQAghnXOvlkK4Bxzuy4L3UgBTV7E0XUWWE3DxvGLiLUG0gjAFMkgYTQuqqkRWBWVWJ5/uUo9CpJZUgNAKqSWNeoSxJUVRMZoWFJWk1qiTj32GgzGFi+jvjpiOxrTveTXTbAhCkMRNvu8/ez3LKx26K0scPdTmP33zw1T5gCvX1lm7cJFiNiZuNLDC49LGgI21bcpqhlZrLB1WdFWM72uSWo1mu0W73abZbNJoNEiTGlGYoj09dx5S39GaAB7QQqi7bogli0quu61v5tzL93G9rRGT7ZxGIwFrESrEhccgvhcbPEtZriN9ha2gyA297YqKsxw+8e28823fyh8+cZ4iy3jrI1/HwQMhZVGwvrlG6QJUEuK0ZH//OvHyPeTqKKsvPoWaKDbX/oDebExz+Rr+SsJrHjzBTzX+Orv9jNOnVjh+sMP55x5jbyvhvrsO0GgkRLUWve3PM+g/y3NrO0ye7PHDb/8WVk44Rs/3qVERRD5pLUUtAmqtfbTy0DpEeRqUhNuc7EKN79IgTzjHzWYPmC+Svls28UY53rKSb+L7h0DuY6UEnSJUDNkazbZlp9ghn9QwVEwGQ2ppjY1VTb11jv/irz3Ed77xIUxWkPgWMxvT293isx9/im7jBGnkM5mNGQ56XFrPuSv6AsfvfpDe5YvIMiU8cJKrz38G3zfU4kM8+MAyVvnYSY8Lz/8BH/nIcwTRYVYOHiNSgrXnnmJvtk1N7HDfPXXC5XsQtQZJcZU4McTMtSIIAjzPn+e4KkArb15k0AqknOPg5s0rOScInNBCiIO3ieQXtR9f+rtwgrgYUxeXcIkCESKFwHoHcSpATvoEvqFzpIW9lrHfN3RP3ctw5zob64pL1z/D1z+8wfLSKZxQ9PbGXLx8iWef6WNzn1cejZn2xuxcf4ZmPeDU8S6hLBmPryBtQdo5TVFZmB7kI7/1p3SORHSXumT5lMsXL3N9PSAKTnLfyRbdRsje3hbSCwgKSSwVx45HrBwL8M0+s7zE8zPc1CFcC6U0gZ8uAFSL+FeC1Le1Zi1C3BSygxro3mA13VEWvA3UOyWyIpr1QRZIO8RxBOstIfyDIJuY7Q9j8wnNlXsZbG3Qakim+5ewQnLi+DJnzw74/d+8SNq4iqkyZiaAyuP40ZMcWFlhqR1RmRG57SE8STneQy5JOpFisyfIdi+hw4ST998LXsXG9U32djWb63284ChnzhxE2YJOIphsb6GUJetv0UhmODPBCw4izBhlE4J0hWb3Gml/icoIpAjQesGevU1dEXJRdRGYBUnAugrpRFcD6e2qejsP5Ut54riaATm4FjiBC+9FRCdwNofwGKKeogpF0roAAwdBjaXGEgfyKa843ubiC5dZ280ZTMacShP8SBEFPs1aSKwNF198ksjfwwbfxNX9FiunmgRejB9fxKqD+KYi2zrP0aUONS9ANFc42m1QjfeRcszBQ4eosgHSV/i1FWQas3ruE5w5PG8z7PX30L5HlU9JIoW6skphj4OwCCFRSt1huoQUCHfTK8zbDtLhnEu1cy64IXE3YsA/2xML/CKfB8xCY6uAyfWz1E51ocrQNU0lLcpFJN0lhnsXSWp1pDJM9vcIkg7Hug2WlkPy0iAo8LVPEHpUSnP52Sdx1Tb1bpPjp46xcuJ+ArGPcDmNdszs3FWsbhPFglk+JBAz3N4lWtonPH4IW2T0d7eYTmYEUYbWPuPROoG9Shx6+L4lN3Wk1yKtLzOdtVnSX+CFfEZVFYsUVd7BphDOgRPzGNDdwfMJ9MvRyl7qQO4IY5xFl0OQAU52qaqAsHYAppchvw5lH6mXQQqiOKK5BBuXP8z+dAVfNRn1RvjSQ9UTlBvQWjoBsx329nusrp6jKlfp1jSt5aNEaQ03uUbOdepLr8HYkvrBLaRKcaVPdW2DervOcLePMgWz7Q3CZp3Q0+gkRqqKva3Ps7vzHIfajjDyCYKIpXoDHUdIpUkbR6nXnqHKS4wxCwqId9v9M29mLajw0tlbJCkxL2flQPxyBMg510TdAheLnmXowpuX3PHQeoyTfUxRoESJ9eo4oRBM0ElKvdlmK+hgx4LB4Cm84CT9qY/tbRJENfbXV9nrXUWJDCkmLKWK5YOH6HRb+K5H2buIjJdAe/hhjbRzmk997GNItUI9imE4xgsShIGoGWDKAmlLtJqwM9xhZ/ca3bqjUXMkaYjna5Q2SJcx7l0gL0Nq9Yh8llFV1U3WxFxw7IIusuDm3OArUgABQK6BsXMmBrGY17idXnsjwzY3yYyu10eZKaAZbV0iPfpaBNVCIpeAAFEOQEu8fB+XJhx/6C3Ud9YYrcHe1iYzu8t0KNhYt6SRIJABSWKJQ01a79I9cg/1pQahLrFiRvPwSUgCZHiEYDrhVQ8+yOqFz7B7fZ3KHaVz+AzTwYRsOGE6y5jM+tiqj8LSqkO769NsRURRgJQVTpSYao9Bv8OHfuVRDj5wlOK+mMpUFM7gc6OQLBdA3iIuLfoNC7qcG+v5+JRbvp28d4vlKe7g4Ann0LNs/ri1pK0QinXQbfCakN6LEz6i/ySi2Md6Pl4UkqoM1emSeK+hvjJjNNhnNAGbO4Q2CJMh7Q6YDVord9PopERpQpo20KqBTWOU0BR7TyGRRCEcPnU/vrL0dwdsXvsoeQ6F1RSVpTSghKTZdLQbmkYjptbwCUKLp8x8ZKIK6fc2ueueu2gd7fBMtTPnGFp3a8pnoadCLHzAPAxEIW+Yt129mD175Q0O3q048HZVvkUwy4VBlA7hO9ApTgRAhTNj3PQ8TjexuYCpwgsdLurghyEkIToeEMwsQVDSdHWqymKyAUXu0KKB7wmiZEqctAgjUH6EDZtI4XCzDWy+horvo5YcQexdZrbfYDIcc/rMw+zvXGavP6QZpEyG+6T1mJWlBmmsqaUBac0SBAIlLFLMaXXXrvS497WvYZrto0qwxuJM9SWyLwELAIUTC4aZ29DAlVtAOZxTC/TtHRTb+fALqJnCFDlC5DilEHaErXogjyKzTRw9xpcv4esZXlshZAunO2g/QFuJchleKpiVG1h1kFJs0Wx2sNMpRTkD2yaQBu3VELXDSCVxxQ6i3MOvH8CIHGmmVF7F0uEDNJdOUlpNXHd0C8Fs5hgMehw56BF6jiCEOAgI/BxPg5Qa4SqUMLzhTacpRcG51evkRTUfjHA3PLH6c1Dz3RUNnLcLfrIUIG2FFbdes3Al8w9gPkBEURqEl6G8GtY68FYQ1QCBQxbb1LpTKD2wIdONT2D9wyRLr8CW+3heA51G6GxKkT9P0mzOB2NUyubqKSL/bpbaLUQQQLGDq0ZYM2Jvc4/lbgxiAsUGgVLI9gmq0lLmE/xwiSzL2NoqqDU71BqWKFRoz+F7IUqVCDkhL9v4ocQY8NwEY3ZY3xtSJB7OWKybs2SdU9yokZbCIWyxIIXIm+AIIc9r4JmbUiYEdiGm1s0r0F9EYvQNZiDRtQ4VDhUtgfSxpg92Ti2TOsYpi3NTgqPfQjHs4aoNIJzbIF+hnIfWdZxTWKEQqsUrlzp40QoijnEIzPB5nC2QxZA0tLhqgivXkeHdaPq4yQWEWMJPl5CzDXytiXzN1a0ZnpgQBT7aA60NWoVYCiazIefP1lhaabHULDHVNlcGGSKZUzuctfP7ujFyIW6ZrxtUDoFAIBFCP6OF4KmFoMm5mi7ivsUg1kuPPPbIJlNqHYVUB7AixwwvoRAILwU0TlQIpXAqRdgpUXcJW/agkMAYhEFphVQNnC2wsjbnWWsQdogbXUdkW9i8x5XViOH2LqfuPYivcoRsIISPED6yftd8EDEfEvoeFSOUhGIsmYYtlkODVCVCFigpkcKn1bA0m4aiWGdjG8LEsTsp8LS6pXZuLkBCzoVKIBAyXPCzb07wWIF8SoPdAndBCPGKO4oGi8zkju4cjshP2d0o6B5sIvwcUUkIVzDOzN0+AswURIq0+Ty9Mz7SSYTMcNU+2Pgmdxl8pAoXjmiIqSpEdgU7PQ/eMo3U0l05TBJqhEoQQR3r9pFaYbAwCN0AABJXSURBVIcX8Rv3gJ9SSYt0O2hVcP/dAQjwAx8hSoT0kMLHoUA5HB7Sg8PpChdWP09PWFphcLOUJdx8Qso6hxT6jkKLWHhlhLvgHFvyNcE7nHQ8JuydsxgvBQ9RISiZqozxCLJK4+ycyCi0jxcdwKkUW1VQVVjtgZuB0GAKHGOszcB5GDvFWRiP5oOAzuzhqgFmNqAcnsVWAmr34ymPWksRhwWoBLw6QnhIY5lMSoYTjSRHMEUUm/NigKiop32aaR8pDUpFyPAkzmvOPaeUIDyEiKiqbXb2J4xDjR/5izExscg4QDmHteWiR25ujlgIfIDHvr31w07OJUs+6oSeTze6AmPzxSTRS2uDFlFP0J0W+UQAGmElOB+jahCdROgO1szA+VjZAlnHMUGUFmHdwgx7VHnJ7vVrjEYVojK4qo9z1dwUSIuyUyphsFXCxcslxCcQ9XswZBg7JQkzlpYjXLlHVfQRtgQshuY8SxAFpS3BP4oIDmL1YSrng/NxQuGEj7Eznt3P8WIPP/LxvQBBgBECIwX2xvzyzVKewyO4YQUfvUlvs4iPOOdGYjGMIoRC3hzDv5HGzCvV1peU7YS9tW1wkjIf45SPnG3ginWcKKlcF4cG/LnUiQbOlYu0UGCNY7CzSaN7gkY9xrgxzgSIaoQV1dzO2ACjD0J0kOah+xB+PE+rXJMyF1gjsNk6NtsAu49z5VxypGY8kThiPFVbEKPsXH1FdzEpGmBEyHBc8YVJSZiEhKGPVGo+9C0F849a3Dkd5ARSOIRgJKX6yE0AXxd+/xhhf49F6jIHT3FjnuD2oUAQzE53mYgVpuMh2g+Q+T6i2EFOLiOLDbQ3Q5rhYmKyDiIFfQBkHWtCTCmYmi7bOxl5AWUGRdanyDNMlTItmxSiBd4RvM5DdNoJxfofIao98vF1huYIk7HAuRoVPtZFN4dq9vcqlG6DaGDtFJOvYbMelRVU6gjGeOTlFYzd49mNHtPQJ2mmRGGA5+kFiOLOzuRNvyAXwbT7vW9v/sj4JQRL9ysvW1AQ1R2TqAJwy3VGwxH71/fIexvYbAMhHEJU4AxS+Qir2bzeA1UHq8FIqsKSZSHZ1JLUPNrLB8nNMfrTI6y+YNnbiuhPW4zFK9nnlfRGmtGVTzHdfR4jj+FsjA6XmA1z1ncEpQswlY+pLNa1caKFnwbg1alMhTCaKi+w2XVMMebalTWGI4FwHQbjEb+/1iOMI6I0RHvBnBgqJXe449syMSk0OA8p5K98EUdaoj9sKS85OOUoEWic47ZqxG0gxgHTM0v0rw7oHoqQHuCqud2zFiUCrIpZOnEvlgyXW8rJlOkkZzSsM9weUQxnCDnCRRGumrG9W+PcZ3uc3dxiff+jZEVGGCqWa4pXnVrmoTPHOdApkX6KSJZR2pKXDjN7gc98bsbrXhfgezN8KblyccBdpz2s20Pc4DlOrvFHv/1xTr/qQR5+2PLRS+vsKY9GPSRJ5m1LpdVtkmcXQCrAoBwo4QNcksL/8MvOC38q+z//nnPmf7OuullQfDkAq6piuL1J/U/WOBz2OP1ACyEljpBqPER5GisSqmoeMw5GMWYm6W/3KPo7lJVAkhM0ltASXtyc8BufOc+5jQlJsoSxFQ6L5/vs7e7Q399lpSb4lvsO8b2vfzVxu0a5u451Bt1oktYCDq70UfRQOsG6CCUN2huhhMaYikrV6G31cI0z9Cbn+adfOI+IIrqHmxw8eojuUpckSQmDGlbL21oc826lshJPBQih//vv6Lz3n70sS18Iftk5+RPA0ny+7OX7I0IIVK1G7x5N90KT6bAgrjcR+KiggS0q+nurZMNlJmaZ8d4WQlqqPEPVl/GsmA/VmALh1fjTc2d55to+p858Hd/wja9DSc35F8/RqNfY3t3hE098nPNbe6z1LrPZG/Huv/EttJM2WZbTW9ulatXpb4w5evcp6i2LryWyGoKuYU2J9SCUHp1DKSOzzYc+f43SUzTSiDiNCcPwBmkIJ25sD+H2qBo1p3TsCCH+xZckmX9j8LeHQoifeelc6suN1fuepjjc4NqhgLVrmmEeU5o+1himRYsB38x+0aYsxwT1DtiApHkA368hpMarN4mDhNmwT1YJRpOSssxZ31hnv7+H1pooThhNZ0RRjEUyzByPPb/Hp8+tUxiHESVhmNA9cTeeirnwuVU+/5kRW1uaStURziG9Or6u4cSQmdM89vxFLuUlURQS1SPiWkIQzlVYCIl5qeO1Ds180wjon3lz+x+M/sw5ESHkBwT6h6wrjwvxpRdbKCmJwibrKz0aZQt/o8Q/dpBZrtlemyHtGJtXqLiOF4Sog/fgxruML58jrjWYGSgHu3hxk3F1ndk049zZ51m7dpXAj1FaM8tmDKdDRvt9Ik9RVeCc4JmLm3zra+6HuEnk9RitnkX6Pr2RY6Xd4urzW2ytwbFTEcsH2tjqKlVVcP7idT6yNSYIPdI0pl6PiKJo7n2Fh5QBToiXGVzQgFmVwv/Alx20+cbgv5l8cvZ/vFc48eu31we/aFeA1PiBJmm0eHq4jjgXkOc7xN178NKQfHMV7aXk/R4zYWA0hWmfViuhMIZylBG0DzEcZzQCSGsJQRCR24rZdDCn1TmBcwo/jZDG4ayjUwt51T1nsMLHjvcxXownKwK/zlJ9hh3vU5UWuz3kXH8f8U0ptVqDq5tX+DcvDJg2JEkSETUSolpCHMf4vj+nHcs7de9GCU8gcPDeN3d+bPLn2plgJR9CiEedE1+ywS6lQiufOKoRLrXZO6TY3/bp77zASIypH70bP0qwBqLGCkwmSAHj/h6BJ9FxTKUVZH3e9MBJHlhuop1BItBa4fvegpMCvhcglcaXjrbMaXsllSmYyA5CRqi0S54XqGYToRW+KrE1ieyWCLHN5vY6v36ux3pdEMQBcT0ibSSkaUoQBCg1p3EIKe+0fw600AghHvVC/aGvaGvHJ6a/eNI6+znnysbtUnh7l87YkqLMmEwG7G9vcPrpgsHZbYL2mAN3vxE2tqidepjx3i5R6JP1NtHNFSajffRgl9yGTEd7ZJnhhavXeHFjwEa/YH1/xMQ4KiuQQBz7LMUex5ohp04d50hNcPrkcWzUglmPNPUZbW3TXm6zt7nO5mQXUdvnzOF1nEr58CXJFxR4oSZtJjS7DdrdFrVajSSp4QcxSnug5B0O05M+WuiBEPahR7r/8PJXvPbkickH326d+b++FGPBOUNlSvI8YzjaZrC2wZnPjdm7tIethxy/937C3hDhFCpM0a3jKC9gMtgj39vGFlOskOyNS5aXD3D96mVckHLx4iWu7Q+p1btko31O3PMAZ04fx+yuonyPYrDD0ROnGY8Lyv46cXMF5QmkrFjrXyU3WyynzzMyHc5uhzzfsKgwJKwHtDsxzU6LerNBkiQEfg0V+gh5qxfsFrVQT6RI5Pd/19KP/+pfeG/ME5Nf+EXL7F04+bIvt9ZQlBlZPqTf32d4/ipHX6zYujAgqte4975TtLyUspRsb42JIw8pHKXxmYw2SZsJk/6U3mjK4ZUuwodcJAyHY5LAZzItaB04gqehGmww2V2ntnwQYS1ZZjFFhpfUqNUcFzYvkrld6sF59icHuDysc7E5BB+SWkjaTqm1E1qtJmm9hheFxCoFT805MLfbdxkinfylR5Z+4ge+qr0xQvIegfqUu337xks9kdYE/ryLFhxb5pkTJfKuiKRu6feHhI0WLoiIvBmYjGw0BA31Rp2osYznezRrCVlmyUcjGq0OyzUPX4KWMBqsMc1mbFzfYrw3pL91nYKArJhS7zYJ1IRze9tMxBrK3+TStSXOlgmXOmNEAGHiEdYCwsQnjiPCMMTXAaGKQN8q3c81TOEJhYBPSane8zXZXPTE7IMr1lSfcM6eZlFUvPFWt9ikUZYlRTllPB6wu7vF2rU1xHqfw9s+h+MznDh5jGp9jyhJmE2HyDjBGIUtJzivQX+vR8AMFaaIckCYtHB+hHBQCUVVVOxubNDodEhjRVGpxYqnMdv5mM3RJptXnsUUDeyJBqu1HkorvFATJgFJPaHWiufEybRGFKV4OsB5CiklWirmFlejEBeFsN/8SPd9W1+z1U+Pj3/+jHX2MevMkXnRUd8BoHOOspyRF1NGowG7u3ts7WyR7ww51o9IdiQnTp6mq32qwseTBi8IGc8ybCkxRUEUSMalQLoCP1AUfgsz6mFcSZo2yacZTisiOybtdNkcZ2wMtrhy8TKXz12hfSDG3FVju5YhpMILBF7kEaURtXqNWjMmTVOSuE4YJiitcVouSC4+Co3AX3OOb3tk6b0Xvua7sx6fvP9ea80fOcwRnLqTSyjmwzhlmZHlYyaTEYP+gEGvT3/Qw9vMaKxXHGuf5vDSERqtNsXuPtXeDl69wXRvB8+PQAnK6YzcSPyVkzDaRZoR1gm0F9M5dYZplbE7HLK3t872hedY3dzHP9JgeBAGQYmSzGO7wCOKA+I0JG3cAC8hiueeV3i37sFXHp7015QMv+NNrR87++9t+djHxz9/xjn3aCWq09LdWKpzyzaWZUlZ5eT5hNlszHg8ZjTs0+vtMt2bEI4khwaae0TCNGxghEekBYHNsLMCCoPzNPWkgb90ElcO0JHP/rVrTITHOBuTDcbosEIMp2zuvsjZM01MqKkUSCXxPB8VePiBJog0cRqR1NK5101jIm8etLOovnhCo5V/UQr9yHd2fuLCV4KH/koB/Jb0hy88Pnn/N0snf8tiXjcv0d/6HObcOh/nuVuUEClQWjP1egyTEefDMcevvUjjbElBDa/mkdeOMhjMGG9sI+M6ulkn2dnHFAUuChlfXKdafYHEFzSDnEoJygrKe5pUscZJgVYK5WmU5+EF8+Fpz9f4gY/neXjenLIr1C2n4YkQLdWnlOR7vqP9E1tfKR5fMYAAr0/+u62PjX/+251wP+esfZd1t42ELVj8WvvzjWnW3pwEUsIgPYnve2wLweHeCxT9CW4k6VR7NHcyxgOYbm+QCUsuxLzfCjSVIPbAr0NpJfkU9IpjZ6mGUgq7mKKSnkb782EgP1iA588BlHrheG7cvNRo4f2SRL7nO9o//hdaf/dVb7D86PBn326d/XlwjTuyFGOozIyqqsjzGXk+ZZYNySdT8umMfDjmjatrtC9fwwygNAI/jZFFRTHMMEbON4EYgVAWlXpYqcjGJSY3iKbg4rE2j3cb8yBYK7Sn0YGHDuZzHkEo8KOQKI7nY/1RiO/7BCoi9KKB1v4Pv2Xlp371L30F6MdG/+ykddUHnXOP3FikaO18dZMxOVVVkOc5WTYhy0dk0ynFdIY/GvCm1U1q69dgZKkKj8o6VOSjVLj4MCRFUVBOcszM4CmgJtjoan6/vcLI0/NSlKdR0UJtPY0fCPwoIggDoiia57xRQKQSfC98VGvvh/7GoZ/+qleAfs2W0H48e78wRfk2h/vH1tnjpTMo4zB2DmBZlhTFfFw2z2fks4xiOkONe7xxt+LI5iZisEc+s9jKURTgdARZgVQgpUEoi409rjda/F6YsKNA+hovDNGRRvse2pN4oSZYqK7v+wRBSBBEBEGy6nnqvdr3P/Q9h/7pX50ltLcfj43+1wR4d2XsjzpTLVlbYWy5ADGjKDOKYkaezSjynGwypRxOebg/4dWTDJ3lqCLDVAbtN8n+v+7OXcWKIAjDf/d0dfecsxqJYqayYqSImaGiIPgAhiKbbyLmPoDBsmCmiKkGRoKgsPgCJiYLKyomsqyXw5y5dFd1zxjMBIoaLl7qDargr6qfgq+az1CK0esCi8JgW1u8dB6V0oAGyHu4mQOVFsYWY/+zBtZakJkk68o952Z3yNDda6sbfycG+WdZbx6UFG7k3K/nXk6kFJByhDBDUgBzAHOEhIiuaVBXS9hFi1OicXxIOJwZKhOqHLGXGB8UYRvAV6XQT7tb4QhuXsLN3DgsvIaZpi0Rgcz8LVna1Fo/WDtzv9qPPPcdBb/1ZaOIubssia/Hobs6MB9Iwsh5tH4iAu4CQh3QLFq01RIhdEDqJ35YD/QFsgby8B2CwBLs3MHPR29beExF80tj3FNjzENny+drZ+/9myj4X9Lgdm+vZAmXWMKVnNIFEV5NudPCMsq5bVEva3RVRGwisvxI5x2Ugir0eIIsDXzp4cuyN86+McZsWUfPtNYv1s8/+n+eEfwuHr+7qUTCkdx351LKpyXKyRjisdiFo6GNh0IbVjiySyzo8xAB1KrQn6DxkQy9NyXteO9fO+deabK7ty4++SPvML4BBgXrL4Wkry8AAAAASUVORK5CYII="></image></svg>
+            </symbol>
+            <symbol id="icon-avatar-4">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 80 80">
+                <image width="80" height="80" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAA0R3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjapZxZltw4k2bfuYpaAgFiXA6I4ZzeQS+/76Urs/6pH6pbypRC4R5OEjD7BoMB1/7f/+tc//Vf/xVC7fFKubbSS7n5lXrqcfBFu3+/xvdnuNP35/cr/3mJf//T96+/X4h86+Hv5/fPVv68/6/vh78/4PfX4Kv8Dx/U5p8X3n9+oac/n9/+5YPi76/HO/Lr9eeD+p8PeuLvhfDnA8bvse7SW/3HR3j37+/115O03/+Xf6T2z7f9b/+ujN7KXOeJcT/hufnzeeLvBh7/j9czfIE/7yfxxvBkvs5P/33/z4cxIP9pnP7+1bmj462m//imf5qVv78K//n717/OVop/3vL8yyCXv//+j9+/Qv6XF56/rxP/8cqp/fkq/vP3Z4zzd0f/Mvr+f85q53tmnmKkwlCXPw/196j5Be97uYSXbhe3Vu7K/5mPqN/vzu9GVE9CYd3zfvk9Qw+R0T8hhRVGOGF/f88wucUU9xUrX3B78fm+2Z4ae5yP85f8HU6szOF6GpM8v2lPT/z7XsJ32X7P67ta48or8NYY+LBgXPxPf1//0x84x7EN4W5/jxX3FaODzW04c/7J25iRcP4Mav4G+K/f//rLeX2YwewomyKdgX1/H/Hm8N9I8HwT/fDGzN+/HAx1/fkAhohLZ24mPMwAs0ZWhBLuGmMNgYFsTNDg1iM58zIDIee4uMmYnqcwNy16aX6khu+tMUe+ffF9wIyZyE95KnNDljFZKWXip6ZGDI385JRzLrnmlnse5Smp5FJKLYLiqE9NV8211Fpb7XW0p6WWW2m1tdbb6LE/gGbupdfeeu9jcM3BJw9+evCGMd74Pm968/WWt77t7e+YhM9MM88y62yzz7Hiehb4scqqq62+xg6bUNpp51123W33PQ6hdp7rpJNPOfW008/4e9b+TOu//f4fzFr4M2vxmynfWP+eNb5b618fEYST7JwxYbBIYMarU0BAR+fsbiGl6Mw5Z3ePZEWO3GR2zlZwxpjBtEPMJ/w1d1f8zagz9/81b1dN/zRv8f915i6n7n84c/8+b/9p1pY0NL8Z+2Whg3o/ZB+v7zZiG5Ldv/19/b54GZS6TJZVx1571TTfep5dUpvc2vuuXJlcxnW+fPjoIS+e9pjeO9bFGGWGyxvnIXYBFJm8me85Do8a+cm2A7f73nXw6ZnRPeMpLQwmoZJoa6Re3ucBIXvJ7Q11jj4DbDcn4+X10nuTrnnMNyUymwjOxMPerZ77jNXHXOudKR7upROQAG4grLr53rmBZ96M4tPPHINRPy28k0d+Q27jbCG2vj3DDTG+NWyGfO9752tnGXkD/CeNcjo/tvO501nlXT5X7EQQj/X0tUp/9yh9MitrQlAtEWbk2mKMzibW+j58biEUw2RA6jlj9wCzhPWePPqd0rPiO8okZON9nljLHu09u54wUAH9XBvgKombermRFRnVTPCcd/HRbQA08xkxrkyw7Ob/vqGFyJcjPj18Vz7ngNljj52esfOcZTCzXP0QONzpHVoLe6XJLBFugSHmNp/+Ehn3Qy7kRcoXH7Refc/5pT6ptMoxFGMm5kuLhYFk2B7j7Emt3WVCfX07UZOsS2UxP3PIzesqnSd7O2M2O4LnGTUxI2+uD9NfIezBqIcxxnrSqc/sDxcMpEBK7yC5Fmx+YilXSajEvDaBkSNhvB36fa/Mm0t41xtXfPL7klU8bOUKb+s5P1NiJWzneGIifa7EGxKTSyLX+Szm7/BRI61ArJe1p4/0tF16ODUqLLitsA8sXl7i4G2RfFkFxQYoFEa1MVHp4dtm4tvamvH/nqL/9vd78eN3qe0Za/N441n55OYrfTFe4EaJrUdAizSdzyaCiNLnHmtN5jEDeaNyT5HIbv15Ogj1vrHvXz6fN6fGIzaQkVTrcRUCORbgjbc+pWSy4gktrjNzC8Tqe21QjeFJTAVDHN5EsD6MzVoNeUXyrV1riLNGpof0fNbob+3jzUbdVojy3rddpGu6Gbu9mNZImHDLjZ8DQk8Z5NoIiUmeO/QFeh+eDMDufRJZUEwNMzMxM16Br/tgQuMA7YEPGICxhvIP3IHyqy0T1vebZjJWEVv5AWfSDRCNitxqARQpF0Pa0T0jh3oHnim8fPstBAzQR7QCKrLG5onu9fsMpAYQkHjEQPJn9Pp4J7zWKjGUuFBoL8REPIICGR7i3dwMfDYO8cd0+rOJ2CzKxKffuY94QCs14DVL5X7GGWByZtQbwM03eppMzxoTPC28j9niEviDWcXtTRyDXUwXcgkAWem6A+TB84V3dB+MyJ7vzzIx9Se/yEsiA7SC2bljeKoxahmgau/Lc3B5M+hidrJjr9ZiQt+YEsn1Ph12bvDHrvAUo3YKn6tLJMkdn/l2eLjOWCDK3eL1hfmc4/5SA0T4x783eEEg3bMBKHOTXtBy28wqz+ATxb/D/vqHuN8ZIJeFVyQ/Orlb40wdwgasVvfyB256QL97AXQPgc4X+xbor+Gkval8LFjF4to3D9243VdkrjwWlN9b3Kj2eENLi7GHGZ5FiDLhI/T+Xt7mSLCywzBAvj+GNO9DjIJKUA7pCOUhJp4XVsIA3N+Lww/esAzvfq+A4hhk682d1v4QPO/sL0lEzt2D5yI5ybsM7RId3K7hfjMHZNkEQQt/hfdNV0ul7kIM8IM75Cetsgl1CDkozqpSpPB94jkjoSGCEfcZPvmJkchHtZ1e9lWVjECHWV3IgILzqwtkBDYJkrUZZnjtAKs3oMAcBC7Io5HTnTkkP5BaO11r3u3BMsPqBWqLoUFrqLG9iP7u7REnk2RZUFRB2eUcurYAWAMW7g0ObdTGRcphBQjufL/MG+E2C4m4TvxpCh4N4d+IZO4ZTBqpMRCkC8JJVr+HEZvL1d9sSjFQk+QeofJeoBNtuBNKCTpEVfIkeewKWlbrILohI37f5aSQmNz3XLg8uDkJne1BsFXIALEEowCDRFsaajbImgdBD4fTExy9KvPKU0YwGVaEb66MbmEyEMF5a8jOOiDMZpb5Lw4iZLSDVUXSMphCew5y2kSLMAyIhCq9zmuqjqIw0kjltAYjRNqWvnSxSOrMTE14lwwmZ0cmuIDUd2aADi/EK1rnpc4eyC7mA+x5X56GCH1+ePbAHityN84SI9sb3vgYnLlWyBpdRbrxBde90HyrvYwMQ4xgQYeTE5IlT44EgMJAwIKaL2hoknhU9UGYAgF4QmigHXkI7ohxRvngDKJyJZRDsOudSl0EOnyGU7nFMhQuaQlvM3swBGwIYvDoB/1dLyKfPAPl4vAtndv5G6z+FaueNyLn3lHlRWJDSuwkBfw0rwMuRQwBEoJo4jrh1eefSiCY5GsXBCS30taWycQabIzKE9StfOhC3PR1jThvpmo3soGhLUi6yEOgtRE0XbLACp1EhsF9eJRnIi8QWJPrE9hbxXuYjuutcB7q5PlIDG5nuBhkiCXf7f1QByRFK8KnjCUcTowBU9akTiflAQGT4CID9nMmOJzACBiKGKkDccTN5A3Q4IgQl0Sd4mM/Tl5Dg0Ahj6jRgN5z93T1lYHmETa6ll88UEdOoTFqAgl5bsCMIKprYyleEI/RmmIjlI3CeETk9WCOn0yi9cUjjADz1YpMyIDQFrXGgrk7Y0z2M3lgDTeBAcAHPHnIY4Dq40CRa3hK5AOQt9EcAY5M6PFZA0aF3NgKUkIzAsJzVUuf52lhotE30U+iVXCVJLwqs2vhZ4NXaIwSH4Z04uJ4/v2uRIzy5lwj3PDT6Sh48jihfJSm6pUCOKCzyWtcAONXb4FDNQIGh0agkLxnnud8qcajYBlPnv658bt4JAKFp5+97QvP8UaG81mN1AbCNlFBsvBMZDOBIxYOcqZDR4Q8tN0Q+50hRMM+BBaoyj1dpqCmCdmi9ZsjOQrYdQKABEWqcC8tI9zROhgA8JGpfFDpxBOJnWFJaDFdhUG8ITVCCb4laPnIOyP2E8OGTYlIdRMcHn37xisdMYnxIAhQkHHNnMmo9zovU4uSAS/ukzZWHLUvYOLF+tvrJFNMV36+IR8QiOG8Y6v6cQggiXUJ7vR6TyTKZuz4WbQ2V+YeySPvCE2lmMYsHwBs1Y0PSOQ2IfyiV/iUAtySQ3iCayK5sg4LV7PRltDji1Nk0paeW9Gl1EWdvTc6Cw3NhW4AkrTb8AEB7/P0KzOQEi/zPzc4XecNu9c5776JijWAHFAkzoIX5uESNzk1IWIMDLXxii8RchmHPER40dB8wKlaWTAO8F8lIoJw0jAA5DsgYliEBMgv/w715bINq4MfLudKUUNdRMgUHCJu682YKYQwNp1YiDwAWA3fgRTHiOflHEABlOobw2Ik73mpRRRH/OjBqiOrMoBChOwEQoFPM6aNkYY7MLjDuighBtF1/RYwGlHRyKYLO0vaoJ4iPwfNEwBYScQatIVslDS0n5Xw2xWVCGaMU89bpHDoOxCfuJWk8UM3Aai3Bg8g4d4xJgwyQ5UTirABmAqPUB404g27oGm1ZhnjiEoLjFt4r4Fg/4QNWFERRfcpi3kmxMEjqJ8ZPSH83CBvOEkgCw8/iiVTGnUrULNf/IiqBazHCxCu2q/JTDGPzHQj8EkmsGY7OtzkfmYKcBS3i01E9IL4L7x04aMhP0SFBRRsjZZgZcxkQaIjcJVzJl3riLNZlpmLgilkIsQap06E+R8XrhgU2EiD+vAooDzqChejYo4JLQKFk3jTkgNkuwLQD0UHrt7kNTC/mJ0XiQgVt3d+VYtT+dEtxqIM/Cb6rAZrQgv88JqhlGBpLy0UFPkgyYNviAgtQmGSwVoZKMO38CEAkvFcwLvwl4KKCQvKvAHsMFSEd2NrmMY7O9iLFGH2+JDnww4YIH4PzRR5K41MQxdUa/U8MxMVA6KHuEvI8bNBVYTJYCYvohvruYhNHgmsnHM9aL0JKb+mw7itGnHXkcvzLkRj7otIJHibZQtUW0TbX5AMWvZYveyHCcEhk3wMdcERBbRlreBiGlx2H0SYwYWk1nWR15M5LhkVfF8POgZrQi5Y7Xm9T9WT1hSYRsDWgokhNW4Gj+kw8zFc06okObzPU88kcEnaFyEIyAV9fP+QuFvtRSnCoUwICSLQNWhACY4cwfy3ozJ4issw4B3yuPZD2rwAWUVPV1Iia/eAGIC1JPRauBFGE3/CE85cAGSrL+QZoN4BngizrQXUkpbwlmq+Ak7kA8yENYOZfIxnxNqDZATagli7WmwDcVJ7mfCsykLUIo8PPAo68V1IlaQHzdBntQPrD2SNdsCY+xUynZCHqGDj+3DhL+oZQgg5HeiIYSeHImaV+/k0zziMNwoEk/JawghnKppQdGT/SuQ2cedqBCyPD8NSznN9sAp6DGRfQW3MJ+Vf7Q4fywjfWHd0A5jUyYel5ko4XoTXRFXApf3F1Ix8cdtMYdM1EC37hboAbzRlfBCPXK9acIvh3FyBbyfBJjK15A0zN2UBgj1fUN/b71hE+vtbRuwHJmQAyK7UktcGHdFQ8T4Yv/vNTDYcfpc7RTQtURawgReAIyN11DNRnL/hABsSHE9UAhrIqu+uULNo1pv3TdkSkVsTmAeSVS07DpJIZLgA35v70L1wt3FhKonCG5zEviaYf0aSNg/Q8B6gMsHOw2uFkzRVr3e/WAScKUIKr0oUA0mBjMuTqWfKrNTDC8gdTE25sbjvsdhv5cS6e2lYUKRfa0o5Pp4hIgGRpcUPRv5wV/jjdA/+wf1i3McLDmVkz2mt89NE2tBparQukFdDhKxNjiNsDeCdGatWCFFh4m+ImQzoGYOJ29oOVWt4BXCoQPf6z0slDTClW86wWAOe7M9iIcRmJLMfKdHiMRaguMpquWqJNth5CI6gxSZdt2U+MLMoM4Ocv/kxIq+8D6A2d/clCEisYiTxB/HcE9ER5Zxh3SKTfxdJCHIizhJWD/2yCRMSH84FkEDAR1h+wM9D4JHR4D68tHpH5NROYKFGraVfVf/7aiIZQLQyb0cfk5RWGAKOD44l8a1IbfPK3G8dqwd8IVL46mckLoSf2srVpdOQ1XxudJQY7sHU7fmVTBBxGx+JE/kUxntc4grjg9YiiO+r4L2xU5gmSJRc/r7CWLV2rIczvkB6WTu4DqE85D0n4USIrQRlNit0U16zrIC+xW113zDJF9J8TxmAJx6AP3g48bbwTEQL3zfC8qtHN8OSFCJu0/UIay8GjmjiybkS4E746I7nV8sgF6u1lUOokapgAIkNf/+FXZk5fev1uLZQUDxInbyLZSPghqBJhBZiH4QG05lHEpKo7DtWPARhHmAu6yTaxgL31/kwmgf9y4SfW4UdopocEfuIUlgBArmYvIoWbD3QqRmMpjJZXlBlkaQ9UEiNTah5LDdje9rRBkPtQAdRBJfzT9cC8YMGKPLtlOmqCUNysnblxWYd8ikfno7Er0rhCogT9L8VGww7YKs/x59CqjBMWkiApTmDW/Da/Br1IsafgtoivOEydC0vCuckZmEYo0td3KpoAnbDwVzAqg1mpm/C+KnPTZa4nMGTlJcZJheYWgSGJRFoYD+IOTRjUwzsdS/UueXWiF4jo1xYLLyCJrZscaFcEV2m3ov1ycw8ZAsCwqYDBl4ulNV14reybsl4WPh8GYdGfLWuXiE1I5RN9uNA81B5EQh8MY/CG/XJYxZ0T0ZA30AKBGddFYbDn2ZuKJ6Qz730ZNfEL/GwyAhYAyFCdOGkI8MlOTGOWCn+e7IOcOBlkXx6OIKqqfN2Jx159AuKApq7ZRHIsCWXuSrj9BB2FiSG5p+ntg2gc8mbuWg53y8gBUcMkBy8yD7agNF4TlxbBSRRnMIFVyczcil3Rwjv6qrOwpDWm/z9GIsQIcaYxVeDN0BIpjHq33EpgA3YR94ibN8XLv6uSdRYLCfoCcao2SJhofJKkKnJEWd1XyMhjYiWtzREaGiWat6k6gT1I34c+oCp5T7S8o4glJ4fCfP6hDfRxnDlDWXDQaMfUgKbnhEhCCVXaJAHCSFEMGLmB47og8bixQhBSzxo0ttaOAB2EBGv6wHYfcvzX/lXoIh8Wz2MY0bQk38kGFqHQMoaFU0WYUpwvFZmCgLsQoEOPSyzBRuMiGREzOJOgUK9F9PXuUhm3HsA0H7550oAqAc2VNJOgoHXEKDfYh++jSxjiFZ2EWioqStihQ9BPBGimKFg3QruBKcL1uaekGTzmfbl+l1AQb/KQZdTmJvj8japF612Mbu5cDXydhPvQBWR6aLJvcuOPi8p99g4sPHDLfMd9HebzAdBTqS73vY18ATkaTjWjpUGlkmxeFhdEvf+Soau8uRLDV27jQ1TlLLWDtO+87OnfSxNBT4XvzI75F4eFwJafvBZmCygUOVH+FxWpDOOaaZ7gbE4zqNFWNHZfUCSYifT6i5ca5RJqzsIv6PfHxXAiJZV8f2umxSMA+MEv32VvP0uHbW4gverYBFpW5QwE1URKhH8bhwImYnIEFXGhfpBYIEqsunjoiJhdSwUo8VO0zZinHNrBcetiAiJj2IKeUw+xBVvcJnpR/QyEq7n6fchgNdCCvqcvMMuoO4icg7xFJVG5DF8VrDzs+Ow9Aso6Qr5Xz3bb5GQGMO1FKD0tXB5gvNtcQug5HZRbMwPtgolBRfJ4+f+FTQXkHjeCz9CTAbEUIB9i8iIOCFmlYgtYZ1WwpnnePOzscrPyVI2KAKr9+/D0FQAmxWHyAig62YvmPnxWEuxxQO73JFGWAdgc2HDiSe0lzaUZ67fkk/nM7mXcDUFQVGAlhZQg8QuWMhniIpo6Ig1wy0g7ExUnTPyUiPAjZKxihS8QC1XvMsDYQO40d6FG69bsXL4QteHQas+U0TOAjtMBlax4hhBFFsbciaz3qoePpfrQjr6hakTzKZLu5bas+kSUOtgt/OLXkyMgL6Z2I5NOxtcZ0f3Hrl/HXSqhEbIMHF8enPlJnMvv7GCtOvrhD/hq8U539H6KywHQ1TAMKV5bddseRlTG2z4IA4a6IT6jH0y2mJZxP0BYEcoJAv2JIRK2UNJc4T/XJ8LFWLjDJz96VP0Vo4bTsULuQRu+wiOD3HAO7CzEQFVHgazuk4FUhB8JMiJlzcfXPg4AB1Zj2UvKByyAaCeSBAS0mLccCX/QyvkZ32IhTmmxN6rXDUv669T4WKluQNyyGcXmWLeTzp3h2vwgkvRHGBYB3agtXEIGfPUGafTbKO4QlJCvDM3gBgQhSdgRSa2PFgsPjMrrEJ647iLbVUAPeYOT4MAIjKR+7fLBGB2O5b/K9GPqgAnyQZXYUExdJotWV/dYqgro/eNouDx0qoWxgCarTm+r7NWTy6tNb1NfGEKDR8m4CnETrr/VB5hFz4R0sYERNwQoEX2Mk0JaBg1Xq/Ly6jEN35rQgwwyk6nPFH/+8GYywZLAwKER3ikAjYg1iC8wT/byJDS8WIIgQ5MxGOfp70Sg0ntLk2hjOfEXiUkny1x5WtOArG4CwRtGfhV3NNwoBYswks1a9EAfTQc4DJmRh7n53EBivjk8d9bpUKioTTKwCIES7GYSdUFeZps9kqWIAYB17FnKCmUE/6nL8Zx66W1JQ1iQBZiJW6QoAgoZWjkobax8yrXhmB62E+1ZCVeMMAuLGZIvy8AmqwaIRT0H8I6A3w1RKJMHtYrJqv7a44Lz4OVfPSYJj/6JWJeEWlSJRMCu+mBEUiMLuoHdYhxrUXBCDVuq3hcr1y3S2VmTgnQ2HqDRXEekDm3Wsh7U+Yea6z3tIMr/VZoNrz94nihK2g3EZDFHhPMn9yUJkJBfWBXCf9AHANa094DMEgBALIxSOcDN4Ry7N3yj9W9y9UyiAugDGii/KDlMMWjVdTCztB6tjOAserrNvjsL3X1HpPeNa+AfcNsN8zxracYKB470mKJ+XA9kM6ai4s6M0NCzPnHdo7bQ4D8kOtJuEaeJ4f3OjcsClgtOQNiKQPUxQ2PpTqHpZO6Vx5c4hEqIKv2sFtzifI3GtYyw+U1mSaQxAgY0Q4PmaS64p8/Z/tobyBOfEM+z1HmTLSJS8cRksaHg93XqFA4XyqbsTBgF06zbKR6Z1oi5oUAIjPknhuNk/Bu6DaQy1Wnbzn5db3l+jE5/xFPD3oL9nRiSvxa6fTjKMtwY9rsPTqgNcw8Jk/+eskQfy2EJC3AmJmGuYAiUPB2ZjFZWGbtvHc3lKUbTz0B72e7uP0cI49cqrBJwL/PyxwkNj+d/b6HRMO6MaF37CTW6lYgurzDGBegiDSGqSIzgKIAS225em7Lh4wB6mHZFFIfhBPIj+Sx9Ey+wI1YHsiO1AYhEQ0q10/7MlgEf7IMCxZ29NHrkhupXeNXt8FJEdLwrA2wPOqTy9a012zXEAHEO2L4sByqfU8gKdHIF46Re57DwlJ7dn5dIVyaMPLJdUiGHdltazpBj46oltoOL8HTy9pt3l08gmyA8Opq3uDjycrlmjJDDK125f8T5RKCd4LyAYHFxN34iD4JiwkJog/ffhFAgCFuzXoRuNwbkIlxc+2fH7cyrMG7j9WNWz+8s61IQe1n0QBH8TKCiNFqLcT2Vjt7IsOeyE1X67dNLWTr3tB2JqzSJnvNIUxDsBPNxSB4AmrpF1ouNWwL8Y4b6apuEq7acH7n1yL3slDLVNhP0zbETVCiCe9ZrXNH/8BhXuhuK9nvip+cAuLXyxjaoToJthwxR0MbviRA49qW6q0rxmjeEI+2c7zXNMXhM0YXeppcayaJGU16Pwxs+laA3kPUEaeOb3bV/MlWXSDyZB/jE8/1cMdDvvtAj+TAtjIaIQ10S3kaeveGCkCtYqGQKOoae6SFXiAGqDjwdPEiVJjeZfk12im6YwJKGE2Hpz+MMe7Bls+73Vu6aOnrNdjAHzb2JYms3BY87YJNwZW5tAsYGAQD04iCNQoWRgQvGm3BBsdrswr3AsXNmnQeMSLZXQO6vM8H7xKRiDym5Z9lscAlbnSLYCdIJyU1cseF8a/sjpvvSD83g8Bgw6QtfC6+wZ4AXDEZFWAlBu4144cSLhwb08FwUr/F6iVQ3zc4H4k5YAyJBh0p0TaYdST1NsH6UcHjBEma3AZxti/T4Y0YkzOrlRIyZApq5UG+INiBFdt5bFoEPZxr9AxYGLFVoz1hHd9428tKln7m2FXXjYDnVlHjD+ELJF0fFW/MybIDU13ztTUnhEaLQDA6FcsFTr1vc1FoBAvWzBMpcuz9hsdHIfuDRdloq/CySIedIoDcDPPtHIAkkz3WfAAe+w6JhL0zsuHgfCqYUm3SxyWni2wu+F979nFlJAt43bCSrsECXM3umWjbfbDKD3AzeITHcnURYdIUfLjZfQF3TEyzcA0AA3MIl2S3MbCyU3qwXtN2HNQ93gltCz9FF9Ta153QIzznQsulmFqIwobkmC58F1d4CHym8JPOiRED8Gzq+XqdAGB4BPPAd86BfPmYWsPFt5ig4Vox/Igcg5qLmh+bb5eDq4PYBgISS2nFiADqx5Z67g/dWK0nM3AXXKyqLvOAvrXiUHawafcBeyZAVbdr28GtUbfduujetyoE3aZnQ2FbJarYBtjBPDNsjJVNHNGhJ5ORty+JuFz4tpsCubXnY/kaPDbrUdXQdHfFbkfM8YPGXR01lNF1eAhXhV2/ApQZYmwLWh0DpBUhwpHuvTEp8ddxHBZwbOPFuogeObny/BtljFIexZYZZ5vIscqDasmW7vhxrH2z9zRhvCCQCY+hGC3JXUSzLgM5sO0n1HyRUcn6HGLqsUPdXr2J+3CfhUvqT25apgjHV6C0A2F3vXhophBgnIhQRL2BibnZ07ZysFTm5dnIg2fqyADg5+XZeX6EkLUn4dKaPxFeUFPkyWp/V6ft1R1FU/S1C4ez7WNFGc2JhFrtr/KQ99UOLsxtZ6iv9e6yQHJ8TE6C47IqRDh+LRTWyiKJnnmRHHI7gO3KEOhcdr8SAe+8ACCsmqzS5u86NVUlHc9zNytBNnHYyLh56AHaEt6gFaAD+USLoiVbrUGw8uCga7HWSaysDQNs9HC0RwdYJK6XPWvkdszE57GW1NFEmRBJ011G9TlX/SysS0S3PeFWswrKOHzj+lYrOny2TRbmNdyerfJ8tWZLIY97Dwjs4e7V860oJXtVnsTXLqxAkcPVEkQvw4JGgeei+1oQdsj9ZFPSjaOEU0K3UHm5UQaBTfBY74AuBKXpopFA88aa3/WekkAhCHBO69j2fDMNXzT5WYmsII4ewtO6hdXXwA2QhFpGQvm1leVNSu2v+MrfQs0hsffXl+bayS7uhYvXg0Al0X1m20zB5w0E6xlJtsBoDsudNqZV7tfNcQlvipUj/5sdxt2qlA1xwcXpUwpQflu2BKT3t0iOjYyM8tS5P99GApe2VjxZcw1Y7PSpWkPmxh3ZzvnttDnKY9Q9ghwHuF2EJdG/jSxzJLRhtg8UpgdOYGRwFe+F8L0/CXtBoi/6QW5+ez/YZkklMo1n/rrrvnIwYxxdl3el7+m3S0kAmYXvrXZM9cK/fj3VIFWFzN36Q+ra5Zcs2pDzuCrEdNcfIA0HviYO93a62GT5tNsePy5c8NAiPssGwKOPeYH1mGO3EV0+f2xx+QzbXO4Tmi5IwXHHdt7uDqev6Pvr8IbaXUC1fuzG5P7NM7eEeoDPUTuoi0AYz+f5vTYR5K+7WpSxgNv1+tpBvM7Q3qB5/Yo89nzeD+Hf4t+rjpItwgdxh6ZeTupJyR2YkOq8zvPt0X143X5bbMQDUBKeC69v01GzzWDGr/EBbWeHYLc1J/C4f8rW+9sHCezjhw8/+KFXs/M9QeQMDiOJskPOEaiBDDgW/gnZ9WTCzRZVd9s9+P2+LicS5YbwRplZ/rO8YS/Otu0abgfUX6JVC5Zca7UtjId7DxrxjmffTI67oJG7W8Bh/Bvsl/GflowldpK5lfVVVBA75lo7WA1UGLalVTsdsqIXANoJu84kaMRxaDU8MTSt6fNNHuh85/oU9SmcHzNmBrJ8rTCBhwPLHpjzaFPp5RpYdhNOdDUvoVeRDqkhEkcr7U12dxB/C8F6l+R3+atHaPx1qe+t5QVt3nLtYUNgcH8GiWHZEb///gwUIwHWElqWb3D+zeIMgVl00WXoQe2iLKoLREScNd9MaFYwl1ZVsxO2vV83Tiy3T6UVUqsOUbc474K3bWi2fC1GH2hmsOH94WrQDfkcWbI/P6/yZ4B5QrcH2BiLMq22E+H/gmD+rbHNB8xWHm+7mN11NF0HRtlPt5+55w9HgMnBLgPP8eGFsn54QEy+xc2Cr1XgMAwm9653F5wfhmFC2vap2MARp5UbKKvhcvrXsoqNqjMFMlqmnOtrNUQIPt++7Oo2QPfvdI1m5ibScQfngz6pBvjT3V9lD2keUpi59MbiXjjLvwo+YHVcZKTu6Vs1FDfAyk1IAQA3aBzdhg6+o3OPxSQwQksEj+QbqxbNxdtdsW7xdKu55eFV3CiUIwLDxsxGEEKNXxtmeGEeOQLZhi6zZNQbhtLNByoLbvvS+Xaw4XGz5EiwLSkLe5MMqPvkdqZgyyu3AhYyufg811R7seXKsgRqpYT7+pr8eY3kBiFiU1NvF+kn/hcnBEbY6wFBhm9UGDkjorvPAWRpORVLWM9XGN/ztW83gKo4GJynu7fcqAU4a4CSpYP6tq9qh2kHZVqbzLodi0haRGy+rDrfbxff1OCAi/aITCEuQJ/solHA4rv7AZd/MFM4QOCDoNdHcHcHc94uHt1KAIyH8rC3tLinxoF+obh5u2Ofh/36ro4bA93/hd3NMLVq4IYjGh4Huw5QF/tuIZ/i7i1yHHfMHFY3vXKhb0E/200Se0A64bfV7v07iKLaHTXR2Qhopp7Heh7kMLc1MeaxfNUNRr2nTy82JAv3i2x4cW7DOLndooIMnS6cPhMWCcN9BUayy5LJCqIrE5Pbel0zdQWdbKuupaTEre3WECcQyWOpwN3OwN1llYcAOnZQP2FYorGBE51Ws2Wzpr4AfMcDiL92FZHt0Pla4+vExbUS6Wdd2VxeVq0WFGOJO7gG0bZ+dhNCtW83uk8CA6FZZM/J/dZ9k8sKtOFqOsBWZAW0jr2dfBQ8OeZXlIWcvtxgjrkkKuogOLB+SBFy4g9dxYOQZ5bCBT6dH6PxpKQRqvFb3UVdkfyTtOuwJ1D/xG+vb5gGNhCGHU+92MCuCKmXG9kjv7Bp9p+6tIoGec75dmi/kC8XZrQQrZ/YIhOXCJXv3eKdVPq2B8TLipgbblO0qIIkClZvMwIqNli7u7+sATELW73cAt4AkduNdRZJGMwOyFT3QRIqX4yOr/UmhV8f3SnWwiAAW92RGSDrCy6QKkTozYVJE1S9C6f6u9QBf/xqVSCT4g0UCh/vuRNmjTjR2vyslQSkn+35PDbuqreXqEeu4ATcurL2ZUXZBo3bGqgxk5YMkIp7TQOmCuqBIVHQ0w3prhhAD0lMWhjfG7cgn1obkWVjVzPYJMSNkJl2WcT6uJz1qD4346pEv6EADRrxCKGhdrr7SAysSxqDEldESoRqRRSMYHYW4t4u/N5iU6RreTsMPr5lzixeuZ2FWXRGc3I79bDCk7ipVw2CDX3dZh55roqXGsHaB4JbNRZIZ3wYD5vdXNBfN2lPZhcruoA1nFtR6VUjVRLAdx/0Czf+/DbloPQBe4bNAoXNfltol7Zs/c8nk7QhMIfkEK4N39MC+cD1pnuO57ceJmS+pERUL6DsHmQjrnfEJh9lpyuHC2dm7dL2OZvGi8tC9kPYYYWVSs/XeEH6gM0aAKBsE7wWQW0FCNn3A7iXO8GxjARR/ZZKx7xdb0bwYQVvpxOy+mrSKEHGv8QbHWqz+HKjPDoCI4aMu1wL45MHD44rsCCN0Gzu2sM5qB6zS58ecmEtvL3Z5RRHGN16PCWiummyokZccik2pWHasaj7fP7JcwyGvW6uFsTmSjGoFqoJ75qwG9ixwcUNL+9y/xpO1CLrE230d4PIfed2b/H465GyHNA8HcL2SvtdPCUBVQutHJf6LAOC6PNiULstF5g5V7H5zxMmbibMRub+kpog9LD7FNx2B4HEbXYPaAsr5/YQhDg2y34MQvv5GpbaLi4vQOKNsHqynUfJTVnl0xD1O7Eo9qrL2suK1pttTbLC7vqdrW7MWnQ5hulhamA+vLZdYpVH+Jqt7cW2VV/TVFBJPOxNGD6KS1PE3jhkqIWBbAe+zTYGCEaXL5pLvaAc0pG42kDktzQG0GHD10o3CPo+s19AsF3vE6NpcykKIeumSvoWq+f+UtJN6IRTdB2biOZjbDURJ/BSDP3jqQxyhRN129ptm391ew9WKe5vxzI6xwb05WYuHblKAUFpW8zK9ho0t8zPK9p+LxNaG4cNwKYAEtrGGTOuZSRmEuQbzEFv385mcGW5QxtzCoyD2DvM9xruyeJmbKi1ZzJE9Jzna2CkUDY2oZPuDG6WCDCpTgozHx+sRXGzATNjSWPGb8NG/7pf3dyIdS/f2SaExB4b1CRIpcr2Egju5IjiIvFMRKneT3UF7nKNwXiB0wswReIyaJEka671MrX/fSbCGbft+086S5b/Gj1wLdUt5ovBflCbvLO4UduDwXgaWM7dJkgR1GE67ix8UcefkhuW8pr90GIJD4YKRRNdtw2S+KC/bvHbBwN43zY5Z1u7oyj7te8tZIxbZF5d4zScIHzYWQK7sJdYNMgBLflkO3HtZ1/QUQeY3VHuBoj0BgLVxVG7D+MIVtTC6550RDJslK8NjaS5HJmnkSPooOOZCOfrqz42F6Ox141ae0UAWPe2DPF66xH88TCIN8Brt0d2kHd2lrix100wYWcIKVhNf4frm5ZGiGkXxSNE9Lj7mHyxrdWKKWN6YcHeYSm+WTd17wGGz8ZsjKT0UYeNEvjx3+EcNk55nI7oA0MQWWoCBMXlJo137/fYR3eQJrG4RY1xeElJBtSOfHfBTO6vfjuG0wtJgRxMV+sNkwDW3JeHVfy8ooJx2j1I1pxoSwfxWNq3Iw1CyN/W9eE2ym97sqfzwJfJDazhadgst6ngRft90DZIG+jpW5tLw8rDO5iCAQ0SD890qWNCJi67ItkQxyPyY9n6EdNkw+kLZVgks2bxbdZ7kBB52i3UBfH+7dkqv+28FlY/ceuSbLdjqVxdrnqNpeGilPtCf6VW0kblntWztk+/y4NkUv8a0sDZ5Mog6v2pMj6UbRmmfi3bvLUPT4OQIsPtep2LAzz411uFTAFE0JMQbuKD3dr4uCU+ZQTPFb8yPuxLlHn0CXOYv91rWHxcL2iKuui2JLlVkigM6baB6LYNF+qfDsReA3mMIFyGEh8i6HXP0cvVPSDYV5D6fG2F1Y1URYwCjxu6HgWhfWMMphl0AVcVxyHrZlst53P/SEbUSk08ZFKaG7Fg12e1BUEFZgXitv3K+VWGXp5wkdWG49vL7+kFegXsPTaHcWcAB2jpBnJ8Nq7vHDeglYD8fmyx52lX7O1q7oplwMEnyMjCHLfmCUVJrVCS+5ZAdVvvmtvezwpIruJhK93OWJVJx89d7id0SZ3HdlUQUedGKRuZ0v0d7fDYE/a6Q0RwI1SWnWvEZv/q3c2DPgC3b/dqcGOp4Abd2H/lZtXtYgVckRfGKUdrJgiI33Z2V9zSf5828+IE5hUAaz1o9KiZ6FZ79w9AZHez7b67H6p0j4bCF9TwbaC35tX0Jn/Om3HHxgUNNg+YGF+PDEaFWCTSwW5SepYK7FlvyugQcH4C0UPLiz4QaD0qxv1js1wu8JfmMUAIgtV+gnIOi74eT1IBR9ujmcbogPFc1Q3zDVsOL4Az5TvDz656i9vbcyKiJz3Y8MI9Ro+dsFDX3urO/uD+mG3rymvRgHGHlmBl+4/tto02DhwMLC+F5ZlVyS2U220jUNbtKq77uBMam9DuNo9NzygsFids0SOfOlaqXTlNJq55vMlXP822VNqWgeYtav0Wv1araHWsIvp1rRFeF3uiXUYOf2gX5MpEdct5MHDE1tgJbcuOJZdthyOS6B71OyLJrU7tOyAECnERNtkVHrDAsMh25bC4vwiBwnxGIMlOdQ2lVY5vuQwt+Z0PUeuys3REVBkiINpW6O7jdO2DvEnLY0M2et2GH0QmmfA1D9eUyJ/nPL89eVgjD2irlrDG3x7qO06IpIW4gbrwrerDxwEDC7VajCfXPc3IBijX2Zi5ftZ245abpkET0q8xfgeKQR/BlfPbiWebLww2bXfzYZknDxpDlNrkRHx1FzrEynNecKSVZ9dv1bmNeVm716hYmCN/BsLzZ9f44ynkIT5hy4HEF8Du2TzI9XhDgAfKOsFrP+W5gkWi7zwRSwF2Y+VvS07J3W3gbmZFeGFLoHMoCYEYgLvNdPIIbmw6tw1kgYDMnoxwu9bPB31bbb4jccAdiQGT5WLmUesieOPkZRevETN7z3vhvgGwPa9nQOjZY1ea66Xf8o5l9MeK6gcMespvC0MTGL7DeFw3t3VPLWpb3umMkQhuSL9fWXBqO9wRAUd6wgmmFLl3/+lGul1XCB7z+H0hS/z196UGbVaSUUUkDcyWLHEnu96qOyrB3Pgt7m4PakMPWqMkZPQd8XdhzwK6Us82ybqBlOhB7Lmxyn0A67akh1TGD3SPIyzzE1h524zoKWdQ12Pd3x2Q76XA93A5gEXgJGSAr2FrAVN0viPvxreIYeemjZZ4OTnX0tRjgUeRc89wua/NBkdFFTrNAvP4tgE1jwjq0GqXSsELIuwJL4m+64vAw3PNb/M2CgjYvmRMmMiNSUMSX8lBKQzyRCzjWqwBeDAHquR1LdNCQwxw1+3pF/U7N3PZfbj2RFr9BKAr+98ipf3e3LRUirRSwHBbxTOV7PgmqGEcPgoWzIGUXt9Rc9pSsshNm+lxfYUnS/b5EvK1YkExcmfA2GmZcujBbWOBuz3d6/dVjRrKv9jaf74TBex+ASL9RH6of32RgBzT10wenQVEXIHd8W159HQrjIQF3XJBZFnnO2vdivfh2SWEarSo4bFteG0XodF9vMWz/OxZaPZHJqPWBfWG4rjS4l/WABHLj6e5eZLTTj/L5GmJupFVdP8ejlUGQ8yjVksf2El0q8d/vZ7sBep5RohpbAMM+T5eMp5XiXGioSccwsK0HbKeP+2eBaQiEgn9lfg0M+/659T778yrei8NLfH12+s9jF0eEmJxeuPPgCH1vy+ufz2D6z/8/Xje2zit2/SVbdqF1FGFPBYMbiEKs3XZnyiz9fidvnC+No4h9mfPOsieYqCosC5a+8quTuUTrWb/OXcyeg4f2d8IqqMO6e9ZqH0PVXAn1PQULmQEwtpeYXdc6Qt/h0e+Lt0TkXtF5GlLuyGP8atb65ogR12RMpS5cG9heBEE3KMNLikojvHWHvEIwvOO5Ekg7kHwzDp35bg/xONYKuOAD1jlW5QP+zuBy5MgPVZyf8dFQrTz63EOkwwgbL/KGsQGsCGQkzv4maYO8d9u9wMsrYAmdzo1K+mWzjxVGLmYRjRytpuYjyvZD9cvl8uesl6y3h9VhnwmSJgsbeW/XrSBGVJFPHbXOwjM6jLqicMSocN9ff9AhmULhZ5G8Z0xhpREzk4XYyqM7LEy5EP4Dge1qb7b3DysECByChixoSPdq83Av/HBSmTu331wQSN+XLez4ed85qy5TmKrpczikph8G5+yL8RI9adAOevD74CLmX6bYZoGKAfCzfab7wSGBS2YqvtNwGwsbm4lpsAewJ/7HeM7E7JGN7QilV5b45MVb7SHR5i45RulA9RNO7SKh2V0d7OgmT2IBd9vH/53QmXyOImW3Lc0v5XT9Ybv2NT+W/19pYyP+Dzb1eWMZ0RPhEyq1Hn9ZDfcWf+vqXbOWf36Pytb84lN/tIhAAABhGlDQ1BJQ0MgcHJvZmlsZQAAeJx9kT1Iw0AcxV/TSqVUHNpBxCFDdbIgKtJRq1CECqFWaNXB5NIvaNKSpLg4Cq4FBz8Wqw4uzro6uAqC4AeIo5OToouU+L+k0CLGg+N+vLv3uHsHCK0q08zABKDplpFJJcVcflUMviKEACJIQJSZWZ+TpDQ8x9c9fHy9i/Ms73N/jgG1YDLAJxLPsrphEW8Qz2xadc77xFFWllXic+Jxgy5I/Mh1xeU3ziWHBZ4ZNbKZeeIosVjqYaWHWdnQiKeJY6qmU76Qc1nlvMVZqzZY5578heGCvrLMdZojSGERS5AgQkEDFVRhIU6rToqJDO0nPfzDjl8il0KuChg5FlCDBtnxg//B727N4tSkmxROAn0vtv0xCgR3gXbTtr+Pbbt9AvifgSu966+1gMQn6c2uFjsCBreBi+uupuwBlzvA0FNdNmRH8tMUikXg/Yy+KQ9EboHQmttbZx+nD0CWukrfAAeHwFiJstc93t3f29u/Zzr9/QCdZnK4lMRQrQAADXppVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+Cjx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDQuNC4wLUV4aXYyIj4KIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIgogICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgIHhtbG5zOkdJTVA9Imh0dHA6Ly93d3cuZ2ltcC5vcmcveG1wLyIKICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIgogICAgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIgogICB4bXBNTTpEb2N1bWVudElEPSJnaW1wOmRvY2lkOmdpbXA6YjQwYmExYWUtMmEwOS00YmRkLTk3OTAtMjg3NmFiMjM2ZTM5IgogICB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOmYyNTg0YzhkLWIzYzQtNGZlZi1hYzQyLTM2OWQyYzA0ZDIzZCIKICAgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOjhkNGRjNzEyLWQzMTQtNGY5Ni05OGQ5LWNmMmI2OTZmZDBiMSIKICAgZGM6Rm9ybWF0PSJpbWFnZS9wbmciCiAgIEdJTVA6QVBJPSIyLjAiCiAgIEdJTVA6UGxhdGZvcm09Ik1hYyBPUyIKICAgR0lNUDpUaW1lU3RhbXA9IjE2NjQ5MTM1NTIwNDE4MTkiCiAgIEdJTVA6VmVyc2lvbj0iMi4xMC4zMiIKICAgdGlmZjpPcmllbnRhdGlvbj0iMSIKICAgeG1wOkNyZWF0b3JUb29sPSJHSU1QIDIuMTAiCiAgIHhtcDpNZXRhZGF0YURhdGU9IjIwMjI6MTA6MDRUMTU6NTk6MTAtMDQ6MDAiCiAgIHhtcDpNb2RpZnlEYXRlPSIyMDIyOjEwOjA0VDE1OjU5OjEwLTA0OjAwIj4KICAgPHhtcE1NOkhpc3Rvcnk+CiAgICA8cmRmOlNlcT4KICAgICA8cmRmOmxpCiAgICAgIHN0RXZ0OmFjdGlvbj0ic2F2ZWQiCiAgICAgIHN0RXZ0OmNoYW5nZWQ9Ii8iCiAgICAgIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6MTRjYmIwYTItN2IxMi00NDZhLThjODktNzc4NTk0MDk3ZmE0IgogICAgICBzdEV2dDpzb2Z0d2FyZUFnZW50PSJHaW1wIDIuMTAgKE1hYyBPUykiCiAgICAgIHN0RXZ0OndoZW49IjIwMjItMTAtMDRUMTU6NTk6MTItMDQ6MDAiLz4KICAgIDwvcmRmOlNlcT4KICAgPC94bXBNTTpIaXN0b3J5PgogIDwvcmRmOkRlc2NyaXB0aW9uPgogPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgIAo8P3hwYWNrZXQgZW5kPSJ3Ij8+Ba/uQwAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+YKBBM7DOJ/Y/MAACAASURBVHja3b15nKV5Xd/7/i3PevZTe+/7dDP7sC8KGNBREDGJCVmUkKhcQSC+4oa+fKmIIUTudQWDejHEm4hXIgovcocwQFgHBmaGmZ6Z7p7urq7urura69TZn/X3u38851RVAyokKprTr6fPU11P13nO53z37+f7LcE36fGWP1gUwyibaXeH93Q63duHg+HJNEuO2Cyfs9ZMGmvL1loPQAoRCyF6CLkhlVpWWi+4vn+xVimdbVT9hz3HXX3LvzpivxnvQ/xNvtgv/Kfr5bX17ks2NrfuHQ76L+73BycG/b6UJkdKgZASKRRSCpASgQAsVgDWYqzFGosxBmMsVkiCMDBhEFxyff8TjUb1vslm+f63v/ZU738bAH/1/cvqymL7pSura6/udjov297armBzHEejtINWGqEUUkmEGB+AEFgEQuzepLECMFhrscZg8hyT5aR5SprlWASVSrlbKoUfnphovHd2ovzRt/7QyfzvJIC/+N6lytWl1X+5tb7xxrW1jWM2T/EcB+16KMdBKI2UEoTYBW0EGAikEFhAiEIKGf9tAQxYicVgLVhrMMaQZzlJmpAkKUII6vXKfLVW+419sxPv+T9fd6r7dwLAt/zBtdLCtY3Xr66s/Pjm+vqUUhLX83EdD6F1AZaUe8ArwEIUCitG/8bo3BYwFspsbzZz1tqdY/x1od6GNE1J4pg0zahUy+uNZu0dszOT7/y1H72l/7cSwHf96ZZ4/NLSq65fX3rb+srqYUcrPD9Aux5C7QJX2LlC4orzEWAFhgh2AbRj9R3hNraFO19/BXh7D2MtxhryJCWOY+Iko1orX52cbLz5yPTU+976I8fs3xoAf/rd80fnr1x/143ri/damxMEIY7rI6QuQFMFaEhVSJyUO5ImpR0BWNyKHN+SYCR7X/HYAYxCOu1YMu1Inb8SSIPNDWmaEcURJjc0m/X7ZmYmXvfun7zzyjcdwNf++8e+f2H+6m92tjZrXhji+QFSOyOJUwVYI8DkSHXH4BVSyI66jm9oj9LefJfW7l6AxVqxB9CvDeDeI88NaZIwjCI8z2tPTzfe8J9/8bl/8E0B8N/+P4v+uYtLv7Fwef6HMDlBqYx0vAIkpUbgieJZiB0Qx6CNz/fegrjpbnaBwbJ77QhAi0XYvUK5RzJH/8eMVdxYsBaLxRhLlmVEUUxqDFOT9d/dP9d846+/6bbobwzAn/69hZlLF69+YGlh4bm+5+OFZaR2YCRhUkjEOK4bO4w9DkKIQpICeZZ+dgYp9Q6ghZClGEMhrRg8Z0gv1kjhIYRAywFpHu5K61jX96r3HmlkRwrH8ZAht5Y4ShjGEbV65YF9sxPf+x9+4s7Vv3YAf/K3L584f+HyfRs3lo+H5TLaL43iuELSdtW0AFHusW87ts0YyuEGcxMfYXX96WR2mihrFgG0HdJvX6JUPsiJQ48SZyusbtzKLUeu8NTVO3BcQRRpkmxm5+eK0Z+bzeSuSotRqIMFg90joRCPVDoM/cv7Z5v3/u6bn37pG8FDfSMX//g7L5158smLH2utrh4pVWu4fgmlNVJplFQoKZFypL5K3hSSjFVUiog82yJw/hilVphubtLvPEWcn8RzBJ5ao7P+AOX60+j2HIT9JJ3Nq4TlNfrt+4kGN+i2mwhnEq3VyGvvOp1dpyJ2ncvoxXdAFhJEcX+OkiitGUZxcziM//63fs+b7nvkY7+z8VcO4E+++/KJJ5+4+LHW+tqBSqWO64dIpZFSoaRCCIXY42nB7gI4UtlxmLJx/b/i6sdZXVqnWa8gZQtXfAbHrnJw/zU2Nx9ionkGJXu0tz+FMZfY3Grz6Jc0rc1bueX0Iojb8d0uUimweqSmX+lMdsHcTQtHMef4fkShMVopojipDobJ97zolf/6Qw9/7He2vh5c5Ndz0c/83tWZC+cu37e9vnagUm3g+CFSjiRvBGKhuoIiARt5PWPITY4UOfHgMoIIJXMOHnsRN64tcmOhx2c/+WUWLs5jzAZp9mXOP2nodZ6i303ptR8lDNscOnArB+aOIMwd3HHPC6jVOgTOW6mHn6dRllRCjadX0GoMTCF5ArsnbjSAQFF8v7hOIGRhax3HIQxD0jQ/sLK2fd9rf+XRmb8SAP/df170Lz618IH1G8vHy5U6jhcglUIphVZydNPpSMqiIke1lsDrE/BBzPBRvPzP6KxeoOTGhOoy9fBTRG2YmWkSuA1q9S7p0JLEJbRzljQSbK5+Hq2nSOKMJO6wsnKDyZlD1OtllhcfI44aLF+/SnvrPGX1x2S9D1Hytij7fVyt0EqgFcWzLOJLMQrG5dhq7sSihe12HYcwDIii9PjKausDP/qrZ/3/ZRWeu/0fv+vq5cvfU6pUcYJSAd5I+gpnkZN234u0Vxh21sA9gO9ZDk49xJWnPoZjH6NWu04t7CPlFUJ5Ab9yjepEzOHj+5jZX6U3XKa1cYhq3eGRBxMq9etI+yXqjS1cJ2R5SVCfgG73aSgeBB5h2FHEw6cw6aP0+heYbFQ5fmSd7bUHsezDcUojw7ibzghRGEorbo6ZLHInG5KisOODQXwwy83Mk595z4f+pwH8kV95/Psvnn/qrZ7r4ZUqI2ehUWrsMCRWSLRMmJl8gM7GBRqNWe45+gTL5z9Ku9ejPmWYmz5ApZ5R90rMHZxiY2OBmakm3e4S/UGEcjIy08L1DLX6Jlm2hec3aU5W6LZjrl+9DnKTSuUKii0GgyXqTZcsa5FGijNPu427br8L2VrhBfIwJ859gsaNcziBohvMYY29OebczQYLKRzroi0kUqkiT+8Poqc/57t+dP7sJ3/vsW8YwJ/53StHzz958c/yOPaDcq0oPY3BUwqlCpunpMTmPQatL/CtR4/wfScPc7c3x8nLfQ5eW6GVZnQDh+Gwz9NuvZvzF79Af7jJ5QsX6HVaTEzU6W2v4DoO3dY2We6SpTmnbnk69fo0YSkhy1YoVzS+3yfZvkptokkUR7Q2BvQ7W7huSKWf8ozsbsq2RP+hJzGf/TzhFz+Bd+QU8VSZLJeYscWyRZHC7kjfuBK0GzUoKckNxHH8bS965Y/90cP3v3v767aB7/5gS8xfWXxXt9WqBeVqkZpJBUohlCoCZCVBFS9u5UFu9w9w7+wLmWscxqs28RuT1K/HPO+BLaYev0S/s8mDj3yMjbUlrl6+RhRrWq2EbmdInsIjX1ymu71N4GXM7CuRRQqb56ytrdOcaFIOSkRdyKzLhSc1iwv7CByohoZyN+PO7C686iTZMGa40SKLcvLIMvUnb2W2/xGSuIUSIAVAukeDzTjQ2RNuFTbRdx2ynNpmq/euH3vnZfF1A/j4peVX3bi6eG9QKqMcbydU2clrJVg5jqpyhLnIna0MPczIO13y7TbKglsqw42EEx/vc3pFsn5jnnKtTKUKadpCAhsrq3Q6UKsq2usGLTPWrhlWbqyw3dtASUm/7RCUS5y+/RSu62OjBJ0tsHIxoZHfxncffRX16TlsktCZXyDeaGO0hhzYzmm+/4P0rj2EVhalBF72FE7+GFKA3PHU9qbQa6zKvufSGyT3rm9svurrAvDtf7hYun5t8W1KgDtyGlKOMo2R6s42H0fbdaSMUGIRLwoIr2yQrq2RLi6Rra9DnKB9H7ccICPB/k+2ef6Gj09KrT5JuVJlc9Vw/ss98n5CyXM4dGyGbAiLVzexRtLf7pKlEVm+TR5b+q0WZH08Z4vJWpl7nvssvu+ul1PWLmm7TfvcBbpPXSZLcjIBRgisFbjXe9wWfxQdX8RLH6Be/jhu/kcoEcEopEHsmsgizi6k0NEKR2s63eHb3vjrT5T+UgAvLWy8fmNl7bBXqqBGTkOO1VZKpBL4nstU5X6yPMcawxH9LtjukMwvkK+tkq6ukff7iCxDKYkrNaKXMX2hyvEHcrJujFYeaWK59c6jVCdmiHqGres3SJIurge1eglDztbGNpMT+/A8nyyJ0a5PY6LByXtO8vyJ09TTgKzdpX3uKfrXbxB3uiS9IUkvIbOQW0gTmJpfJhp8Gpt+iEFviXqjhGYdFZ+npOaLLElKRv5jJ8wpYkRNnOSH1ze7r/8Lncjb/8ty9dz5+fflWV4KStWiEDpyGmPpU0pQ8lcIvcfBfJJDB6+jtnrsf2gNLR2khXwQkXS6ZIMhWZYVVWIrsK4gTEKam5KLuo1f8zh8qsn1hU3qYcixiX0cb9Y4WjnIiUOT9Nd7CD/j5OHTSNdjc71HuxOyuRZAX3JgsI+yF6KylGS7Q9rtk7RaxOtt8nyU/UhBbkHlhi/J8/TyGO0ItGdprS8Rdf8/eoM6KjiO1qMUlJsrRWIUQKa5uevb/+G/efeDH3lXPMZM7wVw/vr6a1obm1PVWgM1chhFbrsrfUJAp1fBqZQYdjt84dyXqMwPeEZvSLq+RT49hRlE5HGKbtRx4oQ0y/CUIMWyfChm61tLvOLYi5lq7iNJ+zzrjiFrS8sc7jU405zBdR207/Pth+5h0Nqk3+1wZdjlsS2PW24tMfeiOmFQYqt1mcevP84d3TPMWLAmJ49j8twUHlaAQWCwiFRyptFgcyJkY32JJC3j6FUGqcLEH8L1amSlp+GEc0XILUBIC6aQRNdRDKJkaqszeA3w618F4G9/aFN97JOPvtEZNX6Qqki4ldgDnsB3WwwGkA8NS1cexxGS/uSQ1LUka1vEjVXQmiROyOIEO4xRQpDECSvfZqm84laec+J5NKoHcFWAsTlZntM/vsGlxbN86tw6zzpwN57MsZlhYDWPrA04m1/hu7/rFk4eegaloIFSLmk6YO3MJZZWr/Kxh+Y51TlItVpBBluYKCt8qxKQCFCKcLvNubxNq9uh1xmgtMHY55Gnm+TpH1GqfTc6fHlRPS96gqPgWmClRGvFcJi+8V+/88nf+rXXPy2/CcDL17ZeurG2eSwMSyilitqeGuW4alzXgySvM9v8BK2tTSamaiwvXmFmcpq00Sa7EpG0ukhHkyUJSbtHXglwb22ydcIhfF7A3We+jcnaYTyngrU5adzDJl1CGXJy/9PBPsgnHn2QZ8/dieuXWO2u88XuBb7rZU/nzOFnU/IbKO0UEuaVCMMq081THJq7zpfmPk/2hymO70CSIzKzU7PLM4u4IVgrD4gyTdu6TE1Zri1uUSoPWd08xdE7T1PKc4SjwAokFjPKWqQErTVRkh7rduKXAvfdBODKysarhTU4nr+jsmMjquXYoBbVi8WVIyxd+hNqpYiZmSp5nhEfKhNc6pBvdSD0MFmGabjMvvI0pcMVHm49zvOOvoCJ6r6iQ4cl2lhkcO1h2hstlARZrTNVnWP94CKLq9tMVDK+vHSDZz7nEEenTxF2N7Er14hRiLCCM3WAsFRDaRetfZ75DJ//0fowZ44fp/3pS2TXImxeVGWyYYocStyGgxdk9IeSWk1zRF+nXHVJ0xuUnUUwh5ASjCneK8ZiJEgDWkkyIej1k1ePAZQAv/L/rpa7ne7LfD8o6nujyopSI9DkGLwCSCMPk+TfiVUaLyyx/+hh+nVJpiXGlZh6meDZs9zyphdRObOfDdVg8nCNemUKx/FQUpFur7D28P186cubPNS6i89d3Uca13FXrjFdP8Kl3gXWt3usqouc2HeMWqdLspVwY3ia//bpLVauRyTXr6HtJL6u47keMxNHuOd5z2LtgOGWH7yb6suPFd05AdaATixhoMlyqDUytFNiavIgl546wdWlO+nHc1hrkFik3K1hip0SmEBpRZLmL3vTb5wv7wC4vNp9SbvVqWjPL8rvUoJQO21IhChK9EIgzAol/yqzc1cIK4JuFy48Oc+K6pEJQ77Vpfytk8y97GnYZpNYV7nQu8H+2WOEQX2US7tE6wt0kyr/13s+Dirg4QvLfPAjD9KoHmSwtoJoDPjso49z/OQcE0YhUo8vnl1luV/ij+97mHe8+4MMh4L1iw8y7A2QSDwnYHbiOK2JiKFT5cS3HObUm+6AfRrjCmIpuTK/hTEOJ06cJk5SvFLOHXe5zMydIgxKqFEhWO0RGrmnCaaUIslMpd2NXrID4Obm1r1SgnLcHaR3gslRuUeM0iDXrZEOL9FZ+TTdrQStIw4fanK2L7AzHpUffBa1O/fTTzWiMgNBlW21QaN2ENepoKQHVoKBQeYyTAy/+vZf5iN/9l+Zv3KNNLPo3GFu5jA3hss06w1EZrEy5P5Pf5nPfvYzXFtY4JOfO8v6Rpfh1mW67XUkHkopXMenNlFho29JS1PM3H6a23/w2zC+IBaCmbkKk9PgBYr6tGIw6LC87FBr1KjVazhaIUdxoBx3I8Su9ikpUEIQRem9APK3/nRLDAeDF3tucQN7249j8OTIE0kpMKJEbk/ieDWiboel+WWG7TXysmbqh7+DuRc8DRqHcGaPYGRB4XAdH4tECo0UDkr6OOVJZmcm8T2XWq1CuVLltjMn2G6tEElF4AV0bItSUCEXDtZaHK344z/8A/I8o1wKqNXqpFlCENbQykXYUf+ZmO3+kNytkciQqaMzPPfn/znxvgZra13ioQCVk/Q9VhYNWi4wHMR4vlsAKMfve3yAFHZHEqWUZLl58U/85nkhe4Nopt+PTmjH3ZPrjqVuLI1yFKmDYkizlnHrrXWm9jWKanqnzD+65YUcOnWIodXEuSDPM3qtdYTU+HmZJBuQmnRcJ8adOEgpTPiZ17+M249O8IpvOcpz7jnIuYWzVJp1NtqrbK1GtHpbDF2fNOnwim9/LnfecoyDMw1+/LWvxNN9WlmK4wcFTwZTVMEzj3gwJM9ylF/BBA2mDk7wz37stTTcJr3ekIuPXuT8k/OcOCO4/Y4Jmo0KSkm0Luy/hBFw7GFPFJqolSTPzYksz2f0RmtwTzSIZLVW2aPrY86K3OkdjD+RJFoh7ryXQSel3+tSbVT4B895KXcd3Ee3N2BleZnm3EG8co1Bewu31GA6r7G4Os9U7TiBUwdrUUGInD3E/vYK3/+9R+j2+yysn6d+y51oX7Nwdol8yXD28XMcmzvDStrlwFzIv/2pVyCUi8naLLYu0jx8OxCTG0mSpvSG61y/tsi+dD9CKpIsx/dCjNJMOoZ//rKX82dnP8LkTJX6TIiygiefuEh9ZoUs3Y/juCgBuQJrihYFZmwLi56KkII8s7IbZfeo277lB/9+e3PrJX6phFS6oGGMexyqQF+P+wZKMuyeZ235BP2lbVYX5onaln/0zHuwwxbWr+HXpnZSv/LkLMZYKvUZLl29QtBUhF4dJRVWZLhhiKxNkvkBqjlNbd8R3HKFq+sXuP+DjzFXOkCvI9h3S4la8wDtZMh2b4mt/iI9mdLYf5TG9DRKafI8o9Nb58K1R7jyuXWOTB1mZm4Oz/OQAtK4T9LdYq7icmU5YWtwjUFf8NCDN9Aa4kyTRxdIBlcIK8dRyseOWn3j/rPdKcgKcpOjlDyrbn3Ba14z7A/u8YISUo+bQ7tNIrUnFtRKUqvup9kIOT6xjj+xxb/5zpdzdP9+olzj16YYDvp4gYdXrmHSpGgyaQ838Xl48dN4JYOrA4SQGGsRSuH4VRw/JLYRV1bO8fGPPcryYzkzU5NMVGZ48vpDHDzSZGrqKOXmfurTB2lMzlGq1pFKkWYR7f46V1fO89mPfpHJ3gSHDh+i2Wjg+y6YjO7mFm4Q4jmSU4eO8qnzj7Kxvk2t6VGplwi8VYxZQQXfzeTMcaSQGLubD5vRsx21BExu0UpeVbe94DVvjOPkmOcHqDERaJR9qLExlRQAakklFLTb72dt9X6m6zO89PRdGCtQYYN40MULQrTjkUV9pF9m0B+gXRfXC0kWYx5fehjrx4AlzXP6cZd+1GZt+xoPP/YQ9//ZFbqLVfxyk+1hztJam7VrOevdK0zMepTLIY4fILUiyXp0+i0Wbpzl0fNf4Av3P0Fje5rjx4/TqNXIhz1830c5Hl6phJUaTE49VNxY6rKwuYLrKxxVYn11mzQ7gh/WmZ49gxAKa0c9RlvInrFj4icYY1FStnRu8jk57uXutX9wk01k5MKTLCaJp8j1kOfUD6CBRGjyLMYrV7Aool67qCUKQXVigtxKkrjL/rkD9J5s88iHzvHIgUeYmJ4jzQZ0WjEXz62ydrGClhX80COK4yIVEzlJKjj7WcPi5f/Gs//eQQ4dnmWyOc3W9irrS8usXshR22UaziQHjh2i0ajRnJpECzB5Sh5naNcjyzPSJALj8D3PPM1DC+e4sdbCmAG1qTozB26n0nw2cZzh+w5SFnGesQJ2+iqFTEohyC1zGsvkOHhE7gaM40a42nHfIETKtYUPo+066wsb3Pq8g0TDCKdex+Q5eZbjeC5+qYLULnmaYJIYoRyUVriez9TUNHZTcuPcGo/99yfpxQnWCNbzCrm14BhElu80xeM4QUlNNIyJrgnOf7jLw8k6iR4QSIeGU+PA3CxTsxNMT04wOzNF4I9CMpujHQewmCxFOQ6OO00+2GKiWublt93Jf3n4cyBTlK4TxwEzlTpBECAQKFF0k6Wwo64ye5gQAoGd1NZSFkLeFCyKm9y22CE5ZtmQIDiLsvO88lkvwwtCjC7RWluivv8YjuOSpTECQZZbrDU4XkiaxuRJhOM4NKenUX6JoYHVYRsSweGpfXzqsQV6UUyS5FgxwGQ5cRKTpslOr1lIKJeqNBsNcpPhSMnM9DT7pieoVStMTU6SDzu4oY/r+iTDHsNBj6BSRyhJGvXR2kP6VfKoxZ1HZrhv0Uf7DpVSwtrWOlnSQjCBlEXjSVnIbdG+lUJg7B5WA6KspcATX0kAGjWhxzXFgoYXIUSA5RX4zq/zzJOnGMQ5Sb9LqTmFyVIGwx7W5mg3wGYxg26bSgOi9ia9YUZfwFObT5GXu6jbIl74wlvZ7qxw5dwKjRWHztWENM+xxpKNJFpgMcIgZY6uaCq3QH3fkIMH9hFFEYNui3ZPIRKXw5U6wtcE5RImi9BK4tcnEFKSDTpI6ZDnGY6CfrvNVL1KyTRQbp/cVqmET7B8NaBRfw2lUgMzqglKY4skwo6YYHani+dps4d4I3aeR7SxnTaqJY4eJxuuUAr3sXWtRP1pLsMoIahOop2i+JoMUqQXkOcW7bqElSrK9fArE3xh5YsEx1LuvuNW6uV9BTsfSZx2OHFkgZlDj9H+k1XaSz5JVjDxkXnBLiBDhx2e/7LDvPiFL2Rm4ji+H2JtSpoM6EVdnrj0eT5/aZPnH30+aZKBljjOqBSnfUQoyJIhWZKjghLlmUOI4RbPOXiEDzzxKEYfQTi3cetdLyAMKqPUtfAFu7JldwRr3P7UQshYQGjFHp7dyEjuuHCTUnIfY2pqg7X1j3NyooGnLMM0xqQDpFcjGXQLPrQQOEEZk0U4gUM0HLIZxwTHEu6+5duolWfwdDDiz8TkJqQSTlEPDxN6Zf70/fdz5SENaFxXkaQDTj3T5e6n38qznv4Cjh68g8AvI4TB2hzCGnWzj3pljmuzT/C5z3+WZ03cTq1WL96k8kCA0g5Z1CcoVQppkhpj4eDEJJk5jFt+JgeO3kO13sTRage13IyykRGnZsfUFcXWWEspegbCHRL3zZzaot4gHDrRC+hfehdbG8tUnH3kWUJQqxOnhngY4bg+WTRAhRWyLMPRLsYaOq1tzkYP84xnfyv18jS+46NHhEqMQToltB4iheZZd/w9pMp4P59i4zGBkDlHn6n5zu94LrccvZOZmQNUy008twYGsqwDQmBsjlI+R/Zpenducf5LV3lGuUSKQDiWeNDHdRzSJMbxXExmcByHxBpCzyWo3kJjqkEQhLhaF5Uniq6eEEVlWkiLsGMHYselrp4UUm1wc1dvlK2OzkbfmJ2ICEuKODHU/TrdrRbKC9BeCCYhzzKM1CzPX0RJiAd9TBrTFYaJQxVqlUkcrdHSRaEg2cbGWyg0gTOFpx2atWnuPP1CXviSM3ihR+NIyL33Pp87zzyP/XPHKIdVfFVF5ZI87hD3llFWooWHIyH0Ssw2j9L3llm9sUyvHxeMV5sjBHilWkGszBLSaIgOKqTpECkeJUltEQWMqdhyVNL6GlTkPQ34Dam0WjZjQuJYt8Ve2g1o0WNz4xxPPLmfIKgzd7iB62pAYNKIOIqRQqCkpTF3AGvBmAyDIjZ9phsHcLXC1W7BFjUpShdxYh4vk8XbKMBRkkZ1hiNHDhHsjzlyq8exw2doNOYIgjKODDHpkGS4iJaSUjiDzSNM1i9eX1mq5Sa2nBIbgeMFmHSIFwQgJFJrkgyQmjQeYrKMLFLkccawM0+epSNeofmKOBj2+lkxxkqKZek4emFvV36vCu/kflRpJ99OozkkKJcQVYdwchalHRw/pDdIR943JAhcChMiSZOYxe48rvYRwqBlFS01Nu8hrEEIhTGQZz2kUGjl4joBc5MnmD1maUyUqVXq+G6Aq0Mc5SGERSkXz6vhOPXiwxCgpAISBDnatXTa26RRD6U11tqRM3EQJqHbKriTg04Lh5Tu4Awms9g8wxqzx8vukjDHccnYwYJFCbEgS4F/Mbe7U0B2x+/uMpgkgolGg+3WJMuLDb70+IUicI4HmDRianaaKLEk/Q55lpMbi+N7OK5LV2/iu9WiFZCnpEkLa9Mis9FVpDuJVBqtvBH90aC1plINGAw7ICRKucWnbhJM1kPYBCkDkuFVlMjx/Wm0rpKbbGe4Jk0SkiSju71FnibFEQ8QUlKqN/HLFRxHsR21qTcctL8fqeQe0hF7NNLu8cQjx2pBa3lRl0v+WSkV9mvM7eyMEQCOUhw+dhcOf8rCwpBep0+pMupLZRGVegOTxcWPzzPiKCI1EFBCKY2wkjRtIaxBSZ8k6WHNEKkqCOmSW0Nus2LuLQNFQNTN6Ect8jzDSImjNI5uAJAkHbTbIE02yfOMJO9hTE4UbRO1I5xuB2syXKeC9gPyJCGLIuJBF8dxSPMUB0MnLdPqH6Du+UhbjEFYM9ZIHUdG+gAAExFJREFUyZhQaPYAND71HH1W1iruw0HgGWt2W4DWih3g7J6xKu2fZL39T3Gb/5Rr6xuYYQfX9fBKVTApeRKzvbZCFg8R1uBoSUk1SdMYayVGgHYCDIY064MQaLeMVB5ZHpHmA+KkTzSM2F6LaV8RXF1+nGHSJSfHSBC6glBl0rRLmsdob5bUJKR5jzzL6EddumsJSjsM+33ydEDS7xL3uyitKNfqOJ6HDkI2VzYYDpsIOyxqn9aMBhdtwWywXz3OMB6d0EqaZkU/rH2tVsPAu9TtDU7tDLaMRwT2TEkaK/DDKQ4dm0SS8VDH5fDwPG58GUoT5MIlN5ZSpYTNEtygRJLmlEWDrfYNGpVZHJ2SmiKA1k4Nx61ghE+a94jyPkkSs925weNPfYHkqT6n5o7y1NmrHD9wBc+9AyESjNlC2KLPqFUFkOQmBuuSZYpOr0N/TaImoT7RLOy06yKsIUsihNDYdICNOqRxziPLHogqSqlCfU0xHmaMRUi7dzRvJEyC3BgcLS95rl6Vb/q+GRsE3iey3O6I6fjCYshHjCRy9JOExHU9+tW7+Nx8wOq1Fcz6NVRviYAhrshwlYFkgCcz9nt1rixdpDPYYpgkxGmfOO8Tmy6DaJ12b55W/xr9QZ/ljSs8efGLPPI/rqBbOfn6OvHZhIce/xyrW/P0Bj2GSZ84a5NhSU1GkidkeU5v2Ob6xiUeeugx/I5GC0s26KG0RzLogcnI+m1Mb424vYlOu3x8vs753mjIB4sYDXNnxmJMUbIaj06YPax/YyyOkp/4uX9x1GqAZqN8343V1mtNbrBKjVTX7oBorR3VxQpwTW7RTpkH1UtYub7K3a0lyqLP5L5pTDwkUx4iN2R5hhUlWouXORuEnD7yDCphA0cJJDkmz4jSlCiJWG8t88jDn6H/yW1u6WryiSoYqLZg/U/P8cmoyzPufDHTzUN4jo9WADFpntCPtrm+ep5PffoLLH54nf0lh/b8edIKJAxxPZd+f4DHkGh7m6Q/5CPXSnxocRpUMbwtbEG0HE82ZRiwqqjk7HEqxhSUzDDUu8yERsW/v1YJusMorTgFpjuAGWuRiFFx0WINZAK0gDAs8TCnePTRj3Kq3MR9skU9dCj7gtLMfqJOm42NRdo9yWOrj3D5eRe47Wl3MNM4jAAGwzaLiwvEa2v0zy8wc2EbbZOiaWPAcySBMOhhTucD2zy41OHgc+6gVm7iuyX6UQtrHZ648CgPfPYy2ZWAiuPSSQ2lWHN9foVobRXlukjts9neYoMqH/pyiyumhhv6KEDafDQaUZSvjC1OjLSjMTu7Izy5sXiO6s7U/PtvCq9f944n//DGautV5dKInSAKZsKYqamVGFFkiyq1VpY06XHt0m+hknMsX7/OxlpCVXv4UmNtxrALialhRUY/u8rQGGYP1rn11gmyfEhrK6e7KPiRYJtm2iPJLakVGAmhA42qxlEWpSBPLZ2u4prw6HmSL5QcVrGsr0SsXrdUy0U3MYqHWGPRogjM49hinVFvQ2RI7WNFQJSdxA3P4LoVPC9gZu4YU7P7qNbr+F6A53sgJcYI4sySZjlxBlGUUS457/u9n779n9zEjZlslt+7stF5VZ4bpCq6T8YW5KYd3d8zhJoZENJhcgJ6rZycnJgjdEQfajlSaiLVZWOriWIbz0shNiwubLJwwWClplruII3lDx3Jm/a7OHGClOAoKAWCalkQlh20Vpg0oe+nNDopC5HPuSe7LGUG6RQBbm4D8jgnSQ1YQ44gTopKQDawWCmo1hykewClJKFWZKYYS3Ndr+jGjSpEQopRCrjnvduxTbRUS+57v4re1ih7H52oh/Ot9vCYdvTOQJ61YmQ4i4Tait2x3TzvYewRupsPoJwQt/RMysEQ31+g05+g0ThPnDfRsg9pYRb6eUimZhDSkiYbdLuSLzoJf+KX+GeHPGqmSxgIgtClXBd4vkA4AXni4LgRC5nlVxcSojLM+Q4ZIF2f9kZCq5VRrrkImeBKi9aFCdINj2E3xfErbHb2Ua9GaDmBEFV8L8APKni+j3Z0kbGM4j8zUlkzAjDLDKHvzE9UvY9+FUP1I3/8DvvSf/jjYr3Vu1crucNSgKIPCnsIRjspjQ/5OoPoIloF5Jyk3jxCynGsnCEzh8isw8xUC6VuIB2L6+ejG/RxVBuTG5LMci1PeWooecahGgeaOaWqwq/4qNAriD6u5NPLkp9+coA76+FXQlw/Q2vF8vIQ1xO0t4vUy/MNpYqgUg+YnJmi3PBx/ZA0mwB1nCCcBDlFGE4QhFXKlRrVWgM/DHFdD600VkqsFRggM5Y0s8RZTqPi/eK/+5GTD3xNhupELfz9RjX82V4/nioAVCB2Y6FxcwUJYhRsr3VO0hm+ko3NPqEvwJmiUg7w4gFZUqdUW+L0CZ8seyaXzn+JXl/R7vmEwTKNWpW22yGJodkUrOucX1r3+cc25ICRVExINQFXRXz80oC3fnGDg0dK7D9ygPWtdZKhS6sV4TrgehqbgdSaoJIRVHxmZg+hXUGSJjQmAqIoJU03GUTPRIgmoR/g+T5BWCEIAjzXGeXUo4mmsQSOAAxctb5vInjPXsxuAvAn/8lc5yd/e/4d7e7w7XluCqbWKBYUI+zE3gxFCCanptHOc3BLawUZOxrieEVTJ3E0NhMo/zPMNg+QpNs8df4yjUaJ3vAIg+QScdomrJTZf3gKm3UISlXuky6t66tMTAicAPq9nHMX1jh4tMzMgRph3ccdhiRRsZ2j2hQEoUd1yhKUY2rNKrVqlVLFY2srZXNrgrl9m9xYqhCb04RhyNRklUq5guP6eH6AF/ho7RTzL7KotuR2JH05ZMbQrPrv+JlXH+3+uQACTDXDd25tl17X7g4PK6WKJRCiIIlji6qE2pOlOFpTr9dwtAYybJ6RJAmZykBAc3IRN7T0k232HTyC0C5bGwN6/WVsto+n2qt4ZUO1UcbRZcgztO8QNg+gJAzjAdZNOHFHgzTbx+q6otzs4PoxuhRx5s4D9Pur+G6d7e02/cEErn8I118iimKCUMKWotU6ilXHOXYwIk5qNJtNwjAcZSoeruuhlC48rxAYI8itJTeWJMkJPXX14FT4zr901Ouj739H+p2v+qnVrc7wH2DZ4cvtrCbZy1xnd1HEmEvoOgWbv/BcCYcOfh6tBrQ2PdbXr1OfLJElZaKoSn9QYXLGEnoeTggnT97OMF7HKhgMBySp4sYiWEKS5BBPPF5jY8NQrd7g0vlNlHYL0zM1hVSC+oSLsD4b7WdRrWlgwMrqEeYOuChZQ+jDCHmU2bl9TDQbBIGP53k4rofWDkKpUfIgySxkuSVJCwLAbDN43S/+0ImHvxIv/bWmb2p1/30z/fIPLK927i0ALOp2EjCqKG1bA0ranckUrTVSgDECrQ2l4AaNxiMovcmwL7k67zIzN4eWOdOzirNnj+LoIcfObHP9qRWCQKNcSK0mySyd9gCEjx9WubFUYrvjkucRJ2/p4IURh45NUanNcvZLV2htxszu34fvlxByk1PHN/DCGo5Yx/OaLG7cQRZHTDQanDxxnDAM8Eb9GyEVBoVFYlFko0A6N5Y0t8RpTr3s3DdTc9/3De1M+KX3Lh2dX9x4ZBClNc91dnchSLuHO1jEiUXqYsjzHGsiQu9z9LqfQumcdBixdN3n0JEUIXL6nTphxXLjRhMTpfjeZ9hc73HbPYdx/RIXzy1RCku4bolHHjb0Bvtx/SpSKQ4euMGJWzb41P0PsO/gMYbdBshFhKrQ670Yz7NYJPVmhzidw2bbVKuncfwj+I5kerJOtVxGa0Ux5DVWVUluJZmxZEaQ5JYkNfSjHK1E++i+8t2/8K9OfM0dM/rPA/DnXr3/ypt/58obrixu/ac0zXFdgTEGSVF0NBKKxim7VFgpKYVPsnTt88xfnOPWO5Z57NEazcaAXk+TRIdYuhESx4o8dymXWzz1xArHTjeo1+ZY3riKdDKiJGNrK6I32M/0gTNUqzEnT1xGu+skA8PRWw7heSWkatDrniYIYraHh3DcBqHfZ5CUyDJJEg9QTpnDkz7TE3Vq1dJoo8goRLGC3AjyDExepHH5SHWj1CAlzDT9N/x54P2FAAK87YeP/sGP/ebFb7m+sv1DIhM4WhX1MiuQhgLE0UCzEgKlYHNjQD/+bs7cfZhoeBnH+RzrG0+jOwgYDApSkdYO2nMx1uL5kpl9FTKb0t0y9FoG14UgSDl5yiN35nDdFdZXLeVKQrtdot16KXm+SaV2mJjDpEOB50OtMYXr7gdryOIB+JpGo069WqZaDnEdB6UUuSmMeJoVxQGLJceS5RRqmxmMNczWvd/9968//Rcu5tF/2cT6ZC14Y5xkt61u9p4rhECPlzONHYq0YwIJQijC6oso10FJGPglqtMVZjwH13XY3m6RpSnacbAWlKhSDfYTJ5rrV5fxg4A0iSlVXFCaVnuC+lwNXTkM2RYr67ex3crAwkSzxHr7MJ5fIixXybKUcjmkUSvhSkua+PiuploKKJUCfN9D6aIRJkepqBl52cxY8hyS3DBMDFGcUy87D8w1y2/8K9kb85b/eG1mca372a3O4LjnOmg1XiC2ZwxixGLVEpQYDe1hSLIUYYuCULc/JM8SBJDmhjRpE7XeRrlqAYcbC9tI5VGrl8jNgCS9GxN8F+VaA2lW2dzI6XU2kFJSrU+htIfrOQS+h6ckE/WAZjXEWouSBaPecfTOfoexzUuzwkFEaREgJ6lhmBqGSc4gyqmWnMvH50rP/6kfOLb6VwIgwC/8/vUTi2vtT2x3owO7IIqbZkhUMVE1AlCMzkcd/dH2ydzkO/v+Bv2niOOHcPWnuPxEwoVzbarhgJn9dYLgHnJ9EBk+g6mZWRCCdqtFHA3wXJdavYbnKHxXE/oOvqNwHYnvOUghdypJ41TUmmLoMM0sSWaIM0gzQ5oV9m4Y5/SinHKgFk/sq7z4za8+9nUt4PmGNhf9wu9fPbO01v3vrW50wHd1QciUshgHGAFZ9IeLkXklwZESJe3NvVVrMTYnTTPOPfllpPkUTzzyBNXp76Dkayr1WUrVCba22jQaTQ4d2o/rOAyjCJNnO6qJEHi6GEEbx6taih127U4KaiAdAZZkliS3RYyXGeLMMoxz+lFO2VeLh2ZL3/7z//LEub+21U9v+Y/XTiyt9+7b6gyOu1oX24PGTPY9IOodEMeAihGQ47WeRSV4eX2T9fVVlq5foFrbx0RzgumpJpWSz+rGNqXAY26qges6pFmGKNqJo61FI97KyIwIy4iWNqqcG8jzQl2TrAiKM2PJRgWMODP045xhlNOoOJcPTJXu/bnXHP+GVj/9Ty0fe8t7r8+stwYfWN3qP7fYz1Js8SgCU7tTdC0a3gW3erRiYYc2LEZknSRNWVlv0e/18VxNtRJQKQWEnkOa5zhaUfI9tJZF30LIkcnYXZG3U78bpZfGFIFwlhXAxakhzcfgjSXPMIhyosQw2/Ae2D8RfO9Pv/r4X//ysV1JvO63+/FvrG72fsgYO9rkIW4aiRifa1GomBSg1Fg6d6efeoOILE2RUhL6Dp4j8Ry9A7aSe0FjFHvuWRNqdpthxu4CV6hsAV4BKMS5IU5y+nGxm/bARPC70zX3jT/xA8f/5tbf7X28+Xfmv3+9NfjNTj+pOVru2D4hxwMrdrReSaC/IoPRqiDwjHf7STHeNFRcq9Ro+xt2R2qLIcAR8VuInX5FNtoRmI1UNh3ZucwYsqyI8eIsZxjnDBNDNdTtfRPBG37ph099cxYw3uRc3nP1aKsbvWt9e3ivMaZQaSV37KEQdge4sXSqcW9lNNu4C+xoqE/uclMko9m90RD0zrpA7Khet5u/jg8ziu+ynZAlZxgX4dRMw79vuh687mf/xbFv/grQndz5966LyKSv2mwP37bVjQ9LUdBBpNpVPyVujhkF7AA5Vmcld7cJjaVNjAiO4wWWZg9lwuzp1Ro7Do4ZSWJh66LEkOWGqap3dbLmvTmz5n1ve+3pvz1LaPc+fv4986Uotq9vdaMfb/XiKSHAVQqpxA44XyWV4wW0Ox56tOWSYrxqDJwU7O6+suPl3LsNn3wEYjoqBsRpMTs3UXbXmzX/HVKYd/7ya0//7VyD/FVA/t/z1Sg1r2n3kjd2+smxJMuL9qgsWqTypvUi7IyWSiFu2qcq9yynLarie5dy70pdmo/UdeQ4PC1pVpz5etn7DWv5/V/+P051/k5tMh8/fvY980rk4qWdfvzqQZy9rDdMKtmoXaDlzeO0Yrx/cES12F3OvcssGXN2CokbhyuGfMSkr5ecbujpD881vfduddOPvv31p/9uroL/mstr/8PlsqN4SXeY3TuMsxcnWX5iEGUyzc3I5o1Y8aPnvXc37s/moyKApfDYFV8bV6tLoa8/UQ2d+3qD9P5fecPp/31+GcGfD+a8wGYzSql7kszcniT5yTTPj+TGzhljJ621ZcAb3WQshOhJKTaUFMuOFgu+qy8Grjrbj9KHE2NXf+0NZ74pvw7j/wdkbDYR148gWwAAAABJRU5ErkJggg=="></image></svg>
+            </symbol>
+            <symbol id="icon-avatar-5">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 80 80">
+                <image width="80" height="80" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAA34HpUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjapZ1ZluQ4ki3/uYpaAjEDy8FAntM76OW3CD0yunLoj3ovszLcw93MSAKqd1AoUNfz3//1Xv/6179CLCFfubReR603/+SRR5x80++ff+b3Z7jz9+f3T/n1K/7+p59fv38R+VHia/r5a6+/Xv/Hz8PvD/j5Mvmu/NsH9f3rF+vPvxj51+f3v3xQ/PmSvCO/P78+aPz6oBR/fhF+fcD8eay7jt7+/RHW8/P1/PEk/ee/yz9y//Nt/+3vjdE7heukGJ8U0s2fKcWfG0j+F680/QV/3inzwpAK35fUvp//cScMyD+N0+9/Bnf0eqv5H1/0p1n5/V34559ff52tHH+9JP1lkOvvr//48yuUv/wi/b5O/Pcr5/7ru/jnn48c3587+svo+9/7nv5+z8xTzFwZ6vrrof54lO87Xre4hJfuF7dW78Z/hY9o37+DfztRvQmFc+978e8OI0Rm5Q05nDDDG57v6w6bW8zxuWLjmxh3TN8Pe2pxxJ2cv+y/4Y0tjXRSZ5L3N+05xd/3Er7Ljntf39U6Vz6Bl8bAhwXj4j/99/pP3/C+pkIId/89VtxXjA42t+HM+ScvY0bC+2tQyzfAf/z713+c18QMFkfZFBkM7Pr5iFXC/yJB+iY68cLC158cDO38+gCGiEsXbiYkZoBZIytCDXeLsYXAQHYmaHLrkZxZzEAoJR5uMuaUKnPTo5fmLS18L40l8uOLnwNmzERJlQzrzNBksnIuxE/LnRiaJZVcSqmllV5GmTXVXEuttVVBcbbU8tVKq6213kabPfXcS6+99d5HnyOOBGiWUUcbfYwxJ9ecfPLk3ZMXzLniSiuvcq262uprrLkJn5132XW33ffY88STDvhx6mmnn3HmEx5C6clPeerTnv6MZ76E2puuN7/lrW97+zve+XvWfk3r3/79D2Yt/Jq1+M2UL2y/Z42ftvbHRwThpDhnTFi8cmDGm1NAQEfn7O4h5+jMOWf3iGRFIcVDcc5OcMaYwfxAQ2/4Y+6u+DOjztz/17xdLf9p3uL/68xdTt1/OHN/n7d/mrUjDe1vxn6y0EG9E9nH758+Y5+S3d++Xj/frCLy3E+d64ltPW0xqs9pz0kAXQg8Wtq75G2ChDRqvFup4R2nlZDeDYycvHIdp5aTZ11hzHMy98wo5cajvdxMz63t1uYz0xNWmTvM3Pp8nsl7+7sXQ1+vzdjGsnp8elvviYvp7nuWwgfU5yl7htjzGjXzAU8oL8kczylzJT4sxnW4es7z2nc86+wcc90Hmmyg5X6ezRVHeh/g4O0lpf3MMPfDT9bKheitzzo5LxB55bGfeg2yp+4KtpT7mfs80xnuudSn8/OSnoPWqfnJ925vmqu/kfnu3F6dxAFPCWKVcHXgPPcRGWPehaQIeaRVeyk9xvHul5kW+kPZu/XFnPS38F8D4UdLkUALBdi9NslwdiEu42Yu0prxHcibh0BNY/an5AB7zPKOOxNQpxFrSLQ10w6M8ssz9Oct1yxKHVTTwxTzl1n46Ccx2rvz7Ocm0TbB0cICSQtcl3JtPP0b9ugwD6JjELvXibn32uKz3vtNedTUX4bzeQnB89bh150PSbXKI7QUEqKOuBrpys3zVKRPyded6sNzvBDoG8o5TAd5V56nEl+bnGnEFUwINzKRc60+WmTgawuHgCEgN+Fc1nWeF7wBZtK+uY38rHlSNCDfGN/4kOTnublYI/V477sCWVrewv2+G5q73zpTQvrNtzG33F0pBwh6DgH4pMhcEXqMLikyD6zYDhHxlj6eeu6nnUgGZb5fT95M/PVGPoMUus94R1hvX7HN8Sye8p6L1xdQ4Y1plf2SQKbpAtf+lrbX/53PRH9qT9ik5GFyWj+p1FMrefu0vMcjqkJ9cXPxSK4xdIsYbGHXUNYCX5I4sEFWbi1UYGoAnu/ep44SxikM986g2v06F60+qcxrEa5lr3vwtD7y4WpIkw3SjvaU7wKrvQGiyOnUdaYTHHj1NngZopEqaXMt8L0+h6mCyDuzHrfTi85dAFKZkUDMJ7anpvLeo5+9wawU95yVSMhlOaTPue4NxQMqaQ3CiKds4TaCAG7gNr/zVJ4OGHj7w13kBcTPvNcikFu9I3ECPrR11ZTO5B7TPumuPL/8s0rc6w3E4KkZlCELSiEgJyqQFGxvqxXyGpMRgwACkH+FSSaTVETc3ZP5l08CPIlvsAzC6/NdjD1R8OTDeAZALryJMTvQSVtNlAEhuXYRGDJYdi9y4yaw4cp59oIZiQMmXvAnOybIteWz+xCsnfsBCfjERcKStNBLwWK0QciBXKgkGC2E00hhnrZx5+t5yM4EQMTMbY37nZUHezpPX3Ii39pFfECWG+dRw0H9ln24WF6TW4IYxAoGERrk0dZgrKCOzeDEyK2vApTu8uw6rv0wNCeBq9wgsUHwhgNOcFUicKF5wXHQC1Ri4iq/nS/xt/Be8wHh0Aqk5duvTNaWG4zJTO8klF7CCww993i5u1bINsCOoAYyxRDeCJRWHhCqay2QluFMxiidlUZgbCbUh/jngm8Pc+1uwOeaBuYvAmvB0WPoQIQbCHtVDYiPM0Zf87kqEZ6elMEVaIjRNJ4QBD3O+bxqp+dWJXQQDwcIMC+mMb+9Y1Y2X6ZhGhrmuHJ9OA0qrfHZL0HBfCBrnwMJlJU22QVwNFIMQPCaEB7CkVtSU5S+yIV9vSRCe2ep8x1wPhKL30AahOmcE4LPRB1Rxp01sDubIGTLgryZEqY68dSz3RczCNBBZGQ0H7EP6guaiO9qcPPdkTcbJib10TGoG17M76FFQI5PQU6lle75AdvK/4B4H7BlLswnJaGmc7G3kMMVaFmDQH5iENthkZkLlA1dM5t7nAVWPwDzQx7KrmMFPmHCKbM+s+Q2G9Iq9xOZE7L4wzcQWvVxX880xshx8GaAR0BVASvG2Bm23CuAKQe9cT4URUyUASU9PBICLWc5eyGBGOxIOsGrXajbk6vnRwX8EI9z7+795uegGoj0BI/tUBj1oj781A2EdOB3hBbSmBybgNg5qER0yB3nXdcsgZ8FmC3fb0aVlDKfiuxCSKdwmBVujABGpLWzri1i86SVnGJuAhydwH0ei8Se4xiq6C2EL3mPiiFybvAW5EcRkEc1LCNlX2PFcUAJbjuASGQcWbFKXZEbQ8yAeWkvoKcArWAnULUlGBK84XYzD1+QAdBRQ41AE2gQ3hMhQxwf9AOTEV08M14XFQoYEgEPOZh5desDIbhnzmQVfBae9wI6NykNvETmjbkBVlQgL0wA/ynUFP+AXrzvCUMh4DqRUtGJPl6DZFSRFzruKZ2RStxjVmOc0LAcD0oH209E5OOgo7GRj2ATOt0L9VNUtnys5quPC0iD/RF++Y1cBsND/lbGlIka8OR7YwkQ3edBWuOLznrJ2wdlhAic3DbSR+9xvQwB+hcMf3UKDa0Ein+Cm5ejLwj7jGJDJnOpCiqocjPIP8lIWJtBzaTVBQiAQkBNJ4hgUn4De/AY77Pvl/j6HkTFfWM2kqDZCWmGvZ6xMBngMP7ovXA+6ZQM4pUTJKBcPzm2CQ4GBRu00dizQbcSwyEgBqODlxnFEWGSa36fcaGcGFsm4t6qi01yIBmIfIAa23OWsbMfZhhtl2GPg/pGZz9M9bPPHUBiJiZeUBK8+M05ari+Yywk40HGVOYV4znR6WsjreutKXwF0rsAq4VPB8x5oGen5+qFyEdtMGfgvQUkwj+gC9+ofAsoWWjcdGor79f/PsqDcQfy41jpwQwx2Pv7924Ja8Dghmc2iKCAXOQwqjYzCqjeMd5zM6kFDc58PkItor8z5sjT3a/R0aC3npBR0Qcd8O6EhDSFcRKPD1QSLyQRlMUN1LX14ruJYxOYgTEAoSvoaGpD74E1vh0KkqAnTvYHdxep8X13k+04tozAmh37E9cKp3Kdxq1fQMkeqjT4GWwCKAOs0ZkneBpN5OcTUw8ghh2c6BB0gZwNOPW9UYxYFe6LXFOFbYLxHnhBLADGdFXFHn64zs/9lREz2Y6CYOB5KDgaWiBuAfeFvSDUL80rsh8IJckikDN56MmXeYhV+YDBT8TihI6QDmVYANINAF4pKjTJpv5eIXLLAzcE7e2OhxrkJkyKwyCiiUIUcyUuGUl+I7we7gO7AXQ8qYGsKDco6bLegCJCUS4iHXmQIjGT+l15ZtI2kyxoZuCeB0INRRI2YfhGgLi36hNhgGK4cGq7AjPr1ekQsch2pCmiH+JAvjxkZOZd3cmF7Ro5xvQzCRm+Bkf1UITTdecYyWmGG0UGU/BhC/0ZdFSwAkRAjD9qlg4CQdUxBVwMiI7Y4CWJiIIRyyUgF8ZIGkMh4pGhXsuXBeVDsjMXAAIBX25CQg1K/MQXJQP4wYWD2Y4MH9PP96DqJPmwUADjPOHegXHFMIwOEhQxEOqeX1koYubI7cXIkZATQQ4MPPPiIWFtRNZLHGKEJ8iayS/MNvpwc5GJxkaUQPylxILuJGKW/IGgbpIkyfWeKyL8jtKTsWCY17PFdFDnybgEQkAQQwA9QV9PyiF1kG1MfGYOGIPdmd7aLqEerGCawBcYiLQGj/t5RF6mGLJDLaDXJz/e5OLQRvshG9YZKgeUcLgvhPsGiKbYh47Dm8mQ4UNqUnU8PELaCF/GNQSjFXyS8AeJ9vTmJ5OX6yr4T2iUyEE3Fkwnd/jWw5QXIb+TPQtNP6HVOaKE5N9girtHGI20uHuGOUDICFsQ6C+jNPLy8VAiBArkkwn58VUUJjRPeEPJwCxYy70y3IwWIHOA3XJZjyMQ0iaeN0Emc0xkZoLYMewVv78Q8yhrRmXd5j2kgD/IRF4lkGLlnsK4OhrA9YBPXL1OT0w4tXxQYg2m2AQg+Z34CP5VdQFYPK0qF1wiHlZTm1yRx2E6jjUEHFoafWyYG2BuKLGItZ7owfXCgTNDBmY46JuY3f0T2vtVfVw8+CCAmad8E3pvQfyBu195CvX2kKpqezUsoRCUbo9m24jDHCYQtEvl148OBmdQ4udlpKCQZ3p99LvyAUyC5bDvZNpEPyGz8L+du+POiY3wtrAQESQ8PhMNjiPC6MyZgUR8DqlAGq3PcGFI0OSY0U3gckVxmO8iL0RdBQd2XC8in78hqeFYQQe1Ruj5PVaoHyumb40vKhMnnPqRx8M78R3A5OZj0oMK2hfECdUR/FgTIJRZJn2xpqSpVyJ5O7nyWXHQdSNOineFFAmoC5A/Dyb3jhcuBkRSIxNlARAg+jMiP23wZHVDSKCe4CpEOdNX2FOug+hIIECFLIL3L5De2g7gv1CMiClMYLKSDkpgqYEA5nHfwNwDASLWYY2fmIM6iQYsWbnfMRGjZOnGX6pZHmzvzZPCIG/Y8DbPgrR2Ispr1fcg77gaf71hw4c0hgQtolpAwEq6OAEBFkCMkX1RRChgPh01BixOHtsHZlS7X0kGywrxwUWmGMo9EO4X/EI6L+wGXLRBvBIR14QfSs3Vk3vzv9uhg2vBUOZj6mb0N+iRyiiiYs64iEsgIStVYYRFvpLZhANhx7W3JXcYlptJKIxw3gL0x7H52GVCo2LSePjfdQMsGG+QoDl9qDc0ZEIsva/BHmC1CNLkXCbMgx/RWA4gPJI7ZB2/tmoyrhreBzhpXO0O8bUUzpPzpPU+25zvr2UYQgHTH6alGBysy4B8RfLwjsrw8EFICligMGUZI34EIf7Ydx7aRivTrfaiWswW47F2YEiHkfFNRxt1HkZjWWNjBBHMeIE9G3MKCwzmuybmG21CfFnWrpqrDIkglV9SR20Ny0NzN4+GGH1XQM9iUyvjHBwnftvjI0Ap2ciA6EoMk8E8IPxyel0zHsZ8Np+Qd4DORVTiJlDDX4Rjm8FE0g5VDL0cb3w1xN5CuRaC4nMyaI0IVeXJIAMZGx/N9BP4xYu+UZaeM5qzOS1uq3SS4Sjg0Ct3y5sL8bnEfYdtkyVi4hIJ5EIdpsVyFfhC5OBi3iVTjtrITj66pgYuy1kdcYyq6T/V7wFgHmWOLnwh0C6ANsMwTDss6/M0P2g56kbnfCU8EpgRaSjeWwUfxGq1Njp4zLkfBudiCKvfciHuP1tDgOrVhpCY9e/betDmzXxeDDxFqZAeMoxIs+iP78C7pmuje/IiwrBaJXMDsSyyQn+F7wA9cADwR8GikNslt0acotc6pPo0NBlXXqdA2fOkByP4ZhDqMOhZLXxcKMnImiRKwx1cgVklu8pJ8UWhMlGWY9BPA78wGOyufrQICzUj3lTIb8mprzQ3z4UqHynAPhUNTgANos+KPRzZbhOriXAHxZaW8VytZmDxoUrsvK6Gh0Ps8TvYqGGN0a6kfIdYpiVpMIF4svp2bjnzAgyy3mNDSiEC9VyIiYEKHaadNsxmeC9iAXC8yScsKPCqi/ugDCNfYr1SQvMAjg2ljYN8rV4TEmu8jFr91iJuHhxNBEEUCJJJ+0g/T6tIXKTq+woOUkwDQY8r6xOWjVDOQBcUFxuYYW5kEmX6VSvQD8OCW04uiQ0XEUZ8O9NPbALrOJ18G6UNpujWFpknAQnCBkMKzDae9pWC0PUBCmdYGyKLWeVnIMRVdE2kr74YzTIA5/IZdKBpkZXkRZVvsRwPcnG23JFeT/F6b+Vp0Rgtn3otohwGQp02TE8FrgpMcH9LUwWwl1qWa22MGOmYUeQb3RKQXrkkVH92tbE/19dDQ64dtDnRofsefA6SDZMejYyeEcPeb/iKdeQGIgBi7GhEcI9PZlT35VLHuxd3VcATBKpVS3mEgAL5LbQT0czziwUZKkuU3Ms0EfYgQe0db4TyuKBlBBuxiqGEB1wNOstFrfwMngQTQk4RJwjcBfzBZuTRnkDo8yBI8L8GZngupFoFksgzPQ+59W6NHY8RiVg7m1q2HePMhn9BO4MyD7OMe6sPv+feoO09rtmhkwJVmSHAJzTjjQEaIHhC6j7gPvIQK4H2L6UzlgOjPj6wi5r8jDq/L/QalLpiH+dTNdqXw21qBrgrBhQRyCSDwxUh8iJLXRZAeiUxDEFFtCK5rhcmkB6xWYirIcphNAP0+HS4sPOUOjMEK8E2NWELHhPAm0vf3D8iZJR4YQn4AZbrG/6PIMPbmeKC10BIJKIUKMTpE50PNggZu6AWHqwi2FtzEe3O90Ukt1W0YcGKLHJGjnYVd+IPYLG7IZqRd8mSjuEBzDzRmjnedkCZhIieFsZOA54gLhH5OHBsz0smt2AZTkWAwjdKkcLwOt6WqSj1zgg/xp4gJOyZ8WtmVMtdgYl4cBIHGTUdm4pgOYV7c36RIxCTi5GudyRw7bWlAIVV9HQwabym4rIG2Afd2NM0YQmXhosmFWDVtgE1nAOoVx4UUcFHmRxw00Hx44CaFf2LD1UhMzoTxIFb1lcQYuJHKxIiccQ0MJMutleIFJhyFWBJ40wOfNFr69de/Sv8wGiavGnNExKqlhBwPvY1IKCja0hF0YD/xF4C1cUkmLIREFkaSbsPQQySMc8vPHWYkGY1B/BrPNtdd987kokk92GsYJ0G/CYSBYwpw0Xg0K+AgkdSDD5kYYyOKqbf2o6fRSfQgtCFZGaD8AY6j3xD9VaiuyODtK6gwnMV66nhq5+vn6IGcRS/lZb908lAvMc0UeJxIXsLppXw7ricwMSSDdkFg/vKL7OAlhZ54wi5RjByq2K+sgvJA/1UbofYPnwIf8kELQYZr4XP/ol2UsQFG2QNv7IfTS1C/jD0cBepEcBJpSg8HiwkB+gKcsKrPApyBWp1oeRplxKFkZb1VlJoZVMEBhjZIkhACAnJj8uF2ICbUdR1VKSJi3/I9ZUXUXMt7hnXNLJqih/AuERDbMHlRBn/9TO7f1VvIFxATfIFuAGFDV90FCF42d2BMAL4qq7MtNbBxxscBJzxTfr4kg8IhfEEvG7V5U7WasjAdodaYwWzYYVvNRnqsQunR/xNhAGB7K9kj1V2tWDnXeXYlMDOtbDgzM1R7Wt79rmgDkUWAY+bJZZMbKswNwZkumQDpqOpE1FOqIfxLSW8gG8DJFKqhCkoNMcVY2XwJykJzlhms/b9YCJqHC+ClsthlYFVeJJ8N5YgKCFsevGSMGO281jzr/NbwCWI1viW5ER/xn10CCFKL3fBdwYSi5sjJyZiA7gb41tsxVqQRReKphrc8SDYrPdWex/2tvtnTeuBB06evE03h2P8UuCrdJUblbZBETA74/tv267OR0FjA8c4aIvIx8J7GQXxIke/CBJIrX8rzxg/pK1Fc5Hu61C50NRIHatY5PoLISLfEPPcP7qGiWYceznIqoLYKlXGVbsR/mV+S/qrWyB7L+gJs6TKNRR36ygMhnAaMXiprX6pCEHrv+15gRMCDO8C/96qTS6Ecl7lQo73alUFjuTTn/wt1aJxm2uVRHd2vQ25W/FeHbaEB5g7+z9qj6ZxtFSQLsgS8OTxEf+jVfUEw3Ar78k/wiAjl97nWWm7XoYpIGNRV7B5xgtW0G4o+S/4s2GDgGbuhNFLwAavKk9/v+rRUP1jGQjVe8FM381VSbM+9rJA205Hvvg4vCD6rGh6owXPB4Czvcw2nginqfNwPQApYc+bTUlr+RpUbVhiaM+VPxfTFfYbE0aYTNVAbg9DzVCiYzVbxC6/sWPECkzSoBTA2mYJYKCncuXkD2CjG8nYTHpiChTBc2uIXIwW+NFk1TU9/BeuCDFjF8mKK472ubZ8lULSMY8VVA+2wz14igQa3C+YEmVHNMSyHPUgOHIoR6vDqKAimGi4/uy7pwu7BE1xxxMIyGttyKPWZr6Fb52rH4wDKMXtgqrIlmI9zh6PbvHb/iqMVblAnWe/PLEa2kJgqB8QveE5X+5mmATIIDPQ0cBGdp1J8VaZThB1usq40/UOFINL7wA+shJRiIzCvSlHjlpz5v2g4+ob7E+D0VHXRCL6D50xdclqtHzVyfR2JguB8YPAjKotefcTul2BcfLQ0YowEiK5oGVl+gCn8x7M+3Hp/cm26JXTI2yREroaIQa6E5026lXlqquiO38UT24+ZldB1ZH/GAOyA+u6C+6Ix3MlAInLq4rtOIhSpKTvDriXYyg4VJ1UJC1dFkUpmdZ6CMQJPoFL4Pu/snJ2UpK1EHviTr/RgQQ/yVAaSguJfPCu2OBkVQR/FFAnIPlNoBtu5bLKdGcCGWBa62s2xWWJDlZtlIXYeAxLQylyJ7cLmvg6Qg0OKuhS0vgFzq8VlGPzW79A8d7MG9NDMG1b+hhiInAhptIwGF0YAD6eSMB634uff62PaEiBnAct3E+wwwlxxcNJOij/11aOoLhrX8ljg4onBLtHSeMVXDia+I0nXJYmbsuoxf5jV9C4qDiR0iTWGGAcSrMwWzOSdtuYStgUKJSf12/heAEqF9p3ojdx1i6yRRIxE3bc/cZwgEO4J/B327jmIiaRZO+k66EZniJTziHgQ0GxVV7B7Q/rwUhwSBGNjIDDEJ/btaKGRRwWBuCjo3NLeBvyIH1LMAL9Xee1VmXYcYt2AhKTTC288NloKBXp96A5P4s2MCdaTdQH+ZjKItpI2lu1O9/LBttkrwBYjJcDEklSfpNuG4rQQa6ZY9U6UgmXAIHiS/AMSE98ZvjlzvC0Hz8LFy09GPhZe/pY3Z7f3Ylw62AMJIGHqEdanOC6CbKlNmW/XRe7pxfB3lAqwHwkaRgYhvrYLwvSRsvH/f5WBJfOQ9UOqiMkJjyjDYFKbQZk2C6ka8nkA5jV/R7N4qo9Hs0e9ldFG0gENBPJ2mDaJuv3/vWV2U/BbTW7fQAfUvXu7imwhsmMY08SaoZhQzOYkzAmIhbMB4bBR/shzH9X93ARgBcAfREW6WOCjKw/thKCVoAOwtjCqKvzYDoIvBCoLq41jTtjjd7BDEAXw9Lce7k4klEuKxfbnbKdaI96koi2VZh7wVW4ykF67kWWMQ+vpYjFGPew7Mxy+kXFYtfu1gFDkX1hkRkYpqnbzcHV0dRS2ovxzNYWb0s1jISggv5Hk5Ii3jOjC0uf5ofyAJXxYlBBRJmSl5HriuqWXKf+ymgMMTqdzMdfkyr89oqvTXiKZ64frSE0pv282MLX9himCNGS8cRZs4hARigSJfK8onIaHwTBVYfLzfXcxO3XaQ5iZHCt8jQJye4yLz6YW4PAQNBhuipebJE4MH2BK2GeS+v8YnJw8wf4JJnxjg+3fWZGcHwtd1zdni4IyZxBNqdJdOMxwv0A7QI0s2bEZqPeZT4e8hPkrh23g69g+MHE8bm7UVyiDF+j6LfOBBR8DEoo7GvYPw85FYLYVXa7RKARgthtNUTgixtv37I8t5UXbI5tHoDSpyMhL1KX2L1cgHQIuQkMGPFXy+20I6UaJon4ISyJNVcKGCFmK9tv8SInmT5EFfMNxc2L8bD3PfxUH1VWriQAOXadt49sSbJuK4RLm6+L5xa8AKLoHgBoFiF7yqX7qVrBhJFfd+83mL6YGZd5LarhQUCfpdhFd2gzk1Wu9FMFIuQg7rDfyyIP9tNuo0mGr4ZoZXIB/fD1O9p7sC1Ifv1e9o+9Jb4ruwA2UhNSE7z02DEuH5yAr4KDXaYmbb8mEl6HUM9fP6evsQLJO8nb6qIJlgI21H5yX/VKY8jya+J6MrMS79u2JdGKmbZdH696mgvqTAiRgNVHIJJhDcWALN+2qTBGxdUihqQfvApJyfy6NeQTHowPANKRtOTIgM1RyXjST09B5+ABpHXsSH3XRUrbScebEDPAv/1gMA0DfDO4Sq1NWk7zHr3vQrhmnSAhjLJj5I46fn3pElCi0ZIVryVSeBc+zwKIvcJ8Fkms3UMARKt2RElNny0muLCaDJYf9DVLkE0pnvaQfV/rIyjStx2L1gFdpdFWoPjJkiCm2Kyfu4XAI2YO8Bc1cn89amQjTmht2Op9dAnfSE1tib07zJrhb49+TaiaF8XycL/WWXoFwmBajCpiD5BytcM2RMtvEumDjopMIPBKHtjINsE+ty48agIIlnRlFlB/tV0wYC9pVBfqyGpmhHgNbtmwRSHb+RNKglIXwHIvbpyZIMSUg92CAzIXBiiXbX+37g9axlZhAcX8mD8Is9PbPSIRW5E+EYAMfNIbQiFaAZaO2yDFK+D/EQqhiZYhktRa0UXYk5tLh6hz0BMKQLQkFwf3AyrKVGiq254XC3C43cms2RUOj7n6jW1GAYavQRMoOSDy09FNyQpiQrikqG0HdrEwj1o8BWluxHkl4l0AykrswIsJsGpPibtHLcjx3HGGT5qUyWVdC+N+RMnhggWDZMfkZfsAL9vunW1Tjsg2I6CLwDib0EcmJmYsm7RnwsEIENxNuDwkUr/nioRA+WdiAj605YEQe75FMBJjTF0SDBJc7E42zuQDYdhViPVmdjD0cdncTriina94btjy6+1t06Xyr49N1Q1sID+ZgA7JJ2gS64uABmVB3uLeHzeg2CKMc9jX+9RXgbi/7T+3XctYXuCjulrizgFbGa1AfBLtAMfgKPwaRFVzJPH0L8rfXSfoozBbsdF/wb+EMRQY8ouKsl2ig99xfg/OjT0bpYfgYP7HVxZSY9bLGt20/wfAwKS5AS1bYd7WVaEd09AdQ3AaATLs4UEA/qwq8VML4OWGwy/GyR6MrARm5my/iXXY2AmVuGEC581HwXMZc/CgY7erZl/XaGZq3tPdEJWwEKt/3dQMqH3MG5GG9K6hfo2xrzRxc7MoXzsfC9L/6TZrkamZ6c/uPoELrncSI3ia8LoGa/ew0ITQyxkUiVprLa+CRzuOi4Cjx1qg+LZGiep8MH7xsn5rYztD9Lhxb67JPyrabyXuq+/zLejSRjwkEBE2wGlLtjDYm92YBCNfWIYMte9u80o4b8NR2sCC7R9j3a47Mw/bBlDLuJbNebeKhszf44UFGUOSlol+AXtw+l42G7nDoTgWdyVQ+AOLll2FdjmKqUtvsrATbReAopGvT7LeeqU1F/H5osSTVjtq38B9K08voXbsgZ/rWw1+5aKJ6bfgDbnc9higNIOlMTXjclNN7S7+WAHCEuFFgDKsEtERbSXgowALEA2kLcONYMSH7ndZKznnvhDM74SQEPDZ1pcXPjsMAIn42Cfogj1Rd+vkyYyl0EIAzfUssJiU2Nzd2/tFPmUX3dzB9qKxgDTpAtrOCF07WhkBVAn2UP5rDEfIH1cnUonRgMlj3PMClfGz2+6P5CKbjbPzQXj2CBhsN0blm4gGaEoLWH43NzEttlEVQc+NuQPp99NlgJ3sqAaGz2ZqwFHn2ci38Ug/CZu0Xgzy4A+cN0rYtj6Q/+Wtm/B5rzwYYvwigy+RgDHo0LitOBJ665Yz11hd3UzmqmjQ1XNgjgAHlM6AHYBG4qhzryDDi+PrXTGNLe88ScokVWVC5I9eIw8D4hGEQeENTxx9/csdFibo4irdPTjFLRy82NW8vFyxcH2BGFkWM0D65voZg8mNYq725nEx2iWs0sHgcbWvUxM9gyQStedBclhfU0ASs/dTbHJmhorbJc+p6jmcq0vQDvqyP7kg/eaTSWe3T4dnCfDEq4bWZ55o+vrTAJSJDI3g8M644P11ggBgbiNJuV4WKFp157q1+q5G6ja3B5cJOjLtFS9gY7exVOYR/4/5JM+Uw68CsuFk+uWmDStT6at1WZ93vRy67GjqlawNuXNFevl6n10X+Cor7gmwSa25VbgEd9SlrXPMkw/MX11hav9sY4bYoQxQ8Xb50y2FNsraxgFxM9jg7MCGWW24xprejdd97OTB0MMnxeMjVKwuAbwmgUuN7rBkRHf/BBDUbJMumTMxTWD24/EDSWflERhHbic2mWbEF94dEnibEaO0OONXQS9bmkHAWOX4TqW48i29Mp84Ql7PYMPsRWn7ukciEQjbbewbY4he03KTcsVi2uwIyFCMloMY9e7s5uJJXp/+4N9UiwB8tKrdvtohOArjPu6HICahJGspjZxF0PPWZ+HXjqY5qDBXxI4cdHs1Gtw9u1207OO1flFcebZgcFtlcNekzfy3+vit7yXe5BfEt8MFW9k8P8C+MiRJBKfL19gAT6i8EDeA7wHMPPCAICGXvk4SzDHmCb0HEK6A7naT13SFAlol7DqpHOxdz64CFNcD3dKyugtm8TvPYbvxdaZ0EefG2dLhPnA4HFm4c0Sne0NR3oTNQpiMT6czMuRQcGsxSWUnmQ1lEFO5IqqmR/uaVFIAPPcREfzH1nLkoVu7SfdIuOD2ZSJ0uI2YCsbwOONf5fbqvgzHsaIPzWNEd4ncJX1tDeWTwki4Zo91z0DjskxuH1R7rF273x062jxasq6fbOPJGokHJu3InGEZ43mnO1tix4V2mB3nZgnP0h8j1ZO90G4mWVgIUb+qG9/bwoyLYADts3u2DxYwz+1rk3x4bFubUQ/vxi0D3rjsvq0qE1U4SMd1Mo2qq8G0c2M2o79AV1csEZjbpQkTGdom5Ddo4H6hYjUUTBjPOJdrMnU9VubxB8rmT6q4ESvbQ0MML2jEDUIoI6vROYDnVaVlG3Sz8yDj+wPCbEO0Ybsbat3VWn9brz02uxO92YILOu2WN6xQpJkJWTe55PyrBXLxQVAB0nm+sW53xKB47IMou7p/Dsx9e/NpnxZR6BgUy+zlfHYdfcEwYTAeYhy/Zv7a1Y5rQhTCD8RSdBuBzZR2MpBy3BJQ42Y9O6kexDQs1cKZ0QXyMO+qg6zzWxjHark468Z0Psei4vjZbXl/MMO8GZ7fVr/gtpPs/hOiw+0wb7ueB1oMWERn5+v05Z2EPcmvm4ITRytuAGl2ZGcbtaBQO31sTwGa9kdt++o2zn+QaXeWwTrctQgH7MfWxm93trYADQHHfovAtrQRC8g5TzZAUjzhXHA1CORmCpTWpxGTe8irGwEs8mai3hXuo2p2mxMf/bX9facK7DQxqti1eA0+3ioR95Af4CvXl3Bz793T7s8MJqQZbGKDeWPEEMkZ8TTd5sSAkR8byB0XCWHdyb2vFkLtqmc0guU/7J1dUYDBBhG41Hn94NcaPdeQRQCTo4W01w9j/7Xau50G5+uui+1m+2RF+4TzLQUioZE4nrIDrT+IBH7JM75n2+U2kHtXc/Gc+E/2JuNDMXs3yud4tAWGhnHiiiu793e+iexzK3UBqXYB3uHy9lj0SpenBYwdUMduDsRODPemrWYzWUQ5b1Io2xS53GdSLd8TiK41ItHWZ+LwhmNd9i8cONyjh1xqVHdkHwkCefAlHbfI5Fg6cEGa8IrKiDtYlhLLi12au13oF5kYweKe1pV7URN6CoJ742yGejQBKn0rBion1wcY+QV34+0LFjB5/lH+ru0CoFBPVEdoCNHPXbqPHrVnB1Mkr6cSxFMX5o1Ws4eAoAL9IzBjIcr2x4kSb9LPFCbsnQPKSAUmO7tr2YI2fpiUncwdQIxK3S7SonFmIfPO5c5fbBDyALMIqwF4qOcwmusv4Iiym7tFboN1uCT38eTk9r0ILmP1MuEPzV1u10wuRM7l9tDqZgibk90UBjZ6htAcS0UE6W63anwbh8XF4oor4pVR2tZqiXYbrl8Pz3B5xiL/s+uxIa4i54vlAOK0NLvobN9vrhrY7dWhotqMznrB8Zo3K+x896saigx9gmsbRAkTPqzkP0RbQTLxCivZPBC+XobOdiByR+6FB3cAUil420/D8ExVNXeXwC8PWjnfqo+LvQp28M22ywh1Dpv2e0VoJXSNvds2m2al9nCvxt2IWJ7INd2vvxR+wRAVZsFWRR5p2TI0vgVMyLRfLtsgahDd3dpM+db4EGrYnv4O+6CIqla4u4BoAbngt6/ju6mAu+oCfZvyZS0huRVJQHc72fH8CoEGcruz2xa7dZuzrb36m45YOHaUhOSZVJYWMU/Xt9M9LGDHDercsBYI8sNyWbp4EQ72dq1PfE2rzMU9Ltl9hbgOO5RzVWff2DwGcn7eIr06k5m5zvro0OMcLPxzs3aslK90bzFhuiX8LBt+Z2iIDab/XlYaPSkDSwFdoW9JhfhVjDC3wXOyWty3RkNCbMs9Pk/99vZhleAFIJGALAov4Ayz6q6r/jWRFffdPt+2IJyaDYWuKKJsQdjiRgnJpX0yS2Lp83o8MSZOuC96HMDJkKl7WFQCYLF93Y8nMKQvDvgD8RT3eQhK4sDqpD37B/BHSuOGGHrDimSP7nOz9pXUmmjwrzy+JS8s+nHG3bgCbiKBg8trn3TC07oJcAKthF+zrI6zb6VZTLVBuMMxtvegMj38AK4qL6yANU34fdcrXAyY7bqZD4QvrM+PbeP8FlPM92DT4kA68JzdY1xet+XCCtGydbCKQ1zxSsLRjblN70vIexIHEtjt3VDbQBQdLBB3jniuNpNuV9buplYjchNKNvWD8oyPKuKCmkeHq5DvCrZn9R+lb7W7fy2eGfEAm7nHdtjc4QEUHjZRwqnuOLSCvqAjbhKEI/Z5gmVTk0Vtbh1f9OJEb0AlwOTtQWgDZWtBWI/7EXRN7wROPYhgXsl2SdBP1DiEmk2f+IvbKjPvfSwZQczMAZq7+eyYUYA+VxVtX70KdjF/a5DWrYdxSNzipu1I21ZZPX1juQbk8TzFi9jqHt0F6jkeROtxy1Jzxem6SRnMR3Wq8nZhg0fu+LOFWFFqEt8qGg/Yam5t9gg69wK+qPaJFfJgsXSea65lMa0w38NDCrj6h+3uE0wj2bf1tXB1XUBTnTEkAS7gVo+d19uu2Kdf97e/cJJQyfOu8hOCSIiUzfhA4k5F80kIkJ4fRswWpmK7USgA24HxtJHxenD4g5+4AHnv8+32AS09Z8btEfK3PViQsB6H0JRku4OQbMAmgZbFdBASeYjEVmLhEm0BbrZjPbaqbJc8Facu/rljxeMQnuGSEqKjKeGJvvR5Cg93SQloCyC2C4PvtuqZ7QsOedsAPUgUd1V2O8RRHxGxsOvI1jkeey46g1kvRu6O7uV32zMRWmzHQ0vUn30/QLVHzb1qk2EDHMkHctpL3NvIHvXSotLy0lozqx4bMJFfvfzARuLnBH9ybxmanrDryPv+tboYbi9u4IvPb9/M28t1bMNCXrV3fVWGQxw9p4JIOOlO+iS0vWecFTesuAztaSDbfTRuSwQJeGNz/1p1qxFvwPLeHuxgW4tgQlwf460GZjNB/3bRQQdDkws46JkfhgJBOnpNl6X9G8iuz08v99d7ZJ18ElOkxv5Yjih21biczZ8gchCTIJIxwsG88b7LbTlMi0VMuE4stb1yalbUdIgyEPz8HKAkmPffB4kwI68tl/ys5YU+Qrsf9VK1ucpQRii4rLwSE/K6CGtaFqKCp3ycquqpLvs7vcQqe5ou+RDH1eIHw8GbPpvdPeHo28pdkMlWcZVUGO0fZ4nlckOlXbV7tIeHRaufK9ofRkrCyeFnQ0AgJ283t34L0C7tuPeJlOB3n5oaN0nh4rM1yrW5W0bh4vlzm9+GG680UQtuWWSM2raD4bbW8v7odaAKa9F0bNWDvCB6Z7CgxfNlL+bwXJqCvX9xsu/+vdQ6PaMMhcQwAAwAdkX+rOc7h+ubkuF2Zc+vK5E4gpQyoTpwUWF7qsqId3+RRfbWBxHsK/k3tz0Nj2x7YU0LSU/16AaebmFdbPUMNodazyiaX08RgeZS/1iDWVG43cHz1yyu7vktEMN5UAmQcr7Di8qBae0Ld1+7B9/BPCiLb7sYI+jRWPjHr+MV++BBTmaM5aSAeVi2OVeCkNnQQqgtPUrOY4gskms89lieCtBAKY+fcfbsK+cO8Q3QR/cIkgTKVM+Tc6WJFLHEBYx7YuJ4bRJ0WcN2fFVpvO/2sxTougP8enjUjlpttjd51M36NgYdBntHkGFHpm7ahOm5Ld8OfhD7PIrKpHx07wX2xG0M+TwZsxKLFY6kBWJWr/ntFsE9kRQ/vWGIN/KxuD+7eQSrbYLTNvZjo2NAkmu6c7SpuwTX/zxI4CIeRGNbbfGZHlJRww2jYMuCm2890egNd8USu5sQ+2iNBZ4lIm67qxWgnuuXPMdlwj8Tj+XeRSuQvbmi4wEcKRuOL07p17rRQszuiBtzG3a2yJbcfdYvTdBRPrgwrj9FNAAQM2itSXF4HIlVPCfOFjWsde5ZwsI9fEdEuE/GneKWz8OZHlWgQA7BOrJV81yDuyWCG7G/jmShCdsTmHJ7t2GAjTcpx8ONzrmae5VAQ/MzWhRbnkQCEtgH4P70kvn4rw3MbpmXe9bN6l+SxYvpllvg4voaj15P0ukzmX7BjdL1O6Vo3Z4OkuPy7EYinUFpUDaekYGzZ64iKJwYCOGaBIq7P4KnP73uo6rjs0U38PDrnJDgepFLRvfvr54UtTFuHiZW0WPT46+YCcvfz0DEEBJx2JON9Adqz9epBRYmF25ta0C4uM2vzWBXHMnJeGOb4jVT+sHazgcl9+C05aZ2q3PDMXVp//nO0NRqgetYcluvhiU06x8gKYN6PTxXsEfPM0CwR3d2Y8pL+gekDpbyyB+mV2o/7T/ozB0+33vQ8Cro47k1lvy+vUQeUIHaifhAoYo0758gMH4xoh4KUtJ9bHLDpzRwcqLDrAsPfHi9Rvz4hFsmYoml572tJR+PX4qLJ5aWmUxAtsMlVmG5+XJXexg9wQoeLmDpRZDej03gLiW9y/2CMXgCBpHppnb3/ntsCiFS9W7gsk0lj56/WuYlMpmOcX3yxjOmmDB3S4fgopxv3B7CFJOVVI9jcQGpuJV/tZc3ZR0lISBGAdfj+tpdGgn68pBkQn2+LedShOsMVhemu7XkGoxBZwIKhhjrM1xBKOSxotXDXQhQHNYjJpAckZGzy0MZNl3jz54YBfFyC9OW7MycJQ/qgqEsymLnEELp8gBepMfEaSvrmKNpZcztMQlod4eva6k7ejKXMvfe93cqFQixYWFCNRhJF3L6PKKTJ4h9HQuFi4+vgbDgYxMKrDxKcBcKYrIJFUgsYXhegA7PjSedMcqdJD/AZ0VBBByER5/iyWu1w3uT4m1/G03doTPFYrLJHQjB1m/QGfGGofjOicjuZKv7p+nMLpDXU16YrGwV1hG83fLsE2OcsBMwj6fW2VuafrYo3hf4yCSSVdGuRs8B8pjO6bFpuhrMHBoYLsy5I7K+xu5d3J4EytpAhEhxs0EHIQ0Az5G5XdIm8pXfFdHqKV7W8RkRMntuT3+yu9hCHlQRjxOLOzMPWrq482ayY+M8HGTZjkc64Zzsh92eKdPdmHH8n3Wkpv21UbR6NnqDZYiJkiDIkCau23LJ9trNvnXUo93+Geh5gTL7KeLt5o1+//VQpF9fr7/+4E+nJlk+DNHqTFNDoszBdObUDTeYcnuoY3psZM54EU88xRtbIfS8rvJA1SiujtzmqYe7nl1mCbFvG/Nq+5x4n1+F73lUEYDLZZRBEzr2kWwVzNZyDRXbZt1o5vMlnnuut3kMTq56hVneUAkrZFRTj1ziSkBylhtp7Akl7qcaz3fUy64xVlvK7GAsb/r6V3gWIsBucmQHsIK+PRZ9gSIdjKd9huf+Sq9WHJ/2tbah9N8XNPeYr/S6F/KAlDyYzXwxPuMj8oYXuJo7XJbna4AbthpL68d92NKHp/nxeChVcCnaW7kR6kH4s6fTcur6jv/p10OsQzNmGKn5nUbAS9+jQ7wBXrcQPx6nMTzTMHlo1Hvb+lXdw9V+TuTstsQwA+Me3zbth/czsu5DIjcymnh69hGG/dfOOVTpsHHWbZsY2/ptV/edY18diRK+1rzn1SRXPTvi5tum7ha34fEKy3vu9gsh8zxHB5dlS8T9tbu5y+tab//a7abn3ebEaG4rE9sTlFNwPwTWpnsUCGqBhEDPkRjI47S+/5uE7+AUzz1e6NBmAfl2EQBTe+wrfwHi8IGbBy4GEu9FihvPdlk7Lyrux121enI08oV6cS9uV1p7ws3jVnsIAseBkrAJL3kImJXD4jd8vtthXLVzMLlGEBK6hwRtCeM7ya7j91NBaz9uPAZwt7vccHSwwI6Y3NvDE6PbWtAyS8BFbHU4nOlH4N+mmp2PyXPHpl7XjXDHZrKYPHflJSpGdx8sNhtNTo4wChEALdFKyUDVDkLlJ+M9qP5vQujnayAAzrj+B4MqfLDZSqXjAAABhGlDQ1BJQ0MgcHJvZmlsZQAAeJx9kT1Iw0AcxV/TSqVUHNpBxCFDdbIgKtJRq1CECqFWaNXB5NIvaNKSpLg4Cq4FBz8Wqw4uzro6uAqC4AeIo5OToouU+L+k0CLGg+N+vLv3uHsHCK0q08zABKDplpFJJcVcflUMviKEACJIQJSZWZ+TpDQ8x9c9fHy9i/Ms73N/jgG1YDLAJxLPsrphEW8Qz2xadc77xFFWllXic+Jxgy5I/Mh1xeU3ziWHBZ4ZNbKZeeIosVjqYaWHWdnQiKeJY6qmU76Qc1nlvMVZqzZY5578heGCvrLMdZojSGERS5AgQkEDFVRhIU6rToqJDO0nPfzDjl8il0KuChg5FlCDBtnxg//B727N4tSkmxROAn0vtv0xCgR3gXbTtr+Pbbt9AvifgSu966+1gMQn6c2uFjsCBreBi+uupuwBlzvA0FNdNmRH8tMUikXg/Yy+KQ9EboHQmttbZx+nD0CWukrfAAeHwFiJstc93t3f29u/Zzr9/QCdZnK4lMRQrQAADXppVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+Cjx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDQuNC4wLUV4aXYyIj4KIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIgogICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgIHhtbG5zOkdJTVA9Imh0dHA6Ly93d3cuZ2ltcC5vcmcveG1wLyIKICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIgogICAgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIgogICB4bXBNTTpEb2N1bWVudElEPSJnaW1wOmRvY2lkOmdpbXA6ODM2MTRjYzQtN2ZmYy00ODk4LWFmZTQtYTdjZmMxMjFmNDliIgogICB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjNiNzRkYzYzLTBiOGEtNDQ1OC1iMjVkLWM5ZTY4MGRhZmE1NCIKICAgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOjcxZDc1ODJkLTJlMzUtNDY4Zi05NmIyLTYwMDkzMWEyYjhmNCIKICAgZGM6Rm9ybWF0PSJpbWFnZS9wbmciCiAgIEdJTVA6QVBJPSIyLjAiCiAgIEdJTVA6UGxhdGZvcm09Ik1hYyBPUyIKICAgR0lNUDpUaW1lU3RhbXA9IjE2NjQ5MTM0MzYxNDcxODkiCiAgIEdJTVA6VmVyc2lvbj0iMi4xMC4zMiIKICAgdGlmZjpPcmllbnRhdGlvbj0iMSIKICAgeG1wOkNyZWF0b3JUb29sPSJHSU1QIDIuMTAiCiAgIHhtcDpNZXRhZGF0YURhdGU9IjIwMjI6MTA6MDRUMTU6NTc6MTQtMDQ6MDAiCiAgIHhtcDpNb2RpZnlEYXRlPSIyMDIyOjEwOjA0VDE1OjU3OjE0LTA0OjAwIj4KICAgPHhtcE1NOkhpc3Rvcnk+CiAgICA8cmRmOlNlcT4KICAgICA8cmRmOmxpCiAgICAgIHN0RXZ0OmFjdGlvbj0ic2F2ZWQiCiAgICAgIHN0RXZ0OmNoYW5nZWQ9Ii8iCiAgICAgIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6NzgzZmNkMGUtNjAyYS00NTUyLWI4NjMtODg2Y2M5OGEyM2FmIgogICAgICBzdEV2dDpzb2Z0d2FyZUFnZW50PSJHaW1wIDIuMTAgKE1hYyBPUykiCiAgICAgIHN0RXZ0OndoZW49IjIwMjItMTAtMDRUMTU6NTc6MTYtMDQ6MDAiLz4KICAgIDwvcmRmOlNlcT4KICAgPC94bXBNTTpIaXN0b3J5PgogIDwvcmRmOkRlc2NyaXB0aW9uPgogPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgIAo8P3hwYWNrZXQgZW5kPSJ3Ij8+uJe5zwAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+YKBBM5EMRIXT4AACAASURBVHja3Lx5sG3pWd73+6Y17unM59x77nxvD1KPak2tWUgKAlGAwKQEBhQcG1whDomTglCusl0pk0Q2pLAwFIODg2IQBiGBAEmgoaVWS2qpUXeLVqv7zvO594x73mv6hvyxr3BRdgBXwpDsf9au2lV77/Ws93u+533eZy3BX9Pr9tmPiN2dydqJM6dfFoK4v65mZ8Afr6tiQ3iz/IkvfKr1O5/71dj5gA/TKmlHk1Yn21NK3orj/Iox5nzt7HMuhKeliLb/1Y9/Ifx1nIf4q/yxgwu/14qr/ltdcuTt06Z+s3P+dKvVk9rkFLMx5f5lVLZEFLcZT3b4gy98lo88+RsEGrI8Ic4FcZoSRTFRlFI7iw/CC/QFIeRjwfiPaZ194r3/8BOT/98AePHsE6qb1m8TVrzbFeN3eOfbgYKyidAiEGVtnMiIZGD32lfoLZ9ERS3qasilrZv81Pv/V8pqwtJyjzQXSKnAKOI4xQeNFwYlLVLEBGmIkniMCL8fmvJX+vv7H/8//pevuL/M85N/WV/8lr+90H70LcmPXLzw4rlmcvDRphi9K8i47THUVtNdWsMYTbCBerSLlp71E6+gHF6nmN5EULG21MEog/fQNJayrildQ103WNsgsAihCEFT2wLhPXVp2/j4XdWMj373G/+rc89+8qd+5OmP/av2/2cAdB/dzD/6nqM/mmtxUYrw07NpdVLpDniHlpqs3SNNcwiCqqxBOkQ9oShrnC1pLW2iZ3vEUYSRmjSJSJIUgsR7SQgKUFSVpa5LpLcINMEZZsUEZRKCz/jet/4g951+8OTSxn0/vXrk9MX+jed+dHL7+fxvLIDhsWURPrX23UKXz7/1vuI9/+29akVrjfFDhC0xaY+mGODKPlJAaMZ0FrsY7fH1gGLcxxVD6iZAvoxQBp1koDRaC0IINIVF+fn74BXOQV2PwWqkiPBNoChLvull38rx5U0o9glNQdm/vDIbb73HBvv8/qXPfPfWhU+Iv1EAhk+unfCWjwT4NSHlMaUDb3yp5L9+JGfj8DG8c6hmhAoV0/EWrqqZjcfYUiFMj/bGPbRaLfAeV40IpoVzAduUVGVB08y5r2kqnLU453DO453CNoG6GaKFQcmYu9Ye5szqYYwUSDnD+CHl4Da7Z79ANd49FoL7NTerP3Lzxc+c+BsBYPjk6vcFEZ7B83Z8IBAQQiCV5x0PS/S4j3cB7zwySml1N7C+QWqNEA5X19iyJM4X0XmbJM+RweJKh2gaBAJnK0JwKKnwPhBCwHtPCGAtOO9wdoqQml6aUxUDqnKKyY8SrT7C6t1vZu3Ug8xuvcDzj72PLIvfnrdaz+x/7Te/768NQPfpI4n/xNovIsX7kKKLl+ACwgd8cCA9Sew4wlm8jhkNbuCcZ7hznVQ5Eu0RWtEUfYa3XiS4ArzFTbaJsOhMUFoPSmKimCQC7zxVZbHWUtc1ddXgPFgvqJuaphxzZvM0eW+RuLXCZLxPObmNSmJM3CVaOMZSp0X/1k0qK7oh3Xjf1ad+9Rf/8D1vTf5KAfTvW1wTs/pTVOHvhVogfCA4N+emMNezQQlwnk7z28STs6S9TcrZAUYKpv3rYD12NkWrmN76cah3kFgOBn0aIhARWgkW4x7OWqyXJGkL13hEJVFK4ZwnOPAV2JBweu0BTq8fR/mA9xNaSRvhFULFyCQj6x0hP/RqpsMB2+efgQB5q/f3Dp++51M3P/sTa38lANrfWz8dTPgc0+bRYAN4R/ABHAgnwSlEMOAUSIHQFd3+r6CnWzDeYrZ/nihqUU738E2NDAGJpr8/pXGBztpLkSZDmTZCRdRWzpeo8ygl0JFAxBopJUKAsw5rLQTD5tpJpBEEV2GrAc5bEA2+LrEWvK1IVg/R6vVYWV+kHt/GESHijUedWfvc9Wc/ePovFUD7iZV7cfaxUMhTeIlA3AFOwG7AzeZA+sYS+g3IgJACzRZR/ylcOaIeHlBNbhKQCCU4uPUVdrdepJqM8Y1kNh4QjMIGz2x8QFXXNI3DWY+1d461wzZuzoGuwTlPU8/IWj3K2YwkzdF6ETvbpzy4RTHsE2xAKY1wFYsnXoKUKdV0RqgaZtuXqev6lMA/tv2137/3LwVA/8TmaWr+UNiwyZUG/Hzp0gRc6eG8haGDmUNc9QRAKAEEggtk7tMkdh+yHiFkNI0lEFDxMktHHiJd6CJkzUIvw02HiPKAKEtZ6h0ieEHdWJzzcz1Ye6wNd0C1jMcTlDccXV4kiRNCECA8PkTUswF1OcP7AhsEvqjYee4JbN2gzAKzYp/8xMvobd5PQG/ubl/9w/f8z//l6f9XAQyPb6xB+BhBbDIQkClC7QmFI1gIVz1+IBG3LOG5Cj8FkSqCl4AkBBBhyqL8JAtqAINn0YOnkfvP0slimukORiRMB3sob0mSFjZEeOfotrp4H+Zypa7wzmGdw3tPU1p8KQhecO/m3SykOQbATan713D1AVK22btxhWo2IwRL1N0g3zhFObiGySWt9hqDmxdxLkGqlA9/9unNx5/7+Me+/ftO/YU4Uf+54H3hcBJq9yHh/SmZgD9bIxY0+ICfekI/0DzjiVoeLnkCAvWKgPcBESA4B0KAEBhVst78LjILoAUBQRgkDJuH6ItX4nSLg9k2cd4h6B7lrGBr9wp5noGYXywCKOHxwuJtwDWCtaVNXn3PQ8RxzmxyjbyzQNruMtjfx4uAn+ySRA+AsEgTE5uYRtZIGVNM99HpAj5MoBmi5RQh7CkT6w99z98/9Q2/9vMXy/9nADr/XuBR/JzPSAEbYM/T3ASxZRGVguCoCkmyIgjeI70k1A6MRKo7hS4ExBLqhiAFQgSELOhFXySpb9KX30V/NENEPZrZFv1RxbXtiwgJcaJRSqGUpJnWjIdTpDR4Lzhz6Ag9aambGaqylKJAqIhUK3ySs/DyN6MyQ1POGPTPk0YtbDDU0wOsUPQOHcV7x8G4z629LZRWCBEeDfBe4Af/LHzUn9NhfJ+w7p8hxRy0xmFvBnzpmXyxobkMdhTQQF0J0p4g9AJeG4JxiFwhtITg7+AnEPIOsEIg7lSmkAItBiTNc6jOK1D5YYrZhOevbPPU154lBIt3DmcbbNPQ1BZrPXXl8D7Qibs8+qo3kKcZJuug7AgfFDLuYMt98CP2r15ARS1EXWCbGUl7CZ22UFIj7Q6T8T6/9MF/x83JDaQAqQSNrR+56/740tmvzP74P5kDn//dkyfGUv5MKdS8crwkDAXFVuDsp+DsM5btrYrx0FKOa4yZ96r1roIViVqQCC3+BDxgrhMbCyEgEAQnCNZD7RAetByzVP4b4ulTDCYFv/nY7yNVNBfntacpHE3ZYK0lWI9vLFSOh1/6ALGU+LKkGu3g9BLGeIT0xJ0Nglpl//oVAFpL63SWV5FJm8m4z3TvCqg2N3bH3BheYzYr0EaB8IRgyfLsZ/7uj5458Z8E4P/wEyfFv35m+nP/5GOT7gvjNl4EQjWvmksvWA5mjnHj2Z7BpACbRVjlkMuC6NUG2REIL6AOCAvCBYT1COvxdUBIBT6A9WAlwSuCmFerimcsuF+jE25ggsBIjzEp3kvK0lPMwDaaJkiEVITgOdpr0VS7iOBRKme2f53aGVApKIPJEk6+4s3Ycg8pFQGB9AoZIuJ0kYvXrvCvf+9/JwgQwgEBay1aG9I07drG/tx/8Q9Pir8wB+qo9a77s/LtLzne5mjXgRKIOjC4WnK90cSZID+ZkY8teVsRtT2sxbh1gccRVXouc6JACNypwkAoAa8ImZ8v5znHghcEJAT5J9W5zIu8/f5jTGdT9kvBUzevYZynbGq89/hgERje+Mjb6PR6aNWiv3OO2c5lNu56BQrDeO8qJumRZSnVrKDYPo9EYLI1yvF1Ku8RScb7//B3caGmsQ1ZlqJUIDjI0oQQApXn7VLJdwHv/3M50H/mWL7ZUR987UnfO5w7cuMIkcQLyfOfszTRBkoqFg8ruquK7FhAb0ZEhzXRkkXHcg5WEOAs1AEK8AeOcAtkTyBMAAt4MQcszDWl8GFOFxKSNIf2m+nkHU7fdR+vfuhR3vjKN2BsTP9gD9topmVJ0yjuvfsldLIYW8xoRlsonZH0NqhHt/HTPqEcUdYziFfJ2is0VUk52WMy2OYLL17i6YtPUjczugttIqNREiITI5XCBYcQEiHly1/2hrVfevZzu82fU4HVD9+dlceoIAgIXiIDuEVFfGqDjRVBN47piglBSKpaMotKTGTmVeTnAITSQenxU09zDbTRiIcUoafAgJDgHMgKaMJcdAtABDACESyHjx7iyKlTVE2DiXLKekb+6Kt5zV3r7N44x+644HLfs7m0ClKStlcpBjPGB5dJuj2SfIXd536XtL1MfPgByp0XGZaXiRaPI2TN088/wwe//HlqX7C00sUYhZQCiULHktrVSOsIThPgmPfuh4F//n9bgf7JIx0R+PUQqVwYkHrOMwQP5x2t1BEBxgwJRKhWwHmJiRQhKHT278GzlWZ6JTDZSzCPGMyjMWpZIBOFiBVCgWhHiMU7K1xJ0BJMAK0IokfovglFRWv5OHWI0EKwsrZKb3GDVnuNsq45vmjotQw+eKrJDt21NRbXNqgnE4KExgV0q4PUUFkFQtFeeQnXb57lvR/4DeJMEScR7U4XISTaSHQM3tfYxtI0Aq8ipAQQDz382o1f+Mrnd6r/aAWK4H4AE1aEDPgQEFpBY0Eq8I5M1eRLBcUsQXUdty56Dp+O8ZMS5wXWSVQ7UJCQ9WpMR9NalehcEpQnSHlHtkiCCAhhCUEiegImzXy+IRUIsHYD01nFVVMObl4gigJ59zC1a8jaXaIkZvXUKerJAa6YEkgobE0iKrxtmA72iVEky4ewdUOoFSEEkl6L/t5X+MrFXYKWSBXotjvESiIVKAUh2Hn/HQRWBrRsCAgQcsWK5geAf/kfVOBv//xRdeqI+bdKNAtBe4ScE7yMFGIaCApCS8JigjgoMT1B75hCtQR6KUKuBppZRDSuiUpL8JJoVYNxoCVSCYRWc+1HQMjwJ+I63NGCeA9SEdJTHFQPo7NNgskYjBtCMyHpnaCcXCIWCUG1EXafVvsw2ClxIknyhChbR0qBF4FieBtry/mGJgTS7iNRXLh0k3/xq79MnAjSdkKsDeBBO6R2eC9o6oCU+o7gF/N2VAq00Xe97I1HfvbZx2+FP1WBf7Rbv+35P3Qn716N0Upwc6y5f1Fx5mib1fUxYTpDGg3BoV+ZwrSZE74GlEXKmDSZwWWH3NWIYPE3LfIhRYj8nU3Ffb3UEV9vTsId8CKN04qGd0Hv1QyuPYE3V8g2H2H1+D3oqE2oZgTXIpgEbVKsXkcY0J1N6mJGM7zKTE6JI0PeWSLP2kwORjihiWKBVS2mjec3PvEkUki0FJgAtbOIOEKhaOq5dlVSY50HNR8nhBAwxhAEJ5Vo3gZ87E8BaJ1997CBJ66VzKY1Kuvy1V3Dw+MOf2exg+QiOIFHoJWDbH7VXBUIOiFcnCEuOcgi3EsCQknkgiAohbCCID0ySFBibjA4RxCe+Z4tQQZC/kNMRksYL1m67+2EpmS8/Szet+geOUmka7qrGzivCZEmHEyoSkvSPkyStwh5iog6hHLEcP8SOs5YOH6IUNc09R7KHKW/X/Diza+RGEWwjsZ5lLOoRs5bSzGXe1IKhJp7jkrNDdwgQAqJgHd/HUAF8E9/8ngL/C+EUMWN9eAB7xEiwruGV917Bu33ofdSyO4lxEcI8SZBHsGKBxGDW8h2jDwekEcUclUhVg20c2hlSNMgtCL4gDDMfUIl7yyNcGcJSxpejc3uxgVF2uvhgsE5aC2ug+oghWJ0sEOIl0niCGEUB1eeJ87a8xmxTghhhkwWiBaPIqM2TT0lhEBdFgRvEUpx7txNFhc2GZS3kVKhTHRn1jJnkRAEXoEXASnn4EkZIIBWishExx592+Gf+eInt2oF8KpvaH2zVPL7Q/AEGgJhPg0rLAtRymte8Tp0cgQR9kDUCBkQtYLS0JQKV+4jV45BfBeCK/P+V4FQFiFr0AJ0mLd2EpB3emCYi3QhaVrvppCPUO6+iGqtU06mSATZ0mFEtkpTDBmPpggJRoNJckQwdFaPMx7u4F0gWT7NeOcGxd6LREkXrRXFYBsdS5xXFCVMDq7ypte/ibe+5T9D+haXtp5HKIE2mnCn7ZRSzblPSqQUGGNQSmCQSB3R4OOmKp56+vHdFzVAUbm3xyZCihwVB7xv0MYzq6dza150cHKBGS+nHt3k1pXHyXSbLO0R50fYHktEfZgT978NM8wQ9qMQJCLMnZmARIpAEB7C100ECNYR5AJWfiMFL8eWfXTWZXDxCapyQO/46wkqZbp/nSiGhfUjBBFTDPvsXb9FrAUqW0YnGTrq0Ez3UXGL7uqDNJWkGR2gpUKLNknmyVoSV96mvv0cqar55re8hUtbX+Pq7rn5jqrUnbmOR/i5HlRKobVGyjlvCwG2rvG2eDvw2+rbf7glbDP9KaXMklQaJRVGBsAxm1k6aonXv+pNBOeok9M8/uSTPH1xgV73HpLeA6iV+5iULY6fOoFQCtF9OdhthL+BCP5O/EYCnvD1roP5MgkemvjvMuQR2kfvI1vYJFpaJ8kWENPriGxj3qmkCStnHsHjaSpB0uoRpRlp+xje1dhqghA12qSE4MDHSBNDpAmuQsUxwZd3Pi8QOmNy6yukSYv7X/oqXrxwhf3xzh2+03jvMUYiJUgpcX4+j0E6rCsIviYQOg+9bu1n1StfH61XVfMTTYMwcY6JJMr4uffGUSLnue/0PQQZ0egeH/vIh3jkgddzaPMknXZCOdhnqZMj6gKEQZgWXj6I95u4RkOSIqMpwTsk4NR9uPStjIu7Gbm30R9HOOnJF+8neEcxG1JPJ/hsjWo0xrmCJEuxzhMbQTnYIeptIIKgnO2AabP1mZ9H+xKRrhG3lwmRxOgMHxp05wizg1t4OyPUDdokd+hphNCSOEt48N5H+PxzX0JpgVIC7/0cTCkwUqFig7U11tYIEbC2wdqwIDC/oP63n/lnbzh57BXfe/nqRSbFiPbqJtK0kDpj5fAm3SP3UFz+A6Rv4eJlWkmLE4fvpd3toYxmYe0oUdYGoZF5D6MktuhjOYRrvw6RvwnHW6D3nTT6Nbj8LTQcpW7aVFaitAKhseUQa6eMty+g8x5RrOmtnSJuL+OLPr4aEoSl2j9HUwdMtkDV36a1epjQQF1cw2THKGqLq0YoE1EPtxA+YvvC02gdSHvrmGyZ6WiE0DGj/i2MDySdNpeubLE32UVKUAikBB1HyDgi0NA0DSGAc4G6LnHOCuvKx9Tf+jvf9h3t1sZbT52+l+ee/yxp2mVh7QHiOKW7eIaq2WanyXjgpe/E7d1kuX2K7spxsDNarZh6648ILkJqSz2tMfkCRAlSd/EqQkUJIl2C5DA2Xp+nsaYjlNLErUPzRj1eJISKZniTKF+ls34c4Rqq/Yuo/BC6t4xOOjSzEoGgrEYoEUi6G3MhHrepCo80kjhKiIyhCnL+HeU+IKmHVyA0yLhHa3GNpik42LqE0R4lLIc3T/L4M08SQkArRZLNd17va8q6wjlHY2uqenYnFREIPjyn3vl9b/mBpgkvS7MVrl69TVVu0+sepb34UrLOcVTcYjS4ykOr9+DtiLR3AldPyfIUHWUI3aEpi/kPR22iyBBsyayomVx6nCjLCKLHZH+P8ZUv45yknt5ivH0BYXfwJqW9dgoTaUyriw+aoDpE+QIiMky2XsALTT28TpIo9PLd+BCBrxnvngM07aVD9I7eDyEgZcNsPCJpLaFkQlPXJGkH3TnMZPss5c7zRAvHkSohmBRXBVy1z/LGMaZjxf5ga+6qiXlQwDbNnxyrqsJ5h9Ya6yzBq6vqnX/7zf+NIDrZhCmL3YybV67QCM/q6sMkOkNrg3IN9516K1JG6KxFcXCdztJhlB3ga4vRDrd/lsY2CO3QboaMNKp9iPHWeZrgyDo5eZagzYTW4hEixmgZIfJVZJQzPRjjzQqmvYpO2ngihImJOutIadHZYVTU5eDas1TDAWl3EakSprMarzO0jknTGCXm5oedHKDyRQbX/giZ95DEdNbuIl44PJ9MuQbhZkStVYrxHjrt0Olu8NS5L+KDQwCNredtofVIIQBBABAenCE2nb761u986Y9NRpdWiskWsTL0uku88LVn6SwtkebLFLMdTvdO0I0VebrBbHCFYrjN2vH7UfECMkmRcUYodumff5yQn8QsnwGZYIshunOIzvJh8HY+vlw4hSAQtMH6GBNniHLMaPcsOs2JQkExvE6QER6PdlOayWB+zj4gETT1BOfsPCbnI1xVoaRDSUE92UZlC0z3t4jay7RWjiL8lNneFVSckXQWqWY3oamQcYdxMaUY75FGAmkUn/rSE1RNSWNrnGuwtqaqKsqyxNWe4AUeEBaSeKFU3/LOh/9JVdzOR4MdytkMLRxVOZ6biQTa3eO8auMowjk6nS6zG1+iu3yIdOlevAd0dy48oxbNwYtEUQ/rBdOdC0wPbtLZvA+tA4QaO7yNl12IOmglcL7EK4NOWmTtVUx7A5Hm2KqZC3bnEGoZmSSoVFNN9lFKU0xGjPu3iZIMG8YgNELESOmpqgbTOozUBleXyGyRYrSLlhHNtI9KYnS0ChTURYFWGtPML6CJBK14iT+++NU7/0FircN78G5u8SdJgkIQjMETgs4nVetg0GfU7zOZbKFlyqgoMWaI1jtY06Z96gx7/SFKOrTOaHZeYNbZJI5TnOkhpEYLyA+9HJmsIKME2ofRJqaZ7aM6i4isR4nE969i7ClEtk7QmungBr3NNarpdUToY/JVsqVDTA626F/5DHHrCMt3vRbTymmbRUJTEYQGV2LLEWlrGZHEiCTHOYX0NXZ0G6Vj9q+eJR7vgS+RzYzW0gmmezcRyiBUQGpNFPeYDS4i1AKTG5d4ycYasV6k9n2qqr6TrnAkqSFJDc7XNB6UVAAt9T++7vD/tDDbkWJUcmvrgJ2dAw52DigmB1g/o7N4ivuP3YdzkjxLYbpH7RpUdpSks0wzGRJcQzWrSNrLKKXwIoagqNUCaWogQDnax1cjXLVL09QMd69x4+xTDK+eo9WKGezfwihFMRoynQ5IY00xHGFay0TtjGp4CyUVMlJIZZAmQScpykQoJCrJEUajTIO3JWVVI3TC9S99mPbKBlG2wWy2R7Jygrk7KrHlBJPmJN27scMbJJ1FpIlZXDzB89dfmG9KCJIsJooMznqq2mKDIEtzTBRJ/XD3ANFLCesad1fOzbHjl5/Z44lbfcriPMudS4RHJQvdJcLoBvXe15iUHZbuXUBMhkhfo5IuYbaLVQtEUY6dltTVDMbb6JXXEEKNaa3ivcdaTyMW+cAHPsDnv/AE7Ry+Yxx49RvfCFGMG+ySZYepgyEog7cTcJ5gPdPpkHbUw2QtrIAwuE1Tz/BRQqJToGA2GaLjBD8bIJXk9Fv/PuMbX0QuKWK9Qrl/HZW0Obj4OZZOvILBxSfIDr+M/PgjzC49TpR22GjHBNdgtMEoRRBfn0G7uSOjBaDwwaD+8bcd/TGpjAGDlBHdxPDAkqIYSr62NWYw3qK1cJi7TtyDrveoBpdpnXk7SRrjAFeMqZuKKM/QSU49uIKptxDFAJF3EaYFpk09GWGtpqDHh3/rt/nkpx/DoplW8LVzNzm9JlhqeRqgnI6hqVhcP402nsn2OUzWIVgoigKvMuIoox7uMty5BOkCptWjCdDMxhSzKXHcoqlmUPQpZmNMvoZOWjgvUHHC+PZ5omSReGGTau8FdLLIYOciQjjyhUUu3hzjQomX4MN8juScm+/EwqBVgnWuVP/0HUd+BKlykAjRQghFpCLuWowp+55BYUkXNnn4JffhmiHkh1g8+tC8moY3wZeEomC0e5Woe4g4O4RPO2hhIVrEVSPq/gWasqAY73Bl64AP/9YfMB5P5kMrJWmcpZsITt19H0IpotBQVzOESUjaPQSeYDrIMMCVBcJNSLrLlNMB/Rt/jHUWUTcoGdHfepbhfp+os0EcpwQ5Y9q/yWz7ItPBLlIbdNSitXEGaVKCiYjSHFn3wTiKwQ5GWnrZAk9deA7nHU1tcd7Oba4AJlYI5fG+6ctg0r1gWgSVzcM+3iBFm3ba410PrPHyjbv4rm/5ToxKkPEKShimkwYRdYh7K5jFTfRCjyhqqCZDmiCwLqL0S9R0Me0l0jwnS2O00cRC8MDrvxFncmoXqG0DWuNUG5116C5vYtIuSeKJwxQnYmS+ThSBUClV7dm98FVmwz5xb4XWofvptHt4GqSYkcQLBB9TzIb0B1tEyQq9tTN0Dx3G+oobX/0041tfJXiNrcdE8SLT/W0a1aaa1Yz6OzR2Sre3fKdtq2kai/df9wMNQiq8t3hv96RMzC0RRcg4RSgNeISdom1BO1c8cvoYC51FRCiw05sImVKPtgjlEGUEOpSkK/ewcPc7SJKUarJPNbjN3q3z8xivbFHqFVR3lXTpCL7YJc0Tjt71EpAaIQQayT13rSMFVHWJ7KwRdY6hEqAeEUmJrw/ACbq9NkX/Gjvnn6UoBFl3Dd3ZRMdr2Nox9W2u3drlF37h1/n0hz9Mv38bdI6KV+ltnGbl5P1MRzt459DeUzUT4oWTlINtsvV70NkirinwWtE0hrqe98C2sVg7nxF7G7CNwzt3SxN1riAkwdcI7xEiATHfqJT3LGQnCdYiYk3UO4ZKFmnKKV4agu6ggqFoHEpnkOaYsIsrp7QyEM0ORuaAoJkpTKtFryO58PH3sXTmtZyta5T2vPoV93Hvw68lai8iRE0z3KN3/CW4YkA5GNJeXoJCMxlepr30Ek6/4fvZv3GB4dZ58jyle+g+hvuXGR7s8Uu/+EFePHeRaVVwIUl44JXXWFzu0Vs5ihtPCc4y6e/SGlwlXz2NxvW4LAAAGDZJREFUmE0IwTDavURKRT0ZY0zKjWvP4cMMpSLqusYYTRwnCATKC2SaYYy6or2fnRdBIjygNdCAlAjfEFyNy9sIUdI4hVGaoAxxZ4X64BxWHKWxCXZygEm7ZN3DNCLAbIzafBlC51R1ycHOLlHnEOt5l837X8sP/XeGizuSjWzKwtIyr3nDN5AudLBVQattqMOM/s5llpfXybspttxjtH0WR4uimpFGCVoZOgvr1PWU6eA21577LM+8sMdOIamEQsmEQVly7vJN3nTXPRSjPfLuBlJK8DOa6S7VQUyysEGYDeideDnj3WuEaoYrHeNJQWMrQKC1IklivPdorcmyDG8kQnBeByuewwZQFqo7cQStYDZBNTWt/RdBvJm4lVI1guAatI7QvSO4coJRHULksLNbjG1N1soJSkOc4m2gHPdJWh18PcZOriPKEaun7qOzPuHB+8+A7yNEIMvXqNjB1g3R0hFk2TC4fQ3yTbQugQzvC5SRSDul012laAqiJKK/f500cfjJDpFO8M7TNAVSCSaTEa5WSKmpptuYfAPTXmZw8wImXUEIQTWbUfWvkHe62CP3UAwu0D8Y0FQKqQJJEtM0zdzeR5FHMVPRIOA5KZV6mvHUh9KBj+Z5lukUihkGS2f8ZfzME3yC1i2yrIMPFq1aGKOx1Q7BlXgPWjmKyYCod5qqcngdIaI2CEO8/2Umf/SbVP1tuPEcun8BPb1JFEqSTBDckN7CIpOdc/jJFKd6NLpDPd3j4PIlfNLl+vkrDLfOI7Smrm8i8VgvaeUpqnWcw/c8zLS/g3OWKNI0Vc3Ju+6jKvYwps10+zrV4Cyt1iLDvQm+PKCuAioWBFvh7ZgGgXOCR156jJXWIlGUAIE4irh/4QTftn4f7+ic5FjoeCXTp6XfHm17JS64coKvSkJdgwjIOEZoRfSy70HpAiUcdT3DhxitImpnUekCJltGCogXDqFMihSauhoRixo520HaijhJUcv3EQlJdP5D6Eu/g7r8BDrRWBKs04y3z1P7mihPKRykvQ4dXdLOO4wOzvLU41/gdz7+DDJU9LcugcpxtqKaDAgmA9HlgVe+nm/+ptcTIbCN5cTxdVYWF+iu3I1QAlsOCbpLWQdWj99NOa3Yu/AYjYM4XwcvqEMJSZfewgrL7fRPgqGv37iH1588RXspRbUcD+adC0sq29b6Rz4V7Pu/8zHZd3cpE2OHM1Se49MuwY/ROkEuniGIhjC5gTc5yIZ69zq2vU7SjondhCAO4/0MnS7gxteoywLZ1PhZhZtA0u4SnflGbj35bxGTAdpUVM9/mFnrfjYefCvDrfMkoxGVjxle/jLIhKW1Y8h6hknX+cxTH+d1r3oJUfsQ5fA25aykvXYYvGbc32f92FGKcsyjjz7MyXvu5sIzj/PgKx7BCMd4+wpLh45D3EWKHBsKsu4Scecupge32T3/WbpZQrSwSW0lB/sD9nYbrg33SY3goeWTnF7eIAgJUuKwAI/93HufDhrAT4cfkwvdH/LTEpHkWA9S5oQ0xvWv40JAq0CcL1FPrpLmGboVYURNaFrMakluwE1u06gFkt4x5HQL7wJpFuaTfhUjjCF/6NsZX34S6yPa6/fQ7q4zs5bl049SDg7w5IT2KWb7tzDZAq1Oj2vXDrixtc/O6DjT6ZAkyinrKVoaVGRJOofAzVDlAaIccezYSzl55LuYjq6jLAyufwXjStIswTYjTJwz2r9CNR3hgNbiPYz7z+Grs1Dsc+6gYFDWuAAqMjywdhR0yqSc0mrFqJDTXu/9+8H6P/rP774hq+ofkLVi4TWiqvFeImRM89C7kIkhypepqz2EjjBRhtSL2OAIOsIHSXFwHZX1EMUQJxSz288RhERrj0rWCcwn/SbqMfVtqnpKJROitMeNpz6AEBqvEraf/wiLax3SNMdOBhyMLPsTz9nzW3zt+a/RygRra6tM+3ukWUzZRAQVEfmCenqAinoMb14gXz5FlrUJkwGTc5/DvvhpxOwK7tazhPYK2IZ8YY0gR8RJF6EU7c5RxpMt9maSTz79ebTWtKM2D6zeiw0FURKjVASCcYT54fd//LlaAiTf+9GJbaLfD8MRQc6tbhkEzeprSI49iJASfI3ULfxsjIwXkTpCaEOwFUkSkK4AYGZneAutzdcR5zlR1kLFGcHkRO1DiCjQWcpZO36Uxdzhmppb585x+ZnPcfnZJ/nVf/dFRkUK8Qr96ZTZ/g3irE1V11gCUhuS9iIyW8Ala4xH+wx3byOyHunSCeJ8hSzPKLe/zPT2JfpP/R5cfZbxlbMUt26g5QSBoqwLyukO5cFtJvs3kDrDiYI4a7GY1sQ6ns+Kg2Y6mSKQeB+QxmKS+Pe/9Ud/dfKnMtLNZPQrZTEiuBp8hTdd9NVPU73wJN7peelHAhcgBIPQGqQhEiWumWAWDxMAPxlRDLexAUx2HCGWsfWQ8bWn2L7yVaI4p5UrTNrFIkgWlzn9tnfjqpKvPPMML1wf8P4PfJLd/hCjM84/92We/NznOH7mbhpbc2R9ARN3aC8dBuG5cX2Hpz7zWYrxBOIepr1EtrSJThLcdId0ZY3paEDRSPyRN+NPfw9Bdmkvn0RGC0xGjuHOWab9GxTjA2zj2RnMrfxISw61F3HlCEnACYFzHlcVv/If5ANlK/84E3vJjnZOBpOjbIWXIK58CXH0OFQBFXeQrmFycInW6kkkgqqaEXcO4Zk7wB6FDlO0CdTCo5jRjC8RJluY1gaz0pJ3jiG4istzqCccPnYaWd6m4llefe8KTbTBL773/2Ry6yY3JiMaK3j0lfcjPDS1ZzCcEsKUWRn44G9/nOFowMOvfoSNdImm3CXSBpsdJtFtXCsl2f8OmF5j4d7Xki1tMN15EesC08kBC8fup56sM94/z3T3HE1wbOQaoySOhluTq5yJl8iDwM803stLjR5+/D8AMP+hj7niXzz63mCin6aaYMsBJtGErc/jw3cQdBcrFPHqKcY3z8LqKbwMKJXhxgO8cHid01o7Q9ZdxbsSEWqCKxFEmM46hEBZVLR6y0iTkLTXqcsSHbdZPvFKIlWz2NNsHcy40n6AL966TqfX4Z3f+bc4udllbAUfe+zLnLi4xzN//CyNzxju7/Fd3/0t9JZXmQ1v0Gp1qasxoaxRkaKROXrzNHnRJURtnFRMmyk0AhUfYnDrq6ydeBAnHXFrhZ1rT7G106emJjJQR1DpHIcDG6hH9Xvf/ZMfdv/RhKqO0n8TIvWPCH7FNw0+CAgVYTZDdA6ho4wQGpLlE9SDq5juUZpyiswWoBoilMDb6TzchcFOtojubEBN3VBNrpOIGNdUBLlAkAVEgdpWGK3oLG1SNp5sER468hBvfvPL8E3D4VP3MB7d5o2P7vCh3/wQly5uQWRYXYR3/uD38/JXPMBCr8Perav4sEjU3kRFQ1Q1wmbL9I5l1NUxTJwSXI2SyxR7X4T2CZI05+DWVymHl9jtb5NGOT7K0UYRx6C04KDY5tBsHYnY1Sb75T/zuTH2Z1/7o9S8JwRP0BluOqBcfSXxt/z3mPbS/AERkxlZp4X3BskY24xpaBGnXexkSDAxk4PLdNfuQalANT7ANQFbThBaYm1D3s4opyVpmjG89sd4nSK7J3CzMSbLUUbRVDWjnXNIs0zSWWLv5lfoLrTZvrmLqycomRAvHiFMrnLsZe+gGOzTjLeJeptE2lONb2Pax9m9/lVUsLRW7qaxM4Rz7L/wW6SdNUynh1Nddi9/iYP9W4ybKe//wnMEA8pY8qyFRZE3kk219mPv+eUv/vM/80Yb5bs/G5L8KolCGEUl4OqLn6GeTajLKcGOEMJSNzVCeappgY4OI+2EpvHIbAGlNXm+jK8nIBTN8AbOOYrJHo0NJJ0VgukSddbAFVSj88wmE6hLOr2crNMlyVvEsWZx/S7aPYVohiyvbJIkGyRhypHjp4m0wlBTV57paEi2vIFMMupZH+vg6rOfwtuSvLuAMoEQalw5YjbbpnvXN1FJwWh/h2LnLO31kyyeegBvEirf4H3Au8Bd9givKU/yusW3Xc0X7/7ZP/dOJfEPPjKVndaPizhGuQPqSZ/zl4d87lf+JW50C2kWkEKjFQgq6uk+ttxHK4FuCprpAShF3F1DSo1rCqLeEbB93Pg6tr+LLRxeJtgApKvo1Ucw3WXypSVkkmPrGUFElGWB9aBNl6S3SbZ8ivbSMmmm8EiUgSTL6fTWmfW3UAo6iz1a7QWEgI3738547xyhrinHM6ajbYRJ5iEnodC6RYgCg+kAGfXwRUNVy/ljC2TgeHyEMyywmneJZtd+/B//5Pumf6FbvWTY+nXppx8jWIT36DiC2W1sXWLLKQJLqC2hHqKzlBC1EKZL4yrc9CbNrMAHhcPhqgEyXSDuLoIw1PU+zWQLUY9pRrepZlPyheMkJqcoZ5RVIEoiXHGbZnSDanAb39TYpp7nFqOc7vq9yP+ruzP7key66/jnLHepe6uruquml+lpj7fxOA6xBbFFBCgErDggEgUZyYoQCMLLCFnCQvETEgJhEwkpD0gEgxQ/RChRhMUW5MQZkViOcWIHeR/v4xn3TE9P9/RWe9VdzsZD+xUxtsN6/oCrez66D/ec3+/7+amU7tHjpElE+8gyzSzDz2a4wlCMd0niBnHeoJqOIWqRL56kGq1Tj0cE0ThslsyPINQKcawY9d/CsseLZ8+927/taKiIOEAa69Od5cW/veqsnPjNHwUR1L3eyGFwgkYzI+aA/XNv4E2FkgqhmoR4CRkOw4jCBdLGPHa2hatHmHJKpBKkq7HjA9K5o7RWT+Jnl4gSQah7NOa6ONND+AnpwiLTrbfZO/sUxqfIaJ7W4hrK7jCaTLD1lMOoACRzS6TNnNHBDq6YYewAqSJ8cFQ+UBtH3ND4Yog1Ff0rGwgdI2QDEYOOm1TVGGdKiv4GqtFBGoMRTSZkRJFACM+m2GVd9YfV7v69dz/w9fCe4q5/8uilwR/+wuLl6czePZ4/QtpsUA8vYmjRWfsJvKgJKkPUNVoZZOMIVgakaiNMD2VGOFsjGqtIZTHVlDhNaHRvRPgamS8h0CBSpqMh7ZU18DX4Go2gqmfErTVknJDqhLIqQAiSLMfaMQRDPRhycO4pirKmfewWgjc448HVxK0V6vEAb2virIueXyKgseMtmt016mrAcO9NQtVjPNxjWhX889MvsdXfQGtPUKCzmP3UnPriV1988n3lhR98fOfMqbtOHGNu6XaVZkgdU0/2aJ24g+BGyCg/7FKSliiZB1MgZISIIryew4sUb0pkqvA2UIwPSFprCBkRVEqQGlNNIGjKyZTOylESVWLKIagWwgfq6QGT0iN0TrvdQpgZ0/4uwUuyuTZ6/jray8eI8iWk8JTWouVh/bmYHRCqMcbOiGVCmgisKSimE2SaUG2/QSPPKYop3zvzEq9fvoCUgSoE0iwlSeKH//6hi1/8QM6EQfuG+6JG45lGI0dJCa6iGgxIqCi3z1C+ayaqhu9AnIHMUFELrRPixgIqa+FKi4oy4tYawnucFSTJHFoLEhUhtMGONzm4fB6RLGOcZ9zfojZTaqERZkCSK+J8DqtzfPA0V04i80XmV0/gnSeOE4LzCCGpvaSe9oiEZ657DXPdVWbFPkhJkIK62GO48QJxe4Xa7eCUpzQKpd4NhQuB1uoZqeR9H1g68bEvPFJGSXq3EPL84Qtq9s49h6sDSdQkbH+fycVz2CKAL4iYEaab6ETj3BBXT4nmlhAywgx3mRxsUVZTvK2QAlSiiHWgtXaCerjFeDyhuXIbrc4RYuXIsowoUmRpxnQ6wweFEDFmengtFaU5rc4xAtPDs/p4l1a7ewhDSsp6hifFzPaZTsaUVYGIDkMz06KiKhyvbfY43zuP0gJrPZGKzksl7/67L2+U/xkfdTVmiocefXl672due8wa+2uouFWNd3HRAq3lY8gkY3jx+0z7Q3Q6T9xqIUQNOiWUQ/z4IlXpSPMFvOkThptICsa9bappRZQtHDb/xDlxvkx/81XqYkbWWUVUe8ikhYwzgkwRoiT4Ct2YQwTB/vrLSKlI28voMCJppJTDIUEf/mYdbLxBc66NkAFTHryb9xA444g7q/S33+D85U2eOP8SzlucDZSl30x0etdjX9u5dDVsrgogwF9960zv1Gc+erouil+djoetrXOv0jx+B/MrNxKHCeVog3K8TZQfI5Lg/RipYmTjGFJqrJOH6fHGHJEylDtnCMYjkkXqwSWCyojzNqOts1SjHeqqZn75elAKWxp00sSakjiZR6UZZtZjcP55XNUjml9Cu0OzG2kTRIb1ge7yCQIGcNTViLS5SJo2KQYbJM0uF69s80/PPQ26xjuLM2rT1vGnnvxW/+zVcrlqgABfeezM/j0f6j4qTO/TZb/fubRXcd1Hfoq41UXWE0SS46zFWEdjbvXwq1EeO97FTseoJCfK55BSoLN5TPDIVHNw6RUAss4aOs2JhKKRNTBOELdW0bKmnvZIU8m4t02adyn7G/hql2K0zfzabZTFDO81TqR4YzGjbYQrcdYQ5SsIqalm+wSgLvepRj3eOfcs66MdkAFTR+erStz19HfGZ98Lk/cEEODr/7bR+8rnb3zkxPGjPzdvr1wz2i9pn7ydKFGgFTo5gisGGNqkzQ7WTFDxHLUdIYREpXOEoJHRAlHaJUhNZ6FzWGsQCq0aNDpH0Y0O1kyppmOS9lFUnIBIUTrFln0wBfHyreSLNyAITEf7zEYTmgtL6CzBlYbxpI8rLVJ6ss4xRgeX0Tpn3HuNN7ev8MSFV9FCcHl98Iwr7ad+eLq49F55vC97W+PUD3aSanrnkq4eXt78JsMfPY5oXE+2cBKpHEkeU+4+y3DrLMgWxBlZvoSKYszgMq4sIAiCLUnjjJC2UXGDSApmO68Qyh183Sdu5NTDywzWX8PXDh8COopQaQvRXEE60NkizYWj4BXOBzwa7yKi9gIiztl6+TGmswleCOKkibc1tWjxwvY6S0dvprfrHvbO3/nD75qd98NC8z6X/N3HS+CUeejjT4XdM18eXfhQOz++TKNzLcEUhNCg6L3NzvZbdE7+DDqNwTjKwSY61HDkFnScHoYQXRNCia09cd7FC4V1Cb4akC0dZ3awjatHJO0uwRrE7ABtDMYr3MxQSEl7+Til9QhTUoz38XZGM8vp3Phh2nNdlLNE2nBl7wo/uHgJmc8PG82F3/uXb+5+7YMIGBUfcD342MaZB+5sPjK58OzN49A9IbI2Sd7FFgeIJCdfu4HBlUvIqHkY2os0gYDOl3AywZMQpRng0VGOUBI37R8KZ72nkXewpjx8pnMY41FpmyhvIWSCCNDbfhUsRNIh/AgzeodysIEjI20foyh6jAZb1CLhnd6I8+Pt0zbw2T//wj88+UH3/4EBAjx4+sLgjz6++o3h+ktvvfLWpTusjOY7x28h6JgkXqDRbNHffJOqKnEG0vYqSIGZ7TPZeh1vLWl7HlMMSZtdgpeU4w0QCqmauOIy6CYiBFQUUQ1HJPkig8uv40xN3j2OjiLirEmUdUlb12Iqx2D/IiKKcBI2BiPe3LlycXuyd68Q8R986fe/0f9x7P3HAhDgz564wF/+6/qrn71p8vDW+beHc8sf/skQJ3kSHdaZYx2BnWKsII4sKE2kG9TjdRQW5KEYouztoLM2KpIkaQsZQdLo4LxF6BglNSoYSCLwJaP9LUSUkc0fPfQLljWoCFOXBF/i0y4Tr/f6hXqgZ6vP3/9bf/rCk99+/n+/yfzh+3+2dfKn7/kdfaR73+LStTcstht4Y7BB4x0kiSPKjmCFRFQls/1zpIvXo+OUuq6x0wN02kbakt7FF7HllKVbfwkVZTg7IziPsxWT3jbZwgrIjFhrZv0dpqNtssVrmPU23tmaFH9xZXD5q79+zx+P/k+q4P/6S59QwxDu+pU77//ttYXVTxsznqusImk0UTIgkzm01rhQ4KuCJE6pyhF1f5PKeForN2KLKbYek3aOMdhYp3O0C6rNpL9PsBUya1MVU4RwWGvHAvHtIO3fEOx3b7r9c/+lKvj/1mEEF57/x+Z6b++TL7z++C9/8udP/WK32TqBdTKJNWkW4Z3A2gJ0jsTBuzfDoRhTjMYEZ6iFoNW9Fh9KTBEwduzz5pFz/YvPPYGqTod0+Xs3f+xz/3+GEfxH69KFN4UdX1kOTn+0lde3BmdvQmfXiXjhKKE+ghk1g2wmCoezVeWKg0mAfZ+sbsdpemE82X07ldkr48nmC6YwOx/5xG/8j4zD+HfczXCNHF8WQgAAAABJRU5ErkJggg=="></image></svg>
+            </symbol>
+            <symbol id="icon-thumb-up">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M1 21h4V9H1v12Zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-1.91l-.01-.01L23 10Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="ugc-icon-check-circle">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M2 12C2 6.48 6.48 2 12 2C17.52 2 22 6.48 22 12C22 17.52 17.52 22 12 22C6.48 22 2 17.52 2 12ZM5 12L10 17L19 8L17.59 6.58L10 14.17L6.41 10.59L5 12Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-time">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M11.99 22C6.47 22 2 17.52 2 12C2 6.48 6.47 2 11.99 2C17.52 2 22 6.48 22 12C22 17.52 17.52 22 11.99 22ZM12 4C7.58 4 4 7.58 4 12C4 16.42 7.58 20 12 20C16.42 20 20 16.42 20 12C20 7.58 16.42 4 12 4ZM12.5 17H11V11L16.25 7.85L17 9.08L12.5 11.75V17Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-star">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M12 17.27L18.18 21L16.54 13.97L22 9.24L14.81 8.63L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+            <symbol id="icon-star-half">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                <path fill-rule="evenodd" d="M22 9.74L14.81 9.12L12 2.5L9.19 9.13L2 9.74L7.46 14.47L5.82 21.5L12 17.77L18.18 21.5L16.55 14.47L22 9.74ZM12 15.9V6.6L13.71 10.64L18.09 11.02L14.77 13.9L15.77 18.18L12 15.9Z" clip-rule="evenodd"></path></svg>
+            </symbol>
+        </defs></svg> <!-- done svg resources -->
+        <!-- Google Tag Manager (Testing) -->
+        <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-P3X3VT7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager -->
+        <header id="header_1-0" class="comp header mntl-header mntl-header--magazine mntl-header--open-search-bar mntl-header--myr" role="banner" data-collapsible="true" data-tracking-container="true">
+            <a href="#main" rel="nocaes" class="mntl-skip-to-content mntl-text-link" id="mntl-skip-to-content_1-0" data-tracking-container="true"><span class="link__wrapper">Skip to content</span></a>
+            <div class="mntl-header__menu-top">
+                <div class="mntl-header__menu-button-container">
+                    <div class="mntl-header__menu-button-inner">
+                        <button class="mntl-header__menu-button" aria-label="Main menu for Allrecipes"><svg class="icon icon-menu mntl-header__menu-icon">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-menu" href="#icon-menu"></use></svg> <svg class="icon icon-close mntl-header__close-icon">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use></svg></button>
+                    </div>
+                </div>
+                <div class="mntl-header__logo-wrapper">
+                    <a href="/" rel="home nocaes" id="header-logo_1-0" aria-label="Visit Allrecipes' homepage">
+                    <div class="is-screenreader-only">
+                        Allrecipes
+                    </div><svg class="icon icon-logo">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo" href="#icon-logo"></use></svg></a>
+                </div>
+                <div id="recipe-utility-nav_1-0" class="comp recipe-utility-nav mm-recipes-utility-nav mntl-block">
+                    <div id="mm-recipes-utility-nav__favorite_1-0" class="comp mm-recipes-utility-nav__favorite mm-myrecipes-favorite" data-tracking-subtype="Sticky - Save" aria-expanded="false" data-tracking-subcategory="Sticky" data-tracking-container="true" data-tracking-category="Recipe Utility Navigation">
+                        <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="false" data-doc-id="11832010" data-doc-heading="Hot Honey Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/KbidNXbhDzZzZjJ50E73S5FhXo4=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg" data-tracking-on="recipe-detail" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><span>Save</span> <svg class="icon icon-favorite">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                    </div><button id="mm-recipes-utility-nav__rate_1-0" class="comp mm-recipes-utility-nav__rate mm-recipes-rate-button mntl-button" data-tracking-subtype="Sticky - Rate" data-tracking-target-url="https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010" data-tracking-subcategory="Sticky" data-tracking-container="true" data-unauthflow-enabled="true" data-tracking-category="Recipe Utility Navigation" aria-label="Rate It">Rate <svg class="icon icon-star-empty mntl-button__icon">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty" href="#icon-star-empty"></use></svg></button>
+                </div>
+                <div id="mntl-utility-nav_1-0" class="comp mntl-utility-nav">
+                    <svg style="width:0;height:0;position:absolute;" aria-hidden="true" focusable="false">
+                    <lineargradient id="myrecipes-gradient" x1="15.8617" y1="11.7222" x2="3.80154" y2="1.08372" gradientunits="userSpaceOnUse">
+                        <stop offset="0.36291" stop-color="#FF597A"></stop>
+                        <stop offset="0.572672" stop-color="#FF29C4"></stop>
+                    </lineargradient></svg>
+                    <ul class="mntl-utility-nav__list text-utility-200">
+                        <li class="loc search-bar mntl-utility-nav__search mntl-utility-nav__partial-menu-item">
+                            <div id="mntl-search-form_1-0" class="comp mntl-search-form text-utility-300 mntl-search-form--mobile" data-tracking-container="true">
+                                <button class="mntl-search-form__icon-button" aria-label="Search"><svg class="icon icon-search">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search" href="#icon-search"></use></svg></button>
+                                <form class="mntl-search-form__form" role="search" action="/search" method="get">
+                                    <div class="mntl-search-form__input-group input-group">
+                                        <label for="mntl-search-form__search-input" class="mntl-search-form__label text-utility-300-prominent">Search</label> <input type="text" name="q" id="mntl-search-form__search-input" class="mntl-search-form__input" placeholder="What are you looking for?" required="required" value="" autocomplete="off" /> <button class="mntl-search-form__button text-label-300 button--contained-standard-square" aria-label="Click to search"><svg class="icon icon-search">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search" href="#icon-search"></use></svg></button> <button class="mntl-search-form__close-button" aria-label="Close search bar"><svg class="icon icon-close">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use></svg></button>
+                                    </div>
+                                </form>
+                                <div class="loc validation-message mntl-search-form__validation">
+                                    <div id="mntl-search-form__validation-message_1-0" class="comp mntl-search-form__validation-message mntl-message-banner--error mntl-message-banner is-hidden mntl-message-banner--error" data-close-class="is-hidden" role="alert">
+                                        <svg class="icon icon-error mntl-message-banner__prefix-icon mntl-message-banner__icon">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-error" href="#icon-error"></use></svg> <span class="text-utility-300-prominent mntl-message-banner__text">Please fill out this field.</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="mntl-search-form--open_1-0" class="comp mntl-search-form--open mntl-search-form text-utility-300" data-click-tracked="false" data-tracking-container="true">
+                                <form class="mntl-search-form--open__form" role="search" action="/search" method="get">
+                                    <div class="mntl-search-form__input-group input-group">
+                                        <label for="mntl-search-form--open__search-input" class="mntl-search-form__label is-vishidden">Search the site</label> <input type="text" name="q" id="mntl-search-form--open__search-input" class="mntl-search-form__input" placeholder="Find a recipe or ingredient" required="required" value="" autocomplete="off" /> <button class="mntl-search-form__button text-label-300 button--contained-standard" aria-label="Click to search"><svg class="icon icon-search">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search" href="#icon-search"></use></svg></button>
+                                    </div>
+                                </form>
+                                <div class="loc validation-message mntl-search-form__validation">
+                                    <div id="mntl-search-form__validation-message_2-0" class="comp mntl-search-form__validation-message mntl-message-banner--error mntl-message-banner is-hidden mntl-message-banner--error" data-close-class="is-hidden" role="alert">
+                                        <svg class="icon icon-error mntl-message-banner__prefix-icon mntl-message-banner__icon">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-error" href="#icon-error"></use></svg> <span class="text-utility-300-prominent mntl-message-banner__text">Please fill out this field.</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </li>
+                        <li class="mntl-utility-nav__signin mntl-utility-nav__signin--login mntl-utility-nav__full-menu-item">
+                            <a href="https://www.allrecipes.com/authentication/login?regSource=3675&amp;relativeRedirectUrl=%2Fhot-honey-brussels-sprouts-recipe-11832010" rel="noopener nofollow nocaes" data-tracking-category="Header" data-tracking-subcategory="Authentication" id="login" data-tracking-subtype="Log In" class="mntl-utility-nav__sublist-link" data-tracking-container="true"><svg class="icon icon-account">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account" href="#icon-account"></use></svg> <span class="mntl-utility-nav__sublist-link-text">Log In</span></a>
+                        </li>
+                        <li class="mntl-utility-nav__account mntl-utility-nav__full-menu-item mntl-utility-nav__list-item state-sign-out">
+                            <button class="mntl-utility-nav__title text-utility-200" aria-label="My Account Button"><span class="mntl-utility-nav__title-text">My Account</span> <svg class="icon icon-caret_down">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-caret_down" href="#icon-caret_down"></use></svg></button>
+                            <div class="mntl-utility-nav__sublist-container">
+                                <ul class="mntl-utility-nav__link-list">
+                                    <li class="mntl-utility-nav__sublist-list-item">
+                                        <a href="/account/add-recipe" rel="nofollow nocaes" class="mntl-utility-nav__sublist-link">Add a Recipe</a>
+                                    </li>
+                                    <li class="mntl-utility-nav__sublist-list-item mntl-utility-nav__sublist-list-item--savedItems">
+                                        <a href="https://www.myrecipes.com/favorites" target="_blank" rel="nofollow noopener nocaes" class="mntl-utility-nav__sublist-link myr-login-trigger" data-myrecipes-regsource="vpgyqb">Saved Recipes &amp; Collections</a>
+                                    </li>
+                                    <li class="mntl-utility-nav__sublist-list-item">
+                                        <a href="/account/settings" rel="nofollow nocaes" class="mntl-utility-nav__sublist-link">Account Settings</a>
+                                    </li>
+                                    <li class="mntl-utility-nav__sublist-list-item">
+                                        <a href="https://support.people.inc/hc/en-us/categories/360003648613-Allrecipes" target="_blank" rel="nofollow noopener nocaes" class="mntl-utility-nav__sublist-link">Help</a>
+                                    </li>
+                                    <li class="mntl-utility-nav__sublist-list-item">
+                                        <a href="https://www.allrecipes.com/authentication/logout?relativeRedirectUrl=%2Fhot-honey-brussels-sprouts-recipe-11832010" rel="nofollow nocaes" class="mntl-utility-nav__sublist-link">Log Out</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="loc newsletter-link-wrapper mntl-utility-nav__newsletter mntl-utility-nav__full-menu-item">
+                            <a href="#" rel="nocaes" data-tracking-metadata-location="header" data-a11y-dialog-show="newsletter-dialog-header" role="button" data-tracking-subtype="Signup CTA" data-tracking-target-url="null" data-tracking-metadata-auth="false" id="mntl-newsletter-dialog--header-link_1-0" class="mntl-newsletter-dialog--header-link dialog-link mntl-text-link" data-tracking-category="Newsletters" data-tracking-container="true"><span class="link__wrapper">Newsletters</span></a>
+                        </li>
+                        <li class="mntl-utility-nav__sweepstakes mntl-utility-nav__full-menu-item">
+                            <a href="/sweepstakes" rel="nocaes">Sweepstakes</a>
+                        </li>
+                        <li class="mntl-utility-nav__signin--myr mntl-utility-nav__full-menu-item mntl-utility-nav__list-item myr-login">
+                            <a class="mntl-utility-nav__sublist-link myr-login-trigger" href="javascript:void(0)" aria-label="Trigger interstitial modal to log in to MyRecipes" data-regsource="vpgyqb" data-login-text="Get Started"><svg class="icon save-icon-favorite icon-myr-favorite">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use></svg> <svg class="icon icon-myr-logo">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-myr-logo" href="#icon-myr-logo"></use></svg></a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="mntl-header__nav-panel">
+                <div class="mntl-header__nav-panel-top">
+                    <button class="mntl-header__nav-panel-button" aria-label="Close menu for Allrecipes"><svg class="icon icon-close mntl-header__nav-panel-close-icon">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use></svg></button>
+                    <div class="mntl-header__nav-panel-logo">
+                        <a href="/" rel="home nocaes" id="header-logo_1-0" aria-label="Visit Allrecipes' homepage">
+                        <div class="is-screenreader-only">
+                            Allrecipes
+                        </div><svg class="icon icon-logo">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo" href="#icon-logo"></use></svg></a>
+                    </div>
+                </div>
+                <nav id="mntl-fullscreen-nav_1-0" class="comp mntl-fullscreen-nav" role="navigation" data-tracking-container="true" aria-label="Header">
+                    <div id="mntl-fullscreen-nav__search_1-0" class="comp mntl-fullscreen-nav__search mntl-search-form text-utility-300" data-tracking-container="true">
+                        <form class="mntl-fullscreen-nav__search__form" role="search" action="/search" method="get">
+                            <div class="mntl-search-form__input-group input-group">
+                                <label for="mntl-fullscreen-nav__search__search-input" class="mntl-search-form__label text-utility-300-prominent">Search</label> <input type="text" name="q" id="mntl-fullscreen-nav__search__search-input" class="mntl-search-form__input" placeholder="What are you looking for?" required="required" value="" autocomplete="off" /> <button class="mntl-search-form__button text-label-300 button--contained-standard-square" aria-label="Click to search"><svg class="icon icon-search">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search" href="#icon-search"></use></svg></button>
+                            </div>
+                        </form>
+                        <div class="loc validation-message mntl-search-form__validation">
+                            <div id="mntl-search-form__validation-message_3-0" class="comp mntl-search-form__validation-message mntl-message-banner--error mntl-message-banner is-hidden mntl-message-banner--error" data-close-class="is-hidden" role="alert">
+                                <svg class="icon icon-error mntl-message-banner__prefix-icon mntl-message-banner__icon">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-error" href="#icon-error"></use></svg> <span class="text-utility-300-prominent mntl-message-banner__text">Please fill out this field.</span>
+                            </div>
+                        </div>
+                    </div>
+                    <ul class="mntl-fullscreen-nav__list">
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/recipes/17562/dinner/" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-dinners-mntl-fullscreen-nav">Dinners <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-dinners-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">Dinners</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/17057/everyday-cooking/more-meal-ideas/5-ingredients/main-dishes/" rel="nocaes">5-Ingredient Dinners</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/15436/everyday-cooking/one-pot-meals/" rel="nocaes">One-Pot Meals</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/1947/everyday-cooking/quick-and-easy/" rel="nocaes">Quick &amp; Easy</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/455/everyday-cooking/more-meal-ideas/30-minute-meals/" rel="nocaes">30-Minute Meals</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/17889/everyday-cooking/family-friendly/family-dinners/" rel="nocaes">Family Dinners</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/94/soups-stews-and-chili/" rel="nocaes">Soups, Stews &amp; Chili</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/16099/everyday-cooking/comfort-food/" rel="nocaes">Comfort Food</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/80/main-dish/" rel="nocaes">Main Dishes</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/22992/everyday-cooking/sheet-pan-dinners/" rel="nocaes">Sheet Pan Dinners</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-label-300">
+                                        <a href="https://www.allrecipes.com/recipes/17562/dinner/" rel="nocaes">View All</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/recipes-a-z-6735880" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-meals-mntl-fullscreen-nav">Meals <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-meals-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">Meals</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/78/breakfast-and-brunch/" rel="nocaes">Breakfast &amp; Brunch</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/17561/lunch/" rel="nocaes">Lunch</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/84/healthy-recipes/" rel="nocaes">Healthy</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/76/appetizers-and-snacks/" rel="nocaes">Appetizers &amp; Snacks</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/96/salad/" rel="nocaes">Salads</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/81/side-dish/" rel="nocaes">Side Dishes</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/16369/soups-stews-and-chili/soup/" rel="nocaes">Soups</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/156/bread/" rel="nocaes">Bread</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/77/drinks/" rel="nocaes">Drinks</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/79/desserts/" rel="nocaes">Desserts</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-label-300">
+                                        <a href="https://www.allrecipes.com/recipes-a-z-6735880" rel="nocaes">View All</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/ingredients-a-z-6740416" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-ingredients-mntl-fullscreen-nav">Ingredients <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-ingredients-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">Ingredients</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/201/meat-and-poultry/chicken/" rel="nocaes">Chicken</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/200/meat-and-poultry/beef/" rel="nocaes">Beef</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/205/meat-and-poultry/pork/" rel="nocaes">Pork</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/93/seafood/" rel="nocaes">Seafood</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/95/pasta-and-noodles/" rel="nocaes">Pasta</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/1058/fruits-and-vegetables/fruits/" rel="nocaes">Fruits</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/1059/fruits-and-vegetables/vegetables/" rel="nocaes">Vegetables</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-label-300">
+                                        <a href="https://www.allrecipes.com/ingredients-a-z-6740416" rel="nocaes">View All</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/recipes/85/holidays-and-events/" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-occasions-mntl-fullscreen-nav">Occasions <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-occasions-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">Occasions</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/15335/holidays-and-events/thanksgiving/leftovers/" rel="nocaes">Thanksgiving Leftovers</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/841/holidays-and-events/christmas/desserts/christmas-cookies/" rel="nocaes">Christmas Cookies</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/190/holidays-and-events/hanukkah/" rel="nocaes">Hanukkah Recipes</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/187/holidays-and-events/christmas/" rel="nocaes">Christmas Recipes</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-label-300">
+                                        <a href="https://www.allrecipes.com/recipes/85/holidays-and-events/" rel="nocaes">View All</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/cuisine-a-z-6740455" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-cuisines-mntl-fullscreen-nav">Cuisines <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-cuisines-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">Cuisines</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/728/world-cuisine/latin-american/mexican/" rel="nocaes">Mexican</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/723/world-cuisine/european/italian/" rel="nocaes">Italian</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/695/world-cuisine/asian/chinese/" rel="nocaes">Chinese</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/233/world-cuisine/asian/indian/" rel="nocaes">Indian</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/722/world-cuisine/european/german/" rel="nocaes">German</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/731/world-cuisine/european/greek/" rel="nocaes">Greek</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/696/world-cuisine/asian/filipino/" rel="nocaes">Filipino</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/699/world-cuisine/asian/japanese/" rel="nocaes">Japanese</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-label-300">
+                                        <a href="https://www.allrecipes.com/cuisine-a-z-6740455" rel="nocaes">View All</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/kitchen-tips/" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-kitchen-tips-mntl-fullscreen-nav">Kitchen Tips <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-kitchen-tips-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">Kitchen Tips</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/22882/everyday-cooking/instant-pot/" rel="nocaes">Instant Pot</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/23070/everyday-cooking/cookware-and-equipment/air-fryer/" rel="nocaes">Air Fryer</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/253/everyday-cooking/slow-cooker/" rel="nocaes">Slow Cooker</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/food-news-trends/product-reviews/" rel="nocaes">Our Favorite Products</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/88/bbq-grilling/" rel="nocaes">BBQ &amp; Grilling</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/recipes/17583/everyday-cooking/cookware-and-equipment/" rel="nocaes">Cooking by Equipment</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/kitchen-tips/all-about-ingredients/substitutions/" rel="nocaes">Ingredient Substitutions</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-label-300">
+                                        <a href="https://www.allrecipes.com/kitchen-tips/" rel="nocaes">View All</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/food-news-trends/" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-news-mntl-fullscreen-nav">News <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-news-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">News</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/food-news-trends/celebrity-entertainment/" rel="nocaes">Celebrity &amp; Entertainment</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/fast-food-8672832" rel="nocaes">Fast Food</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/grocery-8672835" rel="nocaes">Grocery</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/food-news-trends/recalls/" rel="nocaes">Recalls</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/food-news-trends/trends/" rel="nocaes">Trends</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-label-300">
+                                        <a href="https://www.allrecipes.com/food-news-trends/" rel="nocaes">View All</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/black-friday-cyber-monday-deals-8748167" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-black-friday-mntl-fullscreen-nav">Black Friday <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-black-friday-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">Black Friday</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/kitchen-tips/how-to/dinner-fix/" rel="nocaes">Dinner Fix</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/kitchen-tips/how-to/sweet-spot/" rel="nocaes">Sweet Spot</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/kitchen-tips/in-the-kitchen/" rel="nocaes">In the Kitchen</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/black-friday-cyber-monday-deals-8748167" rel="nocaes">Black Friday</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="https://www.allrecipes.com/about-us-6648102" class="mntl-fullscreen-nav__title text-label-300" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-about-us-mntl-fullscreen-nav">About Us <svg class="icon icon-chevron">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></a>
+                            <div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-about-us-mntl-fullscreen-nav">
+                                <div class="mntl-fullscreen-nav__sublist-header">
+                                    <button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="mntl-fullscreen-nav__sublist-header-text text-title-200">About Us</span>
+                                </div>
+                                <ul class="mntl-fullscreen-nav__sublist">
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/about-us-6648102" rel="nocaes">About Allrecipes</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/allstars-8661275" rel="nocaes">Allstars</a>
+                                    </li>
+                                    <li class="mntl-fullscreen-nav__sublist-item text-utility-200">
+                                        <a href="https://www.allrecipes.com/article/how-to-submit-recipes/" rel="nocaes">How to Add a Recipe</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="mntl-fullscreen-nav__list-item">
+                            <a href="#" rel="nofollow nocaes" data-iframe="iframe?container=alr_cxt_r1_012025&amp;utm_source=allrecipes.com&amp;utm_medium=owned&amp;utm_campaign=ad508arr1w3275" class="mntl-fullscreen-nav__link text-label-300 openContextual">GET THE MAGAZINE</a>
+                        </li>
+                    </ul>
+                    <div id="mntl-fullscreen-nav__utility-nav_1-0" class="comp mntl-fullscreen-nav__utility-nav mntl-utility-nav">
+                        <svg style="width:0;height:0;position:absolute;" aria-hidden="true" focusable="false">
+                        <lineargradient id="myrecipes-gradient" x1="15.8617" y1="11.7222" x2="3.80154" y2="1.08372" gradientunits="userSpaceOnUse">
+                            <stop offset="0.36291" stop-color="#FF597A"></stop>
+                            <stop offset="0.572672" stop-color="#FF29C4"></stop>
+                        </lineargradient></svg>
+                        <ul class="mntl-utility-nav__list text-utility-200">
+                            <li class="mntl-utility-nav__signin mntl-utility-nav__signin--login mntl-utility-nav__full-menu-item">
+                                <a href="https://www.allrecipes.com/authentication/login?regSource=3675&amp;relativeRedirectUrl=%2Fhot-honey-brussels-sprouts-recipe-11832010" rel="noopener nofollow nocaes" data-tracking-category="Header" data-tracking-subcategory="Authentication" id="login" data-tracking-subtype="Log In" class="mntl-utility-nav__sublist-link" data-tracking-container="true"><svg class="icon icon-account">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account" href="#icon-account"></use></svg> <span class="mntl-utility-nav__sublist-link-text">Log In</span></a>
+                            </li>
+                            <li class="mntl-utility-nav__account mntl-utility-nav__full-menu-item mntl-utility-nav__list-item state-sign-out">
+                                <button class="mntl-utility-nav__title text-utility-200" aria-label="My Account Button"><span class="mntl-utility-nav__title-text">My Account</span> <svg class="icon icon-chevron">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></button>
+                                <div class="mntl-utility-nav__sublist-container">
+                                    <div class="mntl-utility-nav__sublist-header">
+                                        <button class="mntl-utility-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="text-title-200">My Account</span>
+                                    </div>
+                                    <ul class="mntl-utility-nav__link-list">
+                                        <li class="mntl-utility-nav__sublist-list-item">
+                                            <a href="/account/add-recipe" rel="nofollow nocaes" class="mntl-utility-nav__sublist-link">Add a Recipe</a>
+                                        </li>
+                                        <li class="mntl-utility-nav__sublist-list-item mntl-utility-nav__sublist-list-item--savedItems">
+                                            <a href="https://www.myrecipes.com/favorites" target="_blank" rel="nofollow noopener nocaes" class="mntl-utility-nav__sublist-link myr-login-trigger" data-myrecipes-regsource="vpgyqb">Saved Recipes &amp; Collections</a>
+                                        </li>
+                                        <li class="mntl-utility-nav__sublist-list-item">
+                                            <a href="/account/settings" rel="nofollow nocaes" class="mntl-utility-nav__sublist-link">Account Settings</a>
+                                        </li>
+                                        <li class="mntl-utility-nav__sublist-list-item">
+                                            <a href="https://support.people.inc/hc/en-us/categories/360003648613-Allrecipes" target="_blank" rel="nofollow noopener nocaes" class="mntl-utility-nav__sublist-link">Help</a>
+                                        </li>
+                                        <li class="mntl-utility-nav__sublist-list-item">
+                                            <a href="https://www.allrecipes.com/authentication/logout?relativeRedirectUrl=%2Fhot-honey-brussels-sprouts-recipe-11832010" rel="nofollow nocaes" class="mntl-utility-nav__sublist-link">Log Out</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
+                            <li class="mntl-utility-nav__magazine mntl-utility-nav__full-menu-item mntl-utility-nav__list-item">
+                                <button class="mntl-utility-nav__title text-utility-200"><span>Magazine</span> <svg class="icon icon-chevron">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg></button>
+                                <div class="mntl-utility-nav__sublist-container">
+                                    <div class="mntl-utility-nav__sublist-header">
+                                        <button class="mntl-utility-nav__sublist-back-button" role="button" aria-label="Back to main menu"><svg class="icon icon-arrow-left">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use></svg></button> <span class="text-title-200">Magazine</span>
+                                    </div>
+                                    <ul class="mntl-utility-nav__link-list">
+                                        <li class="mntl-utility-nav__sublist-list-item">
+                                            <a href="https://w1.buysub.com/servlet/CSGateway?cds_mag_code=ALR" target="_blank" rel="noopener nofollow nocaes" class="mntl-utility-nav__sublist-link">Manage Your Subscription</a>
+                                        </li>
+                                        <li class="mntl-utility-nav__sublist-list-item">
+                                            <a href="https://www.magazines.com/customer-care" target="_blank" rel="noopener nofollow nocaes" class="mntl-utility-nav__sublist-link">Get Help</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
+                            <li class="loc newsletter-link-wrapper mntl-utility-nav__newsletter mntl-utility-nav__full-menu-item">
+                                <a href="#" rel="nocaes" data-tracking-metadata-location="header" data-a11y-dialog-show="newsletter-dialog-header" role="button" data-tracking-subtype="Signup CTA" data-tracking-target-url="null" data-tracking-metadata-auth="false" id="mntl-newsletter-dialog--header-link_2-0" class="mntl-newsletter-dialog--header-link dialog-link mntl-text-link" data-tracking-category="Newsletters" data-tracking-container="true"><span class="link__wrapper">Newsletters</span></a>
+                            </li>
+                            <li class="mntl-utility-nav__sweepstakes mntl-utility-nav__full-menu-item">
+                                <a href="/sweepstakes" rel="nocaes">Sweepstakes</a>
+                            </li>
+                            <li class="mntl-utility-nav__signin--myr mntl-utility-nav__full-menu-item mntl-utility-nav__list-item myr-login">
+                                <a class="mntl-utility-nav__sublist-link myr-login-trigger" href="javascript:void(0)" aria-label="Trigger interstitial modal to log in to MyRecipes" data-regsource="vpgyqb" data-login-text="Get Started"><svg class="icon save-icon-favorite icon-myr-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use></svg> <svg class="icon icon-myr-logo">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-myr-logo" href="#icon-myr-logo"></use></svg></a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div id="mntl-fullscreen-nav__social-nav_1-0" class="comp mntl-fullscreen-nav__social-nav allrecipes-social-nav mntl-social-nav" data-tracking-container="true">
+                        <div class="social-nav__title">
+                            Follow Us
+                        </div>
+                        <ul class="social-nav__list">
+                            <li class="social-nav__item social-nav__item--facebook">
+                                <a href="https://www.facebook.com/allrecipes" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--facebook" aria-label="Visit Allrecipes's Facebook"><svg class="icon icon-facebook social-nav__icon">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook" href="#icon-facebook"></use></svg></a>
+                            </li>
+                            <li class="social-nav__item social-nav__item--instagram">
+                                <a href="https://www.instagram.com/allrecipes/" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--instagram" aria-label="Visit Allrecipes's Instagram"><svg class="icon icon-instagram social-nav__icon">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram" href="#icon-instagram"></use></svg></a>
+                            </li>
+                            <li class="social-nav__item social-nav__item--pinterest">
+                                <a href="https://www.pinterest.com/allrecipes/" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--pinterest" aria-label="Visit Allrecipes's Pinterest"><svg class="icon icon-pinterest social-nav__icon">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest" href="#icon-pinterest"></use></svg></a>
+                            </li>
+                            <li class="social-nav__item social-nav__item--tiktok">
+                                <a href="https://www.tiktok.com/@allrecipes" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--tiktok" aria-label="Visit Allrecipes's TikTok"><svg class="icon icon-tiktok social-nav__icon">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-tiktok" href="#icon-tiktok"></use></svg></a>
+                            </li>
+                            <li class="social-nav__item social-nav__item--youtube">
+                                <a href="https://www.youtube.com/user/allrecipes/videos" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--youtube" aria-label="Visit Allrecipes's YouTube"><svg class="icon icon-youtube social-nav__icon">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-youtube" href="#icon-youtube"></use></svg></a>
+                            </li>
+                            <li class="social-nav__item social-nav__item--flipboard">
+                                <a href="https://flipboard.com/@Allrecipes" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--flipboard" aria-label="Visit Allrecipes's Flipboard"><svg class="icon icon-flipboard social-nav__icon">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-flipboard" href="#icon-flipboard"></use></svg></a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+            </div>
+            <nav id="mntl-header-nav_1-0" class="comp mntl-header-nav" role="navigation" aria-label="Header">
+                <div class="mntl-header-nav__list-wrapper">
+                    <ul class="mntl-header-nav__list">
+                        <li class="mntl-header-nav__list-item">
+                            <a href="https://www.allrecipes.com/recipes/17562/dinner/" rel="nocaes">Dinners</a>
+                            <ul class="mntl-header-nav__sublist">
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/17057/everyday-cooking/more-meal-ideas/5-ingredients/main-dishes/" rel="nocaes">5-Ingredient Dinners</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/15436/everyday-cooking/one-pot-meals/" rel="nocaes">One-Pot Meals</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/1947/everyday-cooking/quick-and-easy/" rel="nocaes">Quick &amp; Easy</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/455/everyday-cooking/more-meal-ideas/30-minute-meals/" rel="nocaes">30-Minute Meals</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/17889/everyday-cooking/family-friendly/family-dinners/" rel="nocaes">Family Dinners</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/94/soups-stews-and-chili/" rel="nocaes">Soups, Stews &amp; Chili</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/16099/everyday-cooking/comfort-food/" rel="nocaes">Comfort Food</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/80/main-dish/" rel="nocaes">Main Dishes</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/22992/everyday-cooking/sheet-pan-dinners/" rel="nocaes">Sheet Pan Dinners</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item text-label-300 view-all">
+                                    <a href="https://www.allrecipes.com/recipes/17562/dinner/" rel="nocaes">View All</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="mntl-header-nav__list-item">
+                            <a href="https://www.allrecipes.com/recipes-a-z-6735880" rel="nocaes">Meals</a>
+                            <ul class="mntl-header-nav__sublist">
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/78/breakfast-and-brunch/" rel="nocaes">Breakfast &amp; Brunch</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/17561/lunch/" rel="nocaes">Lunch</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/84/healthy-recipes/" rel="nocaes">Healthy</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/76/appetizers-and-snacks/" rel="nocaes">Appetizers &amp; Snacks</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/96/salad/" rel="nocaes">Salads</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/81/side-dish/" rel="nocaes">Side Dishes</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/16369/soups-stews-and-chili/soup/" rel="nocaes">Soups</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/156/bread/" rel="nocaes">Bread</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/77/drinks/" rel="nocaes">Drinks</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/79/desserts/" rel="nocaes">Desserts</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item text-label-300 view-all">
+                                    <a href="https://www.allrecipes.com/recipes-a-z-6735880" rel="nocaes">View All</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="mntl-header-nav__list-item">
+                            <a href="https://www.allrecipes.com/ingredients-a-z-6740416" rel="nocaes">Ingredients</a>
+                            <ul class="mntl-header-nav__sublist">
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/201/meat-and-poultry/chicken/" rel="nocaes">Chicken</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/200/meat-and-poultry/beef/" rel="nocaes">Beef</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/205/meat-and-poultry/pork/" rel="nocaes">Pork</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/93/seafood/" rel="nocaes">Seafood</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/95/pasta-and-noodles/" rel="nocaes">Pasta</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/1058/fruits-and-vegetables/fruits/" rel="nocaes">Fruits</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/1059/fruits-and-vegetables/vegetables/" rel="nocaes">Vegetables</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item text-label-300 view-all">
+                                    <a href="https://www.allrecipes.com/ingredients-a-z-6740416" rel="nocaes">View All</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="mntl-header-nav__list-item">
+                            <a href="https://www.allrecipes.com/recipes/85/holidays-and-events/" rel="nocaes">Occasions</a>
+                            <ul class="mntl-header-nav__sublist">
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/15335/holidays-and-events/thanksgiving/leftovers/" rel="nocaes">Thanksgiving Leftovers</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/841/holidays-and-events/christmas/desserts/christmas-cookies/" rel="nocaes">Christmas Cookies</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/190/holidays-and-events/hanukkah/" rel="nocaes">Hanukkah Recipes</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/187/holidays-and-events/christmas/" rel="nocaes">Christmas Recipes</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item text-label-300 view-all">
+                                    <a href="https://www.allrecipes.com/recipes/85/holidays-and-events/" rel="nocaes">View All</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="mntl-header-nav__list-item">
+                            <a href="https://www.allrecipes.com/cuisine-a-z-6740455" rel="nocaes">Cuisines</a>
+                            <ul class="mntl-header-nav__sublist">
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/728/world-cuisine/latin-american/mexican/" rel="nocaes">Mexican</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/723/world-cuisine/european/italian/" rel="nocaes">Italian</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/695/world-cuisine/asian/chinese/" rel="nocaes">Chinese</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/233/world-cuisine/asian/indian/" rel="nocaes">Indian</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/722/world-cuisine/european/german/" rel="nocaes">German</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/731/world-cuisine/european/greek/" rel="nocaes">Greek</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/696/world-cuisine/asian/filipino/" rel="nocaes">Filipino</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/699/world-cuisine/asian/japanese/" rel="nocaes">Japanese</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item text-label-300 view-all">
+                                    <a href="https://www.allrecipes.com/cuisine-a-z-6740455" rel="nocaes">View All</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="mntl-header-nav__list-item">
+                            <a href="https://www.allrecipes.com/kitchen-tips/" rel="nocaes">Kitchen Tips</a>
+                            <ul class="mntl-header-nav__sublist">
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/22882/everyday-cooking/instant-pot/" rel="nocaes">Instant Pot</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/23070/everyday-cooking/cookware-and-equipment/air-fryer/" rel="nocaes">Air Fryer</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/253/everyday-cooking/slow-cooker/" rel="nocaes">Slow Cooker</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/food-news-trends/product-reviews/" rel="nocaes">Our Favorite Products</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/88/bbq-grilling/" rel="nocaes">BBQ &amp; Grilling</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/recipes/17583/everyday-cooking/cookware-and-equipment/" rel="nocaes">Cooking by Equipment</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/kitchen-tips/all-about-ingredients/substitutions/" rel="nocaes">Ingredient Substitutions</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item text-label-300 view-all">
+                                    <a href="https://www.allrecipes.com/kitchen-tips/" rel="nocaes">View All</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="mntl-header-nav__list-item">
+                            <a href="https://www.allrecipes.com/food-news-trends/" rel="nocaes">News</a>
+                            <ul class="mntl-header-nav__sublist">
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/food-news-trends/celebrity-entertainment/" rel="nocaes">Celebrity &amp; Entertainment</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/fast-food-8672832" rel="nocaes">Fast Food</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/grocery-8672835" rel="nocaes">Grocery</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/food-news-trends/recalls/" rel="nocaes">Recalls</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/food-news-trends/trends/" rel="nocaes">Trends</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item text-label-300 view-all">
+                                    <a href="https://www.allrecipes.com/food-news-trends/" rel="nocaes">View All</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="mntl-header-nav__list-item">
+                            <a href="https://www.allrecipes.com/black-friday-cyber-monday-deals-8748167" rel="nocaes">Black Friday</a>
+                            <ul class="mntl-header-nav__sublist">
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/kitchen-tips/how-to/dinner-fix/" rel="nocaes">Dinner Fix</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/kitchen-tips/how-to/sweet-spot/" rel="nocaes">Sweet Spot</a>
+                                </li>
+                                <li class="mntl-header-nav__sublist-item">
+                                    <a href="https://www.allrecipes.com/kitchen-tips/in-the-kitchen/" rel="nocaes">In the Kitchen</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+                <div class="mntl-header-nav__list-item mntl-header-nav__list-item-about-us">
+                    <a href="/about-us-6648102" rel="nocaes">About Us</a>
+                    <ul class="mntl-header-nav__sublist">
+                        <li class="mntl-header-nav__sublist-item">
+                            <a href="https://www.allrecipes.com/allstars-8661275" rel="nocaes">The Allrecipes Allstars</a>
+                        </li>
+                        <li class="mntl-header-nav__sublist-item">
+                            <a href="https://www.allrecipes.com/article/how-to-submit-recipes/" rel="nocaes">How to Add a Recipe</a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="loc navigation-links">
+                    <a href="#" rel="nofollow nocaes" data-iframe="iframe?container=alr_cxt_r1_012025&amp;utm_source=allrecipes.com&amp;utm_medium=owned&amp;utm_campaign=ad508arr1w3275" id="mntl-header-nav__subscribe-link_1-0" class="mntl-header-nav__subscribe-link mntl-text-link text-label-300 global-link openContextual" data-tracking-container="true"><span class="link__wrapper">GET THE MAGAZINE</span></a>
+                </div>
+            </nav>
+        </header>
+        <div id="site-wide-notification_1-0" class="comp site-wide-notification mntl-site-wide-notification mntl-notification-banner mntl-block" data-show-until-dismissed="true">
+            <div id="mntl-site-wide-notification__wrapper_1-0" class="comp mntl-site-wide-notification__wrapper mntl-block">
+                <a href="https://www.allrecipes.com/best-amazon-outlet-overstock-black-friday-deals-2025-11833037" rel="nocaes" class="mntl-site-wide-notification__header mntl-text-link" id="mntl-site-wide-notification__header_1-0" data-tracking-container="true"><span class="link__wrapper">Amazon’s overstock outlet has secret Black Friday deals starting at just $4.</span></a> <button id="mntl-site-wide-notification__btn-close_1-0" class="comp mntl-site-wide-notification__btn-close mntl-button js-banner-dismiss" aria-label="Close"><svg class="icon close-icon mntl-button__icon">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close-icon" href="#close-icon"></use></svg></button>
+            </div>
+        </div>
+        <div id="mm-ads-leaderboard-header_1-0" class="comp mm-ads-leaderboard-header mm-ads-leaderboard-fixed-0 mm-ads-leaderboard-fixed mm-ads-gpt-adunit has-right-label leaderboard gpt leaderboard">
+            <div id="leaderboard-fixed-0" class="wrapper" data-timed-refresh="30000"></div>
+        </div>
+        <div id="mm-ads-leaderboard-spacer_1-0" class="comp mm-ads-leaderboard-spacer mntl-block"></div>
+        <div id="mm-myrecipes-toast_1-0" class="comp mm-myrecipes-toast hide is-hidden myr-meridian" data-close-class="hide" data-defer="load" data-favorites-template="false" data-enable-target-blank="true" data-toast-timeout="5000"></div>
+        <main id="main" class="loc main" role="main">
+            <iframe id="height-change-listener" role="none" tabindex="-1" src="about:blank" aria-hidden="true" name="height-change-listener"></iframe>
+            <article id="allrecipes-article_1-0" class="comp allrecipes-article mntl-article mntl-article--two-column-right-rail sc-ad-container adjusted-right-rail" data-content-graph-id="none" data-tracking-container="true">
+                <div class="loc article-header">
+                    <div id="article-preheading_1-0" class="comp article-preheading mntl-block">
+                        <div id="mntl-universal-breadcrumbs--scroll_1-0" class="comp mntl-universal-breadcrumbs--scroll mntl-block breadcrumbs__scroll-wrapper js-breadcrumbs-right-overflow">
+                            <ul id="mntl-universal-breadcrumbs_1-0" class="comp mntl-universal-breadcrumbs mntl-block text-label-300 breadcrumbs" data-tracking-container="true">
+                                <li id="mntl-breadcrumbs__item_1-0" class="comp mntl-breadcrumbs__item mntl-block">
+                                    <a href="https://www.allrecipes.com/recipes/" rel="nocaes" class="mntl-text-link mntl-breadcrumbs__link" id="mntl-text-link_9-0" data-tracking-container="true"><span class="link__wrapper">Recipes</span></a> <svg class="icon icon-chevron">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg>
+                                </li>
+                                <li id="mntl-breadcrumbs__item_2-0" class="comp mntl-breadcrumbs__item mntl-block">
+                                    <a href="https://www.allrecipes.com/recipes/81/side-dish/" rel="nocaes" class="mntl-text-link mntl-breadcrumbs__link" id="mntl-text-link_10-0" data-tracking-container="true"><span class="link__wrapper">Side Dish</span></a> <svg class="icon icon-chevron">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg>
+                                </li>
+                                <li id="mntl-breadcrumbs__item_3-0" class="comp mntl-breadcrumbs__item mntl-block">
+                                    <a href="https://www.allrecipes.com/recipes/225/side-dish/vegetables/" rel="nocaes" class="mntl-text-link mntl-breadcrumbs__link" id="mntl-text-link_11-0" data-tracking-container="true"><span class="link__wrapper">Vegetables</span></a> <svg class="icon icon-chevron">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use></svg>
+                                </li>
+                                <li id="mntl-breadcrumbs__item_4-0" class="comp mntl-breadcrumbs__item mntl-block">
+                                    <a href="https://www.allrecipes.com/recipes/920/side-dish/vegetables/brussels-sprouts/" rel="nocaes" class="mntl-text-link mntl-breadcrumbs__link" id="mntl-text-link_12-0" data-tracking-container="true"><span class="link__wrapper">Brussels Sprouts</span></a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="loc article-post-header">
+                    <div id="article-header--recipe_1-0" class="comp article-header--recipe mm-recipes-article-header mntl-article-header">
+                        <h1 class="article-heading text-headline-400">
+                            Hot Honey Brussels Sprouts
+                        </h1>
+                        <div id="mm-recipes-review-bar_1-0" class="comp mm-recipes-review-bar recipe-review-bar mntl-block js-recipe-review-bar">
+                            <div id="mm-recipes-review-bar__comment-count_1-0" class="comp mm-recipes-review-bar__comment-count mntl-text-block text-utility-300 global-link" data-click-tracked="true" data-tracking-subtype="Top Nav - Jump to Reviews - Reviews" data-tracking-subcategory="Review Bar" data-tracking-container="true" data-tracking-category="User Recipe Action">
+                                Be the first to rate &amp; review!
+                            </div>
+                            <div id="recipe-review-bar__photo-count_1-0" class="comp recipe-review-bar__photo-count mntl-text-block text-label-300 global-link dialog-link" data-click-tracked="false" data-a11y-dialog-show="photo-dialog" data-tracking-container="true">
+                                1 Photo
+                            </div>
+                        </div>
+                        <p class="article-subheading text-utility-300">
+                            These hot honey Brussels sprouts are a simple side dish with all the elements you'll ever need in a side. They're sweet, spicy, crispy, and melt in your mouth. I like to pair this with pork chops but it goes great with chicken or wild game.
+                        </p>
+                        <div id="mntl-article-meta-dynamic_1-0" class="comp mntl-article-meta-dynamic mntl-article-meta mntl-block" data-tracking-container="true">
+                            <div id="bylines_1-0" class="comp bylines allrecipes-bylines mntl-bylines text-utility-200">
+                                <div id="mntl-bylines__group_1-0" class="comp mntl-bylines__group mntl-block mntl-bylines__group--author">
+                                    <div id="mntl-bylines__item_1-0" class="comp mntl-bylines__item mntl-attribution__item mntl-attribution__item--has-date">
+                                        <span class="mntl-attribution__item-descriptor">By</span>
+                                        <div data-tooltip="Nicole Russell is a prolific contributor to Allrecipes and an avid member of the Allrecipes Allstars." tabindex="0" data-inline-tooltip="true">
+                                            <a href="https://www.allrecipes.com/nicole-russell-7113592" rel="nocaes" data-trigger-link="true" class="mntl-attribution__item-name" tabindex="-1">Nicole Russell</a>
+                                            <div id="mntl-author-tooltip_1-0" class="comp mntl-author-tooltip mntl-tooltip mntl-group">
+                                                <div class="mntl-author-tooltip__top">
+                                                    <div class="mntl-author-tooltip__image-wrapper">
+                                                        <div class="img-placeholder" style="padding-bottom:75.0%;">
+                                                            <img data-src="https://www.allrecipes.com/thmb/uYVcXCSJ-dbRVP6aENNapCfLdlY=/75x75/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg" width="75" height="75" data-srcset="https://www.allrecipes.com/thmb/Trlj084IC3wBi4LKJPIKHEidK_Y=/40x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 40w, https://www.allrecipes.com/thmb/PjK7K3x5635tX12yHK_IGTJCha8=/58x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 58w, https://www.allrecipes.com/thmb/r4I1SWydIlNIwza6llxnx6EUpZ4=/76x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 76w, https://www.allrecipes.com/thmb/pp0xDFVleEUku7amHGoSEAIxVdw=/94x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 94w, https://www.allrecipes.com/thmb/XIiaJQ1BUWIDHcE9XW8jQyRKIBQ=/112x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 112w" data-sizes="80px" alt="Nicole Russell" class="lazyload mntl-author-tooltip__image mntl-image universal-image__image" /> <noscript><img src="https://www.allrecipes.com/thmb/uYVcXCSJ-dbRVP6aENNapCfLdlY=/75x75/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg" width="75" height="75" class="img--noscript mntl-author-tooltip__image mntl-image universal-image__image" srcset="https://www.allrecipes.com/thmb/Trlj084IC3wBi4LKJPIKHEidK_Y=/40x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 40w, https://www.allrecipes.com/thmb/PjK7K3x5635tX12yHK_IGTJCha8=/58x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 58w, https://www.allrecipes.com/thmb/r4I1SWydIlNIwza6llxnx6EUpZ4=/76x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 76w, https://www.allrecipes.com/thmb/pp0xDFVleEUku7amHGoSEAIxVdw=/94x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 94w, https://www.allrecipes.com/thmb/XIiaJQ1BUWIDHcE9XW8jQyRKIBQ=/112x0/filters:no_upscale():max_bytes(150000):strip_icc()/NicoleRussellSoupLovingNicole-9607577801804bd09ea93bbdb7fcae6d.jpg 112w" sizes="80px" alt="Nicole Russell" /></noscript>
+                                                        </div>
+                                                    </div>
+                                                    <div id="mntl-author-tooltip__name_1-0" class="comp mntl-author-tooltip__name mntl-attribution__item">
+                                                        <a href="https://www.allrecipes.com/nicole-russell-7113592" rel="nocaes" class="mntl-attribution__item-name" tabindex="0">Nicole Russell</a>
+                                                    </div>
+                                                    <div class="mntl-author-tooltip__bio">
+                                                        Nicole Russell is a prolific contributor to Allrecipes and an avid member of the Allrecipes Allstars.
+                                                    </div>
+                                                </div>
+                                                <div class="mntl-author-tooltip__bottom">
+                                                    <a href="/about-us-6648102#toc-editorial-guidelines" rel="nocaes" class="mntl-author-tooltip__learn-more-link">Allrecipes' editorial guidelines</a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="mntl-attribution__item-date">
+                                        Published on November 3, 2025
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="recipe-social-share_1-0" class="comp recipe-social-share mm-recipes-social-share recipes-social-share">
+                                <div class="mm-recipes-social-share__inner">
+                                    <div class="loc save">
+                                        <div id="mm-myrecipes-favorite_1-0" class="comp mm-myrecipes-favorite">
+                                            <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="false" data-doc-id="11832010" data-doc-heading="Hot Honey Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/KbidNXbhDzZzZjJ50E73S5FhXo4=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg" data-tracking-on="recipe-detail" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><span>Save</span> <svg class="icon icon-favorite">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                                        </div>
+                                    </div>
+                                    <div class="mm-recipes-social-share__rate-wrapper">
+                                        <button id="mm-recipes-social-share__rate-button-1-0" aria-label="Rate" class="mm-recipes-social-share__rate-button" data-click-tracked="true" data-tracking-on="" data-unauthflow-enabled="true" data-qanda-enabled="true" data-tracking-container="true" data-tracking-category="User Recipe Action" data-tracking-subcategory="Recipe Social Share" data-tracking-subtype="Top Nav - Rate Button"><span class="mm-recipes-social-share__rate-label">Rate</span> <svg class="icon icon-recipe-social-share-star-empty">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-recipe-social-share-star-empty" href="#icon-recipe-social-share-star-empty"></use></svg></button>
+                                    </div>
+                                    <div class="loc print mm-recipes-social-share__print-wrapper">
+                                        <form id="mntl-print-button_1-0" class="comp mntl-print-button" method="get" rel="noopener" action="/hot-honey-brussels-sprouts-recipe-11832010?print" data-tracking-container="true" aria-label="Print this article." target="_blank" name="mntl-print-button_1-0">
+                                            <button class="mntl-print-button__btn" aria-label="Print this article.">Print <svg class="icon icon-print mntl-print-button__icon">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print" href="#icon-print"></use></svg></button> <input type="hidden" name="print" />
+                                        </form>
+                                    </div>
+                                    <div class="mm-recipes-social-share__share-wrapper">
+                                        <button id="mm-recipes-social-share__share-button-1-0" aria-label="Share" aria-expanded="false" class="mm-recipes-social-share__share-button" data-click-tracked="true" data-tracking-on="" data-tracking-container="true" data-tracking-category="User Recipe Action" data-tracking-subcategory="Recipe Social Share" data-tracking-subtype="Top Nav - Share Button"><span class="mm-recipes-social-share__share-label">Share</span> <svg class="icon icon-share">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-share" href="#icon-share"></use></svg></button>
+                                    </div>
+                                    <div class="loc social-share">
+                                        <ul id="social-share_1-0" class="comp social-share mntl-universal-social-share share" data-title="Hot Honey Brussels Sprouts" data-description="These hot honey Brussels sprouts are a simple side dish with all the elements you'll ever need in a side. They're sweet, spicy, crispy, and melt in your mouth." data-tracking-container="true">
+                                            <li class="share-item share-item-facebook">
+                                                <span data-href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.allrecipes.com%2Fhot-honey-brussels-sprouts-recipe-11832010%3Futm_source%3Dfacebook.com%26utm_medium%3Dsocial%26utm_campaign%3Dsocial-share-article" data-network="facebook" data-click-tracked="true" class="share-link share-link-facebook" tabindex="0" title="Share on Facebook" aria-label="Share on Facebook" role="link"><svg class="icon icon-facebook">
+                                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook" href="#icon-facebook"></use></svg></span>
+                                            </li>
+                                            <li class="share-item share-item-twitter">
+                                                <span data-href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.allrecipes.com%2Fhot-honey-brussels-sprouts-recipe-11832010%3Futm_source%3Dtwitter%26utm_medium%3Dsocial%26utm_campaign%3Dshareurlbuttons&amp;via=Allrecipes&amp;text=Hot+Honey+Brussels+Sprouts" data-network="twitter" data-click-tracked="true" class="share-link share-link-twitter" tabindex="0" title="Post to X" aria-label="Post to X" role="link"><svg class="icon icon-twitter">
+                                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter" href="#icon-twitter"></use></svg></span>
+                                            </li>
+                                            <li class="share-item share-item-pinterest">
+                                                <span data-href="http://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.allrecipes.com%2Fhot-honey-brussels-sprouts-recipe-11832010%3Futm_source%3Dpinterest%26utm_medium%3Dsocial%26utm_campaign%3Dshareurlbuttons&amp;description=Hot+Honey+Brussels+Sprouts&amp;media=https%3A%2F%2Fwww.allrecipes.com%2Fthmb%2Fy1sNg-Jbng2LlvTEA97Ix1nq54A%3D%2F750x0%2F11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-2x3-d888dd8f10b34e9fab9869f8197a6bac.jpg" data-network="pinterest" data-click-tracked="true" class="share-link share-link-pinterest" tabindex="0" title="Share on Pinterest" aria-label="Share on Pinterest" role="link"><svg class="icon icon-pinterest">
+                                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest" href="#icon-pinterest"></use></svg></span>
+                                            </li>
+                                            <li class="share-item share-item-emailshare">
+                                                <span data-href="https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010?utm_source=emailshare&amp;utm_medium=social&amp;utm_campaign=shareurlbuttons" data-network="emailshare" data-click-tracked="true" class="share-link share-link-emailshare" tabindex="0" title="Email this article" aria-label="Email this article" role="link"><svg class="icon icon-email">
+                                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-email" href="#icon-email"></use></svg></span>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="loc article-content">
+                    <div id="article__primary-video-container_1-0" class="comp article__primary-video-container mntl-block"></div>
+                    <div id="article__broad-video-jw_1-0" class="comp article__broad-video-jw mntl-jwplayer-broad mntl-block is-hidden" data-pixel-depth="100">
+                        <div id="mntl-jwplayer-broad__video_1-0" class="comp mntl-jwplayer-broad__video mntl-jwplayer mm-video lazyload" data-bgset="" data-sizes="auto"></div>
+                        <div id="mntl-jwplayer-broad__title_1-0" class="comp mntl-jwplayer-broad__title mntl-block">
+                            <div id="mntl-jwplayer-broad__title--text_1-0" class="comp mntl-jwplayer-broad__title--text mntl-text-block text-utility-100"></div><button id="mntl-jwplayer-broad__title-icon--close_1-0" class="comp mntl-jwplayer-broad__title-icon--close mntl-block text-label-100" data-click-tracked="false"><span id="mntl-text-block_1-0" class="comp mntl-text-block">Close</span> <svg class="icon close-icon">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close-icon" href="#close-icon"></use></svg></button>
+                        </div>
+                    </div>
+                    <figure id="figure-article_1-0" class="comp figure-article mntl-universal-primary-image right-rail__offset text-utility-100 figure-landscape primary-image" data-click-tracked="false">
+                        <div class="primary-image__media">
+                            <div class="img-placeholder" style="padding-bottom:75.0%;">
+                                <img src="https://www.allrecipes.com/thmb/RDigrCswgpVoo9dPZxanUuRIudI=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg" width="4000" height="3000" srcset="https://www.allrecipes.com/thmb/LNvP40zVI2ZbS5O3gRnmmadoMEM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg 750w" sizes="750px" alt="Dish of roasted brussels sprouts with crumbled cheese and garnish" class="primary-image__image mntl-primary-image--blurry" onload="(function(e){e.classList.add('loaded')})(this)" style="--blurry: url('data:image/gif;charset=utf-8;base64,R0lGODlhCQAHAPUAAAwDAB8NASUIBCoaAzEvGDI1AE8/AVQ0AVtGA3deAhxhiI1XAIlbA4JKPY5pAYpzAYt1AJx/AIJtNI9jNJptMq56AoFGTKp1VbF2TMd8X56IAaWJHL+WAKiLT7KUbq+je6upecWNAsOeNMGmAMelBdutAMWoKMSEYcCYZM2Xf/bcE/DYeLyek6ejhri1ipfE45rH5LTZ67jW8uS3jtfEidzKvu3BmvjNo/7Vtf3Zt//1ltna1P3f1P3h0/L2xAwDACwAAAAACQAHAEUISgBfwIgxw8YNHD14rCgBoECAESI2dNhB4IEDBAl0qOBwYUIDChkwpMiBQoEMDyBcGPjgo4UJBiRCHNBAQ0CFGhAGLIgggcUJCwEBADs=')" /> <noscript><img src="https://www.allrecipes.com/thmb/RDigrCswgpVoo9dPZxanUuRIudI=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg" width="4000" height="3000" class="loaded primary-img--noscript primary-image__image mntl-primary-image--blurry" srcset="https://www.allrecipes.com/thmb/LNvP40zVI2ZbS5O3gRnmmadoMEM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg 750w" sizes="750px" alt="Dish of roasted brussels sprouts with crumbled cheese and garnish" /></noscript>
+                            </div>
+                        </div>
+                    </figure>
+                    <div id="article__photo-ribbon_1-0" class="comp article__photo-ribbon mntl-block total-photos1">
+                        <button id="add-photo_1-0" class="comp add-photo mntl-button">Add Photo <svg class="icon icon-add-photo mntl-button__icon">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-add-photo" href="#icon-add-photo"></use></svg></button>
+                    </div>
+                    <div id="article-content_1-0" class="comp article-content mntl-block">
+                        <div id="mm-recipes-details_1-0" class="comp mm-recipes-details">
+                            <div class="mm-recipes-details__content">
+                                <div class="mm-recipes-details__item">
+                                    <div class="mm-recipes-details__label">
+                                        Prep Time:
+                                    </div>
+                                    <div class="mm-recipes-details__value">
+                                        10 mins
+                                    </div>
+                                </div>
+                                <div class="mm-recipes-details__item">
+                                    <div class="mm-recipes-details__label">
+                                        Cook Time:
+                                    </div>
+                                    <div class="mm-recipes-details__value">
+                                        20 mins
+                                    </div>
+                                </div>
+                                <div class="mm-recipes-details__item">
+                                    <div class="mm-recipes-details__label">
+                                        Total Time:
+                                    </div>
+                                    <div class="mm-recipes-details__value">
+                                        30 mins
+                                    </div>
+                                </div>
+                                <div class="mm-recipes-details__item">
+                                    <div class="mm-recipes-details__label">
+                                        Servings:
+                                    </div>
+                                    <div class="mm-recipes-details__value">
+                                        4
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="loc nutrition-link mm-recipes-details__nutrition-link-container">
+                                <button id="mm-recipes-details__nutrition-link_1-0" class="comp mm-recipes-details__nutrition-link mntl-text-block" data-tracking-subtype="Jump to Nutrition Facts" data-tracking-target-url="https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010" data-tracking-subcategory="Recipe Details" data-tracking-container="true" data-tracking-category="User Recipe Action">Jump to Nutrition Facts</button>
+                            </div>
+                        </div>
+                        <div id="mm-recipes-intro_1-0" class="comp mm-recipes-intro mntl-block">
+                            <div id="mm-recipes-intro__content_1-0" class="comp mm-recipes-intro__content mntl-sc-page mntl-block" data-sc-sticky-offset="190" data-sc-ad-label-height="24" data-sc-ad-track-spacing="100" data-sc-min-track-height="250" data-sc-max-track-height="600" data-sc-breakpoint="50em" data-sc-load-immediate="1" data-sc-content-positions="[1, 1250, 1550, 1950, 2350, 2750, 3150, 3550, 3950]" data-bind-scroll-on-start="true"></div>
+                        </div>
+                        <div id="native-fluid-placeholder_1-0" class="comp native-fluid-placeholder mm-ads-native-fluid mm-ads-native" style="--native-ad-height: auto">
+                            <div id="mm-ads-native__adunit_1-0" class="comp mm-ads-native__adunit mm-ads-gpt-dynamic-adunit mm-ads-gpt-adunit scads-to-load gpt native dynamic">
+                                <div id="native" class="wrapper" data-type="native" data-pos="native" data-priority="4" data-sizes="[[1, 3],&quot;fluid&quot;,[600, 250]]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                            </div>
+                        </div>
+                        <div id="mm-recipes-lrs-ingredients_1-0" class="comp mm-recipes-lrs-ingredients mntl-block" data-content-modified-date="2025-11-03T18:00:00.000Z" data-load-offset="300">
+                            <div id="mm-recipes-structured-ingredients_1-0" class="comp mm-recipes-structured-ingredients">
+                                <div id="mm-recipes-screen-wake_1-0" class="comp mm-recipes-screen-wake" data-screen-wake-locked="false">
+                                    <button id="mm-recipes-screen-wake__button-1-0" class="mm-recipes-screen-wake__button" aria-pressed="false" aria-label="Toggle Screen Wake" data-tracking-container="true" data-tracking-category="User Recipe Action" data-tracking-subcategory="Screen Wake" data-tracking-subtype="On"></button> <span class="mm-recipes-screen-wake__label">Keep Screen Awake</span>
+                                </div>
+                                <div class="loc heading">
+                                    <h2 id="mm-recipes-structured-ingredients__heading_1-0" class="comp mm-recipes-structured-ingredients__heading mntl-text-block">
+                                        Ingredients
+                                    </h2>
+                                </div>
+                                <div id="mm-recipes-serving-size-adjuster_1-0" class="comp mm-recipes-serving-size-adjuster">
+                                    <div class="mm-recipes-serving-size-adjuster__buttons">
+                                        <div class="mm-recipes-serving-size-adjuster__group" data-click-tracked="true">
+                                            <input class="mm-recipes-serving-size-adjuster__input" type="radio" id="serving-size-0.5x_1-0" name="serving-size-adjuster_1-0" data-click-tracked="true" data-tracking-container="true" data-tracking-category="User Recipe Action" data-tracking-subcategory="Scale Ingredients" data-tracking-subtype="Scale Ingredients Factor - 0.5x" value="0.5" /> <label id="serving-adjuster-multiplier-button-1-0-0.5x" class="mm-recipes-serving-size-adjuster__label" for="serving-size-0.5x_1-0" data-click-tracked="false"><svg class="icon icon-check">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-check" href="#icon-check"></use></svg> <span class="mm-recipes-serving-size-adjuster__multiplier">1/2x</span></label>
+                                        </div>
+                                        <div class="mm-recipes-serving-size-adjuster__group" data-click-tracked="true">
+                                            <input class="mm-recipes-serving-size-adjuster__input" type="radio" id="serving-size-1x_1-0" name="serving-size-adjuster_1-0" data-click-tracked="true" data-tracking-container="true" data-tracking-category="User Recipe Action" data-tracking-subcategory="Scale Ingredients" data-tracking-subtype="Scale Ingredients Factor - 1x" checked="checked" value="1" /> <label id="serving-adjuster-multiplier-button-1-0-1x" class="mm-recipes-serving-size-adjuster__label" for="serving-size-1x_1-0" data-click-tracked="false"><svg class="icon icon-check">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-check" href="#icon-check"></use></svg> <span class="mm-recipes-serving-size-adjuster__multiplier">1x</span></label>
+                                        </div>
+                                        <div class="mm-recipes-serving-size-adjuster__group" data-click-tracked="true">
+                                            <input class="mm-recipes-serving-size-adjuster__input" type="radio" id="serving-size-2x_1-0" name="serving-size-adjuster_1-0" data-click-tracked="true" data-tracking-container="true" data-tracking-category="User Recipe Action" data-tracking-subcategory="Scale Ingredients" data-tracking-subtype="Scale Ingredients Factor - 2x" value="2" /> <label id="serving-adjuster-multiplier-button-1-0-2x" class="mm-recipes-serving-size-adjuster__label" for="serving-size-2x_1-0" data-click-tracked="false"><svg class="icon icon-check">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-check" href="#icon-check"></use></svg> <span class="mm-recipes-serving-size-adjuster__multiplier">2x</span></label>
+                                        </div>
+                                    </div>
+                                    <div class="loc errorBanner">
+                                        <div id="mntl-message-banner--error_1-0" class="comp mntl-message-banner--error mntl-message-banner mntl-message-banner--error" data-close-class="is-hidden" role="alert">
+                                            <svg class="icon icon-error mntl-message-banner__prefix-icon mntl-message-banner__icon">
+                                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-error" href="#icon-error"></use></svg> <span class="text-utility-300-prominent mntl-message-banner__text">Oops! Something went wrong. Our team is working on it.</span>
+                                        </div>
+                                    </div>
+                                    <p class="mm-recipes-serving-size-adjuster__meta">
+                                        <button id="serving-adjuster-tooltip-button-1-0" class="mm-recipes-serving-size-adjuster__meta-icon" aria-describedby="serving-adjuster-tooltip-1-0" aria-expanded="false" aria-controls="serving-adjuster-tooltip-1-0" data-tracking-container="true" data-tracking-category="User Action" data-tracking-subcategory="Scale Ingredients" data-tracking-subtype="SSA Tool Tip"><svg class="icon icon-help">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-help" href="#icon-help"></use></svg></button> <span class="mm-recipes-serving-size-adjuster__tooltip" id="serving-adjuster-tooltip-1-0" role="tooltip" aria-hidden="true">This recipe was developed at its original yield. Ingredient amounts are automatically adjusted, but cooking times and steps remain unchanged. Note that not all recipes scale perfectly.</span> Original recipe (1X) yields 4 servings
+                                    </p>
+                                </div>
+                                <ul class="mm-recipes-structured-ingredients__list">
+                                    <li class="mm-recipes-structured-ingredients__list-item" data-nutritionix-id="440">
+                                        <p>
+                                            <span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">pound</span> <span data-ingredient-name="true">Brussels sprouts</span>, trimmed and halved lengthwise
+                                        </p>
+                                    </li>
+                                    <li class="mm-recipes-structured-ingredients__list-item" data-nutritionix-id="42">
+                                        <p>
+                                            <span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">tablespoon</span> <span data-ingredient-name="true">olive oil</span>
+                                        </p>
+                                    </li>
+                                    <li class="mm-recipes-structured-ingredients__list-item" data-nutritionix-id="20">
+                                        <p>
+                                            <span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">tablespoons</span> <span data-ingredient-name="true">hot honey</span>, such as Mike's® Original Hot Honey
+                                        </p>
+                                    </li>
+                                    <li class="mm-recipes-structured-ingredients__list-item" data-nutritionix-id="12822">
+                                        <p>
+                                            <span data-ingredient-name="true">salt and freshly ground black pepper to taste</span>
+                                        </p>
+                                    </li>
+                                    <li class="mm-recipes-structured-ingredients__list-item" data-nutritionix-id="551">
+                                        <p>
+                                            <span data-ingredient-quantity="true">1/4</span> <span data-ingredient-unit="true">cup</span> crumbled <span data-ingredient-name="true">feta cheese</span>
+                                        </p>
+                                    </li>
+                                    <li class="mm-recipes-structured-ingredients__list-item" data-nutritionix-id="1916">
+                                        <p>
+                                            <span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">tablespoon</span> chopped <span data-ingredient-name="true">scallions</span>
+                                        </p>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div id="mm-recipes-steps_1-0" class="comp mm-recipes-steps mntl-block">
+                            <h2 id="mm-recipes-steps__heading_1-0" class="comp mm-recipes-steps__heading mntl-text-block">
+                                Directions
+                            </h2>
+                            <div id="mm-recipes-steps__content_1-0" class="comp mm-recipes-steps__content mntl-sc-page mntl-block">
+                                <ol id="mntl-sc-block_1-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--OL">
+                                    <li id="mntl-sc-block_2-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--LI">
+                                        <p id="mntl-sc-block_3-0" class="comp mntl-sc-block mntl-sc-block-html">
+                                            Gather all ingredients. Preheat the oven to 400 degrees F (200 degrees C). Line a large baking sheet with aluminum foil.
+                                        </p>
+                                        <figure id="mntl-sc-block_4-0" class="comp mntl-sc-block allrecipes-sc-block-image mntl-sc-block-image mntl-sc-block-image--no-theme no-theme figure-landscape figure-high-res">
+                                            <div class="figure-media">
+                                                <div class="img-placeholder" style="padding-bottom:75.0%;">
+                                                    <img data-src="https://www.allrecipes.com/thmb/aqdax3V1v0dM1iYGEdk80SuiUW4=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg" width="4000" height="3000" data-srcset="https://www.allrecipes.com/thmb/YgfY5c5ZN8GjWNeoWQQ5ALoNWhM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg 750w" data-sizes="750px" alt="Ingredients for a recipe including Brussels sprouts oil honey cheese and seasonings arranged in bowls on a marble surface" class="lazyload mntl-image mntl-image universal-image__image" data-expand="300" data-hi-res-src="https://www.allrecipes.com/thmb/aqdax3V1v0dM1iYGEdk80SuiUW4=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg" id="mntl-sc-block-image_1-0" data-tracking-container="true" data-img-lightbox="true" data-click-tracked="true" /> <noscript><img src="https://www.allrecipes.com/thmb/aqdax3V1v0dM1iYGEdk80SuiUW4=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg" width="4000" height="3000" class="img--noscript mntl-image mntl-image universal-image__image" srcset="https://www.allrecipes.com/thmb/YgfY5c5ZN8GjWNeoWQQ5ALoNWhM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-01-ced062a22ba24062afd44585679f2b11.jpg 750w" sizes="750px" alt="Ingredients for a recipe including Brussels sprouts oil honey cheese and seasonings arranged in bowls on a marble surface" /></noscript>
+                                                </div>
+                                            </div>
+                                            <figcaption id="mntl-figure-caption_1-0" class="comp mntl-figure-caption text-utility-100 figure-article-caption">
+                                                <p>
+                                                    <span class="figure-article-caption-owner">Allrecipes / Julia Hartbeck</span>
+                                                </p>
+                                            </figcaption>
+                                        </figure>
+                                        <div id="mntl-sc-block_5-0" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
+                                    </li>
+                                    <li id="mntl-sc-block_7-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--LI">
+                                        <p id="mntl-sc-block_8-0" class="comp mntl-sc-block mntl-sc-block-html">
+                                            Place Brussels sprouts in a bowl. Add oil, hot honey, salt, and pepper. Stir to combine and transfer to the baking sheet.
+                                        </p>
+                                        <figure id="mntl-sc-block_9-0" class="comp mntl-sc-block allrecipes-sc-block-image mntl-sc-block-image mntl-sc-block-image--no-theme no-theme figure-landscape figure-high-res">
+                                            <div class="figure-media">
+                                                <div class="img-placeholder" style="padding-bottom:75.0%;">
+                                                    <img data-src="https://www.allrecipes.com/thmb/eUPioUqRphcDxRjTsAyjPzwxZJc=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg" width="4000" height="3000" data-srcset="https://www.allrecipes.com/thmb/MABSZFZSQiMH9-AAdON6zeW12Xc=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg 750w" data-sizes="750px" alt="A baking sheet with halved Brussels sprouts arranged on foil prepared for cooking" class="lazyload mntl-image mntl-image universal-image__image" data-expand="300" data-hi-res-src="https://www.allrecipes.com/thmb/eUPioUqRphcDxRjTsAyjPzwxZJc=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg" id="mntl-sc-block-image_2-0" data-tracking-container="true" data-img-lightbox="true" data-click-tracked="true" /> <noscript><img src="https://www.allrecipes.com/thmb/eUPioUqRphcDxRjTsAyjPzwxZJc=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg" width="4000" height="3000" class="img--noscript mntl-image mntl-image universal-image__image" srcset="https://www.allrecipes.com/thmb/MABSZFZSQiMH9-AAdON6zeW12Xc=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-02-9032bfa0cf5f484fb0effe17210fb06a.jpg 750w" sizes="750px" alt="A baking sheet with halved Brussels sprouts arranged on foil prepared for cooking" /></noscript>
+                                                </div>
+                                            </div>
+                                            <figcaption id="mntl-figure-caption_2-0" class="comp mntl-figure-caption text-utility-100 figure-article-caption">
+                                                <p>
+                                                    <span class="figure-article-caption-owner">Allrecipes / Julia Hartbeck</span>
+                                                </p>
+                                            </figcaption>
+                                        </figure>
+                                        <div id="mntl-sc-block_10-0" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
+                                    </li>
+                                    <li id="mntl-sc-block_12-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--LI">
+                                        <p id="mntl-sc-block_13-0" class="comp mntl-sc-block mntl-sc-block-html">
+                                            Roast in the preheated oven for 20 minutes.
+                                        </p>
+                                        <figure id="mntl-sc-block_14-0" class="comp mntl-sc-block allrecipes-sc-block-image mntl-sc-block-image mntl-sc-block-image--no-theme no-theme figure-landscape figure-high-res">
+                                            <div class="figure-media">
+                                                <div class="img-placeholder" style="padding-bottom:75.0%;">
+                                                    <img data-src="https://www.allrecipes.com/thmb/UB3Jz-pfoXewTAcjSJz4RBjrigY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg" width="4000" height="3000" data-srcset="https://www.allrecipes.com/thmb/2eqyp1WAanqlJ_UvmyL7dRxlfoM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg 750w" data-sizes="750px" alt="Roasted Brussels sprouts on a foillined baking sheet" class="lazyload mntl-image mntl-image universal-image__image" data-expand="300" data-hi-res-src="https://www.allrecipes.com/thmb/UB3Jz-pfoXewTAcjSJz4RBjrigY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg" id="mntl-sc-block-image_3-0" data-tracking-container="true" data-img-lightbox="true" data-click-tracked="true" /> <noscript><img src="https://www.allrecipes.com/thmb/UB3Jz-pfoXewTAcjSJz4RBjrigY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg" width="4000" height="3000" class="img--noscript mntl-image mntl-image universal-image__image" srcset="https://www.allrecipes.com/thmb/2eqyp1WAanqlJ_UvmyL7dRxlfoM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-03-8b8c035f2a964810b5e253bb4a95ce8d.jpg 750w" sizes="750px" alt="Roasted Brussels sprouts on a foillined baking sheet" /></noscript>
+                                                </div>
+                                            </div>
+                                            <figcaption id="mntl-figure-caption_3-0" class="comp mntl-figure-caption text-utility-100 figure-article-caption">
+                                                <p>
+                                                    <span class="figure-article-caption-owner">Allrecipes / Julia Hartbeck</span>
+                                                </p>
+                                            </figcaption>
+                                        </figure>
+                                        <div id="mntl-sc-block_15-0" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
+                                    </li>
+                                    <li id="mntl-sc-block_17-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--LI">
+                                        <p id="mntl-sc-block_18-0" class="comp mntl-sc-block mntl-sc-block-html">
+                                            Transfer sprouts to a bowl. Top with feta and scallions. Toss to combine. Serve immediately.
+                                        </p>
+                                        <figure id="mntl-sc-block_19-0" class="comp mntl-sc-block allrecipes-sc-block-image mntl-sc-block-image mntl-sc-block-image--no-theme no-theme figure-landscape figure-high-res">
+                                            <div class="figure-media">
+                                                <div class="img-placeholder" style="padding-bottom:75.0%;">
+                                                    <img data-src="https://www.allrecipes.com/thmb/TKyvsRHU4FOU6HJ50w5StS_jOqk=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg" width="4000" height="3000" data-srcset="https://www.allrecipes.com/thmb/lUcNGpjFIbAT1nndRb9huLaamgo=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg 750w" data-sizes="750px" alt="Bowl of roasted Brussels sprouts garnished with toppings and a spoon on the side" class="lazyload mntl-image mntl-image universal-image__image" data-expand="300" data-hi-res-src="https://www.allrecipes.com/thmb/TKyvsRHU4FOU6HJ50w5StS_jOqk=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg" id="mntl-sc-block-image_4-0" data-tracking-container="true" data-img-lightbox="true" data-click-tracked="true" /> <noscript><img src="https://www.allrecipes.com/thmb/TKyvsRHU4FOU6HJ50w5StS_jOqk=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg" width="4000" height="3000" class="img--noscript mntl-image mntl-image universal-image__image" srcset="https://www.allrecipes.com/thmb/lUcNGpjFIbAT1nndRb9huLaamgo=/750x0/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-step-04-59530f25a17644ab8d6d5ebd94c6d064.jpg 750w" sizes="750px" alt="Bowl of roasted Brussels sprouts garnished with toppings and a spoon on the side" /></noscript>
+                                                </div>
+                                            </div>
+                                            <figcaption id="mntl-figure-caption_4-0" class="comp mntl-figure-caption text-utility-100 figure-article-caption">
+                                                <p>
+                                                    <span class="figure-article-caption-owner">Allrecipes / Julia Hartbeck</span>
+                                                </p>
+                                            </figcaption>
+                                        </figure>
+                                        <div id="mntl-sc-block_20-0" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
+                                    </li>
+                                </ol>
+                            </div>
+                        </div>
+                        <div id="mm-recipes-rate-print_1-0" class="comp mm-recipes-rate-print recipe-save-rate-print mm-recipes-save-rate-print mntl-block">
+                            <div id="mm-recipes-save-button-placeholder_1-0" class="comp mm-recipes-save-button-placeholder mm-myrecipes-favorite" data-tracking-subtype="Recipe Save" data-tracking-metadata-label="Hot Honey Brussels Sprouts" data-tracking-subcategory="Bottom Button" data-tracking-container="true" data-tracking-category="MyRecipes">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="false" data-doc-id="11832010" data-doc-heading="Hot Honey Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/KbidNXbhDzZzZjJ50E73S5FhXo4=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg" data-tracking-on="recipe-detail" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><span>Save</span> <svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                            <form id="mntl-print-button_2-0" class="comp mntl-print-button" method="get" rel="noopener" action="/hot-honey-brussels-sprouts-recipe-11832010?print" data-tracking-container="true" aria-label="Print this article." target="_blank" name="mntl-print-button_2-0">
+                                <button class="mntl-print-button__btn" aria-label="Print this article.">Print <svg class="icon icon-print mntl-print-button__icon">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print" href="#icon-print"></use></svg></button> <input type="hidden" name="print" />
+                            </form><button id="mm-recipes-made-it_1-0" class="comp mm-recipes-made-it mntl-button" data-tracking-subtype="I Made It" data-doc-id="11832010" data-tracking-target-url="https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010" data-tracking-subcategory="Rate / Print" data-tracking-container="true" data-tracking-category="Recipe UGC" aria-label="I Made It">I Made It <svg class="icon icon-made-it mntl-button__icon">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-made-it" href="#icon-made-it"></use></svg></button>
+                        </div>
+                        <div id="mm-recipes-nutrition-facts_1-0" class="comp mm-recipes-nutrition-facts mntl-block">
+                            <div id="mm-recipes-nutrition-facts-summary_1-0" class="comp mm-recipes-nutrition-facts-summary">
+                                <h2 class="mm-recipes-nutrition-facts-summary__heading text-headline-300" colspan="2">
+                                    Nutrition Facts <span class="mm-recipes-nutrition-facts-summary__heading-aside text-body-100">(per serving)</span>
+                                </h2>
+                                <table class="mm-recipes-nutrition-facts-summary__table">
+                                    <tbody class="mm-recipes-nutrition-facts-summary__table-body">
+                                        <tr class="mm-recipes-nutrition-facts-summary__table-row">
+                                            <td class="mm-recipes-nutrition-facts-summary__table-cell text-body-100-prominent">
+                                                132
+                                            </td>
+                                            <td class="mm-recipes-nutrition-facts-summary__table-cell text-body-100">
+                                                Calories
+                                            </td>
+                                        </tr>
+                                        <tr class="mm-recipes-nutrition-facts-summary__table-row">
+                                            <td class="mm-recipes-nutrition-facts-summary__table-cell text-body-100-prominent">
+                                                6g
+                                            </td>
+                                            <td class="mm-recipes-nutrition-facts-summary__table-cell text-body-100">
+                                                Fat
+                                            </td>
+                                        </tr>
+                                        <tr class="mm-recipes-nutrition-facts-summary__table-row">
+                                            <td class="mm-recipes-nutrition-facts-summary__table-cell text-body-100-prominent">
+                                                18g
+                                            </td>
+                                            <td class="mm-recipes-nutrition-facts-summary__table-cell text-body-100">
+                                                Carbs
+                                            </td>
+                                        </tr>
+                                        <tr class="mm-recipes-nutrition-facts-summary__table-row">
+                                            <td class="mm-recipes-nutrition-facts-summary__table-cell text-body-100-prominent">
+                                                5g
+                                            </td>
+                                            <td class="mm-recipes-nutrition-facts-summary__table-cell text-body-100">
+                                                Protein
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div><!-- daily values taken from https://www.fda.gov/food/new-nutrition-facts-label/daily-value-new-nutrition-and-supplement-facts-labels as of Feb 2023 -->
+                            <div id="mm-recipes-nutrition-facts-label_1-0" class="comp mm-recipes-nutrition-facts-label allrecipes-nutrition-facts-label" data-click-tracked="freemarker.template.FalseTemplateBooleanModel@1d3b7044">
+                                <button class="mm-recipes-nutrition-facts-label__button mm-recipes-nutrition-facts-label__button--show text-body-100"><span class="mm-recipes-nutrition-facts-label__button-text">Show Full Nutrition Label</span> <span class="mm-recipes-nutrition-facts-label__button-text">Hide Full Nutrition Label</span></button>
+                                <div class="mm-recipes-nutrition-facts-label__wrapper mm-recipes-nutrition-facts-label__wrapper--collapsed">
+                                    <div class="mm-recipes-nutrition-facts-label__contents">
+                                        <table class="mm-recipes-nutrition-facts-label__table">
+                                            <thead class="mm-recipes-nutrition-facts-label__table-head">
+                                                <tr>
+                                                    <th class="mm-recipes-nutrition-facts-label__table-head-title text-title-200" colspan="2">
+                                                        Nutrition Facts
+                                                    </th>
+                                                </tr>
+                                                <tr class="mm-recipes-nutrition-facts-label__servings">
+                                                    <th class="mm-recipes-nutrition-facts-label__table-head-subtitle" colspan="2">
+                                                        <span class="mm-recipes-nutrition-facts-label__table-head-pretext">Servings Per Recipe</span> <span>4</span>
+                                                    </th>
+                                                </tr>
+                                                <tr class="mm-recipes-nutrition-facts-label__calories">
+                                                    <th class="mm-recipes-nutrition-facts-label__table-head-subtitle" colspan="2">
+                                                        <span class="mm-recipes-nutrition-facts-label__table-head-pretext">Calories</span> <span>132</span>
+                                                    </th>
+                                                </tr>
+                                            </thead>
+                                            <tbody class="mm-recipes-nutrition-facts-label__table-body text-utility-300">
+                                                <tr class="mm-recipes-nutrition-facts-label__table-dv-row text-body-100">
+                                                    <td colspan="2">
+                                                        % Daily Value *
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Total Fat</span> 6g
+                                                    </td>
+                                                    <td>
+                                                        8%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Saturated Fat</span> 2g
+                                                    </td>
+                                                    <td>
+                                                        10%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Cholesterol</span> 8mg
+                                                    </td>
+                                                    <td>
+                                                        3%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Sodium</span> 185mg
+                                                    </td>
+                                                    <td>
+                                                        8%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Total Carbohydrate</span> 18g
+                                                    </td>
+                                                    <td>
+                                                        7%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Dietary Fiber</span> 3g
+                                                    </td>
+                                                    <td>
+                                                        11%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td colspan="2">
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Total Sugars</span> 12g
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Protein</span> 5g
+                                                    </td>
+                                                    <td>
+                                                        9%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Vitamin C</span> 98mg
+                                                    </td>
+                                                    <td>
+                                                        109%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Calcium</span> 91mg
+                                                    </td>
+                                                    <td>
+                                                        7%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Iron</span> 2mg
+                                                    </td>
+                                                    <td>
+                                                        9%
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Potassium</span> 414mg
+                                                    </td>
+                                                    <td>
+                                                        9%
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        <div id="mm-recipes-nutrition-facts-label-disclaimer_1-0" class="comp mm-recipes-nutrition-facts-label-disclaimer mntl-block text-utility-300">
+                                            <p id="disclaimer-1_1-0" class="comp disclaimer-1 mntl-text-block mm-recipes-nutrition-facts-label-disclaimer-info">
+                                                * Percent Daily Values are based on a 2,000 calorie diet. Your daily values may be higher or lower depending on your calorie needs.
+                                            </p>
+                                            <p id="mntl-text-block_2-0" class="comp mntl-text-block mm-recipes-nutrition-facts-label-disclaimer-info">
+                                                ** Nutrient information is not available for all ingredients. Amount is based on available nutrient data.
+                                            </p>
+                                            <p id="mntl-text-block_3-0" class="comp mntl-text-block mm-recipes-nutrition-facts-label-disclaimer-info">
+                                                (-) Information is not currently available for this nutrient. If you are following a medically restrictive diet, please consult your doctor or registered dietitian before preparing this recipe for personal consumption.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="ugc_1-0" class="comp ugc mntl-block" data-defer="load"></div>
+                    </div>
+                </div>
+                <div class="loc article-right-rail">
+                    <div id="mm-ads-right-rail_1-0" class="comp mm-ads-right-rail mntl-block">
+                        <div id="recipe-billboard-group_1-0" class="comp recipe-billboard-group mntl-block js-scads-inline-content">
+                            <div id="mntl-block_2-0" class="comp mntl-block">
+                                <div id="mm-ads-squareFlex1-sticky_1-0" class="comp mm-ads-squareFlex1-sticky mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="1090" style="height: 1090px;">
+                                    <div id="mm-ads-sc-sticky-square-ad_1-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square">
+                                        <div id="square-flex-1" class="wrapper" data-timed-refresh="30000"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="mntl-block_3-0" class="comp mntl-block">
+                                <div id="mm-ads-squareFlex2-sticky-dynamic_1-0" class="comp mm-ads-squareFlex2-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;">
+                                    <div id="mm-ads-sc-sticky-square-ad_2-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
+                                        <div id="square-flex-2" class="wrapper" data-timed-refresh="30000" data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[300, 600],[160, 600],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="mntl-block_4-0" class="comp mntl-block">
+                                <div id="mm-ads-squareFixed-sticky-dynamic_1-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;">
+                                    <div id="mm-ads-sc-sticky-square-ad_3-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
+                                        <div id="square-fixed" class="wrapper" data-timed-refresh="30000" data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="mntl-block_5-0" class="comp mntl-block">
+                                <div id="mm-ads-squareFixed-sticky-dynamic_2-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;">
+                                    <div id="mm-ads-sc-sticky-square-ad_4-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
+                                        <div id="square-fixed" class="wrapper" data-timed-refresh="30000" data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="mntl-block_6-0" class="comp mntl-block">
+                                <div id="mm-ads-squareFixed-sticky-dynamic_3-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;">
+                                    <div id="mm-ads-sc-sticky-square-ad_5-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
+                                        <div id="square-fixed" class="wrapper" data-timed-refresh="30000" data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="mntl-block_7-0" class="comp mntl-block">
+                                <div id="mm-ads-squareFixed-sticky-dynamic_4-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;">
+                                    <div id="mm-ads-sc-sticky-square-ad_6-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
+                                        <div id="square-fixed" class="wrapper" data-timed-refresh="30000" data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="mntl-block_8-0" class="comp mntl-block">
+                                <div id="mm-ads-squareFixed-sticky-dynamic_5-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;">
+                                    <div id="mm-ads-sc-sticky-square-ad_7-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
+                                        <div id="square-fixed" class="wrapper" data-timed-refresh="30000" data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="mntl-block_9-0" class="comp mntl-block">
+                                <div id="mm-ads-squareFixed-sticky-dynamic_6-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;">
+                                    <div id="mm-ads-sc-sticky-square-ad_8-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
+                                        <div id="square-fixed" class="wrapper" data-timed-refresh="30000" data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="loc article-footer">
+                    <div id="photo-dialog_1-0" class="comp photo-dialog mntl-dialog dialog__content dialog" data-a11y-dialog="photo-dialog" aria-hidden="true">
+                        <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide=""></div>
+                        <div role="dialog" class="dialog__content" aria-labelledby="photo-dialog_1-0-title">
+                            <div class="dialog__heading">
+                                <span id="photo-dialog_1-0-title" class="dialog__title"></span> <button data-a11y-dialog-hide="" class="dialog__close" data-click-tracked="false" aria-label="Close this dialog window"><svg class="icon icon-arrow_left">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left" href="#icon-arrow_left"></use></svg></button>
+                                <div class="loc heading dialog__heading-content">
+                                    <button id="mntl-button_1-0" class="comp mntl-button text-utility-200-prominent button--contained photo-dialog__add-photo" data-click-tracked="true" data-tracking-subtype="Add Photo" data-tracking-subcategory="Photo Gallery" data-tracking-container="true" data-tracking-category="UGC">Add Your Photo <svg class="icon icon-add-photo mntl-button__icon photo-dialog__add-photo-icon">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-add-photo" href="#icon-add-photo"></use></svg></button>
+                                </div>
+                            </div>
+                            <div class="loc content dialog__main">
+                                <h2 id="photo-dialog__title_1-0" class="comp photo-dialog__title mntl-text-block text-title-200">
+                                    Photos of Hot Honey Brussels Sprouts
+                                </h2>
+                                <div id="photo-dialog__content_1-0" class="comp photo-dialog__content mntl-block" data-limit="10">
+                                    <div id="photo-dialog__page_1-0" class="comp photo-dialog__page" data-page="1" data-active="true">
+                                        <div id="photo-dialog__item_1-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item">
+                                            <div id="mntl-list-marker_1-0" class="comp mntl-list-marker mntl-list-marker--numbers">
+                                                <div class="content-list-number">
+                                                    <span class="content-list-number__item-number text-title-200-moderate">01</span> <span class="content-list-number__total text-utility-100">of 01</span>
+                                                </div>
+                                            </div>
+                                            <figure class="photo mntl-image universal-image__container">
+                                                <div class="img-placeholder" style="padding-bottom:75.0%;">
+                                                    <img data-src="https://www.allrecipes.com/thmb/eD8G2v7vSEJgfAG3TcBSZDGIfTw=/0x512/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg" width="4000" height="3000" alt="Dish of roasted brussels sprouts with crumbled cheese and garnish" class="lazyload universal-image__image" /> <noscript><img src="https://www.allrecipes.com/thmb/eD8G2v7vSEJgfAG3TcBSZDGIfTw=/0x512/filters:no_upscale():max_bytes(150000):strip_icc()/11832010-hot-honey-brussels-sprouts-recipe-VAT-Beauty-4x3-5ee1ce8dde46479da6759f4cf0d8181c.jpg" width="4000" height="3000" class="img--noscript universal-image__image" alt="Dish of roasted brussels sprouts with crumbled cheese and garnish" /></noscript>
+                                                </div>
+                                            </figure>
+                                            <div class="photo-dialog__caption">
+                                                <svg class="icon icon-avatar-1 photo-dialog__icon ugc-icon-avatar-1">
+                                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-1" href="#icon-avatar-1"></use></svg> <span class="photo-title__photo-by">Photo by&#160;</span>
+                                                <p>
+                                                    <span class="photo-dialog__profile photo-dialog__profile--textonly">Allrecipes / Julia Hartbeck</span>
+                                                </p>
+                                                <div id="photo-dialog__review_1-0" class="comp photo-dialog__review ugc-review mntl-block">
+                                                    <div id="ugc-review__meta_1-0" class="comp ugc-review__meta mntl-block"></div>
+                                                    <div id="ugc-review__body-container_1-0" class="comp ugc-review__body-container mntl-block">
+                                                        <div id="ugc-review__body_1-0" class="comp ugc-review__body mntl-block"></div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <ol id="photo-dialog__pagination_1-0" class="comp photo-dialog__pagination photo-dialog__pagination">
+                                            <li class="pagination__item pagination__item--selected button--outlined-little-round text-utility-200-prominent" data-page="1">
+                                                <span class="button--outlined-little-round text-utility-200-prominent">1</span>
+                                            </li>
+                                        </ol>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </article>
+            <div id="leaderboard-post-content_1-0" class="comp leaderboard-post-content mm-ads-leaderboardac mm-ads-flexible-leaderboard-lazy mm-ads-flexible-leaderboard mm-ads-flexible-ad mm-ads-gpt-adunit js-lazy-ad has-right-label leaderboard gpt leaderboard dynamic">
+                <div id="leaderboardac" class="wrapper" data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], &quot;fluid&quot;, [970, 250], [1200, 450]]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+            </div>
+            <div id="recirc-section_1-0" class="comp recirc-section mntl-recirc-section mntl-block js-recirc-section" data-tracking-container="true">
+                <h2 id="mntl-recirc-section__header_1-0" class="comp mntl-recirc-section__header mntl-text-block text-title-300">
+                    You’ll Also Love
+                </h2>
+                <div id="mntl-recirc-section__content_1-0" class="comp mntl-recirc-section__content mntl-block recirc-content">
+                    <div id="mntl-recirc-section__block-1_1-0" class="comp mntl-recirc-section__block-1 mntl-universal-card-list mntl-document-card-list mntl-card-list mntl-block" data-chunk="36">
+                        <a id="mntl-card-list-items_1-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #1" data-doc-id="6564383" data-tracking-target-url="https://www.allrecipes.com/recipe/282853/roasted-brussels-sprouts-with-bacon-and-apples/" data-tax-levels="" href="https://www.allrecipes.com/recipe/282853/roasted-brussels-sprouts-with-bacon-and-apples/" data-tracking-subcategory="Related Articles" data-ordinal="1" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/vrtShHHUtoDPBqCPmTEHiCD7HcY=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/282853roasted-brussels-sprouts-with-bacon-and-appleslutzflcat4x3-560047b0b2954d639c988320eb1d7e87.jpg" width="282" height="188" alt="Roasted Brussels sprouts with bacon and apples in white dish" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/vrtShHHUtoDPBqCPmTEHiCD7HcY=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/282853roasted-brussels-sprouts-with-bacon-and-appleslutzflcat4x3-560047b0b2954d639c988320eb1d7e87.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="Roasted Brussels sprouts with bacon and apples in white dish" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_1-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6564383" data-doc-heading="Roasted Brussels Sprouts with Bacon and Apples" data-doc-image="https://www.allrecipes.com/thmb/T78L_iaE6oVGuXt5tsT5YLn8IrE=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/282853roasted-brussels-sprouts-with-bacon-and-appleslutzflcat4x3-560047b0b2954d639c988320eb1d7e87.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Roasted Brussels Sprouts with Bacon and Apples</span></span>
+                            <div id="mntl-recipe-card-meta_1-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_1-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-empty">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty" href="#icon-star-empty"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    4 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_2-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #2" data-doc-id="7484095" data-tracking-target-url="https://www.allrecipes.com/air-fryer-bacon-wrapped-brussels-sprouts-recipe-7484095" data-tax-levels="" href="https://www.allrecipes.com/air-fryer-bacon-wrapped-brussels-sprouts-recipe-7484095" data-tracking-subcategory="Related Articles" data-ordinal="2" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/ZEhE4rnr7NyUi80nA0Wz18hsRO4=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/ALR-air-fryer-bacon-wrapped-brussels-sprouts-recipe-7484095-VAT-hero-4x3-1-faea859c78b44895a3e5500c2558a509.jpg" width="282" height="188" alt="Bacon-wrapped brussels sprouts in a white ceramic bowl." class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/ZEhE4rnr7NyUi80nA0Wz18hsRO4=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/ALR-air-fryer-bacon-wrapped-brussels-sprouts-recipe-7484095-VAT-hero-4x3-1-faea859c78b44895a3e5500c2558a509.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="Bacon-wrapped brussels sprouts in a white ceramic bowl." /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_2-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="7484095" data-doc-heading="Air Fryer Bacon Wrapped Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/GWDWRSYA55xNxAL_L5OZQthXaQI=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/ALR-air-fryer-bacon-wrapped-brussels-sprouts-recipe-7484095-VAT-hero-4x3-1-faea859c78b44895a3e5500c2558a509.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Air Fryer Bacon Wrapped Brussels Sprouts</span></span>
+                            <div id="mntl-recipe-card-meta_2-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_2-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    3 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_3-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #3" data-doc-id="6580048" data-tracking-target-url="https://www.allrecipes.com/recipe/285424/easy-smashed-brussels-sprouts/" data-tax-levels="" href="https://www.allrecipes.com/recipe/285424/easy-smashed-brussels-sprouts/" data-tracking-subcategory="Related Articles" data-ordinal="3" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/9Y78xk7LJkbvVJgfdZdAoeot7tI=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/285424_easy-smashed-brussels-sprouts_Jonathan-Charbz4x3-e53f1e63d23d43d39a53f3279179b84c.jpg" width="282" height="188" alt="smashed Brussels sprouts with Parmesan cheese on white plate" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/9Y78xk7LJkbvVJgfdZdAoeot7tI=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/285424_easy-smashed-brussels-sprouts_Jonathan-Charbz4x3-e53f1e63d23d43d39a53f3279179b84c.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="smashed Brussels sprouts with Parmesan cheese on white plate" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_3-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6580048" data-doc-heading="Easy Smashed Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/EYWpB2IIF1nMIIoAFmITEITnTvI=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/285424_easy-smashed-brussels-sprouts_Jonathan-Charbz4x3-e53f1e63d23d43d39a53f3279179b84c.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Easy Smashed Brussels Sprouts</span></span>
+                            <div id="mntl-recipe-card-meta_3-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_3-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    21 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_4-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #4" data-doc-id="6603261" data-tracking-target-url="https://www.allrecipes.com/recipe/282213/thyme-roasted-brussels-sprouts-with-fresh-cranberries/" data-tax-levels="" href="https://www.allrecipes.com/recipe/282213/thyme-roasted-brussels-sprouts-with-fresh-cranberries/" data-tracking-subcategory="Related Articles" data-ordinal="4" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/Qy6gkQRpogsAsocpTJGOkqB68tk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/8694987-91789993e84648af932f7ba46e7efaf7.jpg" width="282" height="188" alt="Thyme-Roasted Brussels Sprouts with Fresh Cranberries" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/Qy6gkQRpogsAsocpTJGOkqB68tk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/8694987-91789993e84648af932f7ba46e7efaf7.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="Thyme-Roasted Brussels Sprouts with Fresh Cranberries" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_4-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6603261" data-doc-heading="Thyme-Roasted Brussels Sprouts with Fresh Cranberries" data-doc-image="https://www.allrecipes.com/thmb/nPye7TGt1ElaEX1LbjkQxucTBKk=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/8694987-91789993e84648af932f7ba46e7efaf7.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Vegetables">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Thyme-Roasted Brussels Sprouts with Fresh Cranberries</span></span>
+                            <div id="mntl-recipe-card-meta_4-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_4-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    28 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_5-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #5" data-doc-id="6588978" data-tracking-target-url="https://www.allrecipes.com/recipe/172905/baked-green-vegetables/" data-tax-levels="" href="https://www.allrecipes.com/recipe/172905/baked-green-vegetables/" data-tracking-subcategory="Related Articles" data-ordinal="5" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/rVIkSfzue1Y4XuXlvtBbmJ3_f14=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/913380-c0f4ef468d4e4a08b4a33f6042a557d5.jpg" width="282" height="188" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/rVIkSfzue1Y4XuXlvtBbmJ3_f14=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/913380-c0f4ef468d4e4a08b4a33f6042a557d5.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_5-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6588978" data-doc-heading="Baked Green Vegetables" data-doc-image="https://www.allrecipes.com/thmb/qE36U6n7dgZRu_-dejGpHalxv-8=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/913380-c0f4ef468d4e4a08b4a33f6042a557d5.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Baked Green Vegetables</span></span>
+                            <div id="mntl-recipe-card-meta_5-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_5-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-empty">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty" href="#icon-star-empty"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    20 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_6-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #6" data-doc-id="7094706" data-tracking-target-url="https://www.allrecipes.com/recipe/8525165/roasted-brussels-sprouts-with-grapes/" data-tax-levels="" href="https://www.allrecipes.com/recipe/8525165/roasted-brussels-sprouts-with-grapes/" data-tracking-subcategory="Related Articles" data-ordinal="6" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/g6Uq6S6S3IMSRIfijTxOK2OIYQc=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/4x3-Goldman_ALR0323_Sides_BrusselsSprouts_3238-9867f830fbf14a1a92950326e525d86f.jpg" width="282" height="188" alt="looking down at a platter of roasted brussels sprouts with grapes" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/g6Uq6S6S3IMSRIfijTxOK2OIYQc=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/4x3-Goldman_ALR0323_Sides_BrusselsSprouts_3238-9867f830fbf14a1a92950326e525d86f.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="looking down at a platter of roasted brussels sprouts with grapes" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_6-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="7094706" data-doc-heading="Roasted Brussels Sprouts with Grapes" data-doc-image="https://www.allrecipes.com/thmb/NrpCs9YWMABXudXp9LzppnNZpYA=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/4x3-Goldman_ALR0323_Sides_BrusselsSprouts_3238-9867f830fbf14a1a92950326e525d86f.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Roasted Brussels Sprouts with Grapes</span></span>
+                            <div id="mntl-recipe-card-meta_6-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_6-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    2 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_7-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #7" data-doc-id="6664736" data-tracking-target-url="https://www.allrecipes.com/recipe/228875/maple-roasted-brussels-sprouts-with-bacon/" data-tax-levels="" href="https://www.allrecipes.com/recipe/228875/maple-roasted-brussels-sprouts-with-bacon/" data-tracking-subcategory="Related Articles" data-ordinal="7" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/6ktdZqwyRINotBFfv_0wrC5dqMA=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/228875-maple-roasted-brussels-sprouts-with-bacon-VAT-004-4x3-02-b9ac6ef8e20742f99e208f9432b98102.jpg" width="282" height="188" alt="Maple roasted Brussels sprouts with bacon served in a bowl with a fork" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/6ktdZqwyRINotBFfv_0wrC5dqMA=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/228875-maple-roasted-brussels-sprouts-with-bacon-VAT-004-4x3-02-b9ac6ef8e20742f99e208f9432b98102.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="Maple roasted Brussels sprouts with bacon served in a bowl with a fork" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_7-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6664736" data-doc-heading="Maple Roasted Brussels Sprouts with Bacon" data-doc-image="https://www.allrecipes.com/thmb/a1AXwLZr9BH1gOU763B5jU753c4=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/228875-maple-roasted-brussels-sprouts-with-bacon-VAT-004-4x3-02-b9ac6ef8e20742f99e208f9432b98102.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Roasted">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Maple Roasted Brussels Sprouts with Bacon</span></span>
+                            <div id="mntl-recipe-card-meta_7-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_7-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    573 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_8-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #8" data-doc-id="6738591" data-tracking-target-url="https://www.allrecipes.com/recipe/230157/brussels-sprouts-with-bacon-dressing/" data-tax-levels="" href="https://www.allrecipes.com/recipe/230157/brussels-sprouts-with-bacon-dressing/" data-tracking-subcategory="Related Articles" data-ordinal="8" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/cm78w8ojw7oMY1kRFo9-MPC9QXQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/939678-3d9081735666466f9be24702199d9333.jpg" width="282" height="188" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/cm78w8ojw7oMY1kRFo9-MPC9QXQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/939678-3d9081735666466f9be24702199d9333.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_8-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6738591" data-doc-heading="Brussels Sprouts with Bacon Dressing" data-doc-image="https://www.allrecipes.com/thmb/6Ch-WRoRZB5JYdVd-3dzFVtAP3A=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/939678-3d9081735666466f9be24702199d9333.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Brussels Sprouts with Bacon Dressing</span></span>
+                            <div id="mntl-recipe-card-meta_8-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_8-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    57 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a>
+                    </div>
+                    <div id="leaderboard-deferred-footer_1-0" class="comp leaderboard-deferred-footer mm-ads-leaderboardfooter-flex-1-lazy mm-ads-flexible-leaderboard-lazy mm-ads-flexible-leaderboard mm-ads-flexible-ad mm-ads-gpt-adunit js-lazy-ad has-right-label leaderboard gpt leaderboard dynamic">
+                        <div id="leaderboardfooter-flex-1" class="wrapper" data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], [970, 250], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                    </div>
+                    <div id="mntl-recirc-section__block-2_1-0" class="comp mntl-recirc-section__block-2 mntl-universal-card-list mntl-document-card-list mntl-card-list mntl-block" data-chunk="36">
+                        <a id="mntl-card-list-items_9-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #9" data-doc-id="6738363" data-tracking-target-url="https://www.allrecipes.com/recipe/221963/chef-johns-roasted-brussels-sprouts/" data-tax-levels="" href="https://www.allrecipes.com/recipe/221963/chef-johns-roasted-brussels-sprouts/" data-tracking-subcategory="Related Articles" data-ordinal="1" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/RIMlvMW9putYvZdv3Uz5mQ1eG_o=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/5915709-4c86f266d1414a96a64c056bce730531.jpg" width="282" height="188" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/RIMlvMW9putYvZdv3Uz5mQ1eG_o=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/5915709-4c86f266d1414a96a64c056bce730531.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_9-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6738363" data-doc-heading="Chef John's Roasted Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/fg9gL6U1y8dReEIaWyQIxwOFoz0=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/5915709-4c86f266d1414a96a64c056bce730531.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Onion">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Chef John's Roasted Brussels Sprouts</span></span>
+                            <div id="mntl-recipe-card-meta_9-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_9-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    88 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_10-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #10" data-doc-id="6575463" data-tracking-target-url="https://www.allrecipes.com/recipe/63340/brussels-sprouts-with-mushrooms/" data-tax-levels="" href="https://www.allrecipes.com/recipe/63340/brussels-sprouts-with-mushrooms/" data-tracking-subcategory="Related Articles" data-ordinal="2" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/oxdsp-rum5lAUObrW--Lg6qx5Ks=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/293021-bec4f2c6db4643d08fa3ae94157130cb.jpg" width="282" height="188" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/oxdsp-rum5lAUObrW--Lg6qx5Ks=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/293021-bec4f2c6db4643d08fa3ae94157130cb.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_10-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6575463" data-doc-heading="Brussels Sprouts with Mushrooms" data-doc-image="https://www.allrecipes.com/thmb/4NrLCt8BE4UoFTJ_oWr0VGRON4c=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/293021-bec4f2c6db4643d08fa3ae94157130cb.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Brussels Sprouts with Mushrooms</span></span>
+                            <div id="mntl-recipe-card-meta_10-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_10-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    173 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_11-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #11" data-doc-id="6604511" data-tracking-target-url="https://www.allrecipes.com/recipe/229000/honey-glazed-brussels-sprouts/" data-tax-levels="" href="https://www.allrecipes.com/recipe/229000/honey-glazed-brussels-sprouts/" data-tracking-subcategory="Related Articles" data-ordinal="3" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/U6VjZhfRo7g77kC1w4o9mujX4QE=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/8579366-56b7b8e5b57f4468809dfc243e8e7895.jpg" width="282" height="188" alt="Honey Glazed Brussels Sprouts" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/U6VjZhfRo7g77kC1w4o9mujX4QE=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/8579366-56b7b8e5b57f4468809dfc243e8e7895.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="Honey Glazed Brussels Sprouts" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_11-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6604511" data-doc-heading="Honey Glazed Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/iTslNtPFxCNLRMMMdb-ifzVNrOI=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/8579366-56b7b8e5b57f4468809dfc243e8e7895.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Honey Glazed Brussels Sprouts</span></span>
+                            <div id="mntl-recipe-card-meta_11-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_11-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    60 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_12-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #12" data-doc-id="6586944" data-tracking-target-url="https://www.allrecipes.com/recipe/274675/roasted-brussels-sprouts-with-balsamic-and-honey/" data-tax-levels="" href="https://www.allrecipes.com/recipe/274675/roasted-brussels-sprouts-with-balsamic-and-honey/" data-tracking-subcategory="Related Articles" data-ordinal="4" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/itNKOKXTPTSzSJTTvYO-W3TvT_w=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/7965160-69c52e2b73604b3e8e7ce1f03577c85a.jpg" width="282" height="188" alt="Roasted Brussels Sprouts with Balsamic and Honey" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/itNKOKXTPTSzSJTTvYO-W3TvT_w=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/7965160-69c52e2b73604b3e8e7ce1f03577c85a.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="Roasted Brussels Sprouts with Balsamic and Honey" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_12-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6586944" data-doc-heading="Roasted Brussels Sprouts with Balsamic and Honey" data-doc-image="https://www.allrecipes.com/thmb/JJ8FxP-Ej2DGbgpyi-amNjtkcRY=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/7965160-69c52e2b73604b3e8e7ce1f03577c85a.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Roasted">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Roasted Brussels Sprouts with Balsamic and Honey</span></span>
+                            <div id="mntl-recipe-card-meta_12-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_12-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    20 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_13-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #13" data-doc-id="6592598" data-tracking-target-url="https://www.allrecipes.com/recipe/267255/air-fryer-brussels-sprouts/" data-tax-levels="" href="https://www.allrecipes.com/recipe/267255/air-fryer-brussels-sprouts/" data-tracking-subcategory="Related Articles" data-ordinal="5" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/O4Zn4lqWTy0-COelfgL9T91db28=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/8051141-a32d586e73fe44569081f306e7765065.jpg" width="282" height="188" alt="Air Fryer Brussels Sprouts" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/O4Zn4lqWTy0-COelfgL9T91db28=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/8051141-a32d586e73fe44569081f306e7765065.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="Air Fryer Brussels Sprouts" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_13-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6592598" data-doc-heading="Air Fryer Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/CYynJ6AO3416Vz7q-WT4Ahvm1jc=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/8051141-a32d586e73fe44569081f306e7765065.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Air Fryer Brussels Sprouts</span></span>
+                            <div id="mntl-recipe-card-meta_13-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_13-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    28 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_14-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #14" data-doc-id="6568382" data-tracking-target-url="https://www.allrecipes.com/recipe/271141/pan-seared-brussels-sprouts/" data-tax-levels="" href="https://www.allrecipes.com/recipe/271141/pan-seared-brussels-sprouts/" data-tracking-subcategory="Related Articles" data-ordinal="6" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/4EfzaB-FUv0aG8JToqR2KxTICxY=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/3215843-4392aff127f7430598f58aa03ff83aa1.jpg" width="282" height="188" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/4EfzaB-FUv0aG8JToqR2KxTICxY=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/3215843-4392aff127f7430598f58aa03ff83aa1.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_14-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6568382" data-doc-heading="Pan-Seared Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/85gDLYlovHYNu--daMwItrrCE_4=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/3215843-4392aff127f7430598f58aa03ff83aa1.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Pan-Seared Brussels Sprouts</span></span>
+                            <div id="mntl-recipe-card-meta_14-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_14-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    6 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_15-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #15" data-doc-id="6601701" data-tracking-target-url="https://www.allrecipes.com/recipe/274674/easy-roasted-brussels-sprouts/" data-tax-levels="" href="https://www.allrecipes.com/recipe/274674/easy-roasted-brussels-sprouts/" data-tracking-subcategory="Related Articles" data-ordinal="7" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/YDXwzu5eNxnQXrHBRnH_meAiXnU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/274674-easy-roasted-brussels-sprouts-DDMFS_4x3_Beauty-65eda0bf65374b629b4bb40c5309c578.jpg" width="282" height="188" alt="looking down at a bowl of roasted brussels sprouts" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/YDXwzu5eNxnQXrHBRnH_meAiXnU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/274674-easy-roasted-brussels-sprouts-DDMFS_4x3_Beauty-65eda0bf65374b629b4bb40c5309c578.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" alt="looking down at a bowl of roasted brussels sprouts" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_15-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6601701" data-doc-heading="Easy Roasted Brussels Sprouts" data-doc-image="https://www.allrecipes.com/thmb/KUDer4fYw79Imnhixdso7h4jJlU=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/274674-easy-roasted-brussels-sprouts-DDMFS_4x3_Beauty-65eda0bf65374b629b4bb40c5309c578.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Roasted">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Easy Roasted Brussels Sprouts</span></span>
+                            <div id="mntl-recipe-card-meta_15-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_15-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    6 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a> <a id="mntl-card-list-items_16-0" class="comp mntl-card-list-items mntl-universal-card mntl-document-card mntl-card card card--no-image" data-tracking-subtype="Card #16" data-doc-id="6573200" data-tracking-target-url="https://www.allrecipes.com/recipe/150818/quick-brussels-and-bacon/" data-tax-levels="" href="https://www.allrecipes.com/recipe/150818/quick-brussels-and-bacon/" data-tracking-subcategory="Related Articles" data-ordinal="8" data-tracking-container="true" data-tracking-category="Recirc">
+                        <div class="loc card__top">
+                            <div class="card__media mntl-image card__media universal-image__container">
+                                <div class="img-placeholder" style="padding-bottom:66.6%;">
+                                    <img data-src="https://www.allrecipes.com/thmb/iWWOGxGPSBHRIyKd6iflPy3MqME=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/491844-85f779f1020b40f5be0a94f63de8d956.jpg" width="282" height="188" class="lazyload card__img universal-image__image" data-expand="300" /> <noscript><img src="https://www.allrecipes.com/thmb/iWWOGxGPSBHRIyKd6iflPy3MqME=/282x188/filters:no_upscale():max_bytes(150000):strip_icc()/491844-85f779f1020b40f5be0a94f63de8d956.jpg" width="282" height="188" class="img--noscript card__img universal-image__image" /></noscript>
+                                </div>
+                            </div>
+                            <div id="card__favorite_16-0" class="comp card__favorite mm-myrecipes-favorite">
+                                <button class="mm-myrecipes-favorite__link" data-check-on-load="false" data-scroll-to-favorite="true" data-doc-id="6573200" data-doc-heading="Quick Brussels and Bacon" data-doc-image="https://www.allrecipes.com/thmb/dkolH208q8_YlSSYULojfazl76Q=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/491844-85f779f1020b40f5be0a94f63de8d956.jpg" data-tracking-on="card" data-sign-in="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-sign-up="/authentication/login?regSource=h2j9pq&amp;isMyrecipes=true&amp;relativeRedirectUrl=" data-regsource="h2j9pq" data-is-bookmarked="false" data-enable-custom-tracking="false" tabindex="0" data-interstitial-login-text="Continue to Save" data-save-copy="Save Recipe" data-saved-copy="Recipe Saved" aria-label="Save Recipe"><svg class="icon icon-favorite">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-favorite" href="#icon-favorite"></use></svg></button>
+                            </div>
+                        </div>
+                        <div class="card__content" data-tag="Brussels Sprouts">
+                            <div class="card__header"></div><span class="card__title"><span class="card__title-text">Quick Brussels and Bacon</span></span>
+                            <div id="mntl-recipe-card-meta_16-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+                                <div id="mntl-recipe-star-rating_16-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+                                    <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use></svg> <svg class="icon icon-star-half">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use></svg>
+                                </div>
+                                <div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+                                    111 <span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">Ratings</span>
+                                </div>
+                            </div>
+                        </div></a>
+                    </div>
+                    <div id="leaderboard2-deferred-footer_1-0" class="comp leaderboard2-deferred-footer mm-ads-leaderboardfooter-flex-2-lazy mm-ads-flexible-leaderboard-lazy mm-ads-flexible-leaderboard mm-ads-flexible-ad mm-ads-gpt-adunit js-lazy-ad has-right-label leaderboard gpt leaderboard dynamic">
+                        <div id="leaderboardfooter-flex-2" class="wrapper" data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], [970, 250], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+                    </div>
+                </div>
+            </div>
+        </main>
+        <footer id="mntl-footer_1-0" class="comp mntl-footer" role="contentinfo" data-tracking-container="true">
+            <div class="mntl-footer__inner">
+                <div class="mntl-footer__primary">
+                    <div class="mntl-footer__logo">
+                        <a href="/" rel="home nocaes" id="mntl-logo_1-0" aria-label="Visit Allrecipes' homepage">
+                        <div class="is-screenreader-only">
+                            Allrecipes
+                        </div><svg class="icon icon-logo">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo" href="#icon-logo"></use></svg></a>
+                    </div>
+                    <div class="loc newsletter-link-wrapper mntl-footer__newsletter">
+                        <a href="#" rel="nocaes" data-tracking-metadata-location="footer" data-a11y-dialog-show="newsletter-dialog-footer" role="button" data-tracking-subtype="Signup CTA" data-tracking-target-url="null" data-tracking-metadata-auth="false" id="mntl-newsletter-dialog--footer-link_1-0" class="mntl-newsletter-dialog--footer-link dialog-link mntl-text-link mntl-footer__newsletter-link" data-tracking-category="Newsletters" data-tracking-container="true"><span class="link__wrapper">Newsletters</span></a>
+                    </div>
+                    <div class="mntl-footer__social">
+                        <div id="mntl-footer-social_1-0" class="comp mntl-footer-social allrecipes-social-nav mntl-social-nav" data-tracking-container="true">
+                            <div class="social-nav__title">
+                                Follow Us
+                            </div>
+                            <ul class="social-nav__list">
+                                <li class="social-nav__item social-nav__item--facebook">
+                                    <a href="https://www.facebook.com/allrecipes" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--facebook" aria-label="Visit Allrecipes's Facebook"><svg class="icon icon-facebook social-nav__icon">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook" href="#icon-facebook"></use></svg></a>
+                                </li>
+                                <li class="social-nav__item social-nav__item--instagram">
+                                    <a href="https://www.instagram.com/allrecipes/" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--instagram" aria-label="Visit Allrecipes's Instagram"><svg class="icon icon-instagram social-nav__icon">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram" href="#icon-instagram"></use></svg></a>
+                                </li>
+                                <li class="social-nav__item social-nav__item--pinterest">
+                                    <a href="https://www.pinterest.com/allrecipes/" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--pinterest" aria-label="Visit Allrecipes's Pinterest"><svg class="icon icon-pinterest social-nav__icon">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest" href="#icon-pinterest"></use></svg></a>
+                                </li>
+                                <li class="social-nav__item social-nav__item--tiktok">
+                                    <a href="https://www.tiktok.com/@allrecipes" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--tiktok" aria-label="Visit Allrecipes's TikTok"><svg class="icon icon-tiktok social-nav__icon">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-tiktok" href="#icon-tiktok"></use></svg></a>
+                                </li>
+                                <li class="social-nav__item social-nav__item--youtube">
+                                    <a href="https://www.youtube.com/user/allrecipes/videos" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--youtube" aria-label="Visit Allrecipes's YouTube"><svg class="icon icon-youtube social-nav__icon">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-youtube" href="#icon-youtube"></use></svg></a>
+                                </li>
+                                <li class="social-nav__item social-nav__item--flipboard">
+                                    <a href="https://flipboard.com/@Allrecipes" target="_blank" rel="noopener nocaes" class="social-nav__link social-nav__link--flipboard" aria-label="Visit Allrecipes's Flipboard"><svg class="icon icon-flipboard social-nav__icon">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-flipboard" href="#icon-flipboard"></use></svg></a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="mntl-footer__secondary">
+                    <nav id="mntl-footer-nav_1-0" class="comp mntl-footer-nav mntl-block" aria-label="Footer">
+                        <ul id="mntl-block_1-0" class="comp mntl-block mntl-footer-nav__list">
+                            <li id="mntl-footer-nav__list-item_1-0" class="comp mntl-footer-nav__list-item mntl-block">
+                                <a href="https://www.allrecipes.com/recipes/17562/dinner/" rel="nocaes" class="mntl-text-link text-label-300 global-link" id="mntl-text-link_1-0" data-tracking-container="true"><span class="link__wrapper">Dinners</span></a>
+                            </li>
+                            <li id="mntl-footer-nav__list-item_2-0" class="comp mntl-footer-nav__list-item mntl-block">
+                                <a href="https://www.allrecipes.com/recipes/" rel="nocaes" class="mntl-text-link text-label-300 global-link" id="mntl-text-link_2-0" data-tracking-container="true"><span class="link__wrapper">Meals</span></a>
+                            </li>
+                            <li id="mntl-footer-nav__list-item_3-0" class="comp mntl-footer-nav__list-item mntl-block">
+                                <a href="https://www.allrecipes.com/recipes/17567/ingredients/" rel="nocaes" class="mntl-text-link text-label-300 global-link" id="mntl-text-link_3-0" data-tracking-container="true"><span class="link__wrapper">Ingredients</span></a>
+                            </li>
+                            <li id="mntl-footer-nav__list-item_4-0" class="comp mntl-footer-nav__list-item mntl-block">
+                                <a href="https://www.allrecipes.com/recipes/85/holidays-and-events/" rel="nocaes" class="mntl-text-link text-label-300 global-link" id="mntl-text-link_4-0" data-tracking-container="true"><span class="link__wrapper">Occasions</span></a>
+                            </li>
+                            <li id="mntl-footer-nav__list-item_5-0" class="comp mntl-footer-nav__list-item mntl-block">
+                                <a href="https://www.allrecipes.com/recipes/86/world-cuisine/" rel="nocaes" class="mntl-text-link text-label-300 global-link" id="mntl-text-link_5-0" data-tracking-container="true"><span class="link__wrapper">Cuisines</span></a>
+                            </li>
+                            <li id="mntl-footer-nav__list-item_6-0" class="comp mntl-footer-nav__list-item mntl-block">
+                                <a href="https://www.allrecipes.com/kitchen-tips/" rel="nocaes" class="mntl-text-link text-label-300 global-link" id="mntl-text-link_6-0" data-tracking-container="true"><span class="link__wrapper">Kitchen Tips</span></a>
+                            </li>
+                            <li id="mntl-footer-nav__list-item_7-0" class="comp mntl-footer-nav__list-item mntl-block">
+                                <a href="https://www.allrecipes.com/food-news-trends/" rel="nocaes" class="mntl-text-link text-label-300 global-link" id="mntl-text-link_7-0" data-tracking-container="true"><span class="link__wrapper">News</span></a>
+                            </li>
+                            <li id="mntl-footer-nav__list-item_8-0" class="comp mntl-footer-nav__list-item mntl-block">
+                                <a href="https://www.allrecipes.com/recipes/1642/everyday-cooking/" rel="nocaes" class="mntl-text-link text-label-300 global-link" id="mntl-text-link_8-0" data-tracking-container="true"><span class="link__wrapper">Features</span></a>
+                            </li>
+                        </ul>
+                    </nav>
+                    <ul id="mntl-footer-links_1-0" class="comp mntl-footer-links footer-links">
+                        <li class="mntl-footer-links__item">
+                            <a href="/about-us-6648102" rel="nocaes" data-type="ourStory" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">About Us</a>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="/about-us-6648102#toc-editorial-guidelines" rel="nocaes" data-type="editorialGuidelines" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Editorial Process</a>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="https://www.people.inc/brands-privacy" target="_blank" rel="noopener nofollow nocaes" data-type="privacyPolicy" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Privacy Policy</a>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="/about-us-6648102#toc-product-reviews" rel="nocaes" data-type="productVetting" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Product Vetting</a>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="https://www.people.inc/brands-termsofservice" target="_blank" rel="noopener nofollow nocaes" data-type="termsOfService" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Terms of Service</a>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="https://www.people.inc/brands/food-drink/allrecipes" target="_blank" rel="noopener nofollow nocaes" data-type="advertise" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Advertise</a>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="https://www.people.inc/careers" target="_blank" rel="noopener nofollow nocaes" data-type="careersAtDotDashMeredith" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Careers</a>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="/about-us-6648102#toc-contact-us" rel="nocaes" data-type="contact" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Contact</a>
+                        </li>
+                        <li class="mntl-footer-links__item ot-pref-trigger">
+                            <button class="mntl-footer-links__link mntl-footer-links__privacy text-utility-200 global-link" type="button" data-component="footerLinks" data-type="cmpFooterLink" safelist="true" href="#" data-ordinal="1" data-source="footerLinks" forcenosponsored="true"><span class="link-wrapper">Your Privacy Choices</span> &#160; <span class="post-link-wrapper"><svg class="icon icon-privacy-options" role="img" aria-label="Manage Your Privacy Choices">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-privacy-options" href="#icon-privacy-options"></use></svg></span></button>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="https://w1.buysub.com/servlet/CSGateway?cds_mag_code=ALR" target="_blank" rel="noopener nofollow nocaes" data-type="magazineSubscription" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Manage Your Magazine Subscription</a>
+                        </li>
+                        <li class="mntl-footer-links__item">
+                            <a href="https://www.magazines.com/customer-care" target="_blank" rel="noopener nofollow nocaes" data-type="magazineHelp" data-ordinal="1" class="mntl-footer-links__link text-utility-200 global-link" data-component="footerLinks" data-source="footerLinks">Magazine Subscription Help</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="loc footer-bottom">
+                <div id="mntl-dotdash-universal-nav_1-0" class="comp mntl-dotdash-universal-nav mntl-carbon-dotdash-universal-nav" data-tracking-container="true">
+                    <div class="mntl-dotdash-universal-nav__content">
+                        <svg class="icon mntl-dotdash-universal-nav__logo">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#mntl-dotdash-universal-nav__logo" href="#mntl-dotdash-universal-nav__logo"></use></svg>
+                        <div class="mntl-dotdash-universal-nav__wrapper">
+                            <div class="mntl-dotdash-universal-nav__text">
+                                Allrecipes is part of the <a href="https://www.people.inc" target="_blank" rel="noopener nofollow nocaes" class="mntl-dotdash-universal-nav__text--link">People Inc.</a>&#160;publishing&#160;family.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="mm-myrecipes-interstitial__dialog_1-0" class="comp mm-myrecipes-interstitial__dialog mntl-dialog myrecipes myr-meridian dialog" data-a11y-dialog="mm-myrecipes-interstitial__dialog" aria-hidden="true">
+                    <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide=""></div>
+                    <div role="dialog" class="dialog__content" aria-labelledby="mm-myrecipes-interstitial__dialog_1-0-title">
+                        <div class="dialog__heading">
+                            <span id="mm-myrecipes-interstitial__dialog_1-0-title" class="dialog__title">Myrecipes Dialog</span> <button data-a11y-dialog-hide="" class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window"><svg class="icon icon-close">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use></svg></button>
+                        </div>
+                        <div class="loc content dialog__main">
+                            <div id="mm-myrecipes-interstitial__content_1-0" class="comp mm-myrecipes-interstitial__content mm-myrecipes-interstitial mm-myrecipes-interstitial__content" data-defer="myrecipesInterstitial"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </footer>
+        <div id="newsletter-dialog-header_1-0" class="comp newsletter-dialog-header mntl-newsletter-dialog--header mntl-newsletter-dialog mntl-dialog dialog" data-a11y-dialog="newsletter-dialog-header" aria-hidden="true">
+            <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide=""></div>
+            <div role="dialog" class="dialog__content" aria-labelledby="newsletter-dialog-header_1-0-title">
+                <div class="dialog__heading">
+                    <span id="newsletter-dialog-header_1-0-title" class="dialog__title text-title-100">Newsletter Sign Up</span> <button data-a11y-dialog-hide="" class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window"><svg class="icon icon-close">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use></svg></button>
+                </div>
+                <div class="loc content dialog__main">
+                    <div id="mntl-newsletter_1-0" class="comp mntl-newsletter" data-defer="loadDialogContent"></div>
+                </div>
+            </div>
+        </div>
+        <div id="newsletter-dialog-footer_1-0" class="comp newsletter-dialog-footer mntl-newsletter-dialog--footer mntl-newsletter-dialog mntl-dialog dialog" data-a11y-dialog="newsletter-dialog-footer" aria-hidden="true">
+            <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide=""></div>
+            <div role="dialog" class="dialog__content" aria-labelledby="newsletter-dialog-footer_1-0-title">
+                <div class="dialog__heading">
+                    <span id="newsletter-dialog-footer_1-0-title" class="dialog__title text-title-100">Newsletter Sign Up</span> <button data-a11y-dialog-hide="" class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window"><svg class="icon icon-close">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use></svg></button>
+                </div>
+                <div class="loc content dialog__main">
+                    <div id="mntl-newsletter_2-0" class="comp mntl-newsletter" data-defer="loadDialogContent"></div>
+                </div>
+            </div>
+        </div><svg class="is-hidden">
+        <defs>
+            <symbol id="mntl-sc-block-starrating-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20">
+                <path d="M0,0v20h20V0H0z M14.2,12.2l1.1,6.3l-5.4-3.2l-5.1,3.2l1-6.3L1.4,8l5.9-0.8l2.6-5.8l2.7,5.8L18.5,8L14.2,12.2z"></path></svg>
+            </symbol>
+        </defs></svg>
+        <script type="text/javascript" data-glb-js="bottom" src="/static/4.110.0/cache/eNqNVtGWoyAM_aHNeuYb5nV-IkBULEIXYlvn6zeo7dTW4fDggVy5EMhNoEmMbHUzomdHzZCaUTpwQW-dQ0g6Buf-NPtROozn4Mlzaqxnih5dY6ilmPlLJ5L5IQUzOUrPLI43wLa1ziITMHYdxVfUWX-CSNdoeZ1Y-CNFTaVxBU_ptnpqv1dOynO-gW9eyyCH3zOgKcxtbGdDD4YczmRezAJPBzm-G0_o4IzzuGDDIVyY5GpNR9L2ZLueP3v0HX3ZxOTl3I7AwlydC0qC2ROahZybx_Dacdu0zqplN_jxMYOx6EJXOxXAOJfc9HixnfwLvplYdMAzCPTcL5DbEMfUJMKoe8jGc7_AGykl7AgU-nyye7Mojrz1rVlUVrez7Sjyxn66ddR2ck5Sl8gv9L1ZSsxxzCdP2p4pQYuXkLPqGD3KlPs_yJEoaVZF9EaWm2P-QAQvQ3cyf_ft7kDMWa8mZtnoAVaRKT6wba1ezuoezuEQrg1rKSx0TY5Y6syWBO9IadcXayjAcD3nWhJBxYCm2Zv19Afxt1x16a_qEnGp4o-i-jy2s22dGlUU-eo4jSo997fL5QCqCCGH4Nie722BgRP3IcKdMLwiNZJLQUugIPUY6RAsSX1RZXpcrecod2a9VndLD3u7KlvoYukqco4H0FE9xiiA-LK1sFxGnjf21sC5DxwgWqUeWbjDalwzxChl4tUuUb38uCznsPZqlnExgfWdPElsCa_SwVpEr3iiI6xqCooXWRVSfnKgGaaUnzfFvwWVJI6T5kn28IjTmp_ilJTEr3z5q3D7xBimRK7GwVGuGrD8atdQ_cRS_XP1bFH_joNDRe63EpQEO83KliOS_k33hNDggj7BihwpetXlVnyfjdICCtMyfevoZpWj8gMwkV5KXd5x1HBs_geYsmdN.min.js" async="async" defer="true"></script> 
+        <script type="text/javascript">
+        //<![CDATA[
+
+        Mntl.utilities.scriptsOnLoad(document.querySelectorAll('script[data-glb-js="bottom"]'), function() {
+        var Mntl = window.Mntl || {};
+        window.Mntl = window.Mntl || {};
+        window.Mntl.affiliatePlugins = window.Mntl.affiliatePlugins || [];
+        window.Mntl.affiliateLinkRewriter.setMappings( {
+        DOC_ID: '11832010'
+        ,SITE: 'allrecipes'
+        ,REQUEST_ID: 'n4c7ebd895c384815bf10357e457ed95b19'
+        }
+        );
+        window.Mntl.affiliatePlugins.push(window.Mntl.affiliateLinkRewriter.processLink);window.Mntl.externalizeLinks.init();(function (Mntl) {
+        Mntl.digioh = {
+        script: null,
+        brandId: null,
+        initialized: false,
+        init() {
+        if (this.initialized) return;
+        const brandId = '47b4a4dd-ffd7-43db-8118-8002b7c15352';
+        const digiohFastActivation = 'false';
+        const lightboxJs = digiohFastActivation === 'true' ? '/lightbox_speed.js' : '/lightbox_inline.js';
+        // eslint-disable-next-line prefer-template
+        const script = 'https://www.lightboxcdn.com/vendor/' + brandId + lightboxJs;
+        this.brandId = brandId;
+        this.script = script;
+        this.initialized = true;
+        },
+        load(callback) {
+        this.init();
+        if (callback) {
+        Mntl.utilities.loadExternalJS({ src: this.script }, callback);
+        } else {
+        Mntl.utilities.loadExternalJS({ src: this.script });
+        }
+        }
+        };
+        })(window.Mntl || {});
+        Mntl.digiohTimerDelay = parseFloat('0') * 1000;
+        (function(Mntl) {
+        const setup = {"clickToInitialize":false,"playlistUrl":"https:\/\/cdn.jwplayer.com\/v2\/playlists\/fV1m0Jmn","documentDescription":"These+hot+honey+Brussels+sprouts+are+a+simple+side+dish+with+all+the+elements+you%26%2339%3Bll+ever+need+in+a+side.+They%26%2339%3Bre+sweet%2C+spicy%2C+crispy%2C+and+melt+in+your+mouth.","skin":{"name":"mantle"},"mute":true,"advertising":{"client":"googima","vpaidmode":"enabled","rules":{"frequency":1},"forceNonLinearFullSlot":true,"vpaidcontrols":true,"autoplayadsmuted":true},"autostart":true,"nextUpDisplay":true,"preload":"metadata","captions":{"backgroundOpacity":65,"fontSize":16,"fontFamily":"Arial,Helvetica,sans-serif","edgeStyle":"none"},"aspectratio":"16:9","pauseotherplayers":"true","cast":{},"recsPlaylistId":"ZBQZ5egR","width":"100%","documentTitle":"Hot+Honey+Brussels+Sprouts"};
+        // JW player requires `playlist` to be populated for contextual playlists
+        setup.playlist = setup.playlistUrl;
+        const isImmediateAutoplay = false;
+        const playInView = 0;
+        const encodedPageURL = encodeURIComponent(window.location);
+        const domain = Mntl.utilities.getDomain();
+        const iuPath = '/' + Mntl.GPT.getDfpId() + '/ddm.' + domain.replace('.com', '.video') + (Mntl.GPT.isMobile() ? '.mob' : '');
+        function formatAdSizeArray(sizeArr) {
+        return sizeArr.map(function(sz) {
+        return sz.join('x');
+        }).join('|');
+        }
+        // Assign a randomly-generated, eight character, alpha-numeric value to this property.
+        setup.advertising.adscheduleid = Math.random().toString(36).substr(2,8);
+        // muid - used for audience targeting
+        setup.advertising.ppid = '4a995dca-46e4-4959-b4c5-08b4b9326ada';
+        let custParams = '';
+        custParams += '&' + encodeURIComponent('slot') + '=' + encodeURIComponent('broadmatch');
+        const inFocus = window && window.document && window.document.hasFocus();
+        const durationParams = Mntl.JWPlayer.getDurationParams(0, true);
+        custParams += '&ttid=' + setup.mediaid;
+        custParams += '&play=' + Mntl.JWPlayer.getCustomPlayValue(setup.autostart, isImmediateAutoplay, playInView);
+        custParams += '&in_focus=' + inFocus;
+        custParams += '&videoduration=' + durationParams.duration;
+        custParams += '&duration_over=' + durationParams.durationOver;
+        custParams += '&duration_under=' + durationParams.durationUnder;
+        setup.advertising.schedule = [{
+        "offset": "pre",
+        "tag": [
+        'https://securepubads.g.doubleclick.net/gampad/ads?',
+        'sz=',
+        formatAdSizeArray([[640, 360]]),
+        '&iu=',
+        iuPath,
+        '&env=vp&hl=en&gdfp_req=1&impl=s&output=xml_vast2&unviewed_position_start=1&lid=',
+        '&url=',
+        encodedPageURL,
+        '&description_url=',
+        encodedPageURL,
+        '&correlator=',
+        Math.floor(Date.now() / 1000),
+        '&cust_params=',
+        Mntl.GPT.serializeAllTargeting(),
+        encodeURIComponent(custParams),
+        '&ad_rule=1'
+        ].join('')
+        }];
+        Mntl.JWPlayer.init({
+        accountKey: "oxY0/BqWBX09BISmLN4/xuTz4IdZy713Cdjj4GyHOiYCUCyJ",
+        adSizes: [[640, 360]],
+        defer: true,
+        deferOnRFDS: false,
+        displayMode: "none",
+        divId: "mntl-jwplayer-broad__video_1-0",
+        enableBiddingWithTCData: false,
+        enableTVPEngagementBtns: false,
+        eventCategoryType: "Trending",
+        intersectionMargin: "250px",
+        isImmediateAutoplay: isImmediateAutoplay,
+        isImmediateStickyDisabled: false,
+        isIntersectionDisabled: false,
+        isMobileAdhesive: false,
+        isBroadVideo: true,
+        isPlaylist: true,
+        mediaSize: 1080,
+        playerId: "aiy6MJ4O",
+        playInView: playInView,
+        showCaptions: true,
+        slot: "broadmatch",
+        rtbVideoConfig: {"maxduration":60,"minduration":0,"plcmt":2},
+        useDynamicVideoSizes: true,
+        skipExistingMediaContent: false,
+        stickyplay: false,
+        useMotionThumbnails: false
+        }, setup );
+        }(window.Mntl || {}));
+        (function(Mntl) {
+        Mntl.Tooltip.init({
+        defaultPositionX: "auto",
+        defaultPositionY: "auto"
+        });
+        })(window.Mntl || {});
+        });
+        //]]>
+        </script>
+        <div id="onetrust-consent-sdk" class="" data-tracking-container="true">
+            <div id="onetrust-banner-sdk" class="otFlat bottom ot-wo-title" tabindex="0">
+                <div role="dialog" aria-label="Privacy">
+                    <div class="ot-sdk-container">
+                        <div class="ot-sdk-row">
+                            <div id="onetrust-group-container" class="ot-sdk-eight ot-sdk-columns">
+                                <div class="banner_logo"></div>
+                                <div id="onetrust-policy">
+                                    <div id="onetrust-policy-text">
+                                        By clicking “Accept All Cookies”, you agree to the storing of cookies on your device to enhance site navigation, analyze site usage, and assist in our marketing efforts.
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="onetrust-button-group-parent" class="ot-sdk-three ot-sdk-columns">
+                                <div id="onetrust-button-group">
+                                    <button id="onetrust-pc-btn-handler" aria-label="Cookies Settings, Opens the preference center dialog" class="cookie-setting-link">Cookies Settings</button> <button id="onetrust-accept-btn-handler">Accept All Cookies</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div><!-- Close Button -->
+                    <div id="onetrust-close-btn-container"></div><!-- Close Button END-->
+                </div>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This CL fixes an issue where images nested within `<div>` elements
inside a `<figure>` tag were being incorrectly removed by Readability's
cleaning process. Specifically, a structure like
`<figure><div><div><img></div></div></figure>` would first be
transformed to `<figure><div><p><img></p></div></figure>`, and then
the outer `<div>` (and its contents) would be erroneously identified
as extraneous and removed.

The fix introduces a targeted exception within _cleanConditionally().
It prevents the removal of `<div>` elements that meet the following
criteria:
* The element is a `<div>`.
* The `<div>` is an ancestor of a `<figure>` element.
* The `<div>` contains a single `<img>` element (potentially nested).

Also add test case allrecipes-1 taken from:
https://www.allrecipes.com/hot-honey-brussels-sprouts-recipe-11832010
